### PR TITLE
feat: export to csv from analysis table

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,4 @@
 #!/usr/bin/env sh
 . "$(dirname -- "$0")/_/husky.sh"
 
-npx lint-staged
+pnpm lint-staged

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,11 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Redesigned Analysis view ([#294][#294])
+- Analysis: Redesigned view ([#294][#294])
   - All columns are sortable ascending or descending by clicking the header
-  - Columns for to show Event Type, Aggregated Total Time and Aggregated Self Time.
+  - Columns for to show Event Type, Aggregated Total Time and Aggregated Self Time
   - Virtualised row rendered to greatly improve performance
   - Group by Event Type to show aggregated totals for each type e.g See the Total Time for all `METHOD_ENTRY` events
+- Analysis: Export data ([#25][#25])
+  - Copy data to clipboard directly from Analysis grid by focusing on the grid and using ctrl + c or cmd + c
+  - Export to CSV file using the `Export to CSV` action in the grid header menu
 
 ### Changed
 
@@ -240,3 +243,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#288]: https://github.com/certinia/debug-log-analyzer/issues/288
 [#254]: https://github.com/certinia/debug-log-analyzer/issues/254
 [#294]: https://github.com/certinia/debug-log-analyzer/issues/294
+[#25]: https://github.com/certinia/debug-log-analyzer/issues/25

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Virtualised row rendered to greatly improve performance
   - Group by Event Type to show aggregated totals for each type e.g See the Total Time for all `METHOD_ENTRY` events
 - Analysis: Export data ([#25][#25])
-  - Copy data to clipboard directly from Analysis grid by focusing on the grid and using ctrl + c or cmd + c
+  - Copy data to clipboard directly from Analysis grid by focusing on the grid and using `ctrl + c` or `cmd + c`
   - Export to CSV file using the `Export to CSV` action in the grid header menu
 
 ### Changed

--- a/log-viewer/modules/analysis-view/AnalysisView.ts
+++ b/log-viewer/modules/analysis-view/AnalysisView.ts
@@ -15,6 +15,10 @@ export async function renderAnalysis(rootMethod: RootNode) {
     layout: 'fitColumns',
     placeholder: 'No Analysis Available',
     columnCalcs: 'both',
+    clipboard: true,
+    //@ts-expect-error types need update array is valid
+    keybindings: { copyToClipboard: ['ctrl + 67', 'meta + 67'] },
+    clipboardCopyRowRange: 'active',
     height: '100%',
     groupClosedShowCalcs: true,
     groupStartOpen: false,

--- a/log-viewer/modules/analysis-view/AnalysisView.ts
+++ b/log-viewer/modules/analysis-view/AnalysisView.ts
@@ -1,6 +1,7 @@
 import { ColumnComponent, TabulatorFull as Tabulator } from 'tabulator-tables';
 
 import '../../resources/css/DatabaseView.scss';
+import NumberAccessor from '../datagrid/dataaccessor/Number';
 import Number from '../datagrid/format/Number';
 import { RootNode, TimedNode } from '../parsers/TreeParser';
 import { hostService } from '../services/VSCodeService';
@@ -97,6 +98,7 @@ export async function renderAnalysis(rootMethod: RootNode) {
           thousand: false,
           precision: 3,
         },
+        accessorDownload: NumberAccessor,
         bottomCalcFormatter: Number,
         bottomCalc: 'sum',
         bottomCalcFormatterParams: { precision: 3 },
@@ -115,6 +117,7 @@ export async function renderAnalysis(rootMethod: RootNode) {
           thousand: false,
           precision: 3,
         },
+        accessorDownload: NumberAccessor,
         bottomCalcFormatter: Number,
       },
     ],

--- a/log-viewer/modules/datagrid/dataaccessor/Number.ts
+++ b/log-viewer/modules/datagrid/dataaccessor/Number.ts
@@ -1,0 +1,13 @@
+import { ColumnComponent, RowComponent } from 'tabulator-tables';
+
+export default function (
+  value: any,
+  _data: any,
+  _type: 'data' | 'download' | 'clipboard',
+  accessorParams: any,
+  _column?: ColumnComponent,
+  _row?: RowComponent
+): any {
+  const returnValue = (value || 0) / 1000000;
+  return returnValue.toFixed(accessorParams.precision || 3);
+}

--- a/log-viewer/modules/services/VSCodeService.ts
+++ b/log-viewer/modules/services/VSCodeService.ts
@@ -19,9 +19,11 @@ export function hostService(): HostService {
 
 export interface HostService {
   openPath(path: string): void;
+  saveFile(request: { fileContent: string; defaultFilename: string }): void;
   openType(info: OpenInfo): void;
   openHelp(): void;
   getConfig(): void;
+  showError(text: string): void;
 }
 
 export class VSCodeService implements HostService {
@@ -79,6 +81,29 @@ export class VSCodeService implements HostService {
       this.vscodeAPIInstance.postMessage({ cmd: 'getConfig' });
     } else {
       console.log(`VSCodeService.getConfig() with no VSCode instance.`);
+    }
+  }
+
+  saveFile(request: { fileContent: string; defaultFilename: string }) {
+    if (this.vscodeAPIInstance) {
+      this.vscodeAPIInstance.postMessage({
+        cmd: 'saveFile',
+        text: request.fileContent,
+        options: { defaultUri: request.defaultFilename },
+      });
+    } else {
+      console.log(`VSCodeService.saveFile() with no VSCode instance.`);
+    }
+  }
+
+  showError(text: string) {
+    if (this.vscodeAPIInstance) {
+      this.vscodeAPIInstance.postMessage({
+        cmd: 'showError',
+        text: text,
+      });
+    } else {
+      console.log(`VSCodeService.showError() with no VSCode instance.`);
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "concurrently": "^8.1.0",
     "eslint-config-prettier": "^8.8.0",
     "eslint-plugin-prettier": "^4.2.1",
-    "husky": "^8.0.3",
+    "husky": "^8.0.0",
     "jest": "^29.5.0",
     "jest-environment-jsdom": "^29.5.0",
     "lint-staged": "^13.2.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -51,7 +51,7 @@ importers:
         specifier: ^4.2.1
         version: 4.2.1(eslint-config-prettier@8.8.0)(eslint@8.42.0)(prettier@2.8.8)
       husky:
-        specifier: ^8.0.3
+        specifier: ^8.0.0
         version: 8.0.3
       jest:
         specifier: ^29.5.0


### PR DESCRIPTION
# Description

- Copy data to clipboard directly from Analysis grid by focusing on the grid and using ctrl + c or cmd + c
- Export to CSV file using the `Export to CSV` action in the grid header menu 

## Type of change

- [ ] Bug fix
- [X] New feature
- [ ] Breaking change

resolves #25

**Copied to sheet from clipboard**
![image](https://github.com/certinia/debug-log-analyzer/assets/4013877/ec17f974-849e-4278-844d-4237978a9f74)

**Export to CSV**
![image](https://github.com/certinia/debug-log-analyzer/assets/4013877/11ec262a-07c3-489d-9c13-15653d8f240f)
