### PR TITLE
chore: fix --skip-duplicate being ignored on ovsx stage

### DIFF
--- a/.github/workflows/cd-prerelease.yml
+++ b/.github/workflows/cd-prerelease.yml
@@ -95,11 +95,11 @@ jobs:
 
           echo "Publish to vsce
           vsix name: $pkgPath"
-          vsce publish --packagePath ${pkgPath} --no-dependencies --pre-release -p ${{ secrets.VSCE_TOKEN }} --skip-duplicate
+          vsce publish --packagePath ${pkgPath} --no-dependencies --pre-release --skip-duplicate -p ${{ secrets.VSCE_TOKEN }}
 
           echo "
           Publish to ovsx"
-          ovsx publish ${pkgPath} --no-dependencies --pre-release -p ${{ secrets.OVSX_TOKEN }} --skip-duplicate
+          ovsx publish ${pkgPath} --no-dependencies --pre-release --skip-duplicate -p ${{ secrets.OVSX_TOKEN }}
       - name: Update pre-release tag
         run: |
           echo "Updating pre release tag"


### PR DESCRIPTION
# Description

ci: fix --skip-duplicate being ignored on ovsx stage

## Type of change (check all applicable)

- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] ♻️ Refactor
- [ ] ⚡ Performance Improvement
- [ ] 📝 Documentation
- [X] 🔧 Chore
- [ ] 💥 Breaking change