### PR TITLE
perf: delays some of the rendering of tab content until tab switch

### DIFF
--- a/log-viewer/modules/Util.ts
+++ b/log-viewer/modules/Util.ts
@@ -22,3 +22,22 @@ export function debounce<T extends unknown[]>(callBack: (...args: T) => unknown)
     });
   };
 }
+
+export async function isVisible(
+  element: HTMLElement,
+  options?: IntersectionObserverInit,
+): Promise<boolean> {
+  return new Promise<boolean>((resolve) => {
+    const observer = new IntersectionObserver((entries, observerInstance) => {
+      for (const entry of entries) {
+        if (entry.isIntersecting) {
+          resolve(true);
+          observerInstance.disconnect();
+          return;
+        }
+      }
+    }, options);
+
+    observer.observe(element);
+  });
+}

--- a/log-viewer/modules/components/AppHeader.ts
+++ b/log-viewer/modules/components/AppHeader.ts
@@ -14,12 +14,12 @@ import codiconStyles from '../styles/codicon.css';
 import { globalStyles } from '../styles/global.styles.js';
 import { ApexLog, type TimelineGroup } from '../timeline/Timeline.js';
 import '../timeline/TimelineView.js';
-import './AnalysisView.js';
-import './LogLevels.js';
-import './NavBar.js';
+import './analysis-view/AnalysisView.js';
 import './calltree-view/CalltreeView';
 import './database-view/DatabaseView.js';
 import './find-widget/FindWidget.js';
+import './LogLevels.js';
+import './NavBar.js';
 import { Notification } from './notifications/NotificationPanel.js';
 
 provideVSCodeDesignSystem().register(vsCodePanelTab(), vsCodePanelView(), vsCodePanels());

