### PR TITLE
Feat timeline cursors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Make dragging more obvious on the Timeline by showing different cursors ([#249][#249])
+- Make dragging more obvious on the Timeline by showing different cursors ([#423][#423])
   - Show the pointer cursor by default when hovering the Timeline.
   - Show the grabbing cursor when the mouse is pressed down on the Timeline, to indicate drag is now possible.
   - Show the default cursor when hovering a Timeline event.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+- Make dragging more obvious on the Timeline by showing different cursors ([#249][#249])
+  - Show the pointer cursor by default when hovering the Timeline.
+  - Show the grabbing cursor when the mouse is pressed down on the Timeline, to indicate drag is now possible.
+  - Show the default cursor when hovering a Timeline event.
+
 ## [1.10.0] - 2023-10-19
 
 ### Added
@@ -259,6 +268,10 @@ Skipped due to adopting odd numbering for pre releases and even number for relea
 - Misc Visual tweaks
 - Add explorer menu item
 - Provide more information when selecting log to download
+
+<!-- Unreleased -->
+
+[#423]: https://github.com/certinia/debug-log-analyzer/issues/423
 
 <!-- v1.10.0 -->
 

--- a/log-viewer/modules/timeline/Timeline.ts
+++ b/log-viewer/modules/timeline/Timeline.ts
@@ -482,6 +482,10 @@ function showTooltip(offsetX: number, offsetY: number) {
 function findTimelineTooltip(x: number, depth: number): HTMLDivElement | null {
   const target = findByPosition(timelineRoot, 0, x, depth);
   if (target) {
+    canvas.classList.remove('timeline-hover');
+    canvas.classList.remove('timeline-dragging');
+    canvas.classList.add('timeline-event--hover');
+
     const toolTip = document.createElement('div');
     const brElem = document.createElement('br');
     let displayText = target.text;
@@ -521,6 +525,9 @@ function findTimelineTooltip(x: number, depth: number): HTMLDivElement | null {
 
     return toolTip;
   }
+  canvas.classList.add('timeline-hover');
+  canvas.classList.remove('timeline-event--hover');
+
   return null;
 }
 
@@ -617,14 +624,18 @@ function onClickCanvas(): void {
 }
 
 function onLeaveCanvas() {
-  dragging = false;
+  stopDragging();
   tooltip.style.display = 'none';
 }
 
 let dragging = false;
 let mouseDownPosition: { x: number; y: number };
+
 function handleMouseDown(): void {
   dragging = true;
+
+  canvas.classList.remove('timeline-hover');
+  canvas.classList.add('timeline-dragging');
   tooltip.style.display = 'none';
   mouseDownPosition = {
     x: lastMouseX,
@@ -633,8 +644,14 @@ function handleMouseDown(): void {
 }
 
 function handleMouseUp(): void {
-  dragging = false;
+  stopDragging();
   debounce(showTooltip(lastMouseX, lastMouseY));
+}
+
+function stopDragging() {
+  dragging = false;
+  canvas.classList.remove('timeline-dragging');
+  canvas.classList.add('timeline-hover');
 }
 
 function handleMouseMove(evt: MouseEvent) {

--- a/log-viewer/modules/timeline/TimelineView.ts
+++ b/log-viewer/modules/timeline/TimelineView.ts
@@ -58,6 +58,10 @@ export class TimelineView extends LitElement {
         font-size: 1rem;
       }
 
+      .timeline-event--hover {
+        cursor: auto;
+      }
+
       #timeline-container {
         position: relative;
         overflow: hidden;
@@ -74,6 +78,15 @@ export class TimelineView extends LitElement {
         z-index: 0;
         width: 100%;
         height: 100%;
+      }
+
+      .timeline-hover:hover {
+        cursor: pointer;
+      }
+
+      .timeline-dragging {
+        cursor: -webkit-grabbing;
+        cursor: grabbing;
       }
 
       .skeleton-text {
@@ -103,7 +116,7 @@ export class TimelineView extends LitElement {
   render() {
     const skeleton = !this.timelineRoot
       ? this._getSkeletonTimeline()
-      : html`<canvas id="timeline"></canvas>`;
+      : html`<canvas id="timeline" class="timeline-hover"></canvas>`;
 
     return html`
       <div id="timeline-container">${skeleton}</div>

--- a/log-viewer/package.json
+++ b/log-viewer/package.json
@@ -32,6 +32,7 @@
     "rollup": "^3.29.4",
     "rollup-plugin-polyfill-node": "^0.12.0",
     "rollup-plugin-postcss": "^4.0.2",
+    "sass": "^1.69.4",
     "typescript": "^5.2.2"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -186,6 +186,9 @@ importers:
       rollup-plugin-postcss:
         specifier: ^4.0.2
         version: 4.0.2(postcss@8.4.31)
+      sass:
+        specifier: ^1.69.4
+        version: 1.69.4
       typescript:
         specifier: ^5.2.2
         version: 5.2.2
@@ -2163,6 +2166,11 @@ packages:
     engines: {node: '>=0.6'}
     dev: true
 
+  /binary-extensions@2.2.0:
+    resolution: {integrity: sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==}
+    engines: {node: '>=8'}
+    dev: true
+
   /boolbase@1.0.0:
     resolution: {integrity: sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==}
     dev: true
@@ -2393,6 +2401,21 @@ packages:
   /chardet@0.7.0:
     resolution: {integrity: sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==}
     dev: false
+
+  /chokidar@3.5.3:
+    resolution: {integrity: sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw==}
+    engines: {node: '>= 8.10.0'}
+    dependencies:
+      anymatch: 3.1.3
+      braces: 3.0.2
+      glob-parent: 5.1.2
+      is-binary-path: 2.1.0
+      is-glob: 4.0.3
+      normalize-path: 3.0.0
+      readdirp: 3.6.0
+    optionalDependencies:
+      fsevents: 2.3.3
+    dev: true
 
   /chownr@2.0.0:
     resolution: {integrity: sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==}
@@ -3803,6 +3826,10 @@ packages:
     resolution: {integrity: sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==}
     dev: false
 
+  /immutable@4.3.4:
+    resolution: {integrity: sha512-fsXeu4J4i6WNWSikpI88v/PcVflZz+6kMhUfIwc5SY+poQRPnaf5V7qds6SUyUN3cVxEzuCab7QIoLOQ+DQ1wA==}
+    dev: true
+
   /import-cwd@3.0.0:
     resolution: {integrity: sha512-4pnzH16plW+hgvRECbDWpQl3cqtvSofHWh44met7ESfZ8UZOWWddm8hEyDTqREJ9RbYHY8gi8DqmaelApoOGMg==}
     engines: {node: '>=8'}
@@ -3882,6 +3909,13 @@ packages:
 
   /is-arrayish@0.2.1:
     resolution: {integrity: sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==}
+    dev: true
+
+  /is-binary-path@2.1.0:
+    resolution: {integrity: sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==}
+    engines: {node: '>=8'}
+    dependencies:
+      binary-extensions: 2.2.0
     dev: true
 
   /is-builtin-module@3.2.1:
@@ -6095,6 +6129,13 @@ packages:
       string_decoder: 1.3.0
       util-deprecate: 1.0.2
 
+  /readdirp@3.6.0:
+    resolution: {integrity: sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==}
+    engines: {node: '>=8.10.0'}
+    dependencies:
+      picomatch: 2.3.1
+    dev: true
+
   /redent@3.0.0:
     resolution: {integrity: sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==}
     engines: {node: '>=8'}
@@ -6360,6 +6401,16 @@ packages:
       lodash: 4.17.21
       scss-tokenizer: 0.4.3
       yargs: 17.7.2
+    dev: true
+
+  /sass@1.69.4:
+    resolution: {integrity: sha512-+qEreVhqAy8o++aQfCJwp0sklr2xyEzkm9Pp/Igu9wNPoe7EZEQ8X/MBvvXggI2ql607cxKg/RKOwDj6pp2XDA==}
+    engines: {node: '>=14.0.0'}
+    hasBin: true
+    dependencies:
+      chokidar: 3.5.3
+      immutable: 4.3.4
+      source-map-js: 1.0.2
     dev: true
 
   /sax@1.3.0:


### PR DESCRIPTION
# Description

Make dragging more obvious on the Timeline by showing different cursors
  
- Show the pointer cursor by default when hovering the Timeline.
- Show the grabbing cursor when the mouse is pressed down on the 
Timeline, to indicate drag is now possible.
- Show the default cursor when hovering a Timeline event.

## Type of change (check all applicable)

- [ ] 🐛 Bug fix
- [X] ✨ New feature
- [ ] ♻️ Refactor
- [ ] ⚡ Performance Improvement
- [ ] 📝 Documentation
- [ ] 🔧 Chore
- [ ] 💥 Breaking change

## [optional] Any images / gifs / video
![lana-drag-cursor](https://github.com/certinia/debug-log-analyzer/assets/4013877/1d502440-81f6-49fd-8bf5-810c03e4a7ff)

## Related Tickets & Documents

Related Issue #
fixes #
resolves #423 
closes #

## Added tests?

- [ ] 👍 yes
- [X] 🙅 no, not needed
- [ ] 🙋 no, I need help

## Added to documentation?

- [ ] 🔖 README.md
- [X] 🔖 CHANGELOG.md
- [ ] 📖 help site
- [ ] 🙅 not needed

## [optional] Are there any post-deployment tasks we need to perform?
