### PR TITLE
perf: use code splitting for faster initial load

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Faster Extension startup time, roughly 12 times faster.
+- Faster Extension startup time, roughly 12 times faster and starts up in less than 10ms.
 
 ## [1.14.0] - 2024-02-12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+- Faster Extension startup time, roughly 12 times faster.
+
 ## [1.14.0] - 2024-02-12
 
 ### Added

--- a/lana/src/salesforce/codesymbol/SymbolFinder.ts
+++ b/lana/src/salesforce/codesymbol/SymbolFinder.ts
@@ -1,12 +1,16 @@
 /*
  * Copyright (c) 2020 Certinia Inc. All rights reserved.
  */
-import { Workspace, Workspaces } from '@apexdevtools/apex-ls';
+import { type Workspace } from '@apexdevtools/apex-ls';
 
 import { VSWorkspace } from '../../workspace/VSWorkspace.js';
 
 export class SymbolFinder {
   async findSymbol(workspaces: VSWorkspace[], symbol: string): Promise<string[]> {
+    // Dynamic import for code splitting. Improves performance by reducing the amount of JS that is loaded and parsed at the start.
+    // eslint-disable-next-line @typescript-eslint/naming-convention
+    const { Workspaces } = await import('@apexdevtools/apex-ls');
+
     const paths = [];
     for (const ws of workspaces) {
       const apexWs = Workspaces.get(ws.path());

--- a/log-viewer/modules/__tests__/SOQLParser.test.ts
+++ b/log-viewer/modules/__tests__/SOQLParser.test.ts
@@ -7,7 +7,7 @@ describe('Analyse database tests', () => {
   it('throws on unparsable query', async () => {
     const parser = new SOQLParser();
     try {
-      parser.parse('');
+      await parser.parse('');
       expect(true).toBe(false);
     } catch (ex) {
       expect(ex).toEqual(new SyntaxException(1, 0, "mismatched input '<EOF>' expecting 'select'"));
@@ -16,55 +16,55 @@ describe('Analyse database tests', () => {
 
   it('extracts simple FROM object', async () => {
     const parser = new SOQLParser();
-    const tree = parser.parse('SELECT Id FROM Account');
+    const tree = await parser.parse('SELECT Id FROM Account');
     expect(tree.fromObject()).toEqual('Account');
   });
 
   it('determines if only fields are being selected', async () => {
     const parser = new SOQLParser();
-    const tree = parser.parse('SELECT Id FROM Account');
+    const tree = await parser.parse('SELECT Id FROM Account');
     expect(tree.isSimpleSelect()).toEqual(true);
   });
 
   it('determines if none-fields are being selected', async () => {
     const parser = new SOQLParser();
-    const tree = parser.parse('SELECT Count(Id) FROM Account');
+    const tree = await parser.parse('SELECT Count(Id) FROM Account');
     expect(tree.isSimpleSelect()).toEqual(false);
   });
 
   it('determines if none-trival clauses are being used', async () => {
     const parser = new SOQLParser();
-    const tree = parser.parse('SELECT Id FROM Account GROUP BY Name LIMIT 2');
+    const tree = await parser.parse('SELECT Id FROM Account GROUP BY Name LIMIT 2');
     expect(tree.isTrivialQuery()).toEqual(false);
   });
 
   it('determines no LIMIT', async () => {
     const parser = new SOQLParser();
-    const tree = parser.parse('SELECT Id FROM Account');
+    const tree = await parser.parse('SELECT Id FROM Account');
     expect(tree.limitValue()).toEqual(undefined);
   });
 
   it('determines LIMIT number', async () => {
     const parser = new SOQLParser();
-    const tree = parser.parse('SELECT Id FROM Account LIMIT 2');
+    const tree = await parser.parse('SELECT Id FROM Account LIMIT 2');
     expect(tree.limitValue()).toEqual(2);
   });
 
   it('determines LIMIT expression', async () => {
     const parser = new SOQLParser();
-    const tree = parser.parse('SELECT Id FROM Account LIMIT :tmp');
+    const tree = await parser.parse('SELECT Id FROM Account LIMIT :tmp');
     expect(tree.limitValue()).toEqual(':tmp');
   });
 
   it('determines if does not have ORDER BY', async () => {
     const parser = new SOQLParser();
-    const tree = parser.parse('SELECT Id FROM Account');
+    const tree = await parser.parse('SELECT Id FROM Account');
     expect(tree.isOrdered()).toEqual(false);
   });
 
   it('determines if has ORDER BY', async () => {
     const parser = new SOQLParser();
-    const tree = parser.parse('SELECT Id FROM Account ORDER BY Name');
+    const tree = await parser.parse('SELECT Id FROM Account ORDER BY Name');
     expect(tree.isOrdered()).toEqual(true);
   });
 });

--- a/log-viewer/modules/__tests__/soql/SOQLLinter.test.ts
+++ b/log-viewer/modules/__tests__/soql/SOQLLinter.test.ts
@@ -5,10 +5,10 @@ import { Method } from '../../parsers/ApexLogParser.js';
 import { SOQLLinter } from '../../soql/SOQLLinter.js';
 
 describe('SOQL Linter rule tests', () => {
-  it('No where clause should return rule', () => {
+  it('No where clause should return rule', async () => {
     const soql = 'SELECT Id FROM ANOBJECT__c';
 
-    const results = new SOQLLinter().lint(soql);
+    const results = await new SOQLLinter().lint(soql);
     const undoundedSoqlRule = {
       summary: 'SOQL is unbounded. Add a WHERE or LIMIT clause or both.',
       message:
@@ -19,10 +19,10 @@ describe('SOQL Linter rule tests', () => {
     expect(results).toEqual([undoundedSoqlRule]);
   });
 
-  it('Leading % wildcard should return rule', () => {
+  it('Leading % wildcard should return rule', async () => {
     const soql = "SELECT Id FROM ANOBJECT__c WHERE Name LIKE '%SomeName'";
 
-    const results = new SOQLLinter().lint(soql);
+    const results = await new SOQLLinter().lint(soql);
     const leadingWildcardRule = {
       summary:
         'Avoid a leading "%" wildcard when using a LIKE clause. This will impact query performance.',
@@ -43,26 +43,26 @@ describe('LastModifiedDate Index Rule', () => {
     severity: 'Info',
   };
 
-  it('< on LastModifiedDate should return rule', () => {
+  it('< on LastModifiedDate should return rule', async () => {
     const soql = 'SELECT Id FROM Obj__c WHERE LastModifiedDate < TODAY';
 
-    const results = new SOQLLinter().lint(soql);
+    const results = await new SOQLLinter().lint(soql);
 
     expect(results).toEqual([lastModifiedDateIndexRule]);
   });
 
-  it('> on LastModifiedDate should not return rule', () => {
+  it('> on LastModifiedDate should not return rule', async () => {
     const soql = 'SELECT Id FROM Obj__c WHERE LastModifiedDate > TODAY';
 
-    const results = new SOQLLinter().lint(soql);
+    const results = await new SOQLLinter().lint(soql);
 
     expect(results).toEqual([]);
   });
 
-  it('= on LastModifiedDate should not return rule', () => {
+  it('= on LastModifiedDate should not return rule', async () => {
     const soql = 'SELECT Id FROM Obj__c WHERE LastModifiedDate = TODAY';
 
-    const results = new SOQLLinter().lint(soql);
+    const results = await new SOQLLinter().lint(soql);
 
     expect(results).toEqual([]);
   });
@@ -77,42 +77,42 @@ describe('Negative Filter Operator Rule tests', () => {
     severity: 'Warning',
   };
 
-  it('!= : should return rule', () => {
+  it('!= : should return rule', async () => {
     const soql = "SELECT Id FROM ANOBJECT__c WHERE Name != 'A Name'";
 
-    const results = new SOQLLinter().lint(soql);
+    const results = await new SOQLLinter().lint(soql);
 
     expect(results).toEqual([negativeFilterRule]);
   });
 
-  it('<> : should return rule', () => {
+  it('<> : should return rule', async () => {
     const soql = "SELECT Id FROM ANOBJECT__c WHERE Name <> 'A Name'";
 
-    const results = new SOQLLinter().lint(soql);
+    const results = await new SOQLLinter().lint(soql);
 
     expect(results).toEqual([negativeFilterRule]);
   });
 
-  it('EXCLUDES : should return rule', () => {
+  it('EXCLUDES : should return rule', async () => {
     const soql = "SELECT Id FROM ANOBJECT__c WHERE Name EXCLUDES ('A Name')";
 
-    const results = new SOQLLinter().lint(soql);
+    const results = await new SOQLLinter().lint(soql);
 
     expect(results).toEqual([negativeFilterRule]);
   });
 
-  it('NOT : should return rule', () => {
+  it('NOT : should return rule', async () => {
     const soql = "SELECT Id FROM ANOBJECT__c WHERE NOT Name = 'A Name'";
 
-    const results = new SOQLLinter().lint(soql);
+    const results = await new SOQLLinter().lint(soql);
 
     expect(results).toEqual([negativeFilterRule]);
   });
 
-  it('NOT IN : should return rule', () => {
+  it('NOT IN : should return rule', async () => {
     const soql = "SELECT Id FROM ANOBJECT__c WHERE Id NOT IN ('a0000000000aaaa')";
 
-    const results = new SOQLLinter().lint(soql);
+    const results = await new SOQLLinter().lint(soql);
 
     expect(results).toEqual([negativeFilterRule]);
   });
@@ -127,18 +127,18 @@ describe('Order By Without Limit Rule tests', () => {
     severity: 'Info',
   };
 
-  it('Order by only should return rule', () => {
+  it('Order by only should return rule', async () => {
     const soql = "SELECT Id FROM AnObject__c WHERE Status__c = 'Open' ORDER BY AField__c";
 
-    const results = new SOQLLinter().lint(soql);
+    const results = await new SOQLLinter().lint(soql);
 
     expect(results).toEqual([orderByWithoutLimit]);
   });
 
-  it('Order by with limit should not return rule', () => {
+  it('Order by with limit should not return rule', async () => {
     const soql = 'SELECT Id FROM AnObject__c ORDER BY AField__c LIMIT 1000';
 
-    const results = new SOQLLinter().lint(soql);
+    const results = await new SOQLLinter().lint(soql);
 
     expect(results).toEqual([]);
   });
@@ -152,7 +152,7 @@ describe('SOQL in Trigger Rule tests', () => {
     severity: 'Warning',
   };
 
-  it('soql in trigger should return rule', () => {
+  it('soql in trigger should return rule', async () => {
     const soql = 'SELECT Id FROM AnObject__c WHERE value__c > 0';
     const mockTriggerLine = new Method(
       [
@@ -169,15 +169,15 @@ describe('SOQL in Trigger Rule tests', () => {
     );
     mockTriggerLine.text = 'Account on Account trigger event AfterInsert';
 
-    const results = new SOQLLinter().lint(soql, [mockTriggerLine]);
+    const results = await new SOQLLinter().lint(soql, [mockTriggerLine]);
 
     expect(results).toEqual([triggerNonSelective]);
   });
 
-  it('soql outside trigger should not return rule', () => {
+  it('soql outside trigger should not return rule', async () => {
     const soql = 'SELECT Id FROM AnObject__c WHERE value__c > 0';
 
-    const results = new SOQLLinter().lint(soql);
+    const results = await new SOQLLinter().lint(soql);
 
     expect(results).toEqual([]);
   });

--- a/log-viewer/modules/components/SOQLLinterIssues.ts
+++ b/log-viewer/modules/components/SOQLLinterIssues.ts
@@ -45,12 +45,12 @@ export class SOQLLinterIssues extends LitElement {
     `,
   ];
 
-  updated(changedProperties: PropertyValues): void {
+  async updated(changedProperties: PropertyValues): Promise<void> {
     if (changedProperties.has('soql')) {
       const stack = DatabaseAccess.instance()?.getStack(this.timestamp).reverse() || [];
       const soqlLine = stack[0] as SOQLExecuteBeginLine;
       this.issues = this.getIssuesFromSOQLLine(soqlLine);
-      this.issues = this.issues.concat(new SOQLLinter().lint(this.soql, stack));
+      this.issues = this.issues.concat(await new SOQLLinter().lint(this.soql, stack));
       this.issues.sort((a, b) => {
         return SEVERITY_TYPES.indexOf(a.severity) - SEVERITY_TYPES.indexOf(b.severity);
       });

--- a/log-viewer/modules/soql/SOQLLinter.ts
+++ b/log-viewer/modules/soql/SOQLLinter.ts
@@ -6,10 +6,10 @@ import { SOQLParser, SOQLTree } from './SOQLParser.js';
 
 //todo : need a general concept of stack (to pull out linter)
 export class SOQLLinter {
-  lint(soql: string, stack?: Stack): SOQLLinterRule[] {
+  async lint(soql: string, stack?: Stack): Promise<SOQLLinterRule[]> {
     const results: SOQLLinterRule[] = [];
 
-    const tree = new SOQLParser().parse(soql);
+    const tree = await new SOQLParser().parse(soql);
     const rules = [
       new UnboundedSOQLRule(),
       new LeadingPercentWildcardRule(),

--- a/log-viewer/modules/soql/SOQLParser.ts
+++ b/log-viewer/modules/soql/SOQLParser.ts
@@ -1,19 +1,12 @@
 /*
  * Copyright (c) 2022 Certinia Inc. All rights reserved.
  */
+import { type QueryContext } from '@apexdevtools/apex-parser';
 import {
-  ApexLexer,
-  ApexParser,
-  CaseInsensitiveInputStream,
-  QueryContext,
-} from '@apexdevtools/apex-parser';
-import {
-  CharStreams,
-  CommonTokenStream,
-  RecognitionException,
-  Recognizer,
-  Token,
   type ANTLRErrorListener,
+  type RecognitionException,
+  type Recognizer,
+  type Token,
 } from 'antlr4ts';
 
 // To understand the parser AST see https://github.com/nawforce/apex-parser/blob/master/antlr/ApexParser.g4
@@ -77,7 +70,16 @@ export class SOQLTree {
 }
 
 export class SOQLParser {
-  parse(query: string): SOQLTree {
+  async parse(query: string): Promise<SOQLTree> {
+    // Dynamic import for code splitting. Improves performance by reducing the amount of JS that is loaded and parsed at the start.
+    // eslint-disable-next-line @typescript-eslint/naming-convention
+    const { ApexLexer, ApexParser, CaseInsensitiveInputStream } = await import(
+      '@apexdevtools/apex-parser'
+    );
+    // Dynamic import for code splitting. Improves performance by reducing the amount of JS that is loaded and parsed at the start.
+    // eslint-disable-next-line @typescript-eslint/naming-convention
+    const { CommonTokenStream, CharStreams } = await import('antlr4ts');
+
     const lexer = new ApexLexer(new CaseInsensitiveInputStream(CharStreams.fromString(query)));
     const tokens = new CommonTokenStream(lexer);
     const parser = new ApexParser(tokens);

--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -48,11 +48,12 @@ export default [
     ],
   },
   {
-    input: './log-viewer/modules/Main.ts',
+    input: { bundle: './log-viewer/modules/Main.ts' },
     output: [
       {
         format: 'es',
-        file: './log-viewer/out/bundle.js',
+        dir: './log-viewer/out',
+        chunkFileNames: '[name].js',
         sourcemap: false,
       },
     ],
@@ -79,6 +80,7 @@ export default [
             // swc's minify option here
             mangle: true,
             compress: true,
+            module: true,
           }),
         ),
       minifyHTML({


### PR DESCRIPTION
# Description

Splits som of the deps into separate js bundle files for faster load.
This comes in two parts. On the vscode extension side  and the log viewer side. 

1. @apexdevtools/apex-ls
2. @apexdevtools/apex-parser
3. antlr4ts

 @apexdevtools/apex-ls is only used when clicking on a link in the call tree to go to code, so can be loaded later.
 
 Initial load of the vscode extension is now ~6ms instead of ~100 ms. 
 This means the webview is shown sooner and everything feels faster.
 

## Type of change (check all applicable)

- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] ♻️ Refactor
- [X] ⚡ Performance Improvement
- [ ] 📝 Documentation
- [ ] 🔧 Chore
- [ ] 💥 Breaking change

## [optional] Any images / gifs / video

## Related Tickets & Documents

Related Issue #
fixes #
resolves #
closes #

## Added tests?

- [ ] 👍 yes
- [ ] 🙅 no, not needed
- [ ] 🙋 no, I need help

## Added to documentation?

- [ ] 🔖 README.md
- [ ] 🔖 CHANGELOG.md
- [ ] 📖 help site
- [ ] 🙅 not needed

## [optional] Are there any post-deployment tasks we need to perform?
