### PR TITLE
Perf: parser speed

### DIFF
--- a/log-viewer/modules/components/AnalysisView.ts
+++ b/log-viewer/modules/components/AnalysisView.ts
@@ -303,8 +303,6 @@ function addNodeToMap(map: Map<string, Metric>, node: TimedNode, key?: string) {
   const children = node.children;
 
   if (key) {
-    const totalTime = node.duration.total;
-    const selfTime = node.duration.self;
     let metric = map.get(key);
     if (!metric) {
       metric = new Metric(node);
@@ -312,8 +310,8 @@ function addNodeToMap(map: Map<string, Metric>, node: TimedNode, key?: string) {
     }
 
     ++metric.count;
-    metric.totalTime += totalTime;
-    metric.selfTime += selfTime;
+    metric.totalTime += node.duration.total;
+    metric.selfTime += node.duration.self;
   }
 
   children.forEach(function (child) {

--- a/log-viewer/modules/parsers/ApexLogParser.ts
+++ b/log-viewer/modules/parsers/ApexLogParser.ts
@@ -368,9 +368,7 @@ class ApexLogParser {
     for (let i = 0; i < len; i++) {
       const child = children[i];
       if (child) {
-        const childType = child.type,
-          isPkgType = childType === 'ENTERING_MANAGED_PKG';
-
+        const isPkgType = child.type === 'ENTERING_MANAGED_PKG';
         if (lastPkg && child instanceof TimedNode) {
           if (isPkgType && child.namespace === lastPkg.namespace) {
             // combine adjacent (like) packages

--- a/log-viewer/modules/parsers/ApexLogParser.ts
+++ b/log-viewer/modules/parsers/ApexLogParser.ts
@@ -631,9 +631,8 @@ export abstract class LogLine {
   constructor(parts: string[] | null) {
     if (parts) {
       const [timeData, type] = parts;
-      this.type = type as LogEventType;
-      this.text = this.type;
-      this.timestamp = this.parseTimestamp(timeData as string);
+      this.text = this.type = type as LogEventType;
+      this.timestamp = this.parseTimestamp(timeData || '');
     }
   }
 

--- a/log-viewer/modules/parsers/ApexLogParser.ts
+++ b/log-viewer/modules/parsers/ApexLogParser.ts
@@ -1,5 +1,3 @@
-import { split } from './StringUtils';
-
 /*
  * Copyright (c) 2020 Certinia Inc. All rights reserved.
  */
@@ -122,15 +120,17 @@ class ApexLogParser {
 
     const hascrlf = log.indexOf('\r\n') > -1;
     let lastEntry = null;
-    let eolIndex = log.indexOf('\n');
+    let lfIndex = null;
+    let eolIndex = (lfIndex = log.indexOf('\n'));
     let startIndex = 0;
     let crlfIndex = -1;
 
     while (eolIndex !== -1) {
       if (hascrlf && eolIndex > crlfIndex) {
         crlfIndex = log.indexOf('\r', eolIndex - 1);
+        eolIndex = crlfIndex + 1 === eolIndex ? crlfIndex : lfIndex;
       }
-      const line = log.slice(startIndex, crlfIndex + 1 === eolIndex ? crlfIndex : eolIndex);
+      const line = log.slice(startIndex, eolIndex);
       if (line) {
         // ignore blank lines
         const entry = this.parseLine(line, lastEntry);
@@ -139,8 +139,8 @@ class ApexLogParser {
           yield entry;
         }
       }
-      startIndex = eolIndex + 1;
-      eolIndex = log.indexOf('\n', startIndex);
+      startIndex = lfIndex + 1;
+      lfIndex = eolIndex = log.indexOf('\n', startIndex);
     }
 
     // Parse the last line

--- a/log-viewer/modules/timeline/Timeline.ts
+++ b/log-viewer/modules/timeline/Timeline.ts
@@ -272,8 +272,8 @@ function nodesToRectangles(nodes: Method[]) {
         // The spread operator caused Maximum call stack size exceeded when there are lots of child nodes.
         const children = result.get(currentDepth)!;
         node.children.forEach((child) => {
-          if (child.exitTypes.length) {
-            children.push(child as Method);
+          if (child instanceof Method) {
+            children.push(child);
           }
         });
       }


### PR DESCRIPTION
# Description

More parser performance improvements.
The gets the parse time for a given log down from 2.87s to 0.916s in the best case


## Type of change (check all applicable)

- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] ♻️ Refactor
- [x] ⚡ Performance Improvement
- [ ] 📝 Documentation
- [ ] 🔧 Chore
- [ ] 💥 Breaking change

## [optional] Any images / gifs / video

## Related Tickets & Documents

Related Issue #475 
fixes #
resolves #
closes #

## Added tests?

- [ ] 👍 yes
- [X] 🙅 no, not needed
- [ ] 🙋 no, I need help

## Added to documentation?

- [ ] 🔖 README.md
- [ ] 🔖 CHANGELOG.md
- [ ] 📖 help site
- [X] 🙅 not needed

## [optional] Are there any post-deployment tasks we need to perform?
