### PR TITLE
fix: `ENTERING_MANAGED_PKG` events would wrongly have other events rolled up into them

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Update minimum supported vscode version to v1.74.0 ([#280][#280])
 - Support for more undocumented log events such as `NBA_*`, `ORG_CACHE_*`, `SESSION_CACHE_*`, `FUNCTION_INVOCATION_*` and more ([#246][#246])
 
+### Fixed
+
+- `ENTERING_MANAGED_PKG` events would wrongly have other events rollup into them ([#320][#320])
+  - Note: This now means some events will no longer be rolled up into `ENTERING_MANAGED_PKG`
+  - e.g `SOQL_BEGIN` will be between two `ENTERING_MANAGED_PKG` events instead of nested inside one
+
 ## [1.6.0] - 2023-05-19
 
 ### Added
@@ -255,3 +261,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#294]: https://github.com/certinia/debug-log-analyzer/issues/294
 [#246]: https://github.com/certinia/debug-log-analyzer/issues/246
 [#25]: https://github.com/certinia/debug-log-analyzer/issues/25
+[#320]: https://github.com/certinia/debug-log-analyzer/issues/320

--- a/log-viewer/modules/__tests__/TreeParser.test.ts
+++ b/log-viewer/modules/__tests__/TreeParser.test.ts
@@ -516,12 +516,15 @@ describe('getRootMethod tests', () => {
     expect(rootMethod.executionEndTime).toBe(1100);
 
     const rootChildren = rootMethod.children as Method[];
-    //expect([]).toBe(rootChildren);
+
     const executionChildren = rootChildren[0].children as Method[];
-    expect(executionChildren.length).toBe(3);
+    expect(executionChildren.length).toBe(5);
     expect(executionChildren[0].type).toBe('METHOD_ENTRY');
     expect(executionChildren[0].timestamp).toBe(200);
     expect(executionChildren[0].exitStamp).toBe(300);
+    expect(executionChildren[0].children.length).toBe(1);
+    expect(executionChildren[0].children[0].type).toBe('ENTERING_MANAGED_PKG');
+    expect(executionChildren[0].children[0].namespace).toBe('ns');
 
     expect(executionChildren[1].type).toBe('ENTERING_MANAGED_PKG');
     expect(executionChildren[1].namespace).toBe('ns');
@@ -531,9 +534,17 @@ describe('getRootMethod tests', () => {
     expect(executionChildren[2].type).toBe('ENTERING_MANAGED_PKG');
     expect(executionChildren[2].namespace).toBe('ns2');
     expect(executionChildren[2].timestamp).toBe(700);
-    expect(executionChildren[2].exitStamp).toBe(1100);
-    expect(executionChildren[2].children.length).toBe(1);
-    expect(executionChildren[2].children[0].type).toBe('DML_BEGIN');
+    expect(executionChildren[2].exitStamp).toBe(725);
+
+    expect(executionChildren[3].type).toBe('DML_BEGIN');
+    expect(executionChildren[3].timestamp).toBe(725);
+    expect(executionChildren[3].exitStamp).toBe(750);
+
+    expect(executionChildren[4].type).toBe('ENTERING_MANAGED_PKG');
+    expect(executionChildren[4].namespace).toBe('ns2');
+    expect(executionChildren[4].timestamp).toBe(800);
+    expect(executionChildren[4].exitStamp).toBe(1100);
+    expect(executionChildren[4].children.length).toBe(0);
   });
 });
 


### PR DESCRIPTION
This now means some events will no longer be
rolled up into `ENTERING_MANAGED_PKG`

e.g `SOQL_BEGIN` will be between two
`ENTERING_MANAGED_PKG` events instead of
nested inside one

## Type of change

- [X] Bug fix
- [ ] New feature
- [ ] Breaking change

fixes #320 
