### PR TITLE
chore: update version 1.12.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [1.12.0] - 2023-12-05
 
 ### Added
 
@@ -306,7 +306,7 @@ Skipped due to adopting odd numbering for pre releases and even number for relea
 - Add explorer menu item
 - Provide more information when selecting log to download
 
-<!-- Unreleased -->
+<!-- v1.12.0 -->
 
 [#311]: https://github.com/certinia/debug-log-analyzer/issues/311
 [#336]: https://github.com/certinia/debug-log-analyzer/issues/336

--- a/lana/package.json
+++ b/lana/package.json
@@ -1,7 +1,7 @@
 {
   "name": "lana",
   "displayName": "Apex Log Analyzer",
-  "version": "1.10.4",
+  "version": "1.12.0",
   "description": "Analyzer for Salesforce debug logs - Visualize code execution via a Flame graph and identify performance and SOQL/DML problems via Method and Database analysis",
   "keywords": [
     "apex",


### PR DESCRIPTION
# Description

chore: update version 1.12.0 release
Wait until 2023-12-05 to merge and release.

## Type of change (check all applicable)

- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] ♻️ Refactor
- [ ] ⚡ Performance Improvement
- [ ] 📝 Documentation
- [X] 🔧 Chore
- [ ] 💥 Breaking change
