### PR TITLE
fix: Call Tree expand overflow

### DIFF
--- a/log-viewer/index.html
+++ b/log-viewer/index.html
@@ -54,17 +54,19 @@
       </div>
 
       <div id="treeView" class="tabItem">
-        <div>
-          <strong>Filter</strong>
+        <div id="treeViewContainer">
           <div>
-            <input type="button" id="ct-expand" value="Expand" />
-            <input type="button" id="ct-collapse" value="Collapse" />
-            <input id="calltree-show-details" type="checkbox" />
-            <label for="calltree-show-details">Show Details</label>
+            <strong>Filter</strong>
+            <div>
+              <input type="button" id="ct-expand" value="Expand" />
+              <input type="button" id="ct-collapse" value="Collapse" />
+              <input id="calltree-show-details" type="checkbox" />
+              <label for="calltree-show-details">Show Details</label>
+            </div>
           </div>
-        </div>
-        <div id="calltreeContainer">
-          <div id="calltreeTable"></div>
+          <div id="calltreeContainer">
+            <div id="calltreeTable"></div>
+          </div>
         </div>
       </div>
 

--- a/log-viewer/modules/datagrid/module/RowNavigation.ts
+++ b/log-viewer/modules/datagrid/module/RowNavigation.ts
@@ -27,17 +27,20 @@ export class RowNavigation extends Module {
         row.treeExpand();
       }
 
-      table.getSelectedRows().map((rowToDeselect) => {
+      table.getSelectedRows().forEach((rowToDeselect) => {
         rowToDeselect.deselect();
       });
-      table.restoreRedraw();
       row.select();
 
+      table.restoreRedraw();
       // @ts-expect-error it has 2 params
       row.scrollTo('center', true).then(() => {
-        //NOTE: This is a workaround for the fact that `row.scrollTo('center'` does not work correctly for ros near the bottom.
+        // row.getElement().scrollIntoView({ behavior: 'auto', block: 'center', inline: 'start' });
+        // NOTE: This is a workaround for the fact that `row.scrollTo('center'` does not work correctly for ros near the bottom.
         // This needs fixing in main tabulator lib
-        row.getElement().scrollIntoView({ behavior: 'auto', block: 'center', inline: 'start' });
+        window.requestAnimationFrame(() => {
+          row.getElement().scrollIntoView({ behavior: 'auto', block: 'center', inline: 'start' });
+        });
       });
     }
   }

--- a/log-viewer/resources/css/AnalysisView.css
+++ b/log-viewer/resources/css/AnalysisView.css
@@ -1,6 +1,4 @@
 #analysisContainer {
-  height: 100%;
   display: contents;
-  max-height: 100%;
-  box-sizing: border-box;
+  height: 100%;
 }

--- a/log-viewer/resources/css/TreeView.css
+++ b/log-viewer/resources/css/TreeView.css
@@ -85,9 +85,16 @@
   display: none;
 }
 #calltreeContainer {
+  min-height: 0;
+}
+
+#calltreeTable {
   height: 100%;
-  display: contents;
-  max-height: 100%;
-  box-sizing: border-box;
-  width: 100%;
+}
+
+#treeViewContainer {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  min-height: 0;
 }


### PR DESCRIPTION
# Description

- The end of the row would overflow becoming hidden behind the scrollbar.

## Type of change

- [X] Bug fix
- [ ] New feature
- [ ] Breaking change

 resolves #297 
