### PR TITLE
fix: show timeline node that have children

### DIFF
--- a/log-viewer/src/features/timeline/services/Timeline.ts
+++ b/log-viewer/src/features/timeline/services/Timeline.ts
@@ -252,7 +252,7 @@ function drawScale(ctx: CanvasRenderingContext2D) {
 function nodesToRectangles(rootNodes: LogEvent[]) {
   // seed depth 0
   let depth = 0;
-  let currentLevel = rootNodes.filter((n) => n.duration && n.children.length);
+  let currentLevel = rootNodes.filter((n) => n.duration);
 
   while (currentLevel.length) {
     const nextLevel: LogEvent[] = [];
@@ -263,7 +263,7 @@ function nodesToRectangles(rootNodes: LogEvent[]) {
       }
 
       for (const child of node.children) {
-        if (child.duration && child.children.length) {
+        if (child.duration) {
           nextLevel.push(child);
         }
       }


### PR DESCRIPTION
# 📝 PR Overview

show timeline node that have children

Previously all nodes without children were filtered out. 

This was a regression during a refactor and is not in the released extension.
So no doc, changelog etc needed.

## 🧩 Type of change (check all applicable)

- [X] 🐛 Bug fix - something not working as expected
- [ ] ✨ New feature – adds new functionality
- [ ] ♻️ Refactor - internal changes with no user impact
- [ ] ⚡ Performance Improvement
- [ ] 📝 Documentation - README or documentation site changes
- [ ] 🔧 Chore - dev tooling, CI, config
- [ ] 💥 Breaking change

## 📷 Screenshots / gifs / video [optional]

_Show off your UI changes._

## 🔗 Related Issues

fixes #
resolves #
closes #
related #

## ✅ Tests added?

- [ ] 👍 yes
- [X] 🙅 no, not needed
- [ ] 🙋 no, I need help

## 📚 Docs updated?

- [ ] 🔖 README.md
- [ ] 🔖 CHANGELOG.md
- [ ] 📖 help site
- [X] 🙅 not needed

## Anything else we need to know? [optional]
