### PR TITLE
fix: analysis table table vanishing on scroll drag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Call Tree: Performance regression of Call Tree rendering ([#581][#581]).
 - Call Tree: Call Tree not correctly keeping position when rows where hidden / shown via Details and Debug Only ([#581][#581]).
 - Database: Call stack shows items horizontally instead of vertically ([#582][#582])
+- Analysis: Sometimes disappered when dragging the scroll bar down, sorry about that. ([#590])
 
 ## [1.16.1] - 2024-12-03
 
@@ -384,6 +385,7 @@ Skipped due to adopting odd numbering for pre releases and even number for relea
 [#582]: https://github.com/certinia/debug-log-analyzer/issues/582
 [#588]: https://github.com/certinia/debug-log-analyzer/issues/588
 [#583]: https://github.com/certinia/debug-log-analyzer/issues/583
+[#590]: https://github.com/certinia/debug-log-analyzer/issues/590
 
 <!-- 1.16.1 -->
 

--- a/log-viewer/modules/components/analysis-view/AnalysisView.ts
+++ b/log-viewer/modules/components/analysis-view/AnalysisView.ts
@@ -42,14 +42,32 @@ export class AnalysisView extends LitElement {
         height: 100%;
         width: 100%;
         display: flex;
-        flex-direction: column;
-        flex: 1;
         gap: 1rem;
       }
 
-      #analysis-table-container {
-        display: contents;
+      .analysis-view {
+        display: flex;
+        flex-direction: column;
         height: 100%;
+        width: 100%;
+      }
+
+      #analysis-table-container {
+        height: 100%;
+        width: 100%;
+        min-height: 0;
+        min-width: 0;
+      }
+
+      #analysis-table {
+        display: inline-block;
+        height: 100%;
+        width: 100%;
+      }
+
+      .filter-container {
+        display: flex;
+        gap: 5px;
       }
 
       .dropdown-container {
@@ -106,19 +124,21 @@ export class AnalysisView extends LitElement {
     const skeleton = !this.timelineRoot ? html`<grid-skeleton></grid-skeleton>` : '';
 
     return html`
-      <div class="filter-container">
-        <div class="dropdown-container">
-          <label for="groupby-dropdown">Group by</label>
-          <vscode-dropdown id="groupby-dropdown" @change="${this._groupBy}">
-            <vscode-option>None</vscode-option>
-            <vscode-option>Namespace</vscode-option>
-            <vscode-option>Type</vscode-option>
-          </vscode-dropdown>
+      <div class="analysis-view">
+        <div class="filter-container">
+          <div class="dropdown-container">
+            <label for="groupby-dropdown">Group by</label>
+            <vscode-dropdown id="groupby-dropdown" @change="${this._groupBy}">
+              <vscode-option>None</vscode-option>
+              <vscode-option>Namespace</vscode-option>
+              <vscode-option>Type</vscode-option>
+            </vscode-dropdown>
+          </div>
         </div>
-      </div>
-      <div id="analysis-table-container">
-        ${skeleton}
-        <div id="analysis-table"></div>
+        <div id="analysis-table-container">
+          ${skeleton}
+          <div id="analysis-table"></div>
+        </div>
       </div>
     `;
   }
@@ -230,6 +250,7 @@ export class AnalysisView extends LitElement {
 
         return new Blob([fileContents], { type: mimeType });
       },
+      dataTree: true,
       downloadRowRange: 'all',
       downloadConfig: {
         columnHeaders: true,
@@ -242,6 +263,7 @@ export class AnalysisView extends LitElement {
       keybindings: { copyToClipboard: ['ctrl + 67', 'meta + 67'] },
       clipboardCopyRowRange: 'all',
       height: '100%',
+      maxHeight: '100%',
       groupCalcs: true,
       groupClosedShowCalcs: true,
       groupStartOpen: false,
@@ -299,6 +321,7 @@ export class AnalysisView extends LitElement {
             multiselect: true,
           },
           headerFilterLiveFilter: false,
+          variableHeight: true,
         },
         {
           title: 'Type',

--- a/log-viewer/modules/components/analysis-view/AnalysisView.ts
+++ b/log-viewer/modules/components/analysis-view/AnalysisView.ts
@@ -250,7 +250,7 @@ export class AnalysisView extends LitElement {
 
         return new Blob([fileContents], { type: mimeType });
       },
-      dataTree: true,
+      dataTree: true, // temporary: fixes a disappearing table issue when scroll is dragged (needs fix in Tabulator)
       downloadRowRange: 'all',
       downloadConfig: {
         columnHeaders: true,

--- a/log-viewer/modules/components/calltree-view/CalltreeView.ts
+++ b/log-viewer/modules/components/calltree-view/CalltreeView.ts
@@ -110,18 +110,19 @@ export class CalltreeView extends LitElement {
         flex-direction: column;
         height: 100%;
         width: 100%;
-        min-height: 0;
-        min-width: 0;
       }
 
       #call-tree-table-container {
         height: 100%;
-        flex-grow: 1;
+        width: 100%;
         min-height: 0;
+        min-width: 0;
       }
 
       #call-tree-table {
+        display: inline-block;
         height: 100%;
+        width: 100%;
       }
 
       .header-bar {


### PR DESCRIPTION
# Description

- Fixes an issue where the analysis table would disappear when the scroll pill was dragged halfway down.

The fix is a bit of a hack as `datatree:true` seems to resolve it even when there is not a datatree.
Needs fixing in downstream Tabulator.


## More detailed changes

- Change 1
- Change 2

## Type of change (check all applicable)

- [X] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] ♻️ Refactor
- [ ] ⚡ Performance Improvement
- [ ] 📝 Documentation
- [ ] 🔧 Chore
- [ ] 💥 Breaking change

## Any images / gifs / video [optional]

## Related Issues

fixes #590
resolves #
closes #
related #

## Added tests?

- [ ] 👍 yes
- [ ] 🙅 no, not needed
- [ ] 🙋 no, I need help

## Added to documentation?

- [ ] 🔖 README.md
- [X] 🔖 CHANGELOG.md
- [ ] 📖 help site
- [ ] 🙅 not needed

## Anything else we need to know? [optional]
