### PR TITLE
bug: database UI jumping on group expand

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Call Tree Show Details not showing and hiding correctly ([#433][#433])
 - Infinite loading screen if file can not be found ([#435][#435])
+- Many cases of UI jumping in the Database view when rows and groups are clicked ([#434][#434])
 
 ## [1.10.1] - 2023-10-26
 
@@ -275,6 +276,7 @@ Skipped due to adopting odd numbering for pre releases and even number for relea
 
 <!-- v1.10.2 -->
 
+[#434]: https://github.com/certinia/debug-log-analyzer/issues/434
 [#435]: https://github.com/certinia/debug-log-analyzer/issues/435
 [#433]: https://github.com/certinia/debug-log-analyzer/issues/433
 

--- a/log-viewer/modules/database-view/DatabaseView.scss
+++ b/log-viewer/modules/database-view/DatabaseView.scss
@@ -1,13 +1,5 @@
 @import '../datagrid/style/DataGrid.scss';
 
-#db-container {
-  overflow: scroll;
-}
-#db-dml-table,
-#db-soql-table {
-  margin-bottom: 1rem;
-  height: 100%;
-}
 .row__details-container {
   padding: 4px 0px 4px 0px;
   background-color: var(--vscode-editorHoverWidget-background);

--- a/log-viewer/modules/database-view/DatabaseView.ts
+++ b/log-viewer/modules/database-view/DatabaseView.ts
@@ -95,6 +95,9 @@ export class DatabaseView extends LitElement {
         width: 100%;
         min-height: 0%;
         min-width: 0%;
+        margin-bottom: 1rem;
+        display: flex;
+        flex-direction: column;
       }
     `,
   ];
@@ -320,15 +323,13 @@ function renderDMLTable(dmlTableContainer: HTMLElement, dmlLines: DMLBeginLine[]
     }
   });
 
-  dmlTable.on('groupVisibilityChanged', (group: GroupComponent, visible: boolean) => {
-    const firstRow = visible ? group.getRows()[0] : group.getRows()[0].getPrevRow();
-    if (firstRow) {
-      // @ts-expect-error it has 2 params
-      firstRow.scrollTo('center', true).then(() => {
-        firstRow
-          .getElement()
-          .scrollIntoView({ behavior: 'auto', block: 'center', inline: 'start' });
-      });
+  dmlTable.on('groupVisibilityChanged', (group: GroupComponent, _visible: boolean) => {
+    const groupToFocus = group.getElement() ? group : findGroup(soqlTable, group.getKey());
+
+    if (groupToFocus) {
+      groupToFocus
+        .getElement()
+        .scrollIntoView({ behavior: 'instant', block: 'center', inline: 'start' });
     }
   });
 
@@ -337,18 +338,13 @@ function renderDMLTable(dmlTableContainer: HTMLElement, dmlLines: DMLBeginLine[]
     if (!(data.timestamp && data.dml)) {
       return;
     }
+
     const origRowHeight = row.getElement().offsetHeight;
-
     row.treeToggle();
-    row.getCell('soql').getElement().style.height = origRowHeight + 'px';
+    row.getCell('dml').getElement().style.height = origRowHeight + 'px';
 
-    const nextRow = row.getNextRow() || row.getTreeChildren()[0];
-    if (nextRow) {
-      // @ts-expect-error it has 2 params
-      nextRow.scrollTo('center', true).then(() => {
-        nextRow.getElement().scrollIntoView({ behavior: 'auto', block: 'center', inline: 'start' });
-      });
-    }
+    row &&
+      row.getElement().scrollIntoView({ behavior: 'instant', block: 'center', inline: 'start' });
   });
 }
 
@@ -598,15 +594,13 @@ function renderSOQLTable(soqlTableContainer: HTMLElement, soqlLines: SOQLExecute
     }
   });
 
-  soqlTable.on('groupVisibilityChanged', (group: GroupComponent, visible: boolean) => {
-    const firstRow = visible ? group.getRows()[0] : group.getRows()[0].getPrevRow();
-    if (firstRow) {
-      // @ts-expect-error it has 2 params
-      firstRow.scrollTo('center', true).then(() => {
-        firstRow
-          .getElement()
-          .scrollIntoView({ behavior: 'auto', block: 'center', inline: 'start' });
-      });
+  soqlTable.on('groupVisibilityChanged', (group: GroupComponent, _visible: boolean) => {
+    const groupToFocus = group.getElement() ? group : findGroup(soqlTable, group.getKey());
+
+    if (groupToFocus) {
+      groupToFocus
+        .getElement()
+        .scrollIntoView({ behavior: 'instant', block: 'center', inline: 'start' });
     }
   });
 
@@ -617,17 +611,11 @@ function renderSOQLTable(soqlTableContainer: HTMLElement, soqlLines: SOQLExecute
     }
 
     const origRowHeight = row.getElement().offsetHeight;
-
     row.treeToggle();
     row.getCell('soql').getElement().style.height = origRowHeight + 'px';
 
-    const nextRow = row.getNextRow() || row.getTreeChildren()[0];
-    if (nextRow) {
-      // @ts-expect-error it has 2 params
-      nextRow.scrollTo('center', true).then(() => {
-        nextRow.getElement().scrollIntoView({ behavior: 'auto', block: 'center', inline: 'start' });
-      });
-    }
+    row &&
+      row.getElement().scrollIntoView({ behavior: 'instant', block: 'center', inline: 'start' });
   });
 }
 
@@ -688,4 +676,19 @@ function downlodEncoder(defaultFileName: string) {
 
     return new Blob([fileContents], { type: mimeType });
   };
+}
+
+function findGroup(table: Tabulator, groupKey: string): GroupComponent | null {
+  let foundGroup = null;
+  const groups = soqlTable.getGroups();
+  let len = groups?.length - 1 || 0;
+  while (len >= 0 && !foundGroup) {
+    const toSearch = groups[len];
+    if (toSearch.getKey() === groupKey) {
+      foundGroup = toSearch;
+      break;
+    }
+    len--;
+  }
+  return foundGroup;
 }


### PR DESCRIPTION
# Description

fix: improve the reliability of scroll when rows are clicked

The behaviour of keeping the grouped and normal rows that 
are clicked in focus should be far more reliable.
This should reduce the jumping effect that can be seen 
with tables of a large height.

## Type of change (check all applicable)

- [X] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] ♻️ Refactor
- [ ] ⚡ Performance Improvement
- [X] 📝 Documentation
- [ ] 🔧 Chore
- [ ] 💥 Breaking change

## [optional] Any images / gifs / video

## Related Tickets & Documents

Related Issue #
fixes #434 
resolves #
closes #

## Added tests?

- [ ] 👍 yes
- [X] 🙅 no, not needed
- [ ] 🙋 no, I need help

## Added to documentation?

- [ ] 🔖 README.md
- [X] 🔖 CHANGELOG.md
- [ ] 📖 help site
- [ ] 🙅 not needed

## [optional] Are there any post-deployment tasks we need to perform?
