### PR TITLE
chore: verify marketplace token are valid

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -32,5 +32,8 @@ jobs:
       - name: Publish to VS Code Marketplace + Open VSX Registry
         run: |
           cd lana
+          vsce verify-pat -p ${{ secrets.VSCE_TOKEN }}
+          ovsx verify-pat -p ${{ secrets.OVSX_TOKEN }}
+
           vsce publish -p ${{ secrets.VSCE_TOKEN }} --packagePath lana-${{ github.event.release.tag_name }}.vsix
           ovsx publish -p ${{ secrets.OVSX_TOKEN }} --packagePath lana-${{ github.event.release.tag_name }}.vsix


### PR DESCRIPTION
# Description

chore: verify marketplace tokens are valid
Before trying to publish we should ensure that both tokens are valid. This prevents publishing to vsce and not ovsx.

## More detailed changes

- `vsce verify-pat -p` + `ovsx verify-pat -p`

## Type of change (check all applicable)

- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] ♻️ Refactor
- [ ] ⚡ Performance Improvement
- [ ] 📝 Documentation
- [X] 🔧 Chore
- [ ] 💥 Breaking change
