### PR TITLE
chore: disable some workflows for forks

### DIFF
--- a/.github/workflows/cd-prerelease.yml
+++ b/.github/workflows/cd-prerelease.yml
@@ -52,7 +52,7 @@ jobs:
     name: Publish pre-release
     needs: check
     runs-on: ubuntu-latest
-    if: github.repository_owner == 'certinia'&& needs.check.outputs.exitstatus == 'continue'
+    if: github.repository_owner == 'certinia' && needs.check.outputs.exitstatus == 'continue'
     steps:
       - name: Checkout code
         uses: actions/checkout@v3

--- a/.github/workflows/cd-prerelease.yml
+++ b/.github/workflows/cd-prerelease.yml
@@ -9,6 +9,7 @@ jobs:
   check:
     name: Check for pre release changes
     runs-on: ubuntu-latest
+    if: github.repository_owner == 'certinia'
     permissions:
       contents: write
     outputs:
@@ -51,7 +52,7 @@ jobs:
     name: Publish pre-release
     needs: check
     runs-on: ubuntu-latest
-    if: needs.check.outputs.exitstatus == 'continue'
+    if: github.repository_owner == 'certinia'&& needs.check.outputs.exitstatus == 'continue'
     steps:
       - name: Checkout code
         uses: actions/checkout@v3

--- a/.github/workflows/imgcmp.yml
+++ b/.github/workflows/imgcmp.yml
@@ -6,6 +6,7 @@ on:
 jobs:
   imgcmp:
     runs-on: ubuntu-latest
+    if: github.repository_owner == 'certinia'
     permissions:
       contents: write
       pull-requests: write


### PR DESCRIPTION
# Description

The image optimization job and scheduled pre release should only run in the main repo and not forks.

## Type of change (check all applicable)

- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] ♻️ Refactor
- [ ] ⚡ Performance Improvement
- [ ] 📝 Documentation
- [X] 🔧 Chore
- [ ] 💥 Breaking change

## [optional] Any images / gifs / video

## Related Tickets & Documents

Related Issue #
fixes #
resolves #
closes #

## Added tests?

- [ ] 👍 yes
- [X] 🙅 no, not needed
- [ ] 🙋 no, I need help

## Added to documentation?

- [ ] 🔖 README.md
- [ ] 🔖 CHANGELOG.md
- [ ] 📖 help site
- [X] 🙅 not needed

## [optional] Are there any post-deployment tasks we need to perform?
