### PR TITLE
feat: open large logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Changed
 
+- Support go to log hyperlink opening logs larger than 50MB ([#254][#254])
 - Renamed `Log: Load Apex Log For Analysis` to `Log: Retrieve Apex Log And Show Analysis` ([#288][#288])
 - Update minimum supported vscode version to v1.74.0 ([#280][#280])
 
@@ -229,3 +230,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#264]: https://github.com/certinia/debug-log-analyzer/issues/264
 [#280]: https://github.com/certinia/debug-log-analyzer/issues/280
 [#288]: https://github.com/certinia/debug-log-analyzer/issues/288
+[#254]: https://github.com/certinia/debug-log-analyzer/issues/254

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Changed
 
-- Support go to log hyperlink opening logs larger than 50MB ([#254][#254])
+- Increase the supported log size for the go to log hyperlink to larger than 50MB ([#254][#254])
 - Renamed `Log: Load Apex Log For Analysis` to `Log: Retrieve Apex Log And Show Analysis` ([#288][#288])
 - Update minimum supported vscode version to v1.74.0 ([#280][#280])
 

--- a/lana/src/Display.ts
+++ b/lana/src/Display.ts
@@ -2,7 +2,7 @@
  * Copyright (c) 2020 Certinia Inc. All rights reserved.
  */
 
-import { Uri, window, workspace } from 'vscode';
+import { Uri, window, commands } from 'vscode';
 import { appName } from './AppSettings';
 
 export class Display {
@@ -24,6 +24,6 @@ export class Display {
   }
 
   showFile(path: string): void {
-    workspace.openTextDocument(Uri.file(path)).then((td) => window.showTextDocument(td));
+    commands.executeCommand('vscode.open', Uri.file(path));
   }
 }

--- a/lana/src/display/OpenFileInPackage.ts
+++ b/lana/src/display/OpenFileInPackage.ts
@@ -2,24 +2,29 @@
  * Copyright (c) 2020 Certinia Inc. All rights reserved.
  */
 
-import { Position, Range, Selection, Uri, window, workspace } from 'vscode';
+import { Position, Selection, Uri, TextDocumentShowOptions, commands, ViewColumn } from 'vscode';
 import { Context } from '../Context';
 
 export class OpenFileInPackage {
-  static openFileForSymbol(wsPath: string, context: Context, name: string, line?: number): void {
+  static openFileForSymbol(
+    wsPath: string,
+    context: Context,
+    name: string,
+    lineNumber?: number
+  ): void {
     const path = context.findSymbol(wsPath, name);
-    if (path) {
-      const uri = Uri.file(path);
-      workspace.openTextDocument(uri).then((td) => {
-        window.showTextDocument(td).then((editor) => {
-          if (line) {
-            const zeroBasedLine = line - 1;
-            const position = new Position(zeroBasedLine, 0);
-            editor.selection = new Selection(position, position);
-            editor.revealRange(new Range(position, position));
-          }
-        });
-      });
+    if (path && lineNumber) {
+      const zeroBasedLine = lineNumber - 1;
+      const linePosition = new Position(zeroBasedLine, 0);
+
+      const options: TextDocumentShowOptions = {
+        preserveFocus: false,
+        preview: false,
+        viewColumn: ViewColumn.Active,
+        selection: new Selection(linePosition, linePosition),
+      };
+
+      commands.executeCommand('vscode.open', Uri.file(path), options);
     }
   }
 }


### PR DESCRIPTION
# Description

- Uses [`vscode.open`](https://code.visualstudio.com/api/references/commands) to open logs larger than 50MB.
The previous way was to use `[showTextDocument](https://code.visualstudio.com/api/references/vscode-api#window)` which has a 50MB limit

resolves #254 
