### PR TITLE
chore: github site to publish after release is done

### DIFF
--- a/.github/workflows/publish-gh-pages.yml
+++ b/.github/workflows/publish-gh-pages.yml
@@ -4,7 +4,7 @@ name: Publish GitHub Pages Site
 on:
   # Runs after the publish suceeds
   workflow_run:
-    workflows: [Publish]
+    workflows: ['Publish Stable']
     types: [completed]
 
   # Allows you to run this workflow manually from the Actions tab


### PR DESCRIPTION
# Description

The workflow name of the release job was not updated. This resolves that and fixes the name so the help will auto publish.

## Type of change (check all applicable)

- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] ♻️ Refactor
- [ ] ⚡ Performance Improvement
- [ ] 📝 Documentation
- [X] 🔧 Chore
- [ ] 💥 Breaking change

## [optional] Any images / gifs / video

## Related Tickets & Documents

Related Issue #
fixes #
resolves #
closes #

## Added tests?

- [ ] 👍 yes
- [x] 🙅 no, not needed
- [ ] 🙋 no, I need help

## Added to documentation?

- [ ] 🔖 README.md
- [ ] 🔖 CHANGELOG.md
- [x] 📖 help site
- [ ] 🙅 not needed

## [optional] Are there any post-deployment tasks we need to perform?
