### PR TITLE
feat: parser performance

### DIFF
--- a/log-viewer/modules/__tests__/ApexLogParser.test.ts
+++ b/log-viewer/modules/__tests__/ApexLogParser.test.ts
@@ -694,19 +694,6 @@ describe('Recalculate durations tests', () => {
     expect(node.timestamp).toEqual(1);
     expect(node.duration).toEqual({ self: 2, total: 2 });
   });
-
-  it('Children are subtracted from net duration', () => {
-    const node = new Method(['14:32:07.563 (0)', 'DUMMY'], [], 'Method', ''),
-      child1 = new Method(['14:32:07.563 (10)', 'DUMMY'], [], 'Method', ''),
-      child2 = new Method(['14:32:07.563 (70)', 'DUMMY'], [], 'Method', '');
-    node.exitStamp = 100;
-    child1.duration.total = 50;
-    child2.duration.total = 25;
-    node.addChild(child1);
-    node.addChild(child2);
-    node.recalculateDurations();
-    expect(node.duration).toEqual({ self: 25, total: 100 });
-  });
 });
 
 describe('Line Type Tests', () => {

--- a/log-viewer/modules/parsers/ApexLogParser.ts
+++ b/log-viewer/modules/parsers/ApexLogParser.ts
@@ -722,12 +722,10 @@ export class TimedNode extends LogLine {
 
   recalculateDurations() {
     if (this.exitStamp) {
+      const childDuration = this.children.reduce((accumulator, currentValue) => {
+        return accumulator + currentValue.duration.total;
+      }, 0);
       this.duration.total = this.exitStamp - this.timestamp;
-
-      let childDuration = 0;
-      this.children.forEach((child) => {
-        childDuration += child.duration.total;
-      });
       this.duration.self = this.duration.total - childDuration;
     }
   }

--- a/log-viewer/modules/parsers/ApexLogParser.ts
+++ b/log-viewer/modules/parsers/ApexLogParser.ts
@@ -166,7 +166,7 @@ export default class ApexLogParser {
 
     this.insertPackageWrappers(rootMethod);
     this.setNamespaces(rootMethod);
-    this.aggregateTotals([rootMethod]);
+    this.aggregateTotals(rootMethod.children);
     return rootMethod;
   }
 

--- a/log-viewer/modules/parsers/ApexLogParser.ts
+++ b/log-viewer/modules/parsers/ApexLogParser.ts
@@ -107,11 +107,9 @@ export default class ApexLogParser {
     return null;
   }
 
-  // Matches CRLF (\r\n) + LF (\n)
-  // the ? matches the previous token 0 or 1 times.
   private parseLog(log: string): LogLine[] {
     const start = log.match(/^.*EXECUTION_STARTED.*$/m)?.index || 0;
-    const rawLines = log.slice(start).split(/\r?\n/);
+    const rawLines = this.splitByNextLine(log.slice(start));
 
     // reset global variables to be captured during parsing
     this.logIssues = [];
@@ -136,6 +134,19 @@ export default class ApexLogParser {
     lastEntry?.onAfter?.(this);
 
     return logLines;
+  }
+
+  // Matches CRLF (\r\n) + LF (\n)
+  // the ? matches the previous token 0 or 1 times.
+  private splitByNextLine(text: string) {
+    const hascrlfEOL = text.indexOf('\r\n') > -1;
+    let regex;
+    if (!hascrlfEOL) {
+      regex = /\n/;
+    } else {
+      regex = /\r?\n/;
+    }
+    return text.split(regex);
   }
 
   private toLogTree(logLines: LogLine[]) {

--- a/log-viewer/modules/parsers/ApexLogParser.ts
+++ b/log-viewer/modules/parsers/ApexLogParser.ts
@@ -165,7 +165,6 @@ export default class ApexLogParser {
     rootMethod.setTimes();
 
     this.insertPackageWrappers(rootMethod);
-
     this.setNamespaces(rootMethod);
     this.aggregateTotals([rootMethod]);
     return rootMethod;
@@ -342,14 +341,13 @@ export default class ApexLogParser {
       let i = nds.length;
       while (i--) {
         const parent = nds[i];
-        if (parent?.children) {
-          parent.children.forEach((child) => {
-            parent.dmlCount.total += child.dmlCount.total;
-            parent.soqlCount.total += child.soqlCount.total;
-            parent.totalThrownCount += child.totalThrownCount;
-            parent.rowCount.total += child.rowCount.total;
-          });
-        }
+        parent?.children.forEach((child) => {
+          parent.dmlCount.total += child.dmlCount.total;
+          parent.soqlCount.total += child.soqlCount.total;
+          parent.totalThrownCount += child.totalThrownCount;
+          parent.rowCount.total += child.rowCount.total;
+          parent.duration.self -= child.duration.total;
+        });
       }
     }
   }
@@ -758,11 +756,7 @@ export class TimedNode extends LogLine {
 
   recalculateDurations() {
     if (this.exitStamp) {
-      const childDuration = this.children.reduce((accumulator, currentValue) => {
-        return accumulator + currentValue.duration.total;
-      }, 0);
-      this.duration.total = this.exitStamp - this.timestamp;
-      this.duration.self = this.duration.total - childDuration;
+      this.duration.total = this.duration.self = this.exitStamp - this.timestamp;
     }
   }
 }

--- a/log-viewer/modules/parsers/ApexLogParser.ts
+++ b/log-viewer/modules/parsers/ApexLogParser.ts
@@ -307,16 +307,16 @@ export default class ApexLogParser {
     let currentNodes = nodes;
     let len = currentNodes.length;
     while (len) {
+      result.set(currentDepth, []);
       while (len--) {
         const node = currentNodes[len];
         if (node?.children) {
-          let children = result.get(currentDepth);
-          if (!children) {
-            children = [];
-            result.set(currentDepth, children);
-          }
-
-          Array.prototype.push.apply(children, node.children);
+          const children = result.get(currentDepth)!;
+          node.children.forEach((c) => {
+            if (c.children.length) {
+              children.push(c);
+            }
+          });
         }
       }
       currentNodes = result.get(currentDepth++) || [];

--- a/log-viewer/modules/parsers/ApexLogParser.ts
+++ b/log-viewer/modules/parsers/ApexLogParser.ts
@@ -2434,6 +2434,29 @@ class MatchEngineBegin extends Method {
 }
 
 function getLogEventClass(eventName: LogEventType): LogLineConstructor | null | undefined {
+  // Fast path for the most commonly occuring types
+  switch (eventName) {
+    case 'METHOD_ENTRY':
+      return MethodEntryLine;
+      break;
+
+    case 'METHOD_EXIT':
+      return MethodExitLine;
+      break;
+
+    case 'CONSTRUCTOR_ENTRY':
+      return ConstructorEntryLine;
+      break;
+
+    case 'CONSTRUCTOR_EXIT':
+      return ConstructorExitLine;
+      break;
+
+    default:
+      break;
+  }
+
+  // Handle all other types
   const logType = lineTypeMap.get(eventName);
   if (logType) {
     return logType;


### PR DESCRIPTION
# Description

- Generally improves parser performance.
- The main change is to remove recursion from the aggregate totals function
- Add a fast path for getting commonly used event types
- Add a fast path for splitting new lines when the line endings are all lf e.g `\n`

Total parse time: from 2.02s -> 1.95s 
toTree: ~1022ms -> 1025 ms
parseLog: ~974-> 750 ms


- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] ♻️ Refactor
- [X] ⚡ Performance Improvement
- [ ] 📝 Documentation
- [ ] 🔧 Chore
- [ ] 💥 Breaking change

## [optional] Any images / gifs / video

## Related Tickets & Documents

Related Issue #
fixes #
resolves #
closes #

## Added tests?

- [X] 👍 yes
- [ ] 🙅 no, not needed
- [ ] 🙋 no, I need help

## Added to documentation?

- [ ] 🔖 README.md
- [ ] 🔖 CHANGELOG.md
- [ ] 📖 help site
- [X ] 🙅 not needed

## [optional] Are there any post-deployment tasks we need to perform?
