### PR TITLE
bug: export to csv when no workspace is selected

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Hyperlink styling to align with VSCode ([#248][#248])
 
+### Fixed
+
+- `Export to CSV` not working when a log was opened in a new VSCode window and not associated to a workspace ([#363][#363])
+
 ## [1.7.1] - 2023-08-10
 
 ### Fixed
@@ -243,6 +247,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- Unreleased -->
 
+[#363]: https://github.com/certinia/debug-log-analyzer/issues/363
 [#248]: https://github.com/certinia/debug-log-analyzer/issues/248
 [#249]: https://github.com/certinia/debug-log-analyzer/issues/249
 [#300]: https://github.com/certinia/debug-log-analyzer/issues/300

--- a/lana/src/commands/LogView.ts
+++ b/lana/src/commands/LogView.ts
@@ -3,6 +3,7 @@
  */
 import { createReadStream } from 'fs';
 import { writeFile } from 'fs/promises';
+import { homedir } from 'os';
 import { basename, dirname, join } from 'path';
 import { WebviewPanel, window as vscWindow } from 'vscode';
 import { Uri, commands, workspace } from 'vscode';
@@ -69,7 +70,8 @@ export class LogView {
 
           case 'saveFile': {
             if (request.text && request.options?.defaultUri) {
-              const defaultDir = (workspace.workspaceFolders || [])[0].uri.path;
+              const defaultWorkspace = (workspace.workspaceFolders || [])[0];
+              const defaultDir = defaultWorkspace?.uri.path || homedir();
               vscWindow
                 .showSaveDialog({
                   defaultUri: Uri.file(join(defaultDir, request.options.defaultUri)),


### PR DESCRIPTION
# Description

- Fixes `export to CSV` to work when a log is opened and no workspace is selected

if a log was open and unattached to a workspace `export to csv` would fail to work.

## Type of change (check all applicable)

- [X] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] ♻️ Refactor
- [ ] ⚡ Performance Improvement
- [ ] 📝 Documentation
- [ ] 🔧 Chore
- [ ] 💥 Breaking change

## [optional] Any images / gifs / video

## Related Tickets & Documents

Related Issue #
fixes #363 
resolves #
closes #

## Added tests?

- [ ] 👍 yes
- [x] 🙅 no, not needed
- [ ] 🙋 no, I need help

## Added to documentation?

- [ ] 🔖 README.md
- [x] 🔖 CHANGELOG.md
- [ ] 📖 help site
- [ ] 🙅 not needed

## [optional] Are there any post-deployment tasks we need to perform?
