### PR TITLE
feat: parser add duration for some events without end

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Open Apex Log Analyzer from a dirty vscode editor ([#213][#213])
   - Supports opening Apex Log Analyzer when a log is dragged and dropped into Salesforce Code Builder.
   - It allows for a log analysis to be shown when a file is deleted on local disk or a log is copy and pasted into an editor window without saving.
+- Show time taken for more events within the `Workflow:ApprovalProcessActions` Code Unit ([#336][#336])
+  - Estimates the time taken for some events without an exit event within `Workflow:ApprovalProcessActions` Code Unit e.g `WF_APPROVAl` + `WF_EMAIL_SENT`
 - Make dragging more obvious on the Timeline by showing different cursors ([#423][#423])
   - Show the pointer cursor by default when hovering the Timeline.
   - Show the grabbing cursor when the mouse is pressed down on the Timeline, to indicate drag is now possible.
@@ -304,6 +306,7 @@ Skipped due to adopting odd numbering for pre releases and even number for relea
 
 <!-- Unreleased -->
 
+[#336]: https://github.com/certinia/debug-log-analyzer/issues/336
 [#213]: https://github.com/certinia/debug-log-analyzer/issues/213
 [#86]: https://github.com/certinia/debug-log-analyzer/issues/86
 [#115]: https://github.com/certinia/debug-log-analyzer/issues/115

--- a/log-viewer/modules/components/LogViewer.ts
+++ b/log-viewer/modules/components/LogViewer.ts
@@ -97,8 +97,6 @@ export class LogViewer extends LitElement {
       logMessage.message = element.description;
       logMessage.severity = severity;
       localNotifications.push(logMessage);
-
-      console.debug('s,', severity, logMessage);
     });
     this.notifications = localNotifications;
 

--- a/log-viewer/modules/components/calltree-view/CalltreeView.ts
+++ b/log-viewer/modules/components/calltree-view/CalltreeView.ts
@@ -212,12 +212,17 @@ function deepFilter(
   }
 
   let childMatch = false;
-  for (const childRow of rowData._children || []) {
-    const match = deepFilter(childRow, filterFunction, filterParams);
+  const children = rowData._children || [];
+  let len = children.length;
+  while (len-- > 0) {
+    const childRow = children[len];
+    if (childRow) {
+      const match = deepFilter(childRow, filterFunction, filterParams);
 
-    if (match) {
-      childMatch = true;
-      break;
+      if (match) {
+        childMatch = true;
+        break;
+      }
     }
   }
 

--- a/log-viewer/modules/parsers/ApexLogParser.ts
+++ b/log-viewer/modules/parsers/ApexLogParser.ts
@@ -79,7 +79,7 @@ export default class ApexLogParser {
     if ((!type || !typePattern.test(type)) && lastEntry && lastEntry.acceptsText) {
       // wrapped text from the previous entry?
       lastEntry.text += `\n${line}`;
-    } else if (type) {
+    } else if (type && typePattern.test(type)) {
       const message = `Unsupported log event name: ${type}`;
       !this.parsingErrors.includes(message) && this.parsingErrors.push(message);
     } else {

--- a/log-viewer/modules/parsers/ApexLogParser.ts
+++ b/log-viewer/modules/parsers/ApexLogParser.ts
@@ -3,6 +3,7 @@
  */
 
 // todo: Each type should have namespaces assocated (default of unmanagd) - **NEW FEAT**
+// Add new aggregate tuple {self: , total:} usage sum.dml.self
 
 const typePattern = /^[A-Z_]*$/,
   newlineRegex = /\r?\n/,
@@ -536,7 +537,8 @@ export abstract class LogLine {
   isExit = false;
 
   /**
-   *  Should the exitstamp be the timestamp of the next line?
+   * Should the exitstamp be the timestamp of the next line?
+   * These kind of lines can not be used as exit lines for anything othe than other pseudo exits.
    */
   nextLineIsExit = false;
 
@@ -1931,9 +1933,11 @@ class WFFlowActionErrorDetailLine extends LogLine {
   }
 }
 
-class WFFieldUpdateLine extends LogLine {
+class WFFieldUpdateLine extends Method {
+  isExit = true;
+  nextLineIsExit = true;
   constructor(parts: string[]) {
-    super(parts);
+    super(parts, ['WF_FIELD_UPDATE'], 'Workflow', 'custom');
     this.text = ' ' + parts[2] + ' ' + parts[3] + ' ' + parts[4] + ' ' + parts[5] + ' ' + parts[6];
   }
 }
@@ -1972,11 +1976,13 @@ class WFCriteriaBeginLine extends Method {
   }
 }
 
-class WFFormulaLine extends LogLine {
+class WFFormulaLine extends Method {
   acceptsText = true;
+  isExit = true;
+  nextLineIsExit = true;
 
   constructor(parts: string[]) {
-    super(parts);
+    super(parts, ['WF_FORMULA'], 'Workflow', 'custom');
     this.text = parts[2] + ' : ' + parts[3];
   }
 }
@@ -2002,9 +2008,11 @@ class WFActionTaskLine extends LogLine {
   }
 }
 
-class WFApprovalLine extends LogLine {
+class WFApprovalLine extends Method {
+  isExit = true;
+  nextLineIsExit = true;
   constructor(parts: string[]) {
-    super(parts);
+    super(parts, ['WF_APPROVAL'], 'Workflow', 'custom');
     this.text = `${parts[2]} : ${parts[3]} : ${parts[4]}`;
   }
 }
@@ -2017,8 +2025,10 @@ class WFApprovalRemoveLine extends LogLine {
 }
 
 class WFApprovalSubmitLine extends Method {
+  isExit = true;
+  nextLineIsExit = true;
   constructor(parts: string[]) {
-    super(parts, ['WF_PROCESS_FOUND'], 'Workflow', 'custom');
+    super(parts, ['WF_APPROVAL_SUBMIT'], 'Workflow', 'custom');
     this.text = `${parts[2]}`;
   }
 }
@@ -2037,16 +2047,20 @@ class WFAssignLine extends LogLine {
   }
 }
 
-class WFEmailAlertLine extends LogLine {
+class WFEmailAlertLine extends Method {
+  isExit = true;
+  nextLineIsExit = true;
   constructor(parts: string[]) {
-    super(parts);
+    super(parts, ['WF_EMAIL_ALERT'], 'Workflow', 'custom');
     this.text = `${parts[2]} : ${parts[3]} : ${parts[4]}`;
   }
 }
 
-class WFEmailSentLine extends LogLine {
+class WFEmailSentLine extends Method {
+  isExit = true;
+  nextLineIsExit = true;
   constructor(parts: string[]) {
-    super(parts);
+    super(parts, ['WF_EMAIL_SENT'], 'Workflow', 'custom');
     this.text = `${parts[2]} : ${parts[3]} : ${parts[4]}`;
   }
 }
@@ -2065,9 +2079,11 @@ class WFEscalationActionLine extends LogLine {
   }
 }
 
-class WFEvalEntryCriteriaLine extends LogLine {
+class WFEvalEntryCriteriaLine extends Method {
+  isExit = true;
+  nextLineIsExit = true;
   constructor(parts: string[]) {
-    super(parts);
+    super(parts, ['WF_EVAL_ENTRY_CRITERIA'], 'Workflow', 'custom');
     this.text = `${parts[2]} : ${parts[3]} : ${parts[4]}`;
   }
 }
@@ -2080,9 +2096,11 @@ class WFFlowActionDetailLine extends LogLine {
   }
 }
 
-class WFNextApproverLine extends LogLine {
+class WFNextApproverLine extends Method {
+  isExit = true;
+  nextLineIsExit = true;
   constructor(parts: string[]) {
-    super(parts);
+    super(parts, ['WF_NEXT_APPROVER'], 'Workflow', 'custom');
     this.text = `${parts[2]} : ${parts[3]} : ${parts[4]}`;
   }
 }
@@ -2094,17 +2112,20 @@ class WFOutboundMsgLine extends LogLine {
   }
 }
 
-class WFProcessFoundLine extends LogLine {
+class WFProcessFoundLine extends Method {
   isExit = true;
+  nextLineIsExit = true;
   constructor(parts: string[]) {
-    super(parts);
+    super(parts, ['WF_PROCESS_FOUND'], 'Workflow', 'custom');
     this.text = `${parts[2]} : ${parts[3]}`;
   }
 }
 
-class WFProcessNode extends LogLine {
+class WFProcessNode extends Method {
+  isExit = true;
+  nextLineIsExit = true;
   constructor(parts: string[]) {
-    super(parts);
+    super(parts, ['WF_PROCESS_NODE'], 'Workflow', 'custom');
     this.text = parts[2] || '';
   }
 }
@@ -2130,9 +2151,11 @@ class WFRuleEntryOrderLine extends LogLine {
   }
 }
 
-class WFRuleInvocationLine extends LogLine {
+class WFRuleInvocationLine extends Method {
+  isExit = true;
+  nextLineIsExit = true;
   constructor(parts: string[]) {
-    super(parts);
+    super(parts, ['WF_RULE_INVOCATION'], 'Workflow', 'custom');
     this.text = parts[2] || '';
   }
 }

--- a/log-viewer/modules/parsers/ApexLogParser.ts
+++ b/log-viewer/modules/parsers/ApexLogParser.ts
@@ -1597,9 +1597,9 @@ class FlowStartInterviewsErrorLine extends LogLine {
   }
 }
 
-class FlowStartInterviewBeginLine extends LogLine {
+class FlowStartInterviewBeginLine extends Method {
   constructor(parts: string[]) {
-    super(parts);
+    super(parts, ['FLOW_START_INTERVIEW_END'], 'Flow', 'custom');
     this.text = parts[3] || '';
   }
 }
@@ -2494,7 +2494,6 @@ const basicLogEvents: LogEventType[] = [
   'BULK_COUNTABLE_STATEMENT_EXECUTE',
   'TEMPLATE_PROCESSING_ERROR',
   'EXTERNAL_SERVICE_REQUEST',
-  'FLOW_START_INTERVIEW_END',
   'FLOW_CREATE_INTERVIEW_BEGIN',
   'FLOW_CREATE_INTERVIEW_END',
   'VARIABLE_SCOPE_END',
@@ -2557,6 +2556,7 @@ const basicLogEvents: LogEventType[] = [
 ];
 
 const basicExitLogEvents: LogEventType[] = [
+  'FLOW_START_INTERVIEW_END',
   'VF_DESERIALIZE_VIEWSTATE_END',
   'VF_SERIALIZE_VIEWSTATE_END',
   'CUMULATIVE_LIMIT_USAGE_END',

--- a/log-viewer/modules/parsers/ApexLogParser.ts
+++ b/log-viewer/modules/parsers/ApexLogParser.ts
@@ -1996,9 +1996,9 @@ class WFApprovalRemoveLine extends LogLine {
   }
 }
 
-class WFApprovalSubmitLine extends LogLine {
+class WFApprovalSubmitLine extends Method {
   constructor(parts: string[]) {
-    super(parts);
+    super(parts, ['WF_PROCESS_FOUND'], 'Workflow', 'custom');
     this.text = `${parts[2]}`;
   }
 }
@@ -2075,6 +2075,7 @@ class WFOutboundMsgLine extends LogLine {
 }
 
 class WFProcessFoundLine extends LogLine {
+  isExit = true;
   constructor(parts: string[]) {
     super(parts);
     this.text = `${parts[2]} : ${parts[3]}`;

--- a/package.json
+++ b/package.json
@@ -34,13 +34,13 @@
     "build:dev": "concurrently -r -g 'rm -rf lana/out && rollup -c rollup.config.mjs' 'tsc --noemit --skipLibCheck -p log-viewer/tsconfig.json' 'tsc --noemit --skipLibCheck -p lana/tsconfig.json'",
     "watch": "rm -rf lana/out && rollup -w -c rollup.config.mjs",
     "prepare": "husky install",
-    "lint": "concurrently -r -g 'eslint . --ext ts' 'prettier **/*.{ts,css,md,scss} --check' 'tsc --noemit --skipLibCheck -p log-viewer/tsconfig.json' 'tsc --noemit --skipLibCheck -p lana/tsconfig.json'",
+    "lint": "concurrently -r -g 'eslint . --ext ts' 'prettier --cache **/*.{ts,css,md,scss} --check' 'tsc --noemit --skipLibCheck -p log-viewer/tsconfig.json' 'tsc --noemit --skipLibCheck -p lana/tsconfig.json'",
     "test": "jest",
     "test:ci": "jest --runInBand",
-    "prettier-format": "prettier '**/*.ts' --write"
+    "prettier-format": "prettier '**/*.ts' --cache --write"
   },
   "lint-staged": {
-    "*.{ts,css,md,scss}": "prettier --write"
+    "*.{ts,css,md,scss}": "prettier --cache --write"
   },
   "pnpm": {
     "patchedDependencies": {


### PR DESCRIPTION
# Description

This is adding support to show more events inside the `Workflow:ApprovalProcessActions` code unit
It will also support showing event on the timeline that have now explicit end node but can use following like events to estimate one (looped events). These are both entry and exit nodes.

These are pseudo entry / exit lines and use the timestamp of the next non detail line as their exit. As such this may lead to over estimates in some cases.

**add support for pseudo exit lines**
These lines will use the next lines timetamp as their exit time.
But only if the next line is also a pseudo exit, an exit or an entry.

**show FLOW_START_INTERVIEW_BEGIN lines in timeline**

## Type of change (check all applicable)

- [ ] 🐛 Bug fix
- [X] ✨ New feature
- [ ] ♻️ Refactor
- [ ] ⚡ Performance Improvement
- [ ] 📝 Documentation
- [ ] 🔧 Chore
- [ ] 💥 Breaking change

## [optional] Any images / gifs / video

## Related Tickets & Documents

Related Issue #228 #211 
fixes #
resolves #336 #211
closes #

## Added tests?

- [x] 👍 yes
- [ ] 🙅 no, not needed
- [ ] 🙋 no, I need help

## Added to documentation?

- [ ] 🔖 README.md
- [x] 🔖 CHANGELOG.md
- [ ] 📖 help site
- [ ] 🙅 not needed

## [optional] Are there any post-deployment tasks we need to perform?
