### PR TITLE
feat : db + analysis row navigation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,9 +22,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Columns to show Event Type, Aggregated Total Time and Aggregated Self Time
   - Virtualised row rendered to greatly improve performance
   - Group by Event Type to show aggregated totals for each type e.g See the Total Time for all `METHOD_ENTRY` events
+  - Keyboard navigation to move between selected rows. Use the up and down arrows for up and down
 - Analysis: Export data ([#25][#25])
   - Copy data to clipboard directly from Analysis grid by focusing on the grid and using `ctrl + c` or `cmd + c`
   - Export to CSV file using the `Export to CSV` action in the grid header menu
+- Database: keyboard navigation ([#294][#294])
+  - Keyboard navigation to move between selected rows. Use the up and down arrows for up and down. Left and right arrows will hide / show the detail panel,
 
 ### Changed
 

--- a/log-viewer/modules/analysis-view/AnalysisView.ts
+++ b/log-viewer/modules/analysis-view/AnalysisView.ts
@@ -3,6 +3,7 @@ import { ColumnComponent, TabulatorFull as Tabulator } from 'tabulator-tables';
 import '../../resources/css/DatabaseView.scss';
 import NumberAccessor from '../datagrid/dataaccessor/Number';
 import Number from '../datagrid/format/Number';
+import { RowKeyboardNavigation } from '../datagrid/module/RowKeyboardNavigation';
 import { RootNode, TimedNode } from '../parsers/TreeParser';
 import { hostService } from '../services/VSCodeService';
 
@@ -41,7 +42,10 @@ async function renderAnalysis(rootMethod: RootNode) {
     },
   ];
 
+  Tabulator.registerModule(RowKeyboardNavigation);
   const analysisTable = new Tabulator('#analysisTable', {
+    rowKeyboardNavigation: true,
+    selectable: 1,
     data: metricList,
     layout: 'fitColumns',
     placeholder: 'No Analysis Available',

--- a/log-viewer/modules/database-view/DatabaseView.ts
+++ b/log-viewer/modules/database-view/DatabaseView.ts
@@ -1,10 +1,11 @@
 import { html, render } from 'lit';
-import { RowComponent, TabulatorFull as Tabulator } from 'tabulator-tables';
+import { GroupComponent, RowComponent, TabulatorFull as Tabulator } from 'tabulator-tables';
 
 import '../../resources/css/DatabaseView.scss';
 import { DatabaseAccess } from '../Database';
 import '../components/CallStack';
 import Number from '../datagrid/format/Number';
+import { RowKeyboardNavigation } from '../datagrid/module/RowKeyboardNavigation';
 import { RootNode, SOQLExecuteBeginLine, SOQLExecuteExplainLine } from '../parsers/TreeParser';
 import './DatabaseSOQLDetailPanel';
 import './DatabaseSection';
@@ -17,6 +18,7 @@ export async function initDBRender(rootMethod: RootNode) {
       const visible = entries[0].isIntersecting;
       if (visible) {
         observer.disconnect();
+        Tabulator.registerModule([RowKeyboardNavigation]);
         renderDMLTable();
         renderSOQLTable();
       }
@@ -68,6 +70,8 @@ function renderDMLTable() {
   }
 
   const dmlTable = new Tabulator(dbDmlTable, {
+    // @ts-expect-error: custom + not in types
+    rowKeyboardNavigation: true,
     data: dmlData, //set initial table data
     layout: 'fitColumns',
     placeholder: 'No DML statements found',
@@ -147,6 +151,11 @@ function renderDMLTable() {
         row.getElement().replaceChildren(detailContainer);
       }
     },
+  });
+
+  dmlTable.on('groupClick', (e: UIEvent, group: GroupComponent) => {
+    //@ts-expect-error types field needs update
+    group.isVisible && group.scrollTo('nearest', true);
   });
 
   dmlTable.on('rowClick', function (e, row) {
@@ -254,6 +263,8 @@ function renderSOQLTable() {
   }
 
   const soqlTable = new Tabulator(dbSoqlTable, {
+    // @ts-expect-error: custom + not in types
+    rowKeyboardNavigation: true,
     data: soqlData,
     layout: 'fitColumns',
     placeholder: 'No SOQL queries found',
@@ -384,6 +395,11 @@ function renderSOQLTable() {
         row.getElement().replaceChildren(detailContainer);
       }
     },
+  });
+
+  soqlTable.on('groupClick', (e: UIEvent, group: GroupComponent) => {
+    //@ts-expect-error types field needs update
+    group.isVisible && group.scrollTo('nearest', true);
   });
 
   soqlTable.on('rowClick', function (e, row) {

--- a/log-viewer/modules/datagrid/module/RowKeyboardNavigation.ts
+++ b/log-viewer/modules/datagrid/module/RowKeyboardNavigation.ts
@@ -95,7 +95,7 @@ const rowNavActions: { [key: string]: unknown } = {
 
     const table = this.table as Tabulator;
     const row = table.getSelectedRows()[0];
-    if (!row) {
+    if (!row || !table.options.dataTree) {
       return;
     }
 
@@ -124,7 +124,7 @@ const rowNavActions: { [key: string]: unknown } = {
 
     const table = this.table as Tabulator;
     const row = table.getSelectedRows()[0];
-    if (!row) {
+    if (!row || !table.options.dataTree) {
       return;
     }
 


### PR DESCRIPTION
# Description

- Analysis: keyboard navigation ([#294][#294])
  - Keyboard navigation to move between selected rows. Use the up and down arrows for up and down
- Database: keyboard navigation ([#294][#294])
  - Keyboard navigation to move between selected rows. Use the up and down arrows for up and down. Left and right arrows will hide / show the detail panel,

## Type of change

- [x] Bug fix
- [X] New feature
- [ ] Breaking change

resolves #294
fixes #312 
