### PR TITLE
bug(perf): regression in call tree render performance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Highlight and copy text to clipboard: Call Tree, Analysis and Database views ([#504][#504])
   - Previously the highlighted text would be immediately cleared
 
+### Fixed
+
+- Performance regression of Call Tree rendering ([#581][#581])
+- Call Tree not correctly keeping position when rows where hidden / shown via Details and Debug Only ([#581][#581])
+
 ## [1.16.1] - 2024-12-03
 
 ### Fixed
@@ -369,6 +374,7 @@ Skipped due to adopting odd numbering for pre releases and even number for relea
 <!-- Unreleased -->
 
 [#504]: https://github.com/certinia/debug-log-analyzer/issues/504
+[#581]: https://github.com/certinia/debug-log-analyzer/issues/581
 
 <!-- 1.16.1 -->
 

--- a/log-viewer/modules/components/calltree-view/CalltreeView.ts
+++ b/log-viewer/modules/components/calltree-view/CalltreeView.ts
@@ -571,9 +571,7 @@ export class CalltreeView extends LitElement {
           }
         },
         rowFormatter: (row: RowComponent) => {
-          requestAnimationFrame(() => {
-            formatter(row, this.findArgs);
-          });
+          formatter(row, this.findArgs);
         },
         columnCalcs: 'both',
         columnDefaults: {

--- a/log-viewer/modules/components/calltree-view/module/Find.ts
+++ b/log-viewer/modules/components/calltree-view/module/Find.ts
@@ -157,25 +157,27 @@ export class Find extends Module {
 }
 
 export function formatter(row: RowComponent, findArgs: FindArgs) {
-  if (!findArgs.text || !row.getData()) {
+  const { text, count } = findArgs;
+  if (!text || !count || !row.getData()) {
     return;
   }
+  requestAnimationFrame(() => {
+    const data = row.getData();
+    const highlights = {
+      indexes: data.highlightIndexes,
+      currentMatch: 0,
+    };
 
-  const data = row.getData();
-  const highlights = {
-    indexes: data.highlightIndexes,
-    currentMatch: 0,
-  };
+    row.getCells().forEach((cell) => {
+      const cellElem = cell.getElement();
+      _highlightText(cellElem, findArgs, highlights);
+    });
 
-  row.getCells().forEach((cell) => {
-    const cellElem = cell.getElement();
-    _highlightText(cellElem, findArgs, highlights);
+    //@ts-expect-error This is private to tabulator, but we have no other choice atm.
+    if (row._getSelf().type === 'row') {
+      row.normalizeHeight();
+    }
   });
-
-  //@ts-expect-error This is private to tabulator, but we have no other choice atm.
-  if (row._getSelf().type === 'row') {
-    row.normalizeHeight();
-  }
 }
 
 function _highlightText(

--- a/log-viewer/modules/components/calltree-view/module/MiddleRowFocus.ts
+++ b/log-viewer/modules/components/calltree-view/module/MiddleRowFocus.ts
@@ -16,7 +16,7 @@ const middleRowFocusOption = 'middleRowFocus' as const;
 export class MiddleRowFocus extends Module {
   static moduleName = 'middleRowFocus';
 
-  goToRowId: number = 0;
+  middleRow: RowComponent | null = null;
   constructor(table: Tabulator) {
     super(table);
     this.registerTableOption(middleRowFocusOption, false);
@@ -26,35 +26,36 @@ export class MiddleRowFocus extends Module {
     // @ts-expect-error not in types
     if (this.options(middleRowFocusOption)) {
       this.table.on('dataTreeRowExpanded', () => {
-        window.clearTimeout(this.goToRowId);
-        middleRow = null;
+        this._clearFocusRow();
       });
 
       this.table.on('dataTreeRowCollapsed', () => {
-        window.clearTimeout(this.goToRowId);
-        middleRow = null;
+        this._clearFocusRow();
       });
 
-      let middleRow: RowComponent | null;
       this.table.on('renderStarted', () => {
-        if (this.table && !middleRow) {
-          middleRow = this._findMiddleVisibleRow(this.table);
+        if (this.table && !this.middleRow) {
+          this.middleRow = this._findMiddleVisibleRow(this.table);
         }
       });
 
       this.table.on('renderComplete', async () => {
-        const rowToScrollTo = middleRow;
-        this.goToRowId = this._scrollToRow(rowToScrollTo);
-        middleRow = null;
+        const rowToScrollTo = this.middleRow;
+        this._scrollToRow(rowToScrollTo);
+        this.middleRow = null;
       });
     }
   }
 
-  private _scrollToRow(row: RowComponent | null): number {
+  private _clearFocusRow() {
+    this.middleRow = null;
+  }
+
+  private _scrollToRow(row: RowComponent | null) {
     if (!row) {
-      return 0;
+      return;
     }
-    return window.setTimeout(() => {
+    const timeoutId = window.setTimeout(() => {
       let rowToScrollTo: RowComponent | null = row;
       if (rowToScrollTo) {
         //@ts-expect-error This is private to tabulator, but we have no other choice atm.
@@ -78,6 +79,8 @@ export class MiddleRowFocus extends Module {
           });
         }
       }
+
+      window.clearTimeout(timeoutId);
     });
   }
 

--- a/log-viewer/modules/components/database-view/DMLView.ts
+++ b/log-viewer/modules/components/database-view/DMLView.ts
@@ -338,9 +338,7 @@ export class DMLView extends LitElement {
           row.normalizeHeight();
         }
 
-        requestAnimationFrame(() => {
-          formatter(row, this.findArgs);
-        });
+        formatter(row, this.findArgs);
       },
     });
 

--- a/log-viewer/modules/components/database-view/SOQLView.ts
+++ b/log-viewer/modules/components/database-view/SOQLView.ts
@@ -477,9 +477,7 @@ export class SOQLView extends LitElement {
           row.normalizeHeight();
         }
 
-        requestAnimationFrame(() => {
-          formatter(row, this.findArgs);
-        });
+        formatter(row, this.findArgs);
       },
     });
 


### PR DESCRIPTION
# Description

- Fix a regression in the render performance of the call tree
- The find formatter applied to each row was always executing after each animation frame via `requestAnimationFrame` (RAF) regardless of whether there could possibly be any text to highlight (no search had been done), this is now skipped unless needed.
- The `MiddleRowFocus` was always adding `setTimeout` to the task queue event if there was no row to focus on, this is now skipped unless needed.

## TODO

- [x] Update changelog

## Type of change (check all applicable)

- [X] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] ♻️ Refactor
- [X] ⚡ Performance Improvement
- [ ] 📝 Documentation
- [ ] 🔧 Chore
- [ ] 💥 Breaking change

## [optional] Any images / gifs / video

## Related Tickets & Documents

Related Issue #
fixes #581 
resolves #
closes #

## Added tests?

- [ ] 👍 yes
- [ ] 🙅 no, not needed
- [ ] 🙋 no, I need help

## Added to documentation?

- [ ] 🔖 README.md
- [x] 🔖 CHANGELOG.md
- [ ] 📖 help site
- [ ] 🙅 not needed

## [optional] Are there any post-deployment tasks we need to perform?
