### PR TITLE
chore: switch tsc  to swc for transpiling

### DIFF
--- a/config/tsconfig.json
+++ b/config/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "allowSyntheticDefaultImports": true,
+    "esModuleInterop": true,
+    "experimentalDecorators": true,
+    "forceConsistentCasingInFileNames": true,
+    "importHelpers": true,
+    "isolatedModules": true,
+    "moduleResolution": "node",
+    "noEmitOnError": true,
+    "noUnusedLocals": false,
+    "noUnusedParameters": false,
+    "removeComments": true,
+    "resolveJsonModule": true,
+    "sourceMap": false,
+    "strict": true
+  },
+  "exclude": ["node_modules/", ".*/"]
+}

--- a/lana/package.json
+++ b/lana/package.json
@@ -162,8 +162,6 @@
   "devDependencies": {
     "@rollup/plugin-commonjs": "^25.0.0",
     "@rollup/plugin-node-resolve": "^15.0.2",
-    "@rollup/plugin-terser": "^0.4.0",
-    "@rollup/plugin-typescript": "^11.1.1",
     "@types/node": "^16.x.x",
     "@types/vscode": "^1.74.0",
     "@typescript-eslint/eslint-plugin": "^5.33.0",

--- a/lana/package.json
+++ b/lana/package.json
@@ -151,10 +151,11 @@
     "prettier-format": "prettier 'src/**/*.ts' --write",
     "watch": "rollup -w -c rollup.config.mjs",
     "pretest": "npm run compile && npm run lint",
-    "lint": "eslint src --ext ts",
+    "lint": "concurrently 'eslint src --ext ts' 'npm run tsc:lint'",
     "log-viewer": "npm run log-viewer-build && npm run log-viewer-copy",
     "log-viewer-build": "(cd ../log-viewer; npm ci && npm run build)",
-    "log-viewer-copy": "mkdir -p out; cp ../log-viewer/out/index.html out/. && cp ../log-viewer/out/bundle.js out/."
+    "log-viewer-copy": "mkdir -p out; cp ../log-viewer/out/index.html out/. && cp ../log-viewer/out/bundle.js out/.",
+    "tsc:lint": "tsc --noemit --skipLibCheck"
   },
   "dependencies": {
     "@apexdevtools/apex-ls": "^4.2.0"

--- a/lana/rollup.config.mjs
+++ b/lana/rollup.config.mjs
@@ -1,17 +1,32 @@
 import commonjs from '@rollup/plugin-commonjs';
 import { nodeResolve } from '@rollup/plugin-node-resolve';
-import terser from '@rollup/plugin-terser';
-import typescript from '@rollup/plugin-typescript';
 
-const compact = !process.env.ROLLUP_WATCH;
+import {
+  defineRollupSwcOption,
+  swc,
+  minify,
+  defineRollupSwcMinifyOption,
+} from 'rollup-plugin-swc3';
+
+const production = !process.env.ROLLUP_WATCH;
 const plugins = [
   nodeResolve(),
   commonjs(),
-  typescript({
-    tsconfig: './tsconfig.json',
-    exclude: ['node_modules', '**/__tests__/**'],
-  }),
-  compact && terser(),
+  swc(
+    defineRollupSwcOption({
+      exclude: 'node_modules',
+      tsconfig: production ? 'tsconfig.json' : 'tsconfig-dev.json',
+      jsc: {},
+    })
+  ),
+  production &&
+    minify(
+      defineRollupSwcMinifyOption({
+        // swc's minify option here
+        mangle: true,
+        compress: true,
+      })
+    ),
 ];
 
 export default {

--- a/lana/tsconfig.json
+++ b/lana/tsconfig.json
@@ -1,24 +1,11 @@
 {
+  "extends": "../config/tsconfig.json",
   "compilerOptions": {
-    "allowSyntheticDefaultImports": true,
-    "esModuleInterop": true,
-    "experimentalDecorators": true,
-    "forceConsistentCasingInFileNames": true,
-    "importHelpers": true,
-    "isolatedModules": true,
     "lib": ["es2021"],
     "module": "esnext",
-    "moduleResolution": "node",
-    "noUnusedLocals": false,
-    "noUnusedParameters": false,
     "outDir": "out",
-    "removeComments": true,
-    "resolveJsonModule": true,
     "rootDir": "src",
-    "sourceMap": false,
-    "strict": true,
     "target": "es2021"
   },
-  "include": ["./src/**/*.ts"],
-  "exclude": ["**/node_modules/**", "**/.*/"]
+  "include": ["./src/**/*.ts"]
 }

--- a/log-viewer/package.json
+++ b/log-viewer/package.json
@@ -19,8 +19,6 @@
   "devDependencies": {
     "@rollup/plugin-commonjs": "^25.0.0",
     "@rollup/plugin-node-resolve": "^15.0.2",
-    "@rollup/plugin-terser": "^0.4.0",
-    "@rollup/plugin-typescript": "^11.1.1",
     "@types/tabulator-tables": "^5.4.5",
     "@typescript-eslint/eslint-plugin": "^5.x.x",
     "@typescript-eslint/parser": "^5.x.x",

--- a/log-viewer/package.json
+++ b/log-viewer/package.json
@@ -4,11 +4,12 @@
   "private": true,
   "scripts": {
     "build": "rollup -c rollup.config.mjs",
-    "lint": "eslint modules --ext ts",
+    "lint": "concurrently 'eslint modules --ext ts' 'npm run tsc:lint'",
     "watch": "rollup -w -c rollup.config.mjs",
     "web": "http-server",
-    "debug": "concurrently \"npm:web\" \"npm:watch\"",
-    "prettier-format": "prettier 'modules/**/*.ts' --write"
+    "debug": "concurrently 'npm:web' 'npm:watch'",
+    "prettier-format": "prettier 'modules/**/*.ts' --write",
+    "tsc:lint": "tsc --noemit --skipLibCheck"
   },
   "version": "0.1.0",
   "dependencies": {

--- a/log-viewer/tsconfig.json
+++ b/log-viewer/tsconfig.json
@@ -1,25 +1,11 @@
 {
+  "extends": "../config/tsconfig.json",
   "compilerOptions": {
-    "allowSyntheticDefaultImports": true,
-    "esModuleInterop": true,
-    "experimentalDecorators": true,
-    "forceConsistentCasingInFileNames": true,
-    "importHelpers": true,
-    "isolatedModules": true,
     "lib": ["es2021", "dom"],
     "module": "esnext",
-    "moduleResolution": "node",
-    "noEmitOnError": true,
-    "noUnusedLocals": false,
-    "noUnusedParameters": false,
     "outDir": "out",
-    "removeComments": true,
     "rootDir": "./modules",
-    "resolveJsonModule": true,
-    "sourceMap": false,
-    "strict": true,
     "target": "es2021"
   },
-  "include": ["./modules/**/*.ts"],
-  "exclude": ["**/node_modules/**", "**/.*/"]
+  "include": ["./modules/**/*.ts"]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,15 +10,18 @@
         "log-viewer"
       ],
       "devDependencies": {
-        "@swc/core": "^1.3.58",
+        "@swc/core": "^1.3.62",
+        "@swc/helpers": "^0.5.1",
         "@swc/jest": "^0.2.26",
         "@types/jest": "^29.5.1",
+        "concurrently": "^8.1.0",
         "husky": "^8.0.0",
         "jest": "^29.5.0",
         "jest-environment-jsdom": "^29.5.0",
         "lint-staged": "^13.0.3",
         "prettier": "^2.7.1",
-        "rollup-plugin-copy": "^3.4.0"
+        "rollup-plugin-copy": "^3.4.0",
+        "rollup-plugin-swc3": "^0.8.2"
       }
     },
     "lana": {
@@ -30,8 +33,6 @@
       "devDependencies": {
         "@rollup/plugin-commonjs": "^25.0.0",
         "@rollup/plugin-node-resolve": "^15.0.2",
-        "@rollup/plugin-terser": "^0.4.0",
-        "@rollup/plugin-typescript": "^11.1.1",
         "@types/node": "^16.x.x",
         "@types/vscode": "^1.74.0",
         "@typescript-eslint/eslint-plugin": "^5.33.0",
@@ -64,8 +65,6 @@
       "devDependencies": {
         "@rollup/plugin-commonjs": "^25.0.0",
         "@rollup/plugin-node-resolve": "^15.0.2",
-        "@rollup/plugin-terser": "^0.4.0",
-        "@rollup/plugin-typescript": "^11.1.1",
         "@types/tabulator-tables": "^5.4.5",
         "@typescript-eslint/eslint-plugin": "^5.x.x",
         "@typescript-eslint/parser": "^5.x.x",
@@ -802,6 +801,12 @@
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
     },
+    "node_modules/@fastify/deepmerge": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@fastify/deepmerge/-/deepmerge-1.3.0.tgz",
+      "integrity": "sha512-J8TOSBq3SoZbDhM9+R/u77hP93gz/rajSA+K2kGyijPpORPWUXHUpTaleoj+92As0S9uPRP7Oi8IqMf0u+ro6A==",
+      "dev": true
+    },
     "node_modules/@gar/promisify": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/@gar/promisify/-/promisify-1.1.3.tgz",
@@ -1501,16 +1506,6 @@
         "node": ">=6.0.0"
       }
     },
-    "node_modules/@jridgewell/source-map": {
-      "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.3.tgz",
-      "integrity": "sha512-b+fsZXeLYi9fEULmfBrhxn4IrPlINf8fiNarzTof004v3lFdntdwa9PF7vFJqm3mg7s+ScJMxXaE3Acp1irZcg==",
-      "dev": true,
-      "dependencies": {
-        "@jridgewell/gen-mapping": "^0.3.0",
-        "@jridgewell/trace-mapping": "^0.3.9"
-      }
-    },
     "node_modules/@jridgewell/sourcemap-codec": {
       "version": "1.4.15",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.15.tgz",
@@ -1680,54 +1675,6 @@
         }
       }
     },
