### PR TITLE
bug: fix open log code lense not showing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [1.7.0] - 2023-08-04
+## [1.7.1] - 2023-08-09
+
+### Fixed
+
+- `Log: Show Apex Log Analysis` code lense not showing until another command is used first ([#340][#340])
 
 ### Added
 
@@ -215,6 +219,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Misc Visual tweaks
 - Add explorer menu item
 - Provide more information when selecting log to download
+
+<!-- v1.7.1 -->
+
+[#340]: https://github.com/certinia/debug-log-analyzer/issues/340
+
+<!-- Older Versions -->
 
 [#11]: https://github.com/certinia/debug-log-analyzer/issues/11
 [#18]: https://github.com/certinia/debug-log-analyzer/issues/18

--- a/lana/package.json
+++ b/lana/package.json
@@ -40,7 +40,9 @@
   "categories": [
     "Other"
   ],
-  "activationEvents": [],
+  "activationEvents": [
+    "onLanguage:apexlog"
+  ],
   "contributes": {
     "commands": [
       {


### PR DESCRIPTION

# Description
fix open log code lense not showing
The code lense would not show until the extension
was activated using one of the commands at least once


## Type of change (check all applicable)

- [X] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] ♻️ Refactor
- [ ] ⚡ Performance Improvement
- [ ] 📝 Documentation
- [ ] 🔧 Chore
- [ ] 💥 Breaking change

## [optional] Any images / gifs / video

## Related Tickets & Documents

- Related Issue #
- fixes #340 
- resolves #
- closes #

## Added tests?

- [ ] 👍 yes
- [X] 🙅 no, not needed
- [ ] 🙋 no, I need help

## Added to documentation?

- [ ] 🔖 README.md
- [X] 🔖 CHANGELOG.md
- [ ] 📖 help site
- [ ] 🙅 not needed

## [optional] Are there any post-deployment tasks we need to perform?
