### PR TITLE
fix: hyperlink underline styles accidentally removed

### DIFF
--- a/log-viewer/modules/components/LogTitle.ts
+++ b/log-viewer/modules/components/LogTitle.ts
@@ -42,6 +42,12 @@ export class LogTitle extends LitElement {
         overflow: hidden;
         text-overflow: ellipsis;
       }
+
+      a {
+        &:hover {
+          background-color: var(--button-icon-hover-background, rgba(90, 93, 94, 0.31));
+        }
+      }
     `,
   ];
 

--- a/log-viewer/modules/global.styles.ts
+++ b/log-viewer/modules/global.styles.ts
@@ -6,14 +6,15 @@ export const globalStyles = css`
     text-decoration: none;
     cursor: pointer;
 
-    :hover {
+    &:hover {
       color: var(--vscode-textLink-activeForeground);
       text-decoration: underline;
     }
 
-    :active {
+    &:active {
       background: transparent;
       color: var(--vscode-textLink-activeForeground);
+      text-decoration: underline;
     }
   }
 


### PR DESCRIPTION
# Description

fixes  hyperlink underline styles accidentally removed

## Type of change (check all applicable)

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] ♻️ Refactor
- [ ] ⚡ Performance Improvement
- [ ] 📝 Documentation
- [ ] 🔧 Chore
- [ ] 💥 Breaking change

## [optional] Any images / gifs / video

## Related Tickets & Documents

Related Issue #252 
fixes #
resolves #
closes #

## Added tests?

- [ ] 👍 yes
- [x] 🙅 no, not needed
- [ ] 🙋 no, I need help

## Added to documentation?

- [ ] 🔖 README.md
- [ ] 🔖 CHANGELOG.md
- [ ] 📖 help site
- [ ] 🙅 not needed

## [optional] Are there any post-deployment tasks we need to perform?
