### PR TITLE
chore: bump node to v22

### DIFF
--- a/.github/workflows/cd-prerelease.yml
+++ b/.github/workflows/cd-prerelease.yml
@@ -59,7 +59,7 @@ jobs:
       - name: Setup pnpm
         uses: pnpm/action-setup@v3
         with:
-          version: 8
+          version: 10
       - name: Set up Node
         uses: actions/setup-node@v4
         with:

--- a/.github/workflows/cd-prerelease.yml
+++ b/.github/workflows/cd-prerelease.yml
@@ -63,7 +63,7 @@ jobs:
       - name: Set up Node
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '22'
           cache: 'pnpm'
       - name: Install vsce + ovsx
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Set up Node
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '22'
           cache: 'pnpm'
       - name: Install Packages
         run: HUSKY=0 pnpm install
@@ -37,7 +37,7 @@ jobs:
       - name: Set up Node
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '22'
           cache: 'pnpm'
       - name: Install Packages
         run: HUSKY=0 pnpm install
@@ -56,7 +56,7 @@ jobs:
       - name: Set up Node
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '22'
           cache: 'pnpm'
       - name: Install vsce
         run: pnpm add --global @vscode/vsce

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v3
         with:
-          version: 8
+          version: 10
       - name: Set up Node
         uses: actions/setup-node@v4
         with:
@@ -33,7 +33,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v3
         with:
-          version: 8
+          version: 10
       - name: Set up Node
         uses: actions/setup-node@v4
         with:
@@ -52,7 +52,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v3
         with:
-          version: 8
+          version: 10
       - name: Set up Node
         uses: actions/setup-node@v4
         with:

--- a/.github/workflows/publish-gh-pages.yml
+++ b/.github/workflows/publish-gh-pages.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Set up Node
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '22'
           cache: 'pnpm'
       - name: Dependencies
         run: |

--- a/.github/workflows/publish-gh-pages.yml
+++ b/.github/workflows/publish-gh-pages.yml
@@ -32,7 +32,7 @@ jobs:
       - name: pnpm setup
         uses: pnpm/action-setup@v3
         with:
-          version: 8
+          version: 10
       - name: Set up Node
         uses: actions/setup-node@v4
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,7 +12,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v3
         with:
-          version: 8
+          version: 10
       - name: Set up Node
         uses: actions/setup-node@v4
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Set up Node
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '22'
           cache: 'pnpm'
       - name: Install vsce + ovsx
         run: |

--- a/.npmrc
+++ b/.npmrc
@@ -1,4 +1,4 @@
 registry=https://registry.npmjs.org/
 auto-install-peers=true
-# rollup plugins (commonjs + node resolve)doe not play nice without this.
+# rollup plugins (commonjs + node resolve) do not play nice without this.
 shamefully-hoist=true

--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -18,7 +18,7 @@ Welcome to the development guide for the **Apex Log Analyzer** VS Code extension
 
 Before you start developing, make sure you have the following tools installed:
 
-- **Node.js** v16 or above: [Install Node.js](https://nodejs.org/en/)
+- **Node.js** v22 or above: [Install Node.js](https://nodejs.org/en/)
 - **[pnpm](https://pnpm.io/)**: This package manager will be used for installing dependencies
 - \*\*[VS Code](https://code.visualstudio.com/)
 

--- a/lana/package.json
+++ b/lana/package.json
@@ -189,7 +189,7 @@
     "@salesforce/apex-node": "^1.6.2"
   },
   "devDependencies": {
-    "@types/node": "~20.14.8",
+    "@types/node": "~22.16.0",
     "@types/vscode": "~1.74.0",
     "@typescript-eslint/eslint-plugin": "^8.30.1",
     "@typescript-eslint/parser": "^8.30.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -111,8 +111,8 @@ importers:
         version: 1.6.2
     devDependencies:
       '@types/node':
-        specifier: ~20.14.8
-        version: 20.14.15
+        specifier: ~22.16.0
+        version: 22.16.0
       '@types/vscode':
         specifier: ~1.74.0
         version: 1.74.1
@@ -2389,6 +2389,9 @@ packages:
 
   '@types/node@20.14.15':
     resolution: {integrity: sha512-Fz1xDMCF/B00/tYSVMlmK7hVeLh7jE5f3B7X1/hmV0MJBwE27KlS7EvD/Yp+z1lm8mVhwV5w+n8jOZG8AfTlKw==}
+
+  '@types/node@22.16.0':
+    resolution: {integrity: sha512-B2egV9wALML1JCpv3VQoQ+yesQKAmNMBIAY7OteVrikcOcAkWm+dGL6qpeCktPjAv6N1JLnhbNiqS35UpFyBsQ==}
 
   '@types/parse-json@4.0.2':
     resolution: {integrity: sha512-dISoDXWWQwUquiKsyZ4Ng+HX2KsPL7LyHKHQwgGFEA3IaKac4Obd+h2a/a6waisAoepJlBcx9paWqjA8/HVjCw==}
@@ -7243,6 +7246,9 @@ packages:
   undici-types@5.26.5:
     resolution: {integrity: sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==}
 
+  undici-types@6.21.0:
+    resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
+
   undici@6.21.2:
     resolution: {integrity: sha512-uROZWze0R0itiAKVPsYhFov9LxrPMHLMEQFszeI2gCN6bnIIZ8twzBCJcN2LJrBBLfrP0t1FW0g+JmKVl8Vk1g==}
     engines: {node: '>=18.17'}
@@ -10768,6 +10774,10 @@ snapshots:
   '@types/node@20.14.15':
     dependencies:
       undici-types: 5.26.5
+
+  '@types/node@22.16.0':
+    dependencies:
+      undici-types: 6.21.0
 
   '@types/parse-json@4.0.2': {}
 
@@ -16595,6 +16605,8 @@ snapshots:
   typescript@5.8.3: {}
 
   undici-types@5.26.5: {}
+
+  undici-types@6.21.0: {}
 
   undici@6.21.2: {}
 


### PR DESCRIPTION
# 📝 PR Overview

Updates lana (vscode extension) node version to v22 which is vscode latest supported version
Updates node version in workflows to v22
Updates pnpm version in github workflows to v10

## 🧩 Type of change (check all applicable)

- [ ] 🐛 Bug fix - something not working as expected
- [ ] ✨ New feature – adds new functionality
- [ ] ♻️ Refactor - internal changes with no user impact
- [ ] ⚡ Performance Improvement
- [ ] 📝 Documentation - README or documentation site changes
- [X] 🔧 Chore - dev tooling, CI, config
- [ ] 💥 Breaking change

## 📷 Screenshots / gifs / video [optional]

_Show off your UI changes._

## 🔗 Related Issues

fixes #
resolves #
closes #
related #

## ✅ Tests added?

- [ ] 👍 yes
- [X] 🙅 no, not needed
- [ ] 🙋 no, I need help

## 📚 Docs updated?

- [ ] 🔖 README.md
- [ ] 🔖 CHANGELOG.md
- [ ] 📖 help site
- [X] 🙅 not needed

## Anything else we need to know? [optional]