-    "node_modules/@rollup/plugin-terser": {
-      "version": "0.4.3",
-      "resolved": "https://registry.npmjs.org/@rollup/plugin-terser/-/plugin-terser-0.4.3.tgz",
-      "integrity": "sha512-EF0oejTMtkyhrkwCdg0HJ0IpkcaVg1MMSf2olHb2Jp+1mnLM04OhjpJWGma4HobiDTF0WCyViWuvadyE9ch2XA==",
-      "dev": true,
-      "dependencies": {
-        "serialize-javascript": "^6.0.1",
-        "smob": "^1.0.0",
-        "terser": "^5.17.4"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      },
-      "peerDependencies": {
-        "rollup": "^2.x || ^3.x"
-      },
-      "peerDependenciesMeta": {
-        "rollup": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@rollup/plugin-typescript": {
-      "version": "11.1.1",
-      "resolved": "https://registry.npmjs.org/@rollup/plugin-typescript/-/plugin-typescript-11.1.1.tgz",
-      "integrity": "sha512-Ioir+x5Bejv72Lx2Zbz3/qGg7tvGbxQZALCLoJaGrkNXak/19+vKgKYJYM3i/fJxvsb23I9FuFQ8CUBEfsmBRg==",
-      "dev": true,
-      "dependencies": {
-        "@rollup/pluginutils": "^5.0.1",
-        "resolve": "^1.22.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      },
-      "peerDependencies": {
-        "rollup": "^2.14.0||^3.0.0",
-        "tslib": "*",
-        "typescript": ">=3.7.0"
-      },
-      "peerDependenciesMeta": {
-        "rollup": {
-          "optional": true
-        },
-        "tslib": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/@rollup/pluginutils": {
       "version": "5.0.2",
       "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-5.0.2.tgz",
@@ -1775,9 +1722,9 @@
       }
     },
     "node_modules/@swc/core": {
-      "version": "1.3.61",
-      "resolved": "https://registry.npmjs.org/@swc/core/-/core-1.3.61.tgz",
-      "integrity": "sha512-p58Ltdjo7Yy8CU3zK0cp4/eAgy5qkHs35znGedqVGPiA67cuYZM63DuTfmyrOntMRwQnaFkMLklDAPCizDdDng==",
+      "version": "1.3.62",
+      "resolved": "https://registry.npmjs.org/@swc/core/-/core-1.3.62.tgz",
+      "integrity": "sha512-J58hWY+/G8vOr4J6ZH9hLg0lMSijZtqIIf4HofZezGog/pVX6sJyBJ40dZ1ploFkDIlWTWvJyqtpesBKS73gkQ==",
       "dev": true,
       "hasInstallScript": true,
       "engines": {
@@ -1788,16 +1735,16 @@
         "url": "https://opencollective.com/swc"
       },
       "optionalDependencies": {
-        "@swc/core-darwin-arm64": "1.3.61",
-        "@swc/core-darwin-x64": "1.3.61",
-        "@swc/core-linux-arm-gnueabihf": "1.3.61",
-        "@swc/core-linux-arm64-gnu": "1.3.61",
-        "@swc/core-linux-arm64-musl": "1.3.61",
-        "@swc/core-linux-x64-gnu": "1.3.61",
-        "@swc/core-linux-x64-musl": "1.3.61",
-        "@swc/core-win32-arm64-msvc": "1.3.61",
-        "@swc/core-win32-ia32-msvc": "1.3.61",
-        "@swc/core-win32-x64-msvc": "1.3.61"
+        "@swc/core-darwin-arm64": "1.3.62",
+        "@swc/core-darwin-x64": "1.3.62",
+        "@swc/core-linux-arm-gnueabihf": "1.3.62",
+        "@swc/core-linux-arm64-gnu": "1.3.62",
+        "@swc/core-linux-arm64-musl": "1.3.62",
+        "@swc/core-linux-x64-gnu": "1.3.62",
+        "@swc/core-linux-x64-musl": "1.3.62",
+        "@swc/core-win32-arm64-msvc": "1.3.62",
+        "@swc/core-win32-ia32-msvc": "1.3.62",
+        "@swc/core-win32-x64-msvc": "1.3.62"
       },
       "peerDependencies": {
         "@swc/helpers": "^0.5.0"
@@ -1809,9 +1756,9 @@
       }
     },
     "node_modules/@swc/core-darwin-arm64": {
-      "version": "1.3.61",
-      "resolved": "https://registry.npmjs.org/@swc/core-darwin-arm64/-/core-darwin-arm64-1.3.61.tgz",
-      "integrity": "sha512-Ra1CZIYYyIp/Y64VcKyaLjIPUwT83JmGduvHu8vhUZOvWV4dWL4s5DrcxQVaQJjjb7Z2N/IUYYS55US1TGnxZw==",
+      "version": "1.3.62",
+      "resolved": "https://registry.npmjs.org/@swc/core-darwin-arm64/-/core-darwin-arm64-1.3.62.tgz",
+      "integrity": "sha512-MmGilibITz68LEje6vJlKzc2gUUSgzvB3wGLSjEORikTNeM7P8jXVxE4A8fgZqDeudJUm9HVWrxCV+pHDSwXhA==",
       "cpu": [
         "arm64"
       ],
@@ -1825,9 +1772,9 @@
       }
     },
     "node_modules/@swc/core-darwin-x64": {
-      "version": "1.3.61",
-      "resolved": "https://registry.npmjs.org/@swc/core-darwin-x64/-/core-darwin-x64-1.3.61.tgz",
-      "integrity": "sha512-LUia75UByUFkYH1Ddw7IE0X9usNVGJ7aL6+cgOTju7P0dsU0f8h/OGc/GDfp1E4qnKxDCJE+GwDRLoi4SjIxpg==",
+      "version": "1.3.62",
+      "resolved": "https://registry.npmjs.org/@swc/core-darwin-x64/-/core-darwin-x64-1.3.62.tgz",
+      "integrity": "sha512-Xl93MMB3sCWVlYWuQIB+v6EQgzoiuQYK5tNt9lsHoIEVu2zLdkQjae+5FUHZb1VYqCXIiWcULFfVz0R4Sjb7JQ==",
       "cpu": [
         "x64"
       ],
@@ -1841,9 +1788,9 @@
       }
     },
     "node_modules/@swc/core-linux-arm-gnueabihf": {
-      "version": "1.3.61",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm-gnueabihf/-/core-linux-arm-gnueabihf-1.3.61.tgz",
-      "integrity": "sha512-aalPlicYxHAn2PxNlo3JFEZkMXzCtUwjP27AgMqnfV4cSz7Omo56OtC+413e/kGyCH86Er9gJRQQsxNKP8Qbsg==",
+      "version": "1.3.62",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm-gnueabihf/-/core-linux-arm-gnueabihf-1.3.62.tgz",
+      "integrity": "sha512-nJsp6O7kCtAjTTMcIjVB0g5y1JNiYAa5q630eiwrnaHUusEFoANDdORI3Z9vXeikMkng+6yIv9/V8Rb093xLjQ==",
       "cpu": [
         "arm"
       ],
@@ -1857,9 +1804,9 @@
       }
     },
     "node_modules/@swc/core-linux-arm64-gnu": {
-      "version": "1.3.61",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-gnu/-/core-linux-arm64-gnu-1.3.61.tgz",
-      "integrity": "sha512-9hGdsbQrYNPo1c7YzWF57yl17bsIuuEQi3I1fOFSv3puL3l5M/C/oCD0Bz6IdKh6mEDC5UNJE4LWtV1gFA995A==",
+      "version": "1.3.62",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-gnu/-/core-linux-arm64-gnu-1.3.62.tgz",
+      "integrity": "sha512-XGsV93vpUAopDt5y6vPwbK1Nc/MlL55L77bAZUPIiosWD1cWWPHNtNSpriE6+I+JiMHe0pqtfS/SSTk6ZkFQVw==",
       "cpu": [
         "arm64"
       ],
@@ -1873,9 +1820,9 @@
       }
     },
     "node_modules/@swc/core-linux-arm64-musl": {
-      "version": "1.3.61",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-musl/-/core-linux-arm64-musl-1.3.61.tgz",
-      "integrity": "sha512-mVmcNfFQRP4SYbGC08IPB3B9Xox+VpGIQqA3Qg7LMCcejLAQLi4Lfe8CDvvBPlQzXHso0Cv+BicJnQVKs8JLOA==",
+      "version": "1.3.62",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-musl/-/core-linux-arm64-musl-1.3.62.tgz",
+      "integrity": "sha512-ESUmJjSlTTkoBy9dMG49opcNn8BmviqStMhwyeD1G8XRnmRVCZZgoBOKdvCXmJhw8bQXDhZumeaTUB+OFUKVXg==",
       "cpu": [
         "arm64"
       ],
@@ -1889,9 +1836,9 @@
       }
     },
     "node_modules/@swc/core-linux-x64-gnu": {
-      "version": "1.3.61",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-gnu/-/core-linux-x64-gnu-1.3.61.tgz",
-      "integrity": "sha512-ZkRHs7GEikN6JiVL1/stvq9BVHKrSKoRn9ulVK2hMr+mAGNOKm3Y06NSzOO+BWwMaFOgnO2dWlszCUICsQ0kpg==",
+      "version": "1.3.62",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-gnu/-/core-linux-x64-gnu-1.3.62.tgz",
+      "integrity": "sha512-wnHJkt3ZBrax3SFnUHDcncG6mrSg9ZZjMhQV9Mc3JL1x1s1Gy9rGZCoBNnV/BUZWTemxIBcQbANRSDut/WO+9A==",
       "cpu": [
         "x64"
       ],
@@ -1905,9 +1852,9 @@
       }
     },
     "node_modules/@swc/core-linux-x64-musl": {
-      "version": "1.3.61",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-musl/-/core-linux-x64-musl-1.3.61.tgz",
-      "integrity": "sha512-zK7VqQ5JlK20+7fxI4AgvIUckeZyX0XIbliGXNMR3i+39SJq1vs9scYEmq8VnAfvNdMU5BG+DewbFJlMfCtkxQ==",
+      "version": "1.3.62",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-musl/-/core-linux-x64-musl-1.3.62.tgz",
+      "integrity": "sha512-9oRbuTC/VshB66Rgwi3pTq3sPxSTIb8k9L1vJjES+dDMKa29DAjPtWCXG/pyZ00ufpFZgkGEuAHH5uqUcr1JQg==",
       "cpu": [
         "x64"
       ],
@@ -1921,9 +1868,9 @@
       }
     },
     "node_modules/@swc/core-win32-arm64-msvc": {
-      "version": "1.3.61",
-      "resolved": "https://registry.npmjs.org/@swc/core-win32-arm64-msvc/-/core-win32-arm64-msvc-1.3.61.tgz",
-      "integrity": "sha512-e9kVVPk5iVNhO41TvLvcExDHn5iATQ5/M4U7/CdcC7s0fK19TKSEUqkdoTLIJvHBFhgR7w3JJSErfnauO0xXoA==",
+      "version": "1.3.62",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-arm64-msvc/-/core-win32-arm64-msvc-1.3.62.tgz",
+      "integrity": "sha512-zv14vlF2VRrxS061XkfzGjCYnOrEo5glKJjLK5PwUKysIoVrx/L8nAbFxjkX5cObdlyoqo+ekelyBPAO+4bS0w==",
       "cpu": [
         "arm64"
       ],
@@ -1937,9 +1884,9 @@
       }
     },
     "node_modules/@swc/core-win32-ia32-msvc": {
-      "version": "1.3.61",
-      "resolved": "https://registry.npmjs.org/@swc/core-win32-ia32-msvc/-/core-win32-ia32-msvc-1.3.61.tgz",
-      "integrity": "sha512-7cJULfa6HvKqvFh6M/f7mKiNRhE2AjgFUCZfdOuy5r8vbtpk+qBK94TXwaDjJYDUGKzDVZw/tJ1eN4Y9n9Ls/Q==",
+      "version": "1.3.62",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-ia32-msvc/-/core-win32-ia32-msvc-1.3.62.tgz",
+      "integrity": "sha512-8MC/PZQSsOP2iA/81tAfNRqMWyEqTS/8zKUI67vPuLvpx6NAjRn3E9qBv7iFqH79iqZNzqSMo3awnLrKZyFbcw==",
       "cpu": [
         "ia32"
       ],
@@ -1953,9 +1900,9 @@
       }
     },
     "node_modules/@swc/core-win32-x64-msvc": {
-      "version": "1.3.61",
-      "resolved": "https://registry.npmjs.org/@swc/core-win32-x64-msvc/-/core-win32-x64-msvc-1.3.61.tgz",
-      "integrity": "sha512-Jx8S+21WcKF/wlhW+sYpystWUyymDTEsbBpOgBRpXZelakVcNBCIIYSZOKW/A9PwWTpu6S8yvbs9nUOzKiVPqA==",
+      "version": "1.3.62",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-x64-msvc/-/core-win32-x64-msvc-1.3.62.tgz",
+      "integrity": "sha512-GJSmUJ95HKHZXAxiuPUmrcm/S3ivQvEzXhOZaIqYBIwUsm02vFZkClsV7eIKzWjso1t0+I/8MjrnUNaSWqh1rQ==",
       "cpu": [
         "x64"
       ],
@@ -1966,6 +1913,15 @@
       ],
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/@swc/helpers": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.1.tgz",
+      "integrity": "sha512-sJ902EfIzn1Fa+qYmjdQqh8tPsoxyBz+8yBKC2HKUxyezKJFwPGOn7pv4WY6QuQW//ySQi5lJjA/ZT9sNWWNTg==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
       }
     },
     "node_modules/@swc/jest": {
@@ -4559,6 +4515,18 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/get-tsconfig": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.6.0.tgz",
+      "integrity": "sha512-lgbo68hHTQnFddybKbbs/RDRJnJT5YyGy2kQzVwbq+g67X73i+5MVTval34QxGkOe9X5Ujf1UYpCaphLyltjEg==",
+      "dev": true,
+      "dependencies": {
+        "resolve-pkg-maps": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
       }
     },
     "node_modules/glob": {
@@ -8938,15 +8906,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/randombytes": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
-      "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
-      "dev": true,
-      "dependencies": {
-        "safe-buffer": "^5.1.0"
-      }
-    },
     "node_modules/react-is": {
       "version": "18.2.0",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz",
@@ -9178,6 +9137,15 @@
         "node": ">=4"
       }
     },
