### PR TITLE
feat: select row when tree expanded/collapsed

### DIFF
--- a/log-viewer/modules/calltree-view/CalltreeView.ts
+++ b/log-viewer/modules/calltree-view/CalltreeView.ts
@@ -220,19 +220,6 @@ export async function renderCallTree(rootMethod: RootNode): Promise<void> {
       ],
     });
 
-    calltreeTable.on('dataTreeRowExpanded', (row, _level) => {
-      const selectedRow = row.getTable().getSelectedRows()[0];
-      if (!selectedRow) {
-        row.select();
-      }
-    });
-
-    calltreeTable.on('dataTreeRowCollapsed', (row, _level) => {
-      const selectedRow = row.getTable().getSelectedRows()[0];
-      if (!selectedRow) {
-        row.select();
-      }
-    });
     calltreeTable.on('dataFiltered', () => {
       totalTimeFilterCache.clear();
       selfTimeFilterCache.clear();


### PR DESCRIPTION
# Description
Improves the call tree keyboard navigation

- Auto select a row If a row is expanded or collapsed and no row is currently selected.
- Ensure tableholder gets focus when a row is expanded / collapsed with the tree toggle, this allows the keys for row selection to be used.

## Type of change

- [ ] Bug fix
- [X] New feature
- [ ] Breaking change

resolves #297
