### PR TITLE
feat: whats new notification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Log issues show in a separate dialog when the issues count tag is clicked on the navigation bar
 - Show skeleton loading UIs / UI Outlines when waiting for the log to be processed e.g when running `Log: Retrieve Apex Log And Show Analysis` and `Log: Show Apex Log Analysis` ([#252][#252])
   - This could be waiting for the log to download from the org or to be parsed and processed.
-- Show the Certinia logo next to the Open Log Analyzer tab and next to the file name on the file list in the quick open menu ([#250][#250])
+- What's new notification to open the change log on upgrades ([#210][#210])
+- Show the Certinia logo next to the currently opened Log Analyzer tab and next to the file name on the file list in the quick open menu ([#250][#250])
 - The Log Analyzer will be published as a pre-release extension weekly ([#300][#300])
   - Click `Switch to Pre-Release Version` on the banner to get bleeding edge changes and help us to resolve bugs before the stable release.
 
@@ -250,6 +251,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- Unreleased -->
 
+[#210]: https://github.com/certinia/debug-log-analyzer/issues/210
 [#250]: https://github.com/certinia/debug-log-analyzer/issues/250
 [#252]: https://github.com/certinia/debug-log-analyzer/issues/252
 [#363]: https://github.com/certinia/debug-log-analyzer/issues/363

--- a/lana/src/Context.ts
+++ b/lana/src/Context.ts
@@ -5,6 +5,7 @@ import { ExtensionContext, workspace } from 'vscode';
 
 import { Display } from './Display';
 import { SymbolFinder } from './SymbolFinder';
+import { WhatsNewNotification } from './WhatsNewNotification';
 import ShowAnalysisCodeLens from './codelenses/ShowAnalysisCodeLens';
 import { RetrieveLogFile } from './commands/RetrieveLogFile';
 import { ShowLogAnalysis } from './commands/ShowLogAnalysis';
@@ -29,6 +30,7 @@ export class Context {
     RetrieveLogFile.apply(this);
     ShowLogAnalysis.apply(this);
     ShowAnalysisCodeLens.apply(this);
+    WhatsNewNotification.apply(this);
   }
 
   findSymbol(wsPath: string, symbol: string): string | null {

--- a/lana/src/WhatsNewNotification.ts
+++ b/lana/src/WhatsNewNotification.ts
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2023 Certinia Inc. All rights reserved.
+ */
+import { commands, window } from 'vscode';
+
+import { Context } from './Context';
+
+export class WhatsNewNotification {
+  static async apply(context: Context): Promise<void> {
+    const extensionInfo = context.context.extension;
+    const versionNumber: string[] = extensionInfo.packageJSON.version.split(/[.-]/);
+    const versionText = versionNumber.slice(0, 3).join('.');
+
+    const changeLogViewedkey = 'update.confirmed.versions';
+    const changelogViewedVersions =
+      context.context.globalState.get<string[]>(changeLogViewedkey) || [];
+
+    // Only show the whats new notification if this is a minor version or larger (not a bug fix) + if the notification for this minor has not been dismissed or viewed already.
+    if (versionNumber[2] !== '0' || changelogViewedVersions.includes(versionText)) {
+      return;
+    }
+
+    const extensionId = extensionInfo.id;
+    const whatsNew = "See What's New";
+    window
+      .showInformationMessage("Apex Log Analyzer has been updated. See What's New.", whatsNew)
+      .then((selection) => {
+        if (selection === whatsNew) {
+          commands.executeCommand('extension.open', extensionId, 'changelog');
+        }
+      });
+
+    // if whats new was clicked, dismissed or timed out we do not want to show the notification again so register this version in the change log viewed state.
+    context.context.globalState.update(changeLogViewedkey, [versionText]);
+  }
+}

--- a/log-viewer/modules/calltree-view/CalltreeView.ts
+++ b/log-viewer/modules/calltree-view/CalltreeView.ts
@@ -2,6 +2,7 @@
  * Copyright (c) 2022 Certinia Inc. All rights reserved.
  */
 // todo: add breadcrumbs back? - I will do this but in a later PR + better
+// todo: improve scroll rows performance
 //
 //todo: ** future **
 //todo: show total and self as percentage of total? + do the same on the analysis view?

--- a/log-viewer/modules/timeline/Timeline.ts
+++ b/log-viewer/modules/timeline/Timeline.ts
@@ -407,6 +407,7 @@ export function setColors(timelineColors: TimelineColors) {
   state.requestRedraw();
 }
 
+// todo: this is slugish on zoom. Can be improve without swith from 2dgl?
 function drawTimeLine() {
   if (ctx) {
     resize();


### PR DESCRIPTION
# Description

Shows an vscode info notification when the extension first runs.
Includes a what' new button to take the user to the change log.

This will only run if it is not a bug fix version e.g v1.10.0 + v1.11.0 it will be shown but not for v1.10.1
If the notification has already been shown it will not be show again for the current version.

## Type of change (check all applicable)

- [ ] 🐛 Bug fix
- [X] ✨ New feature
- [ ] ♻️ Refactor
- [ ] ⚡ Performance Improvement
- [ ] 📝 Documentation
- [ ] 🔧 Chore
- [ ] 💥 Breaking change

## [optional] Any images / gifs / video
![image](https://github.com/certinia/debug-log-analyzer/assets/4013877/77e5c4a9-1451-4e3a-b991-7c40659c747f)
![image](https://github.com/certinia/debug-log-analyzer/assets/4013877/e1dd6cf6-fa65-45f3-af90-f7566617494a)


## Related Tickets & Documents

Related Issue #
fixes #
resolves #210 
closes #

## Added tests?

- [ ] 👍 yes
- [ ] 🙅 no, not needed
- [X] 🙋 no, I need help

## Added to documentation?

- [ ] 🔖 README.md
- [X] 🔖 CHANGELOG.md
- [ ] 📖 help site
- [] 🙅 not needed

## [optional] Are there any post-deployment tasks we need to perform?
