### PR TITLE
fix: analysis total time overstated - show max time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Fixed search being triggered by and hijacking the "Find in Files" keybinding (CMD / CTRL + SHIFT + f) ([#537][#537])
+- Analysis: Total Time showing a higher value than it should ([#526][#526])
 
 ## [1.16.0] - 2024-07-23
 
@@ -360,6 +361,7 @@ Skipped due to adopting odd numbering for pre releases and even number for relea
 <!-- Unreleased -->
 
 [#537]: https://github.com/certinia/debug-log-analyzer/issues/537
+[#526]: https://github.com/certinia/debug-log-analyzer/issues/526
 
 <!-- v1.16.0 -->
 

--- a/data/fflib.log
+++ b/data/fflib.log
@@ -1767,6 +1767,7 @@ Execute Anonymous: insert accs2;
 04:16:47.550 (10362229050)|SOQL_EXECUTE_BEGIN|[76]|Aggregations:0|SELECT Id, Name FROM Account WHERE Name != 'An Account' ORDER BY Name
 04:16:47.550 (10362229050)|SOQL_EXECUTE_EXPLAIN|[76]|TableScan on Account : [], cardinality: 2001, sobjectCardinality: 2001, relativeCost 2.834
 04:16:48.550 (11362229050)|SOQL_EXECUTE_END|[76]|Rows:2951
+04:16:48.375 (11362229150)|FATAL_ERROR|System.LimitException: Apex CPU time limit exceeded
 
 04:16:48.362 (11375731384)|CUMULATIVE_LIMIT_USAGE
 04:16:48.362 (11375731384)|LIMIT_USAGE_FOR_NS|(default)|

--- a/log-viewer/modules/components/AnalysisView.ts
+++ b/log-viewer/modules/components/AnalysisView.ts
@@ -322,7 +322,7 @@ async function renderAnalysis(rootMethod: ApexLog) {
         },
         accessorDownload: NumberAccessor,
         bottomCalcFormatter: progressFormatter,
-        bottomCalc: 'sum',
+        bottomCalc: 'max',
         bottomCalcFormatterParams: { precision: 3, totalValue: rootMethod.duration.total },
       },
       {


### PR DESCRIPTION
# Description

Changes the TotalTime column to show max time. 

This is more accurate but will not show an accurate number until we change the logic to sum unique paths in the stack.
Filtering could easily break this. 

For example filter by namespace and now the only two methods in the analysis are siblings 
Method 1 in pkg1 calls to Method2 and Method 3 in pkg2
Filter by pkg2 and both Method2 and Method3 should be included in the total with this change only the largest will be.
There will be a follow fix to be accurate

## Type of change (check all applicable)

- [X] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] ♻️ Refactor
- [ ] ⚡ Performance Improvement
- [ ] 📝 Documentation
- [ ] 🔧 Chore
- [ ] 💥 Breaking change

## [optional] Any images / gifs / video

## Related Tickets & Documents

Related Issue #526
fixes #
resolves #
closes #

## Added tests?

- [ ] 👍 yes
- [X] 🙅 no, not needed
- [ ] 🙋 no, I need help

## Added to documentation?

- [ ] 🔖 README.md
- [X] 🔖 CHANGELOG.md
- [ ] 📖 help site
- [ ] 🙅 not needed

## [optional] Are there any post-deployment tasks we need to perform?
