### PR TITLE
feat: open viewer from dirty editor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Open Apex Log Analyzer from a dirty vscode editor ([#213][#213])
+  - Supports opening Apex Log Analyzer when a log is dragged and dropped into Salesforce Code Builder.
+  - It allows for a log analysis to be shown when a file is deleted on local disk or a log is copy and pasted into an editor window without saving.
 - Make dragging more obvious on the Timeline by showing different cursors ([#423][#423])
   - Show the pointer cursor by default when hovering the Timeline.
   - Show the grabbing cursor when the mouse is pressed down on the Timeline, to indicate drag is now possible.
@@ -295,6 +298,7 @@ Skipped due to adopting odd numbering for pre releases and even number for relea
 
 <!-- Unreleased -->
 
+[#213]: https://github.com/certinia/debug-log-analyzer/issues/213
 [#86]: https://github.com/certinia/debug-log-analyzer/issues/86
 [#115]: https://github.com/certinia/debug-log-analyzer/issues/115
 [#423]: https://github.com/certinia/debug-log-analyzer/issues/423

--- a/lana/src/commands/RetrieveLogFile.ts
+++ b/lana/src/commands/RetrieveLogFile.ts
@@ -60,7 +60,7 @@ export class RetrieveLogFile {
     if (logFileId) {
       const logFilePath = this.getLogFilePath(ws, logFileId);
       const writeLogFile = this.writeLogFile(ws, logFilePath);
-      return LogView.createView(ws, context, logFilePath, writeLogFile);
+      return LogView.createView(ws, context, writeLogFile, logFilePath);
     }
   }
 

--- a/lana/src/commands/ShowLogAnalysis.ts
+++ b/lana/src/commands/ShowLogAnalysis.ts
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2020 Certinia Inc. All rights reserved.
  */
+import { existsSync } from 'fs';
 import { Uri, window } from 'vscode';
 
 import { appName } from '../AppSettings.js';
@@ -32,11 +33,12 @@ export class ShowLogAnalysis {
   }
 
   private static async command(context: Context, uri: Uri): Promise<void> {
-    const filePath = uri?.fsPath || window?.activeTextEditor?.document.fileName;
+    const filePath = uri?.fsPath || window?.activeTextEditor?.document.fileName || '';
+    const fileContent = !existsSync(filePath) ? window?.activeTextEditor?.document.getText() : '';
 
-    if (filePath) {
+    if (filePath || fileContent) {
       const ws = await QuickPickWorkspace.pickOrReturn(context);
-      LogView.createView(ws, context, filePath);
+      LogView.createView(ws, context, Promise.resolve(), filePath, fileContent);
     } else {
       context.display.showErrorMessage(
         'No file selected or the file is too large. Try again using the file explorer or text editor command.',


### PR DESCRIPTION
# Description

feat: open viewer with editor content if file does not exist

This is mainly to support drag and drop file in code builder.
It also helps when a file is deleted on local disk or a log is 
copy and pasted into an editor window without saving.

## Type of change (check all applicable)

- [ ] 🐛 Bug fix
- [X] ✨ New feature
- [ ] ♻️ Refactor
- [ ] ⚡ Performance Improvement
- [ ] 📝 Documentation
- [ ] 🔧 Chore
- [ ] 💥 Breaking change

## [optional] Any images / gifs / video

## Related Tickets & Documents

Related Issue #
fixes #
resolves #213 
closes #

## Added tests?

- [ ] 👍 yes
- [X] 🙅 no, not needed
- [ ] 🙋 no, I need help

## Added to documentation?

- [ ] 🔖 README.md
- [X] 🔖 CHANGELOG.md
- [ ] 📖 help site
- [ ] 🙅 not needed

## [optional] Are there any post-deployment tasks we need to perform?
