### PR TITLE
perf: speed up regex searching for EXECUTION_STARTED line

### DIFF
--- a/log-viewer/modules/parsers/ApexLogParser.ts
+++ b/log-viewer/modules/parsers/ApexLogParser.ts
@@ -153,45 +153,6 @@ export class ApexLogParser {
     }
   }
 
-  // private *generateLogLines(log: string): Generator<LogLine> {
-  //   const start = log.match(/^.*EXECUTION_STARTED.*$/m)?.index ?? 0;
-  //   if (start > 0) {
-  //     log = log.slice(start).replaceAll('\r\n', '\n');
-  //   }
-
-  //   // const hascrlf = log.indexOf('\r\n') > -1;
-  //   let lastEntry = null;
-  //   let lfIndex = null;
-  //   let eolIndex = (lfIndex = log.indexOf('\n'));
-  //   let startIndex = 0;
-  //   // let crlfIndex = -1;
-
-  //   while (eolIndex !== -1) {
-  //     const line = log.slice(startIndex, eolIndex);
-  //     if (line) {
-  //       // ignore blank lines
-  //       const entry = this.parseLine(line, lastEntry);
-  //       if (entry) {
-  //         lastEntry = entry;
-  //         yield entry;
-  //       }
-  //     }
-  //     startIndex = lfIndex + 1;
-  //     lfIndex = eolIndex = log.indexOf('\n', startIndex);
-  //   }
-
-  //   // Parse the last line
-  //   const line = log.slice(startIndex, log.length);
-  //   if (line) {
-  //     // ignore blank lines
-  //     const entry = this.parseLine(line, lastEntry);
-  //     if (entry) {
-  //       entry?.onAfter?.(this);
-  //       yield entry;
-  //     }
-  //   }
-  // }
-
   private toLogTree(lineGenerator: Generator<LogLine>) {
     const rootMethod = new ApexLog(this),
       stack: Method[] = [];

--- a/log-viewer/modules/parsers/ApexLogParser.ts
+++ b/log-viewer/modules/parsers/ApexLogParser.ts
@@ -111,8 +111,8 @@ export class ApexLogParser {
   }
 
   private *generateLogLines(log: string): Generator<LogLine> {
-    const start = log.match(/^.*EXECUTION_STARTED.*$/m)?.index ?? 0;
-    if (start > 0) {
+    const start = log.search(/^\d{2}:\d{2}:\d{2}.\d{1} \(\d+\)\|EXECUTION_STARTED$/m);
+    if (start > -1) {
       log = log.slice(start);
     }
 
@@ -152,6 +152,45 @@ export class ApexLogParser {
       }
     }
   }
+
+  // private *generateLogLines(log: string): Generator<LogLine> {
+  //   const start = log.match(/^.*EXECUTION_STARTED.*$/m)?.index ?? 0;
+  //   if (start > 0) {
+  //     log = log.slice(start).replaceAll('\r\n', '\n');
+  //   }
+
+  //   // const hascrlf = log.indexOf('\r\n') > -1;
+  //   let lastEntry = null;
+  //   let lfIndex = null;
+  //   let eolIndex = (lfIndex = log.indexOf('\n'));
+  //   let startIndex = 0;
+  //   // let crlfIndex = -1;
+
+  //   while (eolIndex !== -1) {
+  //     const line = log.slice(startIndex, eolIndex);
+  //     if (line) {
+  //       // ignore blank lines
+  //       const entry = this.parseLine(line, lastEntry);
+  //       if (entry) {
+  //         lastEntry = entry;
+  //         yield entry;
+  //       }
+  //     }
+  //     startIndex = lfIndex + 1;
+  //     lfIndex = eolIndex = log.indexOf('\n', startIndex);
+  //   }
+
+  //   // Parse the last line
+  //   const line = log.slice(startIndex, log.length);
+  //   if (line) {
+  //     // ignore blank lines
+  //     const entry = this.parseLine(line, lastEntry);
+  //     if (entry) {
+  //       entry?.onAfter?.(this);
+  //       yield entry;
+  //     }
+  //   }
+  // }
 
   private toLogTree(lineGenerator: Generator<LogLine>) {
     const rootMethod = new ApexLog(this),


### PR DESCRIPTION
# Description
Speeds up regex searching for EXECUTION_STARTED line by 668% (7.68X) faster

Mainly faster in the case when the log has no `EXECUTION_STARTED` line

Roughly the same time when `EXECUTION_STARTED` is near the start.
When no EXECUTION_STARTED is in the log perf is ~22ms vs ~169ms for a 72MB log.

## Type of change (check all applicable)

- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] ♻️ Refactor
- [X] ⚡ Performance Improvement
- [ ] 📝 Documentation
- [ ] 🔧 Chore
- [ ] 💥 Breaking change

## [optional] Any images / gifs / video

## Related Tickets & Documents

Related Issue #
fixes #
resolves #
closes #

## Added tests?

- [ ] 👍 yes
- [ ] 🙅 no, not needed
- [X] 🙋 no, I need help

## Added to documentation?

- [ ] 🔖 README.md
- [ ] 🔖 CHANGELOG.md
- [ ] 📖 help site
- [X] 🙅 not needed

## [optional] Are there any post-deployment tasks we need to perform?