--- a/log-viewer/modules/components/analysis-view/AnalysisView.ts
+++ b/log-viewer/modules/components/analysis-view/AnalysisView.ts
@@ -91,7 +91,11 @@ export class AnalysisView extends LitElement {
   }
 
   updated(changedProperties: PropertyValues): void {
-    if (this.timelineRoot && !changedProperties.get('timelineRoot')) {
+    if (
+      this.timelineRoot &&
+      changedProperties.has('timelineRoot') &&
+      !changedProperties.get('timelineRoot')
+    ) {
       this._appendTableWhenVisible();
     }
   }
@@ -131,6 +135,10 @@ export class AnalysisView extends LitElement {
   }
 
   _appendTableWhenVisible() {
+    if (this.analysisTable) {
+      return;
+    }
+
     isVisible(this).then((isVisible) => {
       if (this.timelineRoot && isVisible) {
         this._renderAnalysis(this.timelineRoot);

--- a/log-viewer/modules/components/analysis-view/AnalysisView.ts
+++ b/log-viewer/modules/components/analysis-view/AnalysisView.ts
@@ -10,56 +10,28 @@ import {
 import { LitElement, css, html, unsafeCSS, type PropertyValues } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
 import { Tabulator, type ColumnComponent, type RowComponent } from 'tabulator-tables';
-import * as CommonModules from '../datagrid/module/CommonModules.js';
+import * as CommonModules from '../../datagrid/module/CommonModules.js';
 
-import NumberAccessor from '../datagrid/dataaccessor/Number.js';
-import { progressFormatter } from '../datagrid/format/Progress.js';
-import { RowKeyboardNavigation } from '../datagrid/module/RowKeyboardNavigation.js';
-import dataGridStyles from '../datagrid/style/DataGrid.scss';
-import { ApexLog, LogLine } from '../parsers/ApexLogParser.js';
-import { vscodeMessenger } from '../services/VSCodeExtensionMessenger.js';
-import { globalStyles } from '../styles/global.styles.js';
-import './skeleton/GridSkeleton.js';
+import NumberAccessor from '../../datagrid/dataaccessor/Number.js';
+import { progressFormatter } from '../../datagrid/format/Progress.js';
+import { RowKeyboardNavigation } from '../../datagrid/module/RowKeyboardNavigation.js';
+import dataGridStyles from '../../datagrid/style/DataGrid.scss';
+import { ApexLog, LogLine } from '../../parsers/ApexLogParser.js';
+import { vscodeMessenger } from '../../services/VSCodeExtensionMessenger.js';
+import { globalStyles } from '../../styles/global.styles.js';
+import { isVisible } from '../../Util.js';
 
-import { callStackSum } from '../components/analysis-view/column-calcs/CallStackSum.js';
-import { Find, formatter } from '../components/calltree-view/module/Find.js';
-import { RowNavigation } from '../datagrid/module/RowNavigation.js';
+import { RowNavigation } from '../../datagrid/module/RowNavigation.js';
+import { Find, formatter } from '../calltree-view/module/Find.js';
+import { callStackSum } from './column-calcs/CallStackSum.js';
+
+// Components
+import '../skeleton/GridSkeleton.js';
 
 provideVSCodeDesignSystem().register(vsCodeCheckbox(), vsCodeDropdown(), vsCodeOption());
 
 @customElement('analysis-view')
 export class AnalysisView extends LitElement {
-  @property()
-  timelineRoot: ApexLog | null = null;
-
-  analysisTable: Tabulator | null = null;
-  tableContainer: HTMLDivElement | null = null;
-  findMap: { [key: number]: RowComponent } = {};
-  findArgs: { text: string; count: number; options: { matchCase: boolean } } = {
-    text: '',
-    count: 0,
-    options: { matchCase: false },
-  };
-  totalMatches = 0;
-
-  get _tableWrapper(): HTMLDivElement | null {
-    return (this.tableContainer = this.renderRoot?.querySelector('#analysis-table') ?? null);
-  }
-
-  constructor() {
-    super();
-
-    document.addEventListener('lv-find', this._findEvt);
-    document.addEventListener('lv-find-match', this._findEvt);
-    document.addEventListener('lv-find-close', this._findEvt);
-  }
-
-  updated(changedProperties: PropertyValues): void {
-    if (this.timelineRoot && changedProperties.has('timelineRoot')) {
-      this._appendTableWhenVisible();
-    }
-  }
-
   static styles = [
     unsafeCSS(dataGridStyles),
     globalStyles,
@@ -97,6 +69,33 @@ export class AnalysisView extends LitElement {
     `,
   ];
 
+  @property()
+  timelineRoot: ApexLog | null = null;
+
+  analysisTable: Tabulator | null = null;
+  tableContainer: HTMLDivElement | null = null;
+  findMap: { [key: number]: RowComponent } = {};
+  findArgs: { text: string; count: number; options: { matchCase: boolean } } = {
+    text: '',
+    count: 0,
+    options: { matchCase: false },
+  };
+  totalMatches = 0;
+
+  constructor() {
+    super();
+
+    document.addEventListener('lv-find', this._findEvt);
+    document.addEventListener('lv-find-match', this._findEvt);
+    document.addEventListener('lv-find-close', this._findEvt);
+  }
+
+  updated(changedProperties: PropertyValues): void {
+    if (this.timelineRoot && !changedProperties.get('timelineRoot')) {
+      this._appendTableWhenVisible();
+    }
+  }
+
   render() {
     const skeleton = !this.timelineRoot ? html`<grid-skeleton></grid-skeleton>` : '';
 
@@ -118,6 +117,10 @@ export class AnalysisView extends LitElement {
     `;
   }
 
+  get _tableWrapper(): HTMLDivElement | null | undefined {
+    return (this.tableContainer ??= this.renderRoot?.querySelector('#analysis-table'));
+  }
+
   _findEvt = ((event: FindEvt) => this._find(event)) as EventListener;
 
   _groupBy(event: Event) {
@@ -128,18 +131,11 @@ export class AnalysisView extends LitElement {
   }
 
   _appendTableWhenVisible() {
-    const rootMethod = this.timelineRoot;
-    const tableWrapper = this._tableWrapper;
-    if (tableWrapper && rootMethod) {
-      const analysisObserver = new IntersectionObserver((entries, observer) => {
-        const visible = entries[0]?.isIntersecting;
-        if (visible) {
-          this._renderAnalysis(rootMethod);
-          observer.disconnect();
-        }
-      });
-      analysisObserver.observe(tableWrapper);
-    }
+    isVisible(this).then((isVisible) => {
+      if (this.timelineRoot && isVisible) {
+        this._renderAnalysis(this.timelineRoot);
+      }
+    });
   }
 
   _find(e: CustomEvent<{ text: string; count: number; options: { matchCase: boolean } }>) {
@@ -186,7 +182,7 @@ export class AnalysisView extends LitElement {
   }
 
   async _renderAnalysis(rootMethod: ApexLog) {
-    if (!this.tableContainer) {
+    if (!this._tableWrapper) {
       return;
     }
     const metricList = groupMetrics(rootMethod);
@@ -202,7 +198,7 @@ export class AnalysisView extends LitElement {
 
     Tabulator.registerModule(Object.values(CommonModules));
     Tabulator.registerModule([RowKeyboardNavigation, RowNavigation, Find]);
-    this.analysisTable = new Tabulator(this.tableContainer, {
+    this.analysisTable = new Tabulator(this._tableWrapper, {
       rowKeyboardNavigation: true,
       selectableRows: 1,
       data: metricList,

--- a/log-viewer/modules/components/analysis-view/column-calcs/CallStackSum.ts
+++ b/log-viewer/modules/components/analysis-view/column-calcs/CallStackSum.ts
@@ -1,5 +1,5 @@
 import type { LogLine } from '../../../parsers/ApexLogParser';
-import { type Metric } from '../../AnalysisView.js';
+import { type Metric } from '../AnalysisView.js';
 
 export function callStackSum(_values: number[], data: Metric[], _calcParams: unknown) {
   const nodes: LogLine[] = [];


### PR DESCRIPTION
# Description

perf: delays some of the rendering of tab content until tab switch.
This is to improve performance of timeline render.

## Type of change (check all applicable)

- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] ♻️ Refactor
- [X] ⚡ Performance Improvement
- [ ] 📝 Documentation
- [ ] 🔧 Chore
- [ ] 💥 Breaking change

## [optional] Any images / gifs / video

## Related Tickets & Documents

resolves #553
Related Issue #
fixes #
closes #

## Added tests?

- [ ] 👍 yes
- [X] 🙅 no, not needed
- [ ] 🙋 no, I need help

## Added to documentation?

- [ ] 🔖 README.md
- [ ] 🔖 CHANGELOG.md
- [ ] 📖 help site
- [ ] 🙅 not needed

## [optional] Are there any post-deployment tasks we need to perform?
