### PR TITLE
feat: call tree search within filtered visible rows only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Highlight and copy text to clipboard: Call Tree, Analysis and Database views ([#504][#504]).
   - Previously the highlighted text would be immediately cleared.
 - Sharper timeline rending on HiDPI displays ([#588][#588]).
+- Call Tree search will now only search in the visible filtered rows ([#539]).
 
 ### Fixed
 
@@ -394,6 +395,7 @@ Skipped due to adopting odd numbering for pre releases and even number for relea
 [#590]: https://github.com/certinia/debug-log-analyzer/issues/590
 [#592]: https://github.com/certinia/debug-log-analyzer/issues/592
 [#93]: https://github.com/certinia/debug-log-analyzer/issues/93
+[#539]: https://github.com/certinia/debug-log-analyzer/issues/539
 
 <!-- 1.16.1 -->
 

--- a/log-viewer/modules/components/calltree-view/CalltreeView.ts
+++ b/log-viewer/modules/components/calltree-view/CalltreeView.ts
@@ -302,6 +302,7 @@ export class CalltreeView extends LitElement {
     }
     this.calltreeTable.blockRedraw();
     this._expandCollapseAll(this.calltreeTable.getRows(), true);
+    this.calltreeTable.element?.querySelector<HTMLElement>('.tabulator-tableholder')?.focus();
     this.calltreeTable.restoreRedraw();
   }
 
@@ -311,6 +312,7 @@ export class CalltreeView extends LitElement {
     }
     this.calltreeTable.blockRedraw();
     this._expandCollapseAll(this.calltreeTable.getRows(), false);
+    this.calltreeTable.element?.querySelector<HTMLElement>('.tabulator-tableholder')?.focus();
     this.calltreeTable.restoreRedraw();
   }
 

--- a/log-viewer/modules/components/calltree-view/CalltreeView.ts
+++ b/log-viewer/modules/components/calltree-view/CalltreeView.ts
@@ -345,15 +345,12 @@ export class CalltreeView extends LitElement {
     this.calltreeTable.goToRow(treeRow, { scrollIfVisible: true, focusRow: true });
   }
 
-  _find(
-    e: CustomEvent<{ text: string; count: number; options: { matchCase: boolean } }>,
-    canClearOverride = true,
-  ) {
+  _find(e: CustomEvent<{ text: string; count: number; options: { matchCase: boolean } }>) {
     const isTableVisible = !!this.calltreeTable?.element?.clientHeight;
     if (!isTableVisible && !this.totalMatches) {
       return;
     }
-    this.canClearSearchHighlights = canClearOverride;
+    this.canClearSearchHighlights = false;
 
     const newFindArgs = JSON.parse(JSON.stringify(e.detail));
     const newSearch =
@@ -362,7 +359,8 @@ export class CalltreeView extends LitElement {
     this.findArgs = newFindArgs;
 
     const clearHighlights =
-      e.type === 'lv-find-close' || (!isTableVisible && newFindArgs.count === 0);
+      e.type === 'lv-find-close' ||
+      (this.canClearSearchHighlights && !isTableVisible && newFindArgs.count === 0);
     if (clearHighlights) {
       newFindArgs.text = '';
     }
@@ -379,6 +377,7 @@ export class CalltreeView extends LitElement {
       }
     }
 
+    this.calltreeTable?.blockRedraw();
     const currentRow = this.findMap[this.findArgs.count];
     const rows = [
       currentRow,
@@ -393,6 +392,8 @@ export class CalltreeView extends LitElement {
       //@ts-expect-error This is a custom function added in by RowNavigation custom module
       this.calltreeTable.goToRow(currentRow, { scrollIfVisible: false, focusRow: false });
     }
+    this.calltreeTable?.restoreRedraw();
+    this.canClearSearchHighlights = true;
   }
 
   _highlight(inputString: string, substring: string) {
@@ -807,7 +808,6 @@ export class CalltreeView extends LitElement {
       new CustomEvent('lv-find', {
         detail: { text: '', count: 0, options: { matchCase: false } },
       }),
-      false,
     );
   }
 

--- a/log-viewer/modules/components/calltree-view/module/MiddleRowFocus.ts
+++ b/log-viewer/modules/components/calltree-view/module/MiddleRowFocus.ts
@@ -75,11 +75,9 @@ export class MiddleRowFocus extends Module {
       if (rowToScrollTo) {
         this.table.scrollToRow(rowToScrollTo, 'center', true).then(() => {
           setTimeout(() => {
-            if (rowToScrollTo) {
-              rowToScrollTo
-                ?.getElement()
-                .scrollIntoView({ behavior: 'auto', block: 'center', inline: 'start' });
-            }
+            rowToScrollTo
+              ?.getElement()
+              .scrollIntoView({ behavior: 'auto', block: 'center', inline: 'start' });
           });
         });
       }

--- a/log-viewer/modules/datagrid/module/RowKeyboardNavigation.ts
+++ b/log-viewer/modules/datagrid/module/RowKeyboardNavigation.ts
@@ -48,13 +48,10 @@ export class RowKeyboardNavigation extends Module {
 
   rowExpandedToggled(row: RowComponent, _level: number) {
     const table = row.getTable();
-    this.tableHolder ??= table.element.querySelector('.tabulator-tableholder') as HTMLElement;
-
-    const selectedRow = table.getSelectedRows()[0];
-    if (!selectedRow) {
+    const selectedRows = table.getSelectedRows();
+    if (!selectedRows.length) {
       row.select();
     }
-    this.tableHolder?.focus();
   }
 
   rowClick(event: UIEvent, row: RowComponent) {


### PR DESCRIPTION
# Description

- call tree search will now only search within the filtered visible rows only.
It used to search in non visible rows which was misleading to step through results and show nothing, It was also slow.

## Type of change (check all applicable)

- [ ] 🐛 Bug fix
- [X] ✨ New feature
- [ ] ♻️ Refactor
- [ ] ⚡ Performance Improvement
- [ ] 📝 Documentation
- [ ] 🔧 Chore
- [ ] 💥 Breaking change

## Any images / gifs / video [optional]

## Related Issues

fixes #
resolves #539 
closes #
related #

## Added tests?

- [ ] 👍 yes
- [X] 🙅 no, not needed
- [ ] 🙋 no, I need help

## Added to documentation?

- [ ] 🔖 README.md
- [X] 🔖 CHANGELOG.md
- [ ] 📖 help site
- [ ] 🙅 not needed

## Anything else we need to know? [optional]
