### PR TITLE
bug: UI hanging if file does not exist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.10.2] - 2023-11-07
+
+- Getting stuck on loading screen if file can not be found ([#435][#435])
+
 ## [1.10.1] - 2023-10-26
 
 ### Fixed
@@ -265,6 +269,10 @@ Skipped due to adopting odd numbering for pre releases and even number for relea
 - Misc Visual tweaks
 - Add explorer menu item
 - Provide more information when selecting log to download
+
+<!-- v1.10.2 -->
+
+[#435]: https://github.com/certinia/debug-log-analyzer/issues/435
 
 <!-- v1.10.1 -->
 

--- a/lana/src/Display.ts
+++ b/lana/src/Display.ts
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2020 Certinia Inc. All rights reserved.
  */
-import { Uri, commands, window } from 'vscode';
+import { MessageOptions, Uri, commands, window } from 'vscode';
 
 import { appName } from './AppSettings';
 
@@ -19,8 +19,8 @@ export class Display {
     window.showInformationMessage(s);
   }
 
-  showErrorMessage(s: string): void {
-    window.showErrorMessage(s);
+  showErrorMessage(s: string, options: MessageOptions = {}): void {
+    window.showErrorMessage(s, options);
   }
 
   showFile(path: string): void {

--- a/lana/src/commands/RetrieveLogFile.ts
+++ b/lana/src/commands/RetrieveLogFile.ts
@@ -4,7 +4,7 @@
 import { LogRecord } from '@salesforce/apex-node';
 import { existsSync } from 'fs';
 import { join, parse } from 'path';
-import { Uri, WebviewPanel, window } from 'vscode';
+import { WebviewPanel, window } from 'vscode';
 
 import { appName } from '../AppSettings';
 import { Context } from '../Context';
@@ -13,7 +13,7 @@ import { QuickPickWorkspace } from '../display/QuickPickWorkspace';
 import { GetLogFile } from '../sfdx/logs/GetLogFile';
 import { GetLogFiles } from '../sfdx/logs/GetLogFiles';
 import { Command } from './Command';
-import { FetchLogCallBack, LogView } from './LogView';
+import { LogView } from './LogView';
 
 class DebugLogItem extends Item {
   logId: string;
@@ -60,19 +60,7 @@ export class RetrieveLogFile {
     if (logFileId) {
       const logFilePath = this.getLogFilePath(ws, logFileId);
       const writeLogFile = this.writeLogFile(ws, logFilePath);
-      const getLogCallBack: FetchLogCallBack = async (panel: WebviewPanel) => {
-        await writeLogFile;
-        panel.webview.postMessage({
-          command: 'fetchLog',
-          data: {
-            logName: logFileId,
-            logUri: panel.webview.asWebviewUri(Uri.file(logFilePath)).toString(true),
-            logPath: logFilePath,
-          },
-        });
-      };
-
-      return LogView.createView(ws, context, logFilePath, logFileId, getLogCallBack);
+      return LogView.createView(ws, context, logFilePath, writeLogFile);
     }
   }
 

--- a/lana/src/commands/ShowLogAnalysis.ts
+++ b/lana/src/commands/ShowLogAnalysis.ts
@@ -1,15 +1,13 @@
 /*
  * Copyright (c) 2020 Certinia Inc. All rights reserved.
  */
-import { parse } from 'path';
 import { Uri, window } from 'vscode';
-import { WebviewPanel } from 'vscode';
 
 import { appName } from '../AppSettings';
 import { Context } from '../Context';
 import { QuickPickWorkspace } from '../display/QuickPickWorkspace';
 import { Command } from './Command';
-import { FetchLogCallBack, LogView } from './LogView';
+import { LogView } from './LogView';
 
 export class ShowLogAnalysis {
   static getCommand(context: Context): Command {
@@ -37,20 +35,8 @@ export class ShowLogAnalysis {
     const filePath = uri?.fsPath || window?.activeTextEditor?.document.fileName;
 
     if (filePath) {
-      const name = parse(filePath).name;
       const ws = await QuickPickWorkspace.pickOrReturn(context);
-      const getLogCallBack: FetchLogCallBack = (panel: WebviewPanel) => {
-        panel.webview.postMessage({
-          command: 'fetchLog',
-          data: {
-            logName: name,
-            logUri: panel.webview.asWebviewUri(Uri.file(filePath)).toString(true),
-            logPath: filePath,
-          },
-        });
-      };
-
-      LogView.createView(ws, context, name, filePath, getLogCallBack);
+      LogView.createView(ws, context, filePath);
     } else {
       context.display.showErrorMessage(
         'No file selected or the file is too large. Try again using the file explorer or text editor command.'

--- a/log-viewer/modules/LogViewer.ts
+++ b/log-viewer/modules/LogViewer.ts
@@ -13,7 +13,6 @@ import parseLog, {
   getLogSettings,
   getRootMethod,
   totalDuration,
-  truncateLog,
   truncated,
 } from './parsers/TreeParser';
 import { hostService } from './services/VSCodeService';
@@ -115,7 +114,7 @@ export class LogViewer extends LitElement {
           if (response.ok) {
             return response.text();
           } else {
-            throw Error(response.statusText);
+            throw Error(response.statusText || `Error reading log file: ${response.status}`);
           }
         })
         .catch((err: unknown) => {
@@ -125,9 +124,13 @@ export class LogViewer extends LitElement {
           } else {
             msg = String(err);
           }
+          const logMessage = new Notification();
+          logMessage.summary = 'Could not read log';
+          logMessage.message = msg || '';
+          logMessage.severity = 'Error';
+          this.notifications.push(logMessage);
 
-          truncateLog(0, 'Could not read log', msg || '', 'error');
-          return Promise.reject('');
+          return Promise.resolve('');
         });
     } else {
       return Promise.resolve('');

--- a/log-viewer/modules/log-levels/LogLevels.ts
+++ b/log-viewer/modules/log-levels/LogLevels.ts
@@ -11,7 +11,7 @@ import { LogSetting } from '../parsers/TreeParser';
 @customElement('log-levels')
 export class LogLevels extends LitElement {
   @state()
-  logSettings: LogSetting[] = [];
+  logSettings: LogSetting[] | null = null;
 
   constructor() {
     super();
@@ -56,7 +56,7 @@ export class LogLevels extends LitElement {
   ];
 
   render() {
-    if (this.logSettings.length < 1) {
+    if (!this.logSettings) {
       const logLevels = [];
       for (let i = 0; i < 8; i++) {
         const levelHtml = html`<div class="setting-skeleton skeleton"></div>`;

--- a/log-viewer/modules/navbar/NavBar.ts
+++ b/log-viewer/modules/navbar/NavBar.ts
@@ -91,7 +91,7 @@ export class NavBar extends LitElement {
   ];
 
   render() {
-    const sizeText = this.logSize ? (this.logSize / 1000000).toFixed(2) + ' MB' : '',
+    const sizeText = this._toSize(this.logSize),
       elapsedText = this._toDuration(this.logDuration);
 
     const status =
@@ -139,5 +139,13 @@ export class NavBar extends LitElement {
     }
 
     return (duration / 1_000_000_000).toFixed(3) + 's';
+  }
+
+  _toSize(fileSize: number | null) {
+    if (!fileSize && fileSize !== 0) {
+      return '';
+    }
+
+    return (fileSize / 1000000).toFixed(2) + ' MB';
   }
 }


### PR DESCRIPTION
# Description
**show error modal if log does not exist**

If the log file does not exist when retrieve or show is
called an error modal will be show in the vscode ui.

for retrieve this will only be shown after the log
download finishes and therefore should only occur if
there is an issues with the file download.

**show error when file can not be found**

This will be shown in the error list on the 
log viewer UI when the file can not be read 
from file system.

## Type of change (check all applicable)

- [X] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] ♻️ Refactor
- [ ] ⚡ Performance Improvement
- [ ] 📝 Documentation
- [ ] 🔧 Chore
- [ ] 💥 Breaking change

## [optional] Any images / gifs / video
![image](https://github.com/certinia/debug-log-analyzer/assets/4013877/78152bcb-848b-409c-965f-376c6aafc7ec)
![image](https://github.com/certinia/debug-log-analyzer/assets/4013877/e976d2bd-2060-42ed-88cc-cd2afda083b1)


## Related Tickets & Documents

Related Issue #
fixes #435 
resolves #
closes #

## Added tests?

- [ ] 👍 yes
- [X] 🙅 no, not needed
- [ ] 🙋 no, I need help

## Added to documentation?

- [ ] 🔖 README.md
- [X] 🔖 CHANGELOG.md
- [ ] 📖 help site
- [ ] 🙅 not needed

## [optional] Are there any post-deployment tasks we need to perform?
