### PR TITLE
feat: show an error if log not found

### DIFF
--- a/log-viewer/modules/Main.ts
+++ b/log-viewer/modules/Main.ts
@@ -21,6 +21,7 @@ import parseLog, {
   getLogSettings,
   getRootMethod,
   totalDuration,
+  truncateLog,
   truncated,
 } from './parsers/TreeParser';
 import { hostService } from './services/VSCodeService';
@@ -173,10 +174,26 @@ function readLog() {
   if (logUri) {
     fetch(logUri)
       .then((response) => {
-        return response.text();
+        if (response.ok) {
+          return response.text();
+        } else {
+          throw Error(response.statusText);
+        }
       })
       .then((data) => {
         displayLog(data ?? '', name ?? '', path ?? '');
+      })
+      .catch((err: unknown) => {
+        let msg;
+        if (err instanceof Error) {
+          msg = err.name === 'TypeError' ? name : err.message;
+        } else {
+          msg = String(err);
+        }
+        msg = `Could not read log: ${msg}`;
+
+        truncateLog(0, msg, 'error');
+        setStatus(name || '', path || '', 'Ready', 'red');
       });
   }
 }

--- a/log-viewer/modules/parsers/TreeParser.ts
+++ b/log-viewer/modules/parsers/TreeParser.ts
@@ -29,7 +29,7 @@ const typePattern = /^[A-Z_]*$/,
   settingsPattern = /^\d+\.\d+\sAPEX_CODE,\w+;APEX_PROFILING,.+$/m;
 
 let logLines: LogLine[] = [],
-  truncated: TruncationEntry[],
+  truncated: TruncationEntry[] = [],
   maxSizeTimestamp: number | null = null,
   reasons: Set<string> = new Set<string>(),
   cpuUsed = 0,


### PR DESCRIPTION
# Description

If the log can not be fetch from local disk,
will now show an error in the status bar.

![image](https://github.com/certinia/debug-log-analyzer/assets/4013877/122610b5-8bbe-4b7c-b296-04c9f64549dd)

