### PR TITLE
chore: update pre release schedule time

### DIFF
--- a/.github/workflows/cd-prerelease.yml
+++ b/.github/workflows/cd-prerelease.yml
@@ -2,7 +2,7 @@ name: Publish pre-release
 
 on:
   schedule:
-    - cron: '0 10 * * 2' # every tuesday at 10am UTC
+    - cron: '15 4 * * 2' # every tuesday at 4:15AM UTC
   workflow_dispatch:
 
 jobs:
@@ -72,7 +72,7 @@ jobs:
           HUSKY=0 pnpm install
       - name: update pre-release version
         run: |
-          echo "\n\033[1mUpdating pre-release version"
+          echo "\nUpdating pre-release version"
           pnpm run bump-prerelease;
       - name: Package the extension
         run: |
@@ -84,19 +84,19 @@ jobs:
           echo "Verify vsce token has not expired"
           vsce verify-pat -p ${{ secrets.VSCE_TOKEN }}
 
-          echo "Verify ovsx token has not expired"
+          echo "\nVerify ovsx token has not expired"
           ovsx verify-pat -p ${{ secrets.OVSX_TOKEN }}
 
           versionNum=$(cat package.json | jq -r '.version')
           pkgPath=lana-${versionNum}.vsix
 
-          echo "Publish to vsce"
+          echo "\nPublish to vsce"
           echo "vsix name: $pkgPath"
           vsce publish --pre-release -p ${{ secrets.VSCE_TOKEN }} --packagePath ${pkgPath}
-          echo "Publish to ovsx"
+          echo "\nPublish to ovsx"
           ovsx publish --pre-release -p ${{ secrets.OVSX_TOKEN }} --packagePath ${pkgPath}
       - name: Update pre-release tag
         run: |
-          echo "\n\033[1mUpdating pre release tag"
+          echo "Updating pre release tag"
           git tag -f pre
           git push origin pre


### PR DESCRIPTION
# Description

Will now publish at 4:15AM to reduce the risk of the job being dropped.

_Note: The schedule event can be delayed during periods of high loads of GitHub Actions workflow runs. High load times include the start of every hour. If the load is sufficiently high enough, some queued jobs may be dropped. To decrease the chance of delay, schedule your workflow to run at a different time of the hour._

https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows

## Type of change (check all applicable)

- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] ♻️ Refactor
- [ ] ⚡ Performance Improvement
- [ ] 📝 Documentation
- [X] 🔧 Chore
- [ ] 💥 Breaking change

## [optional] Any images / gifs / video

## Related Tickets & Documents

Related Issue #300 
fixes #
resolves #
closes #

## Added tests?

- [ ] 👍 yes
- [X] 🙅 no, not needed
- [ ] 🙋 no, I need help

## Added to documentation?

- [ ] 🔖 README.md
- [ ] 🔖 CHANGELOG.md
- [ ] 📖 help site
- [X] 🙅 not needed

## [optional] Are there any post-deployment tasks we need to perform?
No
