### PR TITLE
feat: add certinia icon to webview

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Log issues show in a separate dialog when the issues count tag is clicked on the navigation bar
 - Display Ui outline while waiting for other actions for both `Log: Retrieve Apex Log And Show Analysis` and `Log: Show Apex Log Analysis` ([#252][#252])
   - This could be waiting for the log to download from the org or to be parsed and processed.
+- Show Certinia log next to the Open Log Analyzer tab and next to the file name on the file list in th quick open menu ([#250][#250])
 - The Log Analyzer will be published as a pre-release extension weekly ([#300][#300])
   - Click `Switch to Pre-Release Version` on the banner to get bleeding edge changes and help us to resolve bugs before the stable release.
 
@@ -249,6 +250,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- Unreleased -->
 
+[#250]: https://github.com/certinia/debug-log-analyzer/issues/250
 [#252]: https://github.com/certinia/debug-log-analyzer/issues/252
 [#363]: https://github.com/certinia/debug-log-analyzer/issues/363
 [#248]: https://github.com/certinia/debug-log-analyzer/issues/248

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Log issues show in a separate dialog when the issues count tag is clicked on the navigation bar
 - Display Ui outline while waiting for other actions for both `Log: Retrieve Apex Log And Show Analysis` and `Log: Show Apex Log Analysis` ([#252][#252])
   - This could be waiting for the log to download from the org or to be parsed and processed.
-- Show Certinia log next to the Open Log Analyzer tab and next to the file name on the file list in th quick open menu ([#250][#250])
+- Show the Certinia logo next to the Open Log Analyzer tab and next to the file name on the file list in the quick open menu ([#250][#250])
 - The Log Analyzer will be published as a pre-release extension weekly ([#300][#300])
   - Click `Switch to Pre-Release Version` on the banner to get bleeding edge changes and help us to resolve bugs before the stable release.
 

--- a/lana/package.json
+++ b/lana/package.json
@@ -47,11 +47,13 @@
     "commands": [
       {
         "command": "lana.retrieveLogFile",
-        "title": "Log: Retrieve Apex Log And Show Analysis"
+        "title": "Log: Retrieve Apex Log And Show Analysis",
+        "icon": "./certinia-icon-color.png"
       },
       {
         "command": "lana.showLogAnalysis",
-        "title": "Log: Show Apex Log Analysis"
+        "title": "Log: Show Apex Log Analysis",
+        "icon": "./certinia-icon-color.png"
       }
     ],
     "languages": [

--- a/lana/src/commands/LogView.ts
+++ b/lana/src/commands/LogView.ts
@@ -44,6 +44,7 @@ export class LogView {
     const bundleUri = panel.webview.asWebviewUri(Uri.file(join(logViewerRoot, 'bundle.js')));
     const indexSrc = await this.getFile(index);
     panel.webview.html = indexSrc.replace('bundle.js', bundleUri.toString(true));
+    panel.iconPath = Uri.file(join(logViewerRoot, 'certinia-icon-color.png'));
 
     panel.webview.onDidReceiveMessage(
       (msg: WebViewLogFileRequest) => {

--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -120,6 +120,7 @@ export default [
         targets: [
           { src: 'log-viewer/out/*', dest: 'lana/out' },
           { src: ['CHANGELOG.md', 'LICENSE.txt', 'README.md'], dest: 'lana' },
+          { src: 'lana/certinia-icon-color.png', dest: 'lana/out' },
         ],
       }),
     ],


### PR DESCRIPTION
# Description

Show the Certinia logo next to the Open Log Analyzer tab and next to the file name on the file list in the quick open menu 

## Type of change (check all applicable)

- [ ] 🐛 Bug fix
- [X] ✨ New feature
- [ ] ♻️ Refactor
- [ ] ⚡ Performance Improvement
- [ ] 📝 Documentation
- [ ] 🔧 Chore
- [ ] 💥 Breaking change

## [optional] Any images / gifs / video
![image](https://github.com/certinia/debug-log-analyzer/assets/4013877/fef38241-4323-49f0-898c-64eaa7198bec)

![image](https://github.com/certinia/debug-log-analyzer/assets/4013877/4a95f70a-e5a7-401e-85d2-fcc53bfc444d)


## Related Tickets & Documents

Related Issue #
fixes #
resolves #250 
closes #

## Added tests?

- [ ] 👍 yes
- [X] 🙅 no, not needed
- [ ] 🙋 no, I need help

## Added to documentation?

- [ ] 🔖 README.md
- [X] 🔖 CHANGELOG.md
- [ ] 📖 help site
- [ ] 🙅 not needed

## [optional] Are there any post-deployment tasks we need to perform?