+    "node_modules/resolve-pkg-maps": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
+      "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
+      "dev": true,
+      "funding": {
+        "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+      }
+    },
     "node_modules/resolve.exports": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/resolve.exports/-/resolve.exports-2.0.2.tgz",
@@ -9376,6 +9344,37 @@
         "postcss": "8.x"
       }
     },
+    "node_modules/rollup-plugin-swc3": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-swc3/-/rollup-plugin-swc3-0.8.2.tgz",
+      "integrity": "sha512-8C8rw7Iw3s+RvIooDu0IaXGQDijYFiDpKMuwQPxv3onwa/ysojz3BzG8Lr2AbhX6Hd/2UT2wkerFFwOWQ3ytOQ==",
+      "dev": true,
+      "dependencies": {
+        "@fastify/deepmerge": "^1.1.0",
+        "@rollup/pluginutils": "^4.2.1",
+        "get-tsconfig": "^4.2.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "@swc/core": ">=1.2.165",
+        "rollup": "^2.0.0 || ^3.0.0"
+      }
+    },
+    "node_modules/rollup-plugin-swc3/node_modules/@rollup/pluginutils": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-4.2.1.tgz",
+      "integrity": "sha512-iKnFXr7NkdZAIHiIWE+BX5ULi/ucVFYWD6TbAV+rZctiRTY2PL6tsIKhoIOaoskiWAkgu+VsbXgUVDNLHf+InQ==",
+      "dev": true,
+      "dependencies": {
+        "estree-walker": "^2.0.1",
+        "picomatch": "^2.2.2"
+      },
+      "engines": {
+        "node": ">= 8.0.0"
+      }
+    },
     "node_modules/rollup-pluginutils": {
       "version": "2.8.2",
       "resolved": "https://registry.npmjs.org/rollup-pluginutils/-/rollup-pluginutils-2.8.2.tgz",
@@ -9563,15 +9562,6 @@
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
       "dev": true
     },
