### PR TITLE
fix: find in files keybinding triggering search in log analyzer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- Fixed search being triggered by and hijacking the "Find in Files" keybinding (CMD / CTRL + SHIFT + f) ([#537][#537])
+
 ## [1.16.0] - 2024-07-23
 
 ### Added
@@ -350,6 +356,10 @@ Skipped due to adopting odd numbering for pre releases and even number for relea
 - Misc Visual tweaks
 - Add explorer menu item
 - Provide more information when selecting log to download
+
+<!-- Unreleased -->
+
+[#537]: https://github.com/certinia/debug-log-analyzer/issues/537
 
 <!-- v1.16.0 -->
 

--- a/log-viewer/modules/components/find-widget/FindWidget.ts
+++ b/log-viewer/modules/components/find-widget/FindWidget.ts
@@ -18,16 +18,13 @@ export class FindWidget extends LitElement {
 
   lastMatch: string | null = null;
   nextMatchDirection = true;
-  debounce: ReturnType<typeof setTimeout> | null = null;
 
   constructor() {
     super();
-    document.addEventListener('keydown', (e: KeyboardEvent) => {
-      this.debounce && clearTimeout(this.debounce);
-      this.debounce = setTimeout(() => {
-        this._keyPress(e);
-      }, 20);
+    window.addEventListener('keydown', (e: KeyboardEvent) => {
+      this._keyPress(e);
     });
+
     document.addEventListener('lv-find-results', ((
       e: CustomEvent<{ totalMatches: number; count?: number }>,
     ) => {
@@ -243,7 +240,11 @@ export class FindWidget extends LitElement {
   }
 
   _keyPress(e: KeyboardEvent) {
-    if (e.key === 'f' && (e.metaKey || e.ctrlKey)) {
+    if (e.repeat) {
+      return;
+    }
+
+    if (e.key === 'f' && (e.metaKey || e.ctrlKey) && !e.shiftKey) {
       e.preventDefault();
 
       !this.isVisble && !this.totalMatches && this._triggerFind();


### PR DESCRIPTION


# Description
Fixes  find in files keybinding triggering search in log analyzer

When the log analyzer webview had focus this hijacked the find in files vscode search and focused the analyzer search.

- [X] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] ♻️ Refactor
- [ ] ⚡ Performance Improvement
- [ ] 📝 Documentation
- [ ] 🔧 Chore
- [ ] 💥 Breaking change

## [optional] Any images / gifs / video

## Related Tickets & Documents

Related Issue #
fixes #537 
resolves #
closes #

## Added tests?

- [ ] 👍 yes
- [X] 🙅 no, not needed
- [ ] 🙋 no, I need help

## Added to documentation?

- [ ] 🔖 README.md
- [X] 🔖 CHANGELOG.md
- [ ] 📖 help site
- [ ] 🙅 not needed

## [optional] Are there any post-deployment tasks we need to perform?
