### PR TITLE
ci: fix publish jobs

### DIFF
--- a/.github/workflows/cd-prerelease.yml
+++ b/.github/workflows/cd-prerelease.yml
@@ -95,11 +95,11 @@ jobs:
 
           echo "Publish to vsce
           vsix name: $pkgPath"
-          vsce publish --no-dependencies --pre-release -p ${{ secrets.VSCE_TOKEN }} --packagePath ${pkgPath}
+          vsce publish --packagePath ${pkgPath} --no-dependencies --pre-release -p ${{ secrets.VSCE_TOKEN }} --skip-duplicate
 
           echo "
           Publish to ovsx"
-          ovsx publish --no-dependencies --pre-release -p ${{ secrets.OVSX_TOKEN }} --packagePath ${pkgPath}
+          ovsx publish ${pkgPath} --no-dependencies --pre-release -p ${{ secrets.OVSX_TOKEN }} --skip-duplicate
       - name: Update pre-release tag
         run: |
           echo "Updating pre release tag"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -38,6 +38,6 @@ jobs:
           ovsx verify-pat -p ${{ secrets.OVSX_TOKEN }}
 
           echo "Publish to vsce"
-          vsce publish --no-dependencies -p ${{ secrets.VSCE_TOKEN }} --packagePath lana-${{ github.event.release.tag_name }}.vsix
+          vsce publish --packagePath lana-${{ github.event.release.tag_name }}.vsix --no-dependencies -p ${{ secrets.VSCE_TOKEN }}
           echo "Publish to ovsx"
-          ovsx publish --no-dependencies -p ${{ secrets.OVSX_TOKEN }} --packagePath lana-${{ github.event.release.tag_name }}.vsix
+          ovsx publish lana-${{ github.event.release.tag_name }}.vsix --no-dependencies -p ${{ secrets.OVSX_TOKEN }}


### PR DESCRIPTION
# Description

The ovsx cli behaves differently when --packagePath is passed compared to vsce. It causes the package command in vsce to be called again and and extension vsix re created.

## Type of change (check all applicable)

- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] ♻️ Refactor
- [ ] ⚡ Performance Improvement
- [ ] 📝 Documentation
- [X] 🔧 Chore
- [ ] 💥 Breaking change

## [optional] Any images / gifs / video

## Related Tickets & Documents

Related Issue #
fixes #
resolves #
closes #

## Added tests?

- [ ] 👍 yes
- [X] 🙅 no, not needed
- [ ] 🙋 no, I need help

## Added to documentation?

- [ ] 🔖 README.md
- [ ] 🔖 CHANGELOG.md
- [ ] 📖 help site
- [X] 🙅 not needed

## [optional] Are there any post-deployment tasks we need to perform?