-    "node_modules/serialize-javascript": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.1.tgz",
-      "integrity": "sha512-owoXEFjWRllis8/M1Q+Cw5k8ZH40e3zhp/ovX+Xr/vi1qj6QesbyXXViFbpNvWvPNAD62SutwEXavefrLJWj7w==",
-      "dev": true,
-      "dependencies": {
-        "randombytes": "^2.1.0"
-      }
-    },
     "node_modules/set-blocking": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
@@ -9680,12 +9670,6 @@
         "node": ">= 6.0.0",
         "npm": ">= 3.0.0"
       }
-    },
-    "node_modules/smob": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/smob/-/smob-1.4.0.tgz",
-      "integrity": "sha512-MqR3fVulhjWuRNSMydnTlweu38UhQ0HXM4buStD/S3mc/BzX3CuM9OmhyQpmtYCvoYdl5ris6TI0ZqH355Ymqg==",
-      "dev": true
     },
     "node_modules/socks": {
       "version": "2.7.1",
@@ -10119,40 +10103,6 @@
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
       "dev": true
-    },
-    "node_modules/terser": {
-      "version": "5.17.7",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-5.17.7.tgz",
-      "integrity": "sha512-/bi0Zm2C6VAexlGgLlVxA0P2lru/sdLyfCVaRMfKVo9nWxbmz7f/sD8VPybPeSUJaJcwmCJis9pBIhcVcG1QcQ==",
-      "dev": true,
-      "dependencies": {
-        "@jridgewell/source-map": "^0.3.3",
-        "acorn": "^8.8.2",
-        "commander": "^2.20.0",
-        "source-map-support": "~0.5.20"
-      },
-      "bin": {
-        "terser": "bin/terser"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/terser/node_modules/commander": {
-      "version": "2.20.3",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
-      "dev": true
-    },
-    "node_modules/terser/node_modules/source-map-support": {
-      "version": "0.5.21",
-      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
-      "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
-      "dev": true,
-      "dependencies": {
-        "buffer-from": "^1.0.0",
-        "source-map": "^0.6.0"
-      }
     },
     "node_modules/test-exclude": {
       "version": "6.0.0",

--- a/package.json
+++ b/package.json
@@ -6,15 +6,18 @@
     "log-viewer"
   ],
   "devDependencies": {
-    "@swc/core": "^1.3.58",
+    "@swc/core": "^1.3.62",
+    "@swc/helpers": "^0.5.1",
     "@swc/jest": "^0.2.26",
     "@types/jest": "^29.5.1",
+    "concurrently": "^8.1.0",
     "husky": "^8.0.0",
     "jest": "^29.5.0",
     "jest-environment-jsdom": "^29.5.0",
     "lint-staged": "^13.0.3",
     "prettier": "^2.7.1",
-    "rollup-plugin-copy": "^3.4.0"
+    "rollup-plugin-copy": "^3.4.0",
+    "rollup-plugin-swc3": "^0.8.2"
   },
   "scripts": {
     "build": "NODE_ENV=production npm run build:dev",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   },
   "scripts": {
     "build": "NODE_ENV=production npm run build:dev",
-    "build:dev": "rm -rf lana/out && rollup -c rollup.config.mjs",
+    "build:dev": "concurrently 'rm -rf lana/out && rollup -c rollup.config.mjs' 'npm run tsc:lint -w log-viewer' 'npm run tsc:lint -w lana'",
     "watch": "rm -rf lana/out && rollup -w -c rollup.config.mjs",
     "prepare": "husky install",
     "lint": "eslint . --ext ts",


### PR DESCRIPTION
# Description

- use swc to transpile ts to js instead of tsc, because it is much faster.
- tsc is run as a lint step to address type issues.

resolves #287
