### PR TITLE
fix: analysis total time overstated

### DIFF
--- a/log-viewer/modules/components/AnalysisView.ts
+++ b/log-viewer/modules/components/AnalysisView.ts
@@ -16,7 +16,7 @@ import NumberAccessor from '../datagrid/dataaccessor/Number.js';
 import { progressFormatter } from '../datagrid/format/Progress.js';
 import { RowKeyboardNavigation } from '../datagrid/module/RowKeyboardNavigation.js';
 import dataGridStyles from '../datagrid/style/DataGrid.scss';
-import { ApexLog, TimedNode } from '../parsers/ApexLogParser.js';
+import { ApexLog, LogLine } from '../parsers/ApexLogParser.js';
 import { vscodeMessenger } from '../services/VSCodeExtensionMessenger.js';
 import { globalStyles } from '../styles/global.styles.js';
 import './skeleton/GridSkeleton.js';
@@ -189,10 +189,7 @@ export class AnalysisView extends LitElement {
     if (!this.tableContainer) {
       return;
     }
-    const methodMap: Map<string, Metric> = new Map();
-
-    addNodeToMap(methodMap, rootMethod);
-    const metricList = Array.from(methodMap.values());
+    const metricList = groupMetrics(rootMethod);
 
     const headerMenu = [
       {
@@ -378,20 +375,29 @@ export class Metric {
   totalTime = 0;
   selfTime = 0;
   namespace;
-  nodes: TimedNode[] = [];
+  nodes: LogLine[] = [];
 
-  constructor(node: TimedNode) {
+  constructor(node: LogLine) {
     this.name = node.text;
     this.type = node.type;
     this.namespace = node.namespace;
-    this.nodes.push(node);
   }
 }
 
-function addNodeToMap(map: Map<string, Metric>, node: TimedNode, key?: string) {
-  const children = node.children;
+function groupMetrics(root: LogLine) {
+  const methodMap: Map<string, Metric> = new Map();
 
-  if (key) {
+  for (const child of root.children) {
+    if (child.duration.total) {
+      addNodeToMap(methodMap, child);
+    }
+  }
+  return Array.from(methodMap.values());
+}
+
+function addNodeToMap(map: Map<string, Metric>, node: LogLine) {
+  if (node.duration.total) {
+    const key = node.namespace + node.text;
     let metric = map.get(key);
     if (!metric) {
       metric = new Metric(node);
@@ -404,11 +410,11 @@ function addNodeToMap(map: Map<string, Metric>, node: TimedNode, key?: string) {
     metric.nodes.push(node);
   }
 
-  children.forEach(function (child) {
-    if (child instanceof TimedNode) {
-      addNodeToMap(map, child, child.namespace + child.text);
+  for (const child of node.children) {
+    if (child.duration.total) {
+      addNodeToMap(map, child);
     }
-  });
+  }
 }
 
 type VSCodeSaveFile = {

--- a/log-viewer/modules/components/AnalysisView.ts
+++ b/log-viewer/modules/components/AnalysisView.ts
@@ -21,6 +21,7 @@ import { vscodeMessenger } from '../services/VSCodeExtensionMessenger.js';
 import { globalStyles } from '../styles/global.styles.js';
 import './skeleton/GridSkeleton.js';
 
+import { callStackSum } from '../components/analysis-view/column-calcs/CallStackSum.js';
 import { Find, formatter } from '../components/calltree-view/module/Find.js';
 import { RowNavigation } from '../datagrid/module/RowNavigation.js';
 
@@ -191,7 +192,7 @@ export class AnalysisView extends LitElement {
     const methodMap: Map<string, Metric> = new Map();
 
     addNodeToMap(methodMap, rootMethod);
-    const metricList = [...methodMap.values()];
+    const metricList = Array.from(methodMap.values());
 
     const headerMenu = [
       {
@@ -328,7 +329,7 @@ export class AnalysisView extends LitElement {
           },
           accessorDownload: NumberAccessor,
           bottomCalcFormatter: progressFormatter,
-          bottomCalc: 'max',
+          bottomCalc: callStackSum,
           bottomCalcFormatterParams: { precision: 3, totalValue: rootMethod.duration.total },
         },
         {
@@ -377,11 +378,13 @@ export class Metric {
   totalTime = 0;
   selfTime = 0;
   namespace;
+  nodes: TimedNode[] = [];
 
   constructor(node: TimedNode) {
     this.name = node.text;
     this.type = node.type;
     this.namespace = node.namespace;
+    this.nodes.push(node);
   }
 }
 
@@ -398,6 +401,7 @@ function addNodeToMap(map: Map<string, Metric>, node: TimedNode, key?: string) {
     ++metric.count;
     metric.totalTime += node.duration.total;
     metric.selfTime += node.duration.self;
+    metric.nodes.push(node);
   }
 
   children.forEach(function (child) {

--- a/log-viewer/modules/components/analysis-view/column-calcs/CallStackSum.ts
+++ b/log-viewer/modules/components/analysis-view/column-calcs/CallStackSum.ts
@@ -1,46 +1,31 @@
-import type { LogLine, TimedNode } from '../../../parsers/ApexLogParser';
+import type { LogLine } from '../../../parsers/ApexLogParser';
 import { type Metric } from '../../AnalysisView.js';
 
-export function callStackSum(values: number[], data: Metric[], _calcParams: unknown) {
-  // All filtered debug logs nodes
-  const includedNodes = new Set<TimedNode>();
-  data.forEach((row) => {
-    row.nodes.forEach((node) => {
-      includedNodes.add(node);
-    });
-  });
+export function callStackSum(_values: number[], data: Metric[], _calcParams: unknown) {
+  const nodes: LogLine[] = [];
+  for (const row of data) {
+    Array.prototype.push.apply(nodes, row.nodes);
+  }
+  const allNodes = new Set<LogLine>(nodes);
 
   let total = 0;
-  data.forEach((row, i) => {
-    // All the parents (to root) of the log nodes for this row.
-    const parents = _getParentNodes(row.nodes);
-    // If any of these parent are else where in the (filtered) stacks do not include in the sum.
-    // This value will be included when the parent is summed e.g m1 -> m2 -> m3 (no need to include m2 + m3)
-    if (!_containsAny(parents, includedNodes)) {
-      total += values[i] ?? 0;
+  for (const node of nodes) {
+    if (!_isChildOfOther(node, allNodes)) {
+      total += node.duration.total;
     }
-  });
+  }
 
   return total;
 }
 
-const _getParentNodes = (nodes: TimedNode[]) => {
-  const parents = new Set<LogLine>();
-  nodes.forEach((node) => {
-    let parent = node.parent;
-    while (parent && !parents.has(parent)) {
-      parents.add(parent);
-      parent = parent.parent;
-    }
-  });
-  return parents;
-};
-
-const _containsAny = (target: Set<LogLine>, toCheck: Set<LogLine>) => {
-  for (const t of target) {
-    if (toCheck.has(t)) {
+function _isChildOfOther(node: LogLine, filteredNodes: Set<LogLine>) {
+  let parent = node.parent;
+  while (parent) {
+    if (filteredNodes.has(parent)) {
       return true;
     }
+    parent = parent.parent;
   }
+
   return false;
-};
+}

--- a/log-viewer/modules/components/analysis-view/column-calcs/CallStackSum.ts
+++ b/log-viewer/modules/components/analysis-view/column-calcs/CallStackSum.ts
@@ -1,0 +1,46 @@
+import type { LogLine, TimedNode } from '../../../parsers/ApexLogParser';
+import { type Metric } from '../../AnalysisView.js';
+
+export function callStackSum(values: number[], data: Metric[], _calcParams: unknown) {
+  // All filtered debug logs nodes
+  const includedNodes = new Set<TimedNode>();
+  data.forEach((row) => {
+    row.nodes.forEach((node) => {
+      includedNodes.add(node);
+    });
+  });
+
+  let total = 0;
+  data.forEach((row, i) => {
+    // All the parents (to root) of the log nodes for this row.
+    const parents = _getParentNodes(row.nodes);
+    // If any of these parent are else where in the (filtered) stacks do not include in the sum.
+    // This value will be included when the parent is summed e.g m1 -> m2 -> m3 (no need to include m2 + m3)
+    if (!_containsAny(parents, includedNodes)) {
+      total += values[i] ?? 0;
+    }
+  });
+
+  return total;
+}
+
+const _getParentNodes = (nodes: TimedNode[]) => {
+  const parents = new Set<LogLine>();
+  nodes.forEach((node) => {
+    let parent = node.parent;
+    while (parent && !parents.has(parent)) {
+      parents.add(parent);
+      parent = parent.parent;
+    }
+  });
+  return parents;
+};
+
+const _containsAny = (target: Set<LogLine>, toCheck: Set<LogLine>) => {
+  for (const t of target) {
+    if (toCheck.has(t)) {
+      return true;
+    }
+  }
+  return false;
+};

--- a/log-viewer/modules/parsers/ApexLogParser.ts
+++ b/log-viewer/modules/parsers/ApexLogParser.ts
@@ -164,6 +164,7 @@ export class ApexLogParser {
       if (line instanceof Method) {
         this.parseTree(line, lineIter, stack);
       }
+      line.parent = rootMethod;
       rootMethod.addChild(line);
     }
     rootMethod.setTimes();
@@ -225,6 +226,7 @@ export class ApexLogParser {
           this.parseTree(nextLine, lineIter, stack);
         }
 
+        nextLine.parent = currentLine;
         currentLine.children.push(nextLine);
       }
 
@@ -486,6 +488,8 @@ export abstract class LogLine {
   logParser: ApexLogParser;
 
   // common metadata (available for all lines)
+
+  parent: LogLine | null = null;
 
   /**
    * All child nodes of the current node


### PR DESCRIPTION
# Description

analysis total time sum unique stacks

Collect the stacks and only sum the unique entries e.g
If we have an analysis like this

methodA: 5s
methodB: 3s
methodC: 2s

Sibling Methods
The three methods are at the same level directly called from EXECUTION_STARTED.
All 3 should be summed as they are in different stacks.

Total: 10s

Child Methods

methodB is a child of methodA and methodC is a sibling of methodA.
we first add methodA to the total but the total for methodB has already been accounted by including methodA so we skip it and any other children of methodA.
methodC is in a unique stack and needs to be added to the total.

Total: 7s

## Type of change (check all applicable)

- [X] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] ♻️ Refactor
- [ ] ⚡ Performance Improvement
- [ ] 📝 Documentation
- [ ] 🔧 Chore
- [ ] 💥 Breaking change

## [optional] Any images / gifs / video

## Related Tickets & Documents

Related Issue #
fixes #526 
resolves #
closes #

## Added tests?

- [X] 👍 yes
- [ ] 🙅 no, not needed
- [ ] 🙋 no, I need help

## Added to documentation?

- [ ] 🔖 README.md
- [X] 🔖 CHANGELOG.md
- [ ] 📖 help site
- [ ] 🙅 not needed

## [optional] Are there any post-deployment tasks we need to perform?
