### PR TITLE
feat:  governor limit reporting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - To sort a group by the number of items within the group click the Group Name column until the third sort state is shown.
 - **🔢 New Call Tree Columns**: The Rows column is replaced with the DML Rows and SOQL Rows columns ([#93]).
 - **⏱️ New Timeline Tooltip values**: The Rows count in the Timeline tooltip is now split into DML Rows and SOQL Rows ([#93]).
+- **⏱️ New Timeline Tooltip**: The tooltip is much easier to read a glance([#308]).
 - **📋💾 Table Actions**: Added options to Copy to Clipboard and Export to CSV directly from the table action buttons above the Analysis and Database tables ([#589]).
 
 ### Changed
@@ -397,6 +398,7 @@ Skipped due to adopting odd numbering for pre releases and even number for relea
 [#93]: https://github.com/certinia/debug-log-analyzer/issues/93
 [#539]: https://github.com/certinia/debug-log-analyzer/issues/539
 [#619]: https://github.com/certinia/debug-log-analyzer/issues/619
+[#308]: https://github.com/certinia/debug-log-analyzer/issues/308
 
 <!-- 1.16.1 -->
 

--- a/lana/package.json
+++ b/lana/package.json
@@ -2,7 +2,7 @@
   "name": "lana",
   "displayName": "Apex Log Analyzer",
   "version": "1.16.1",
-  "description": "Salesforce Apex Debug Log Analyzer for VS Code - Apex Log Analyzer is a blazing-fast VS Code extension for Salesforce developers. Instantly visualize and debug Apex logs with interactive flame charts, dynamic call trees, and detailed SOQL/DML breakdowns. Identify performance bottlenecks, gain deep insight into complex transactions and optimize slow Apex methods faster than ever.",
+  "description": "Salesforce Apex Debug Log Analyzer: Blazing-fast VS Code extension for Salesforce. Visualize and debug Apex logs with interactive flame charts, dynamic call trees, and detailed SOQL/DML breakdowns. Identify performance bottlenecks, gain deep transaction insights and optimize slow Apex.",
   "keywords": [
     "analysis",
     "apex",

--- a/log-viewer/modules/Util.ts
+++ b/log-viewer/modules/Util.ts
@@ -8,7 +8,7 @@ export default function formatDuration(durationNs: number, totalNs = 0) {
   const textPadded = text.length < 4 ? '0000'.substring(text.length) + text : text; // length min = 4
   const millis = textPadded.slice(0, -3); // everything before last 3 chars
   const micros = textPadded.slice(-3); // last 3 chars
-  const suffix = totalNs > 0 ? `/${(totalNs / 1_000_000).toFixed(3)}` : '';
+  const suffix = totalNs > 0 ? `/${Math.round(totalNs / 1_000_000)}` : '';
   return `${millis}.${micros}${suffix} ms`;
 }
 

--- a/log-viewer/modules/Util.ts
+++ b/log-viewer/modules/Util.ts
@@ -3,12 +3,13 @@
  */
 let requestId: number = 0;
 
-export default function formatDuration(duration: number) {
-  const text = `${~~(duration / 1000)}`; // convert from nano-seconds to micro-seconds
+export default function formatDuration(durationNs: number, totalNs = 0) {
+  const text = `${~~(durationNs / 1000)}`; // convert from nano-seconds to micro-seconds
   const textPadded = text.length < 4 ? '0000'.substring(text.length) + text : text; // length min = 4
   const millis = textPadded.slice(0, -3); // everything before last 3 chars
   const micros = textPadded.slice(-3); // last 3 chars
-  return `${millis}.${micros} ms`;
+  const suffix = totalNs > 0 ? `/${(totalNs / 1_000_000).toFixed(3)}` : '';
+  return `${millis}.${micros}${suffix} ms`;
 }
 
 export function debounce<T extends unknown[]>(callBack: (...args: T) => unknown) {

--- a/log-viewer/modules/Util.ts
+++ b/log-viewer/modules/Util.ts
@@ -8,7 +8,7 @@ export default function formatDuration(duration: number) {
   const textPadded = text.length < 4 ? '0000'.substring(text.length) + text : text; // length min = 4
   const millis = textPadded.slice(0, -3); // everything before last 3 chars
   const micros = textPadded.slice(-3); // last 3 chars
-  return `${millis}.${micros}ms`;
+  return `${millis}.${micros} ms`;
 }
 
 export function debounce<T extends unknown[]>(callBack: (...args: T) => unknown) {

--- a/log-viewer/modules/__tests__/ApexLogParser.test.ts
+++ b/log-viewer/modules/__tests__/ApexLogParser.test.ts
@@ -324,7 +324,7 @@ describe('parseLog tests', () => {
     const execEvent = apexLog.children[0] as MethodEntryLine;
     expect(execEvent.children[0]?.namespace).toBe('appirio_core');
   });
-  it('Limit Usage for NS provides cpuUsed', async () => {
+  it('Limit Usage for NS as child of CUMULATIVE_LIMIT_USAGE', async () => {
     const log =
       '09:18:22.6 (6574780)|EXECUTION_STARTED\n' +
       '14:29:44.163 (40163621912)|CUMULATIVE_LIMIT_USAGE\n' +
@@ -345,7 +345,6 @@ describe('parseLog tests', () => {
       '09:19:13.82 (51595120059)|EXECUTION_FINISHED\n';
 
     const apexLog = parse(log);
-    expect(apexLog.cpuTime).toBe(4564000000);
     const execEvent = apexLog.children[0] as MethodEntryLine;
     expect(execEvent.children.length).toBe(1);
 
@@ -363,8 +362,6 @@ describe('parseLog tests', () => {
       '09:19:13.82 (51595120059)|EXECUTION_FINISHED';
 
     const apexLog = parse(log);
-
-    expect(apexLog.cpuTime).toBe(0);
 
     const execEvent = apexLog.children[0] as MethodEntryLine;
     expect(execEvent.children.length).toBe(1);
@@ -1124,6 +1121,128 @@ describe('Recalculate durations tests', () => {
     node.recalculateDurations();
     expect(node.timestamp).toEqual(1);
     expect(node.duration).toEqual({ self: 2, total: 2 });
+  });
+});
+
+describe('Governor Limits Parsing', () => {
+  it('should parse LIMIT_USAGE_FOR_NS lines and populate governorLimits for multiple namespaces', () => {
+    const log = [
+      '09:18:22.6 (6574780)|EXECUTION_STARTED',
+      '12:43:02.105 (48105827767)|LIMIT_USAGE_FOR_NS|(default)|',
+      '  Number of SOQL queries: 17 out of 100',
+      '  Number of query rows: 121 out of 50000',
+      '  Number of SOSL queries: 3 out of 20',
+      '  Number of DML statements: 8 out of 150',
+      '  Number of Publish Immediate DML: 5 out of 150',
+      '  Number of DML rows: 113 out of 10000',
+      '  Maximum CPU time: 15008 out of 10000 ******* CLOSE TO LIMIT',
+      '  Maximum heap size: 300 out of 6000000',
+      '  Number of callouts: 2 out of 100',
+      '  Number of Email Invocations: 1 out of 10',
+      '  Number of future calls: 2 out of 50',
+      '  Number of queueable jobs added to the queue: 6 out of 50',
+      '  Number of Mobile Apex push calls: 1 out of 10',
+      '12:43:02.105 (48105827768)|LIMIT_USAGE_FOR_NS|myNS|',
+      '  Number of SOQL queries: 2 out of 100',
+      '  Number of query rows: 10 out of 50000',
+      '  Number of SOSL queries: 1 out of 20',
+      '  Number of DML statements: 1 out of 150',
+      '  Number of Publish Immediate DML: 0 out of 150',
+      '  Number of DML rows: 5 out of 10000',
+      '  Maximum CPU time: 2000 out of 10000',
+      '  Maximum heap size: 100 out of 6000000',
+      '  Number of callouts: 1 out of 100',
+      '  Number of Email Invocations: 5 out of 10',
+      '  Number of future calls: 2 out of 50',
+      '  Number of queueable jobs added to the queue: 3 out of 50',
+      '  Number of Mobile Apex push calls: 0 out of 10',
+      '09:19:13.82 (51595120059)|EXECUTION_FINISHED',
+    ].join('\n');
+
+    const apexLog = parse(log);
+
+    expect(apexLog.governorLimits).toBeDefined();
+    expect([...apexLog.governorLimits.limitsByNamespace.keys()]).toEqual(['default', 'myNS']);
+
+    expect(apexLog.governorLimits.limitsByNamespace.get('default')).toMatchObject({
+      soqlQueries: { used: 17, limit: 100 },
+      queryRows: { used: 121, limit: 50000 },
+      soslQueries: { used: 3, limit: 20 },
+      dmlStatements: { used: 8, limit: 150 },
+      publishImmediateDml: { used: 5, limit: 150 },
+      dmlRows: { used: 113, limit: 10000 },
+      cpuTime: { used: 15008, limit: 10000 },
+      heapSize: { used: 300, limit: 6000000 },
+      callouts: { used: 2, limit: 100 },
+      emailInvocations: { used: 1, limit: 10 },
+      futureCalls: { used: 2, limit: 50 },
+      queueableJobsAddedToQueue: { used: 6, limit: 50 },
+      mobileApexPushCalls: { used: 1, limit: 10 },
+    });
+
+    expect(apexLog.governorLimits.limitsByNamespace.get('myNS')).toMatchObject({
+      soqlQueries: { used: 2, limit: 100 },
+      queryRows: { used: 10, limit: 50000 },
+      soslQueries: { used: 1, limit: 20 },
+      dmlStatements: { used: 1, limit: 150 },
+      publishImmediateDml: { used: 0, limit: 150 },
+      dmlRows: { used: 5, limit: 10000 },
+      cpuTime: { used: 2000, limit: 10000 },
+      heapSize: { used: 100, limit: 6000000 },
+      callouts: { used: 1, limit: 100 },
+      emailInvocations: { used: 5, limit: 10 },
+      futureCalls: { used: 2, limit: 50 },
+      queueableJobsAddedToQueue: { used: 3, limit: 50 },
+      mobileApexPushCalls: { used: 0, limit: 10 },
+    });
+
+    expect(apexLog.governorLimits.totals).toMatchObject({
+      soqlQueries: { used: 19, limit: 100 },
+      queryRows: { used: 131, limit: 50000 },
+      soslQueries: { used: 4, limit: 20 },
+      dmlStatements: { used: 9, limit: 150 },
+      publishImmediateDml: { used: 5, limit: 150 },
+      dmlRows: { used: 118, limit: 10000 },
+      cpuTime: { used: 17008, limit: 10000 },
+      heapSize: { used: 400, limit: 6000000 },
+      callouts: { used: 3, limit: 100 },
+      emailInvocations: { used: 6, limit: 10 },
+      futureCalls: { used: 4, limit: 50 },
+      queueableJobsAddedToQueue: { used: 9, limit: 50 },
+      mobileApexPushCalls: { used: 1, limit: 10 },
+    });
+  });
+
+  it('should handle missing or partial LIMIT_USAGE_FOR_NS sections gracefully', () => {
+    const log = [
+      '09:18:22.6 (6574780)|EXECUTION_STARTED',
+      '12:43:02.105 (48105827767)|LIMIT_USAGE_FOR_NS|(default)|',
+      '  Number of SOQL queries: 5 out of 100',
+      '  Number of query rows: 10 out of 50000',
+      // missing other lines
+      '09:19:13.82 (51595120059)|EXECUTION_FINISHED',
+    ].join('\n');
+
+    const apexLog = parse(log);
+
+    expect(apexLog.governorLimits).toBeDefined();
+    const expected = {
+      soqlQueries: { used: 5, limit: 100 },
+      queryRows: { used: 10, limit: 50000 },
+      soslQueries: { used: 0, limit: 0 },
+      dmlStatements: { used: 0, limit: 0 },
+      publishImmediateDml: { used: 0, limit: 0 },
+      dmlRows: { used: 0, limit: 0 },
+      cpuTime: { used: 0, limit: 0 },
+      heapSize: { used: 0, limit: 0 },
+      callouts: { used: 0, limit: 0 },
+      emailInvocations: { used: 0, limit: 0 },
+      futureCalls: { used: 0, limit: 0 },
+      queueableJobsAddedToQueue: { used: 0, limit: 0 },
+      mobileApexPushCalls: { used: 0, limit: 0 },
+    };
+    expect(apexLog.governorLimits.limitsByNamespace.get('default')).toMatchObject(expected);
+    expect(apexLog.governorLimits.totals).toMatchObject(expected);
   });
 });
 

--- a/log-viewer/modules/__tests__/ApexLogParser.test.ts
+++ b/log-viewer/modules/__tests__/ApexLogParser.test.ts
@@ -1162,9 +1162,9 @@ describe('Governor Limits Parsing', () => {
     const apexLog = parse(log);
 
     expect(apexLog.governorLimits).toBeDefined();
-    expect([...apexLog.governorLimits.limitsByNamespace.keys()]).toEqual(['default', 'myNS']);
+    expect([...apexLog.governorLimits.byNamespace.keys()]).toEqual(['default', 'myNS']);
 
-    expect(apexLog.governorLimits.limitsByNamespace.get('default')).toMatchObject({
+    expect(apexLog.governorLimits.byNamespace.get('default')).toMatchObject({
       soqlQueries: { used: 17, limit: 100 },
       queryRows: { used: 121, limit: 50000 },
       soslQueries: { used: 3, limit: 20 },
@@ -1180,7 +1180,7 @@ describe('Governor Limits Parsing', () => {
       mobileApexPushCalls: { used: 1, limit: 10 },
     });
 
-    expect(apexLog.governorLimits.limitsByNamespace.get('myNS')).toMatchObject({
+    expect(apexLog.governorLimits.byNamespace.get('myNS')).toMatchObject({
       soqlQueries: { used: 2, limit: 100 },
       queryRows: { used: 10, limit: 50000 },
       soslQueries: { used: 1, limit: 20 },
@@ -1196,7 +1196,7 @@ describe('Governor Limits Parsing', () => {
       mobileApexPushCalls: { used: 0, limit: 10 },
     });
 
-    expect(apexLog.governorLimits.totals).toMatchObject({
+    expect(apexLog.governorLimits).toMatchObject({
       soqlQueries: { used: 19, limit: 100 },
       queryRows: { used: 131, limit: 50000 },
       soslQueries: { used: 4, limit: 20 },
@@ -1241,8 +1241,8 @@ describe('Governor Limits Parsing', () => {
       queueableJobsAddedToQueue: { used: 0, limit: 0 },
       mobileApexPushCalls: { used: 0, limit: 0 },
     };
-    expect(apexLog.governorLimits.limitsByNamespace.get('default')).toMatchObject(expected);
-    expect(apexLog.governorLimits.totals).toMatchObject(expected);
+    expect(apexLog.governorLimits.byNamespace.get('default')).toMatchObject(expected);
+    expect(apexLog.governorLimits).toMatchObject(expected);
   });
 });
 

--- a/log-viewer/modules/__tests__/Util.test.ts
+++ b/log-viewer/modules/__tests__/Util.test.ts
@@ -14,4 +14,27 @@ describe('Format duration tests', () => {
   it('Value truncated at 3dp', () => {
     expect(formatDuration(1234567)).toBe('1.234 ms');
   });
+  it('pads microseconds correctly for short durations', () => {
+    expect(formatDuration(5)).toBe('0.000 ms');
+    expect(formatDuration(50)).toBe('0.000 ms');
+    expect(formatDuration(500)).toBe('0.000 ms');
+  });
+});
+
+describe('Adds out off suffix', () => {
+  it('rounds up to 0dp', () => {
+    expect(formatDuration(1000, 2_000_600_000)).toBe('0.001/2001 ms');
+  });
+
+  it('handles zero duration and total', () => {
+    expect(formatDuration(0, 0)).toBe('0.000 ms');
+  });
+
+  it('handles zero duration with totalNs', () => {
+    expect(formatDuration(0, 1_000_000)).toBe('0.000/1 ms');
+  });
+
+  it('handles large duration and totalNs', () => {
+    expect(formatDuration(12_345_678_900, 123_456_789_000)).toBe('12345.678/123457 ms');
+  });
 });

--- a/log-viewer/modules/__tests__/Util.test.ts
+++ b/log-viewer/modules/__tests__/Util.test.ts
@@ -6,12 +6,12 @@ import formatDuration from '../Util.js';
 
 describe('Format duration tests', () => {
   it('Value converted from nanoseconds to milliseconds', () => {
-    expect(formatDuration(1000)).toBe('0.001ms');
+    expect(formatDuration(1000)).toBe('0.001 ms');
   });
   it('Value always has 3dp', () => {
-    expect(formatDuration(1000000)).toBe('1.000ms');
+    expect(formatDuration(1000000)).toBe('1.000 ms');
   });
   it('Value truncated at 3dp', () => {
-    expect(formatDuration(1234567)).toBe('1.234ms');
+    expect(formatDuration(1234567)).toBe('1.234 ms');
   });
 });

--- a/log-viewer/modules/components/CallStack.ts
+++ b/log-viewer/modules/components/CallStack.ts
@@ -27,6 +27,7 @@ export class CallStack extends LitElement {
         min-height: 1ch;
         max-height: 30vh;
         padding: 0px 5px 0px 5px;
+        white-space: normal;
       }
 
       :host(:hover) {

--- a/log-viewer/modules/components/analysis-view/AnalysisView.ts
+++ b/log-viewer/modules/components/analysis-view/AnalysisView.ts
@@ -18,7 +18,7 @@ import { globalStyles } from '../../styles/global.styles.js';
 import { Tabulator, type RowComponent } from 'tabulator-tables';
 import { isVisible } from '../../Util.js';
 import NumberAccessor from '../../datagrid/dataaccessor/Number.js';
-import { progressFormatter } from '../../datagrid/format/Progress.js';
+import { progressFormatterMS } from '../../datagrid/format/ProgressMS.js';
 import { GroupCalcs } from '../../datagrid/groups/GroupCalcs.js';
 import { GroupSort } from '../../datagrid/groups/GroupSort.js';
 import * as CommonModules from '../../datagrid/module/CommonModules.js';
@@ -265,14 +265,14 @@ export class AnalysisView extends LitElement {
     if (!this._tableWrapper) {
       return;
     }
-    const metricList = groupMetrics(rootMethod);
 
     Tabulator.registerModule(Object.values(CommonModules));
     Tabulator.registerModule([RowKeyboardNavigation, RowNavigation, Find, GroupCalcs, GroupSort]);
+
     this.analysisTable = new Tabulator(this._tableWrapper, {
       rowKeyboardNavigation: true,
       selectableRows: 'highlight',
-      data: metricList,
+      data: groupMetrics(rootMethod),
       layout: 'fitColumns',
       placeholder: 'No Analysis Available',
       columnCalcs: 'table',
@@ -388,16 +388,15 @@ export class AnalysisView extends LitElement {
           width: 165,
           hozAlign: 'right',
           headerHozAlign: 'right',
-          formatter: progressFormatter,
+          bottomCalc: callStackSum,
+          bottomCalcFormatter: progressFormatterMS,
+          bottomCalcFormatterParams: { precision: 3, totalValue: rootMethod.duration.total },
+          formatter: progressFormatterMS,
           formatterParams: {
-            thousand: false,
             precision: 3,
             totalValue: rootMethod.duration.total,
           },
           accessorDownload: NumberAccessor,
-          bottomCalcFormatter: progressFormatter,
-          bottomCalc: callStackSum,
-          bottomCalcFormatterParams: { precision: 3, totalValue: rootMethod.duration.total },
         },
         {
           title: 'Self Time (ms)',
@@ -407,15 +406,14 @@ export class AnalysisView extends LitElement {
           hozAlign: 'right',
           headerHozAlign: 'right',
           bottomCalc: 'sum',
+          bottomCalcFormatter: progressFormatterMS,
           bottomCalcFormatterParams: { precision: 3, totalValue: rootMethod.duration.total },
-          formatter: progressFormatter,
+          formatter: progressFormatterMS,
           formatterParams: {
-            thousand: false,
             precision: 3,
             totalValue: rootMethod.duration.total,
           },
           accessorDownload: NumberAccessor,
-          bottomCalcFormatter: progressFormatter,
         },
       ],
     });

--- a/log-viewer/modules/components/analysis-view/AnalysisView.ts
+++ b/log-viewer/modules/components/analysis-view/AnalysisView.ts
@@ -16,7 +16,7 @@ import { globalStyles } from '../../styles/global.styles.js';
 
 // Tabulator custom modules, imports + styles
 import { Tabulator, type RowComponent } from 'tabulator-tables';
-import { isVisible } from '../../Util.js';
+import formatDuration, { isVisible } from '../../Util.js';
 import NumberAccessor from '../../datagrid/dataaccessor/Number.js';
 import { progressFormatterMS } from '../../datagrid/format/ProgressMS.js';
 import { GroupCalcs } from '../../datagrid/groups/GroupCalcs.js';
@@ -320,6 +320,7 @@ export class AnalysisView extends LitElement {
         headerTooltip: true,
         headerWordWrap: true,
       },
+      tooltipDelay: 100,
       initialSort: [{ column: 'selfTime', dir: 'desc' }],
       headerSortElement: function (column, dir) {
         switch (dir) {
@@ -397,6 +398,9 @@ export class AnalysisView extends LitElement {
             totalValue: rootMethod.duration.total,
           },
           accessorDownload: NumberAccessor,
+          tooltip(_event, cell, _onRender) {
+            return formatDuration(cell.getValue(), rootMethod.duration.total);
+          },
         },
         {
           title: 'Self Time (ms)',
@@ -414,6 +418,9 @@ export class AnalysisView extends LitElement {
             totalValue: rootMethod.duration.total,
           },
           accessorDownload: NumberAccessor,
+          tooltip(_event, cell, _onRender) {
+            return formatDuration(cell.getValue(), rootMethod.duration.total);
+          },
         },
       ],
     });

--- a/log-viewer/modules/components/analysis-view/column-calcs/CallStackSum.ts
+++ b/log-viewer/modules/components/analysis-view/column-calcs/CallStackSum.ts
@@ -1,5 +1,5 @@
 import type { LogLine } from '../../../parsers/ApexLogParser';
-import { type Metric } from '../AnalysisView.js';
+import type { Metric } from '../AnalysisView.js';
 
 export function callStackSum(_values: number[], data: Metric[], _calcParams: unknown) {
   const nodes: LogLine[] = [];

--- a/log-viewer/modules/components/calltree-view/CalltreeView.ts
+++ b/log-viewer/modules/components/calltree-view/CalltreeView.ts
@@ -719,7 +719,7 @@ export class CalltreeView extends LitElement {
             headerHozAlign: 'right',
             tooltip(_event, cell, _onRender) {
               const maxDmlStatements = governorLimits.dmlStatements.limit;
-              return cell.getValue() + maxDmlStatements > 0 ? '/' + maxDmlStatements : '';
+              return cell.getValue() + (maxDmlStatements > 0 ? '/' + maxDmlStatements : '');
             },
           },
           {
@@ -745,7 +745,7 @@ export class CalltreeView extends LitElement {
             headerHozAlign: 'right',
             tooltip(_event, cell, _onRender) {
               const maxSoql = governorLimits.soqlQueries.limit;
-              return cell.getValue() + maxSoql > 0 ? '/' + maxSoql : '';
+              return cell.getValue() + (maxSoql > 0 ? '/' + maxSoql : '');
             },
           },
           {
@@ -781,7 +781,7 @@ export class CalltreeView extends LitElement {
             headerHozAlign: 'right',
             tooltip(_event, cell, _onRender) {
               const maxDmlRows = governorLimits.dmlRows.limit;
-              return cell.getValue() + maxDmlRows > 0 ? '/' + maxDmlRows : '';
+              return cell.getValue() + (maxDmlRows > 0 ? '/' + maxDmlRows : '');
             },
           },
           {
@@ -807,7 +807,7 @@ export class CalltreeView extends LitElement {
             headerHozAlign: 'right',
             tooltip(_event, cell, _onRender) {
               const maxQueryRows = governorLimits.queryRows.limit;
-              return cell.getValue() + maxQueryRows > 0 ? '/' + maxQueryRows : '';
+              return cell.getValue() + (maxQueryRows > 0 ? '/' + maxQueryRows : '');
             },
           },
           {

--- a/log-viewer/modules/components/calltree-view/CalltreeView.ts
+++ b/log-viewer/modules/components/calltree-view/CalltreeView.ts
@@ -15,7 +15,7 @@ import {
   vsCodeDropdown,
   vsCodeOption,
 } from '@vscode/webview-ui-toolkit';
-import { LitElement, css, html, unsafeCSS, type PropertyValues } from 'lit';
+import { css, html, LitElement, unsafeCSS, type PropertyValues } from 'lit';
 import { customElement, property, state } from 'lit/decorators.js';
 import { repeat } from 'lit/directives/repeat.js';
 import { Tabulator, type RowComponent } from 'tabulator-tables';
@@ -24,6 +24,8 @@ import * as CommonModules from '../../datagrid/module/CommonModules.js';
 import MinMaxEditor from '../../datagrid/editors/MinMax.js';
 import MinMaxFilter from '../../datagrid/filters/MinMax.js';
 import { progressFormatter } from '../../datagrid/format/Progress.js';
+import { progressFormatterMS } from '../../datagrid/format/ProgressMS.js';
+
 import { RowKeyboardNavigation } from '../../datagrid/module/RowKeyboardNavigation.js';
 import { RowNavigation } from '../../datagrid/module/RowNavigation.js';
 import dataGridStyles from '../../datagrid/style/DataGrid.scss';
@@ -577,7 +579,7 @@ export class CalltreeView extends LitElement {
         //  custom property for module/MiddleRowFocus
         middleRowFocus: true,
         dataTree: true,
-        dataTreeChildColumnCalcs: true,
+        dataTreeChildColumnCalcs: true, // todo: fix
         dataTreeBranchElement: '<span/>',
         selectableRows: 1,
         // @ts-expect-error it is possible to pass a function to intitialFilter the types need updating
@@ -680,7 +682,7 @@ export class CalltreeView extends LitElement {
             title: 'Namespace',
             field: 'namespace',
             sorter: 'string',
-            width: 120,
+            width: 100,
             headerFilter: 'list',
             headerFilterFunc: this._namespaceFilter,
             headerFilterFuncParams: { filterCache: namespaceFilterCache },
@@ -697,9 +699,21 @@ export class CalltreeView extends LitElement {
             sorter: 'number',
             cssClass: 'number-cell',
             width: 60,
+            bottomCalc: 'max',
+            bottomCalcFormatter: progressFormatter,
+            bottomCalcFormatterParams: {
+              precision: 0,
+              totalValue: 100,
+              showPercentageText: false,
+            },
+            formatter: progressFormatter,
+            formatterParams: {
+              precision: 0,
+              totalValue: 100,
+              showPercentageText: false,
+            },
             hozAlign: 'right',
             headerHozAlign: 'right',
-            bottomCalc: 'max',
           },
           {
             title: 'SOQL Count',
@@ -707,9 +721,21 @@ export class CalltreeView extends LitElement {
             sorter: 'number',
             cssClass: 'number-cell',
             width: 60,
+            bottomCalc: 'max',
+            bottomCalcFormatter: progressFormatter,
+            bottomCalcFormatterParams: {
+              precision: 0,
+              totalValue: 100,
+              showPercentageText: false,
+            },
+            formatter: progressFormatter,
+            formatterParams: {
+              precision: 0,
+              totalValue: 100,
+              showPercentageText: false,
+            },
             hozAlign: 'right',
             headerHozAlign: 'right',
-            bottomCalc: 'max',
           },
           {
             title: 'Throws Count',
@@ -727,9 +753,21 @@ export class CalltreeView extends LitElement {
             sorter: 'number',
             cssClass: 'number-cell',
             width: 60,
+            bottomCalc: 'max',
+            bottomCalcFormatter: progressFormatter,
+            bottomCalcFormatterParams: {
+              precision: 0,
+              totalValue: 10000,
+              showPercentageText: false,
+            },
+            formatter: progressFormatter,
+            formatterParams: {
+              precision: 0,
+              totalValue: 10000,
+              showPercentageText: false,
+            },
             hozAlign: 'right',
             headerHozAlign: 'right',
-            bottomCalc: 'max',
           },
           {
             title: 'SOQL Rows',
@@ -737,9 +775,21 @@ export class CalltreeView extends LitElement {
             sorter: 'number',
             cssClass: 'number-cell',
             width: 60,
+            bottomCalc: 'max',
+            bottomCalcFormatter: progressFormatter,
+            bottomCalcFormatterParams: {
+              precision: 0,
+              totalValue: 50000,
+              showPercentageText: false,
+            },
+            formatter: progressFormatter,
+            formatterParams: {
+              precision: 0,
+              totalValue: 50000,
+              showPercentageText: false,
+            },
             hozAlign: 'right',
             headerHozAlign: 'right',
-            bottomCalc: 'max',
           },
           {
             title: 'Total Time (ms)',
@@ -749,13 +799,12 @@ export class CalltreeView extends LitElement {
             width: 150,
             hozAlign: 'right',
             headerHozAlign: 'right',
-            formatter: progressFormatter,
+            formatter: progressFormatterMS,
             formatterParams: {
-              thousand: false,
               precision: 3,
               totalValue: rootMethod.duration.total,
             },
-            bottomCalcFormatter: progressFormatter,
+            bottomCalcFormatter: progressFormatterMS,
             bottomCalc: 'max',
             bottomCalcFormatterParams: { precision: 3, totalValue: rootMethod.duration.total },
             headerFilter: MinMaxEditor,
@@ -773,10 +822,9 @@ export class CalltreeView extends LitElement {
             headerHozAlign: 'right',
             bottomCalc: 'sum',
             bottomCalcFormatterParams: { precision: 3, totalValue: rootMethod.duration.total },
-            bottomCalcFormatter: progressFormatter,
-            formatter: progressFormatter,
+            bottomCalcFormatter: progressFormatterMS,
+            formatter: progressFormatterMS,
             formatterParams: {
-              thousand: false,
               precision: 3,
               totalValue: rootMethod.duration.total,
             },

--- a/log-viewer/modules/components/calltree-view/CalltreeView.ts
+++ b/log-viewer/modules/components/calltree-view/CalltreeView.ts
@@ -565,7 +565,9 @@ export class CalltreeView extends LitElement {
       const selfTimeFilterCache = new Map<string, boolean>();
       const totalTimeFilterCache = new Map<string, boolean>();
       const namespaceFilterCache = new Map<string, boolean>();
+
       const excludedTypes = new Set<LogEventType>(['SOQL_EXECUTE_BEGIN', 'DML_BEGIN']);
+      const governorLimits = rootMethod.governorLimits.totals;
 
       let childIndent;
       this.calltreeTable = new Tabulator(callTreeTableContainer, {
@@ -703,13 +705,13 @@ export class CalltreeView extends LitElement {
             bottomCalcFormatter: progressFormatter,
             bottomCalcFormatterParams: {
               precision: 0,
-              totalValue: 100,
+              totalValue: governorLimits.dmlStatements.limit,
               showPercentageText: false,
             },
             formatter: progressFormatter,
             formatterParams: {
               precision: 0,
-              totalValue: 100,
+              totalValue: governorLimits.dmlStatements.limit,
               showPercentageText: false,
             },
             hozAlign: 'right',
@@ -725,13 +727,13 @@ export class CalltreeView extends LitElement {
             bottomCalcFormatter: progressFormatter,
             bottomCalcFormatterParams: {
               precision: 0,
-              totalValue: 100,
+              totalValue: governorLimits.soqlQueries.limit,
               showPercentageText: false,
             },
             formatter: progressFormatter,
             formatterParams: {
               precision: 0,
-              totalValue: 100,
+              totalValue: governorLimits.soqlQueries.limit,
               showPercentageText: false,
             },
             hozAlign: 'right',
@@ -757,13 +759,13 @@ export class CalltreeView extends LitElement {
             bottomCalcFormatter: progressFormatter,
             bottomCalcFormatterParams: {
               precision: 0,
-              totalValue: 10000,
+              totalValue: governorLimits.dmlRows.limit,
               showPercentageText: false,
             },
             formatter: progressFormatter,
             formatterParams: {
               precision: 0,
-              totalValue: 10000,
+              totalValue: governorLimits.dmlRows.limit,
               showPercentageText: false,
             },
             hozAlign: 'right',
@@ -779,13 +781,13 @@ export class CalltreeView extends LitElement {
             bottomCalcFormatter: progressFormatter,
             bottomCalcFormatterParams: {
               precision: 0,
-              totalValue: 50000,
+              totalValue: governorLimits.queryRows.limit,
               showPercentageText: false,
             },
             formatter: progressFormatter,
             formatterParams: {
               precision: 0,
-              totalValue: 50000,
+              totalValue: governorLimits.queryRows.limit,
               showPercentageText: false,
             },
             hozAlign: 'right',

--- a/log-viewer/modules/components/calltree-view/CalltreeView.ts
+++ b/log-viewer/modules/components/calltree-view/CalltreeView.ts
@@ -718,7 +718,8 @@ export class CalltreeView extends LitElement {
             hozAlign: 'right',
             headerHozAlign: 'right',
             tooltip(_event, cell, _onRender) {
-              return cell.getValue() + '/' + governorLimits.dmlStatements.limit;
+              const maxDmlStatements = governorLimits.dmlStatements.limit;
+              return cell.getValue() + maxDmlStatements > 0 ? '/' + maxDmlStatements : '';
             },
           },
           {
@@ -743,7 +744,8 @@ export class CalltreeView extends LitElement {
             hozAlign: 'right',
             headerHozAlign: 'right',
             tooltip(_event, cell, _onRender) {
-              return cell.getValue() + '/' + governorLimits.soqlQueries.limit;
+              const maxSoql = governorLimits.soqlQueries.limit;
+              return cell.getValue() + maxSoql > 0 ? '/' + maxSoql : '';
             },
           },
           {
@@ -778,7 +780,8 @@ export class CalltreeView extends LitElement {
             hozAlign: 'right',
             headerHozAlign: 'right',
             tooltip(_event, cell, _onRender) {
-              return cell.getValue() + '/' + governorLimits.dmlRows.limit;
+              const maxDmlRows = governorLimits.dmlRows.limit;
+              return cell.getValue() + maxDmlRows > 0 ? '/' + maxDmlRows : '';
             },
           },
           {
@@ -803,7 +806,8 @@ export class CalltreeView extends LitElement {
             hozAlign: 'right',
             headerHozAlign: 'right',
             tooltip(_event, cell, _onRender) {
-              return cell.getValue() + '/' + governorLimits.queryRows.limit;
+              const maxQueryRows = governorLimits.queryRows.limit;
+              return cell.getValue() + maxQueryRows > 0 ? '/' + maxQueryRows : '';
             },
           },
           {

--- a/log-viewer/modules/components/calltree-view/CalltreeView.ts
+++ b/log-viewer/modules/components/calltree-view/CalltreeView.ts
@@ -32,7 +32,7 @@ import dataGridStyles from '../../datagrid/style/DataGrid.scss';
 import { ApexLog, LogLine, TimedNode, type LogEventType } from '../../parsers/ApexLogParser.js';
 import { vscodeMessenger } from '../../services/VSCodeExtensionMessenger.js';
 import { globalStyles } from '../../styles/global.styles.js';
-import { isVisible } from '../../Util.js';
+import formatDuration, { isVisible } from '../../Util.js';
 import '../skeleton/GridSkeleton.js';
 import { Find, formatter } from './module/Find.js';
 import { MiddleRowFocus } from './module/MiddleRowFocus.js';
@@ -583,6 +583,7 @@ export class CalltreeView extends LitElement {
         dataTree: true,
         dataTreeChildColumnCalcs: true, // todo: fix
         dataTreeBranchElement: '<span/>',
+        tooltipDelay: 100,
         selectableRows: 1,
         // @ts-expect-error it is possible to pass a function to intitialFilter the types need updating
         initialFilter: this._showDetailsFilter,
@@ -716,6 +717,9 @@ export class CalltreeView extends LitElement {
             },
             hozAlign: 'right',
             headerHozAlign: 'right',
+            tooltip(_event, cell, _onRender) {
+              return cell.getValue() + '/' + governorLimits.dmlStatements.limit;
+            },
           },
           {
             title: 'SOQL Count',
@@ -738,6 +742,9 @@ export class CalltreeView extends LitElement {
             },
             hozAlign: 'right',
             headerHozAlign: 'right',
+            tooltip(_event, cell, _onRender) {
+              return cell.getValue() + '/' + governorLimits.soqlQueries.limit;
+            },
           },
           {
             title: 'Throws Count',
@@ -770,6 +777,9 @@ export class CalltreeView extends LitElement {
             },
             hozAlign: 'right',
             headerHozAlign: 'right',
+            tooltip(_event, cell, _onRender) {
+              return cell.getValue() + '/' + governorLimits.dmlRows.limit;
+            },
           },
           {
             title: 'SOQL Rows',
@@ -792,6 +802,9 @@ export class CalltreeView extends LitElement {
             },
             hozAlign: 'right',
             headerHozAlign: 'right',
+            tooltip(_event, cell, _onRender) {
+              return cell.getValue() + '/' + governorLimits.queryRows.limit;
+            },
           },
           {
             title: 'Total Time (ms)',
@@ -813,6 +826,9 @@ export class CalltreeView extends LitElement {
             headerFilterFunc: MinMaxFilter,
             headerFilterFuncParams: { columnName: 'duration', filterCache: totalTimeFilterCache },
             headerFilterLiveFilter: false,
+            tooltip(_event, cell, _onRender) {
+              return formatDuration(cell.getValue(), rootMethod.duration.total);
+            },
           },
           {
             title: 'Self Time (ms)',
@@ -837,6 +853,9 @@ export class CalltreeView extends LitElement {
               filterCache: selfTimeFilterCache,
             },
             headerFilterLiveFilter: false,
+            tooltip(_event, cell, _onRender) {
+              return formatDuration(cell.getValue(), rootMethod.duration.total);
+            },
           },
         ],
       });

--- a/log-viewer/modules/components/calltree-view/CalltreeView.ts
+++ b/log-viewer/modules/components/calltree-view/CalltreeView.ts
@@ -413,11 +413,18 @@ export class CalltreeView extends LitElement {
   }
 
   _showDetailsFilter = (data: CalltreeRow) => {
+    const excludedTypes = new Set<string>([
+      'CUMULATIVE_LIMIT_USAGE',
+      'LIMIT_USAGE_FOR_NS',
+      'CUMULATIVE_PROFILING',
+      'CUMULATIVE_PROFILING_BEGIN',
+    ]);
+
     return this._deepFilter(
       data,
       (rowData) => {
         const logLine = rowData.originalData;
-        return logLine.duration.total > 0 || logLine.exitTypes.length > 0 || logLine.discontinuity;
+        return logLine.duration.total > 0 || logLine.exitTypes.length > 0 || logLine.discontinuity || !!(logLine.type && excludedTypes.has(logLine.type));
       },
       {
         filterCache: this.showDetailsFilterCache,
@@ -426,7 +433,7 @@ export class CalltreeView extends LitElement {
   };
 
   _debugFilter = (data: CalltreeRow) => {
-    const debugValues = [
+    const debugValues =  new Set<string>([
       'USER_DEBUG',
       'DATAWEAVE_USER_DEBUG',
       'USER_DEBUG_FINER',
@@ -436,11 +443,11 @@ export class CalltreeView extends LitElement {
       'USER_DEBUG_INFO',
       'USER_DEBUG_WARN',
       'USER_DEBUG_ERROR',
-    ];
+    ]);
     return this._deepFilter(
       data,
       (rowData) => {
-        return debugValues.includes(rowData.originalData.type || '');
+        return !!(rowData.originalData.type && debugValues.has(rowData.originalData.type));
       },
       {
         filterCache: this.debugOnlyFilterCache,

--- a/log-viewer/modules/components/calltree-view/CalltreeView.ts
+++ b/log-viewer/modules/components/calltree-view/CalltreeView.ts
@@ -567,7 +567,7 @@ export class CalltreeView extends LitElement {
       const namespaceFilterCache = new Map<string, boolean>();
 
       const excludedTypes = new Set<LogEventType>(['SOQL_EXECUTE_BEGIN', 'DML_BEGIN']);
-      const governorLimits = rootMethod.governorLimits.totals;
+      const governorLimits = rootMethod.governorLimits;
 
       let childIndent;
       this.calltreeTable = new Tabulator(callTreeTableContainer, {

--- a/log-viewer/modules/datagrid/format/Progress.ts
+++ b/log-viewer/modules/datagrid/format/Progress.ts
@@ -7,28 +7,29 @@ import './Progress.css';
 
 export function progressFormatter(
   cell: CellComponent,
-  formatterParams: Params,
+  formatterParams: ProgressParams,
   _onRendered: EmptyCallback,
 ) {
   const value = (cell.getValue() || 0) / 1000000;
-
   const roundedValue = `${value.toFixed(formatterParams.precision || 3)}`;
 
   if (formatterParams.totalValue !== undefined && formatterParams.totalValue !== null) {
+    const totalValAsMs =
+      formatterParams.totalValue !== 0 ? formatterParams.totalValue / 1000000 : 0;
     const percentComplete =
-      formatterParams.totalValue !== 0 ? (value / (formatterParams.totalValue / 1000000)) * 100 : 0;
-    const percentage = `(${percentComplete.toFixed(2)}%)`;
+      totalValAsMs !== 0 ? (Math.round((value / totalValAsMs) * 100) / 100) * 100 : 0;
+    const percentageText = `(${percentComplete.toFixed(2)}%)`;
 
     return `<div class="progress-wrapper">
-        <div class="progress-bar" style="width: ${percentComplete}%;"></div>
-        <div class="progress-bar__text"><span>${roundedValue}</span><span class="progress-bar__text__percent">${percentage}</span></div>
+        ${percentComplete ? `<div class="progress-bar" style="width: ${percentComplete}%;"></div>` : ''}
+        <div class="progress-bar__text"><span>${roundedValue}</span><span class="progress-bar__text__percent">${percentageText}</span></div>
       </div>`;
   }
 
   return `${roundedValue}`;
 }
 
-export interface Params {
+export interface ProgressParams {
   precision?: number;
   totalValue?: number;
 }

--- a/log-viewer/modules/datagrid/format/ProgressComponent.ts
+++ b/log-viewer/modules/datagrid/format/ProgressComponent.ts
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2025 Certinia Inc. All rights reserved.
+ */
+
+export function progressComponent(
+  value: number,
+  totalValue: number,
+  options: { showPercentageText?: boolean; precision?: number } = {
+    showPercentageText: true,
+    precision: 3,
+  },
+) {
+  const roundedValue = `${(value || 0).toFixed(options.precision ?? 3)}`;
+
+  if (totalValue !== undefined && totalValue !== null) {
+    const showPercent = options.showPercentageText ?? true;
+    const percentComplete =
+      totalValue !== 0 ? (Math.round((value / totalValue) * 100) / 100) * 100 : 0;
+
+    const percentageText = showPercent ? `(${percentComplete.toFixed(2)}%)` : '';
+
+    const progressBarElem = `${percentComplete ? `<div class="progress-bar" style="width: ${percentComplete}%;"></div>` : ''}`;
+    const progressBarTextElem = `<div class="progress-bar__text">
+      <span>${roundedValue}</span>
+      ${showPercent ? `<span class="progress-bar__text__percent">${percentageText}</span>` : ''}
+    </div>`;
+
+    return `<div class="progress-wrapper">
+        ${progressBarElem}
+        ${progressBarTextElem}
+      </div>`;
+  }
+
+  return roundedValue;
+}

--- a/log-viewer/modules/datagrid/format/ProgressMS.ts
+++ b/log-viewer/modules/datagrid/format/ProgressMS.ts
@@ -5,15 +5,16 @@ import { type CellComponent, type EmptyCallback } from 'tabulator-tables';
 import './Progress.css';
 import { progressComponent } from './ProgressComponent.js';
 
-export function progressFormatter(
+export function progressFormatterMS(
   cell: CellComponent,
   formatterParams: ProgressParams,
   _onRendered: EmptyCallback,
 ) {
-  const value = cell.getValue() ?? 0;
+  const value = (cell.getValue() || 0) / 1000000;
   const totalVal = formatterParams.totalValue ?? 0;
+  const totalValAsMs = totalVal > 0 ? totalVal / 1000000 : 0;
 
-  return progressComponent(value, totalVal, {
+  return progressComponent(value, totalValAsMs, {
     showPercentageText: formatterParams.showPercentageText,
     precision: formatterParams.precision,
   });

--- a/log-viewer/modules/datagrid/style/DataGrid.scss
+++ b/log-viewer/modules/datagrid/style/DataGrid.scss
@@ -111,7 +111,7 @@ $footerActiveColor: #d00 !default; //footer bottom active text color
   }
 
   .tabulator-cell.datagrid-textarea {
-    white-space: normal;
+    white-space: pre-wrap;
     overflow-wrap: break-word;
     min-height: 0;
     height: 100%;

--- a/log-viewer/modules/parsers/ApexLogParser.ts
+++ b/log-viewer/modules/parsers/ApexLogParser.ts
@@ -43,22 +43,20 @@ export class ApexLogParser {
   discontinuity = false;
   namespaces = new Set<string>();
   governorLimits: GovernorLimits = {
-    totals: {
-      soqlQueries: { used: 0, limit: 0 },
-      soslQueries: { used: 0, limit: 0 },
-      queryRows: { used: 0, limit: 0 },
-      dmlStatements: { used: 0, limit: 0 },
-      publishImmediateDml: { used: 0, limit: 0 },
-      dmlRows: { used: 0, limit: 0 },
-      cpuTime: { used: 0, limit: 0 },
-      heapSize: { used: 0, limit: 0 },
-      callouts: { used: 0, limit: 0 },
-      emailInvocations: { used: 0, limit: 0 },
-      futureCalls: { used: 0, limit: 0 },
-      queueableJobsAddedToQueue: { used: 0, limit: 0 },
-      mobileApexPushCalls: { used: 0, limit: 0 },
-    },
-    limitsByNamespace: new Map<string, Limits>(),
+    soqlQueries: { used: 0, limit: 0 },
+    soslQueries: { used: 0, limit: 0 },
+    queryRows: { used: 0, limit: 0 },
+    dmlStatements: { used: 0, limit: 0 },
+    publishImmediateDml: { used: 0, limit: 0 },
+    dmlRows: { used: 0, limit: 0 },
+    cpuTime: { used: 0, limit: 0 },
+    heapSize: { used: 0, limit: 0 },
+    callouts: { used: 0, limit: 0 },
+    emailInvocations: { used: 0, limit: 0 },
+    futureCalls: { used: 0, limit: 0 },
+    queueableJobsAddedToQueue: { used: 0, limit: 0 },
+    mobileApexPushCalls: { used: 0, limit: 0 },
+    byNamespace: new Map<string, Limits>(),
   };
 
   /**
@@ -82,9 +80,9 @@ export class ApexLogParser {
   }
 
   private addGovernorLimits(apexLog: ApexLog) {
-    const totalLimits = apexLog.governorLimits.totals;
+    const totalLimits = apexLog.governorLimits;
     if (totalLimits) {
-      for (const limitsForNs of apexLog.governorLimits.limitsByNamespace.values()) {
+      for (const limitsForNs of apexLog.governorLimits.byNamespace.values()) {
         for (const [key, value] of Object.entries(limitsForNs) as Array<
           [keyof Limits, Limits[keyof Limits]]
         >) {
@@ -537,9 +535,8 @@ export interface Limits {
   mobileApexPushCalls: { used: number; limit: number };
 }
 
-export interface GovernorLimits {
-  totals: Limits;
-  limitsByNamespace: Map<string, Limits>;
+export interface GovernorLimits extends Limits {
+  byNamespace: Map<string, Limits>;
 }
 /**
  * All log lines extend this base class.
@@ -879,22 +876,20 @@ export class ApexLog extends Method {
   public parsingErrors: string[] = [];
 
   public governorLimits: GovernorLimits = {
-    totals: {
-      soqlQueries: { used: 0, limit: 0 },
-      soslQueries: { used: 0, limit: 0 },
-      queryRows: { used: 0, limit: 0 },
-      dmlStatements: { used: 0, limit: 0 },
-      publishImmediateDml: { used: 0, limit: 0 },
-      dmlRows: { used: 0, limit: 0 },
-      cpuTime: { used: 0, limit: 0 },
-      heapSize: { used: 0, limit: 0 },
-      callouts: { used: 0, limit: 0 },
-      emailInvocations: { used: 0, limit: 0 },
-      futureCalls: { used: 0, limit: 0 },
-      queueableJobsAddedToQueue: { used: 0, limit: 0 },
-      mobileApexPushCalls: { used: 0, limit: 0 },
-    },
-    limitsByNamespace: new Map<string, Limits>(),
+    soqlQueries: { used: 0, limit: 0 },
+    soslQueries: { used: 0, limit: 0 },
+    queryRows: { used: 0, limit: 0 },
+    dmlStatements: { used: 0, limit: 0 },
+    publishImmediateDml: { used: 0, limit: 0 },
+    dmlRows: { used: 0, limit: 0 },
+    cpuTime: { used: 0, limit: 0 },
+    heapSize: { used: 0, limit: 0 },
+    callouts: { used: 0, limit: 0 },
+    emailInvocations: { used: 0, limit: 0 },
+    futureCalls: { used: 0, limit: 0 },
+    queueableJobsAddedToQueue: { used: 0, limit: 0 },
+    mobileApexPushCalls: { used: 0, limit: 0 },
+    byNamespace: new Map<string, Limits>(),
   };
 
   /**
@@ -1653,7 +1648,7 @@ class LimitUsageForNSLine extends LogLine {
       }
     }
 
-    parser.governorLimits.limitsByNamespace.set(this.namespace, limits);
+    parser.governorLimits.byNamespace.set(this.namespace, limits);
   }
 }
 

--- a/log-viewer/modules/parsers/ApexLogParser.ts
+++ b/log-viewer/modules/parsers/ApexLogParser.ts
@@ -1521,7 +1521,11 @@ class LimitUsageForNSLine extends LogLine {
 
   onAfter(parser: ApexLogParser, _next?: LogLine): void {
     this.namespace = this.text.slice(0, this.text.indexOf('\n')).replace(/\(|\)/g, '');
-    this.text = this.text.replace(/^\s+/gm, '');
+
+    this.text = this.text
+      .replace(/^\s+/gm, '')
+      .replaceAll('******* CLOSE TO LIMIT', '')
+      .replaceAll(' out of ', '/');
 
     const matched = this.text.match(/Maximum CPU time: (\d+)/),
       cpuText = matched?.[1] || '0',

--- a/log-viewer/modules/parsers/ApexLogParser.ts
+++ b/log-viewer/modules/parsers/ApexLogParser.ts
@@ -1511,15 +1511,16 @@ class LimitUsageLine extends LogLine {
 }
 
 class LimitUsageForNSLine extends LogLine {
-  acceptsText = true;
-  namespace = 'default';
-
   constructor(parser: ApexLogParser, parts: string[]) {
     super(parser, parts);
+    this.acceptsText = true;
+    this.namespace = 'default';
+
     this.text = parts[2] || '';
   }
 
   onAfter(parser: ApexLogParser, _next?: LogLine): void {
+    this.namespace = this.text.slice(0, this.text.indexOf('\n')).replace(/\(|\)/g, '');
     this.text = this.text.replace(/^\s+/gm, '');
 
     const matched = this.text.match(/Maximum CPU time: (\d+)/),

--- a/log-viewer/modules/parsers/ApexLogParser.ts
+++ b/log-viewer/modules/parsers/ApexLogParser.ts
@@ -1520,6 +1520,8 @@ class LimitUsageForNSLine extends LogLine {
   }
 
   onAfter(parser: ApexLogParser, _next?: LogLine): void {
+    this.text = this.text.replace(/^\s+/gm, '');
+
     const matched = this.text.match(/Maximum CPU time: (\d+)/),
       cpuText = matched?.[1] || '0',
       cpuTime = parseInt(cpuText, 10) * 1000000; // convert from milli-seconds to nano-seconds

--- a/log-viewer/modules/timeline/Timeline.ts
+++ b/log-viewer/modules/timeline/Timeline.ts
@@ -666,7 +666,7 @@ function findTimelineTooltip(
 
     if (target.exitStamp) {
       if (target.duration.total) {
-        let val = formatDuration(target.duration.total);
+        let val = formatDuration(target.duration.total, timelineRoot.duration.total);
         if (target.cpuType === 'free') {
           val += ' (free)';
         } else if (target.duration.self) {
@@ -676,45 +676,70 @@ function findTimelineTooltip(
         rows.push({ label: 'total:', value: val });
       }
 
+      const govLimits = timelineRoot.governorLimits.totals;
       if (target.dmlCount.total) {
         rows.push({
           label: 'DML:',
-          value: `${target.dmlCount.total} (self ${target.dmlCount.self})`,
+          value: formatLimit(
+            target.dmlCount.total,
+            target.dmlCount.self,
+            govLimits.dmlStatements.limit,
+          ),
         });
       }
 
       if (target.dmlRowCount.total) {
         rows.push({
           label: 'DML rows:',
-          value: `${target.dmlRowCount.total} (self ${target.dmlRowCount.self})`,
+          value: formatLimit(
+            target.dmlRowCount.total,
+            target.dmlRowCount.self,
+            govLimits.dmlRows.limit,
+          ),
         });
       }
 
       if (target.soqlCount.total) {
         rows.push({
           label: 'SOQL:',
-          value: `${target.soqlCount.total} (self ${target.soqlCount.self})`,
+          value: formatLimit(
+            target.soqlCount.total,
+            target.soqlCount.self,
+            govLimits.soqlQueries.limit,
+          ),
         });
       }
 
       if (target.soqlRowCount.total) {
         rows.push({
           label: 'SOQL rows:',
-          value: `${target.soqlRowCount.total} (self ${target.soqlRowCount.self})`,
+          value: formatLimit(
+            target.soqlRowCount.total,
+            target.soqlRowCount.self,
+            govLimits.queryRows.limit,
+          ),
         });
       }
 
       if (target.soslCount.total) {
         rows.push({
           label: 'SOSL:',
-          value: `${target.soslCount.total} (self ${target.soslCount.self})`,
+          value: formatLimit(
+            target.soslCount.total,
+            target.soslCount.self,
+            govLimits.soslQueries.limit,
+          ),
         });
       }
 
       if (target.soslRowCount.total) {
         rows.push({
           label: 'SOSL rows:',
-          value: `${target.soslRowCount.total} (self ${target.soslRowCount.self})`,
+          value: formatLimit(
+            target.soslRowCount.total,
+            target.soslRowCount.self,
+            govLimits.soslQueries.limit,
+          ),
         });
       }
     }
@@ -729,6 +754,11 @@ function findTimelineTooltip(
   canvas.classList.remove('timeline-event--hover');
 
   return null;
+}
+
+function formatLimit(val: number, self: number, total = 0) {
+  const outOf = total > 0 ? `/${total}` : '';
+  return `${val}${outOf} (self ${self})`;
 }
 
 function createTooltip(title: string, rows: { label: string; value: string }[], color: string) {

--- a/log-viewer/modules/timeline/Timeline.ts
+++ b/log-viewer/modules/timeline/Timeline.ts
@@ -676,7 +676,7 @@ function findTimelineTooltip(
         rows.push({ label: 'total:', value: val });
       }
 
-      const govLimits = timelineRoot.governorLimits.totals;
+      const govLimits = timelineRoot.governorLimits;
       if (target.dmlCount.total) {
         rows.push({
           label: 'DML:',

--- a/log-viewer/modules/timeline/TimelineView.ts
+++ b/log-viewer/modules/timeline/TimelineView.ts
@@ -44,20 +44,63 @@ export class TimelineView extends LitElement {
         flex-direction: column;
         flex: 1;
         position: relative;
-        height: 75%;
+        height: 80%;
       }
 
       #timeline-tooltip {
         display: none;
         position: absolute;
-        max-width: 90%;
+        max-width: 75%;
+        min-width: 150px;
+      }
+
+      .timeline-tooltip {
+        position: relative;
+        box-shadow: 0 8px 24px rgba(0, 0, 0, 0.5);
+        backdrop-filter: blur(6px);
         z-index: 1000;
         padding: 5px;
         border-radius: 4px;
+        border-left: 4px solid;
         background-color: var(--vscode-editor-background);
         color: var(--vscode-editor-foreground);
         font-family: monospace;
-        font-size: 1rem;
+        font-size: 0.92rem;
+        pointer-events: none;
+        transition: opacity 0.15s ease;
+      }
+
+      .tooltip-header {
+        font-weight: 500;
+        margin-bottom: 10px;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        line-height: 1em;
+      }
+
+      .tooltip-row {
+        display: flex;
+        justify-content: space-between;
+        align-items: baseline;
+        padding: 2px 0;
+      }
+
+      .tooltip-label {
+        flex: 1 1 auto;
+        overflow: hidden;
+        white-space: nowrap;
+        text-overflow: ellipsis;
+        padding-right: 12px;
+      }
+
+      .tooltip-value {
+        flex-shrink: 0;
+        font-variant-numeric: tabular-nums;
+        font-weight: 500;
+        font-family: monospace;
+        opacity: 0.9;
+        text-align: right;
+        white-space: nowrap;
       }
 
       .timeline-event--hover {


### PR DESCRIPTION
# 📝 PR Overview

- Add formatting for cumulative limit usage in the call tree.
- Always show the cumulative limit usage rows (even though time is 0)
- Add percentage bars in cells that use cumulative limit usage totals for the percent.
  - DML + SOQL rows, DML + SOQL statements 
- Show governor limits totals on timeline tooltip e.g 1000/50000 for row s
-show tooltip on call tree and analysis grid to show Governor totals e.g 4000/10000 for dml rows.
-
> Example: "Adds a flame chart view for CPU time analysis in Apex logs to improve log analysis performance."

## 🧩 Type of change (check all applicable)

- [ ] 🐛 Bug fix - something not working as expected
- [X] ✨ New feature – adds new functionality
- [ ] ♻️ Refactor - internal changes with no user impact
- [ ] ⚡ Performance Improvement
- [ ] 📝 Documentation - README or documentation site changes
- [ ] 🔧 Chore - dev tooling, CI, config
- [ ] 💥 Breaking change

## 📷 Screenshots / gifs / video [optional]

_Show off your UI changes._

## 🔗 Related Issues

fixes #
resolves #308 
resolves #309
closes #
related #

## ✅ Tests added?

- [ ] 👍 yes
- [ ] 🙅 no, not needed
- [ ] 🙋 no, I need help

## 📚 Docs updated?

- [ ] 🔖 README.md
- [ ] 🔖 CHANGELOG.md
- [ ] 📖 help site
- [ ] 🙅 not needed

## Anything else we need to know? [optional]
