### PR TITLE
feat: rename load apex log command to `Log: Retrieve Apex Log And Show Analysis`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Changed
 
+- Renamed `Log: Load Apex Log For Analysis` to `Log: Retrieve Apex Log And Show Analysis` ([#288][#288])
 - Update minimum supported vscode version to v1.74.0 ([#280][#280])
 
 ## [1.6.0] - 2023-05-19
@@ -227,3 +228,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#235]: https://github.com/certinia/debug-log-analyzer/issues/235
 [#264]: https://github.com/certinia/debug-log-analyzer/issues/264
 [#280]: https://github.com/certinia/debug-log-analyzer/issues/280
+[#288]: https://github.com/certinia/debug-log-analyzer/issues/288

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ With the `.log` file open in VSCode.
 
 ### Download a log
 
-1. Open command pallette (CMD/CTRL + Shift + P) -> 'Log: Load Apex Log for Analysis'
+1. Open command pallette (CMD/CTRL + Shift + P) -> 'Log: Retrieve Apex Log And Show Analysis
 
 ## Features
 

--- a/lana/package.json
+++ b/lana/package.json
@@ -48,7 +48,7 @@
         "title": "Log: Retrieve Apex Log And Show Analysis"
       },
       {
-        "command": "lana.showLogFile",
+        "command": "lana.showLogAnalysis",
         "title": "Log: Show Apex Log Analysis"
       }
     ],
@@ -69,19 +69,19 @@
     "menus": {
       "commandPalette": [
         {
-          "command": "lana.showLogFile",
+          "command": "lana.showLogAnalysis",
           "when": "resourceLangId == apexlog"
         }
       ],
       "editor/context": [
         {
-          "command": "lana.showLogFile",
+          "command": "lana.showLogAnalysis",
           "when": "resourceLangId == apexlog"
         }
       ],
       "explorer/context": [
         {
-          "command": "lana.showLogFile",
+          "command": "lana.showLogAnalysis",
           "when": "resourceLangId == apexlog"
         }
       ]

--- a/lana/package.json
+++ b/lana/package.json
@@ -44,8 +44,8 @@
   "contributes": {
     "commands": [
       {
-        "command": "lana.loadLogFile",
-        "title": "Log: Load Apex Log For Analysis"
+        "command": "lana.retrieveLogFile",
+        "title": "Log: Retrieve Apex Log And Show Analysis"
       },
       {
         "command": "lana.showLogFile",

--- a/lana/src/Context.ts
+++ b/lana/src/Context.ts
@@ -3,7 +3,7 @@
  */
 
 import { ExtensionContext, workspace } from 'vscode';
-import { LoadLogFile } from './commands/LoadLogFile';
+import { RetrieveLogFile } from './commands/RetrieveLogFile';
 import { ShowLogFile } from './commands/ShowLogFile';
 import ShowAnalysisCodeLens from './codelenses/ShowAnalysisCodeLens';
 import { Display } from './Display';
@@ -26,7 +26,7 @@ export class Context {
       });
     }
 
-    LoadLogFile.apply(this);
+    RetrieveLogFile.apply(this);
     ShowLogFile.apply(this);
     ShowAnalysisCodeLens.apply(this);
   }

--- a/lana/src/Context.ts
+++ b/lana/src/Context.ts
@@ -4,7 +4,7 @@
 
 import { ExtensionContext, workspace } from 'vscode';
 import { RetrieveLogFile } from './commands/RetrieveLogFile';
-import { ShowLogFile } from './commands/ShowLogFile';
+import { ShowLogAnalysis } from './commands/ShowLogAnalysis';
 import ShowAnalysisCodeLens from './codelenses/ShowAnalysisCodeLens';
 import { Display } from './Display';
 import { SymbolFinder } from './SymbolFinder';
@@ -27,7 +27,7 @@ export class Context {
     }
 
     RetrieveLogFile.apply(this);
-    ShowLogFile.apply(this);
+    ShowLogAnalysis.apply(this);
     ShowAnalysisCodeLens.apply(this);
   }
 

--- a/lana/src/codelenses/ShowAnalysisCodeLens.ts
+++ b/lana/src/codelenses/ShowAnalysisCodeLens.ts
@@ -1,5 +1,5 @@
 import { CodeLensProvider, TextDocument, CodeLens, Range, languages } from 'vscode';
-import { ShowLogFile } from '../commands/ShowLogFile';
+import { ShowLogAnalysis } from '../commands/ShowLogAnalysis';
 import { Context } from '../Context';
 
 class ShowAnalysisCodeLens implements CodeLensProvider {
@@ -13,7 +13,7 @@ class ShowAnalysisCodeLens implements CodeLensProvider {
     const topOfDocument = new Range(0, 0, 0, 0);
 
     // Define what command we want to trigger when activating the CodeLens
-    const command = ShowLogFile.getCommand(this.context);
+    const command = ShowLogAnalysis.getCommand(this.context);
     const codeLens = new CodeLens(topOfDocument, {
       command: command.fullName,
       title: command.title,

--- a/lana/src/commands/RetrieveLogFile.ts
+++ b/lana/src/commands/RetrieveLogFile.ts
@@ -30,17 +30,17 @@ class DebugLogItem extends Item {
   }
 }
 
-export class LoadLogFile {
+export class RetrieveLogFile {
   static apply(context: Context): void {
-    new Command('loadLogFile', 'Log: Load Apex Log For Analysis', () =>
-      LoadLogFile.safeCommand(context)
+    new Command('retrieveLogFile', 'Log: Retrieve Apex Log And Show Analysis', () =>
+      RetrieveLogFile.safeCommand(context)
     ).register(context);
-    context.display.output(`Registered command '${appName}: Load Log'`);
+    context.display.output(`Registered command '${appName}: Retrieve Log'`);
   }
 
   private static async safeCommand(context: Context): Promise<WebviewPanel | void> {
     try {
-      return LoadLogFile.command(context);
+      return RetrieveLogFile.command(context);
     } catch (err: unknown) {
       const msg = err instanceof Error ? err.message : String(err);
       context.display.showErrorMessage(`Error loading logfile: ${msg}`);
@@ -50,12 +50,15 @@ export class LoadLogFile {
 
   private static async command(context: Context): Promise<WebviewPanel | void> {
     const ws = await QuickPickWorkspace.pickOrReturn(context);
-    const [logFiles] = await Promise.all([GetLogFiles.apply(ws), LoadLogFile.showLoadingPicker()]);
+    const [logFiles] = await Promise.all([
+      GetLogFiles.apply(ws),
+      RetrieveLogFile.showLoadingPicker(),
+    ]);
 
     if (logFiles.status !== 0) {
       throw new Error('Failed to load available log files');
     }
-    const logFileId = await LoadLogFile.getLogFile(logFiles.result);
+    const logFileId = await RetrieveLogFile.getLogFile(logFiles.result);
     if (logFileId) {
       const logFilePath = this.getLogFilePath(ws, logFileId);
       const [view] = await Promise.all([

--- a/lana/src/commands/ShowLogAnalysis.ts
+++ b/lana/src/commands/ShowLogAnalysis.ts
@@ -10,21 +10,21 @@ import { LogView } from './LogView';
 import { Command } from './Command';
 import { appName } from '../AppSettings';
 
-export class ShowLogFile {
+export class ShowLogAnalysis {
   static getCommand(context: Context): Command {
-    return new Command('showLogFile', 'Log: Show Apex Log Analysis', (uri: Uri) =>
-      ShowLogFile.safeCommand(context, uri)
+    return new Command('showLogAnalysis', 'Log: Show Apex Log Analysis', (uri: Uri) =>
+      ShowLogAnalysis.safeCommand(context, uri)
     );
   }
 
   static apply(context: Context): void {
-    ShowLogFile.getCommand(context).register(context);
+    ShowLogAnalysis.getCommand(context).register(context);
     context.display.output(`Registered command '${appName}: Show Log'`);
   }
 
   private static async safeCommand(context: Context, uri: Uri): Promise<void> {
     try {
-      return ShowLogFile.command(context, uri);
+      return ShowLogAnalysis.command(context, uri);
     } catch (err: unknown) {
       const msg = err instanceof Error ? err.message : String(err);
       context.display.showErrorMessage(`Error showing logfile: ${msg}`);


### PR DESCRIPTION
# Description

Renames the `Log: Load Apex Log For Analysis` command to `Log: Retrieve Apex Log And Show Analysis`
This makes it generally clearer what it does  and that it will get the log from an org and 

resolves #288 
