### PR TITLE
fix: ensure TotalTime on analysis does not double count

### DIFF
--- a/log-viewer/src/features/analysis/components/AnalysisView.ts
+++ b/log-viewer/src/features/analysis/components/AnalysisView.ts
@@ -12,10 +12,11 @@ import { LitElement, css, html, unsafeCSS, type PropertyValues } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
 import { Tabulator, type RowComponent } from 'tabulator-tables';
 
-import type { ApexLog, LogEvent } from '../../../core/log-parser/LogEvents.js';
+import type { ApexLog } from '../../../core/log-parser/LogEvents.js';
 import { vscodeMessenger } from '../../../core/messaging/VSCodeExtensionMessenger.js';
 import formatDuration, { isVisible } from '../../../core/utility/Util.js';
-import { callStackSum } from '../services/CallStackSum.js';
+import { sumRootNodesOnly } from '../services/CallStackSum.js';
+import { group } from '../services/RowGrouper.js';
 
 // Tabulator custom modules, imports + styles
 import NumberAccessor from '../../../tabulator/dataaccessor/Number.js';
@@ -275,7 +276,7 @@ export class AnalysisView extends LitElement {
     this.analysisTable = new Tabulator(this._tableWrapper, {
       rowKeyboardNavigation: true,
       selectableRows: 'highlight',
-      data: groupMetrics(rootMethod),
+      data: group(rootMethod),
       layout: 'fitColumns',
       placeholder: 'No Analysis Available',
       columnCalcs: 'table',
@@ -392,7 +393,7 @@ export class AnalysisView extends LitElement {
           width: 165,
           hozAlign: 'right',
           headerHozAlign: 'right',
-          bottomCalc: callStackSum,
+          bottomCalc: sumRootNodesOnly,
           bottomCalcFormatter: progressFormatterMS,
           bottomCalcFormatterParams: { precision: 3, totalValue: rootMethod.duration.total },
           formatter: progressFormatterMS,
@@ -447,54 +448,6 @@ export class AnalysisView extends LitElement {
     this.analysisTable.clearFindHighlights(Object.values(this.findMap));
     this.findMap = {};
     this.totalMatches = 0;
-  }
-}
-export class Metric {
-  name: string;
-  type;
-  count = 0;
-  totalTime = 0;
-  selfTime = 0;
-  namespace;
-  nodes: LogEvent[] = [];
-
-  constructor(node: LogEvent) {
-    this.name = node.text;
-    this.type = node.type;
-    this.namespace = node.namespace;
-  }
-}
-
-function groupMetrics(root: LogEvent) {
-  const methodMap: Map<string, Metric> = new Map();
-
-  for (const child of root.children) {
-    if (child.duration.total) {
-      addNodeToMap(methodMap, child);
-    }
-  }
-  return Array.from(methodMap.values());
-}
-
-function addNodeToMap(map: Map<string, Metric>, node: LogEvent) {
-  if (node.duration.total) {
-    const key = node.namespace + node.text;
-    let metric = map.get(key);
-    if (!metric) {
-      metric = new Metric(node);
-      map.set(key, metric);
-    }
-
-    ++metric.count;
-    metric.totalTime += node.duration.total;
-    metric.selfTime += node.duration.self;
-    metric.nodes.push(node);
-  }
-
-  for (const child of node.children) {
-    if (child.duration.total) {
-      addNodeToMap(map, child);
-    }
   }
 }
 

--- a/log-viewer/src/features/analysis/services/CallStackSum.ts
+++ b/log-viewer/src/features/analysis/services/CallStackSum.ts
@@ -1,31 +1,59 @@
-import type { LogEvent } from '../../../core/log-parser/LogEvents.js';
-import type { Metric } from '../../analysis/components/AnalysisView.js';
+/*
+ * Copyright (c) 2024 Certinia Inc. All rights reserved.
+ */
 
-export function callStackSum(_values: number[], data: Metric[], _calcParams: unknown) {
-  const nodes: LogEvent[] = [];
+import type { LogEvent } from '../../../core/log-parser/LogEvents.js';
+import type { Metric } from '../../analysis/services/RowGrouper.js';
+
+/**
+ * Calculates the sum of total execution time for root nodes only (nodes without ancestors in the set).
+ * This prevents double-counting when multiple nodes from the same call chain are present in the filtered set.
+ *
+ * For each node, walks up the parent chain to check if any ancestor is also in the node set.
+ * Only nodes without ancestors contribute their totalTime to the sum.
+ *
+ * @param _values - Unused parameter (required by Tabulator's calc function signature)
+ * @param data - Array of Metric objects containing the nodes to sum
+ * @param _calcParams - Unused parameter (required by Tabulator's calc function signature)
+ * @returns The sum of totalTime in nanoseconds for all root nodes (nodes without ancestors in the set)
+ *
+ * @example
+ * ```typescript
+ * // If we have nodes: A -> B -> C and the filtered set contains [B, C]
+ * // Only B's time is counted (C is excluded because B is its ancestor)
+ * const total = sumRootNodesOnly([], [metricB, metricC], {});
+ * ```
+ *
+ * @remarks
+ * This function is designed as a Tabulator column calc function, hence the unused parameters.
+ * It's used to calculate accurate totals in analysis tables where filtered results may include
+ * nodes from the same call stack.
+ */
+export function sumRootNodesOnly(_values: number[], data: Metric[], _calcParams: unknown) {
+  const allNodes = new Set<LogEvent>();
   for (const row of data) {
-    Array.prototype.push.apply(nodes, row.nodes);
+    for (const node of row.nodes) {
+      allNodes.add(node);
+    }
   }
-  const allNodes = new Set<LogEvent>(nodes);
 
   let total = 0;
-  for (const node of nodes) {
-    if (!_isChildOfOther(node, allNodes)) {
+  for (const node of allNodes) {
+    let parent = node.parent;
+    let hasAncestor = false;
+
+    while (parent) {
+      if (allNodes.has(parent)) {
+        hasAncestor = true;
+        break;
+      }
+      parent = parent.parent;
+    }
+
+    if (!hasAncestor) {
       total += node.duration.total;
     }
   }
 
   return total;
-}
-
-function _isChildOfOther(node: LogEvent, filteredNodes: Set<LogEvent>) {
-  let parent = node.parent;
-  while (parent) {
-    if (filteredNodes.has(parent)) {
-      return true;
-    }
-    parent = parent.parent;
-  }
-
-  return false;
 }

--- a/log-viewer/src/features/analysis/services/RowGrouper.ts
+++ b/log-viewer/src/features/analysis/services/RowGrouper.ts
@@ -1,0 +1,152 @@
+/*
+ * Copyright (c) 2025 Certinia Inc. All rights reserved.
+ */
+
+import type { LogEvent } from '../../../core/log-parser/LogEvents';
+
+/**
+ * Represents aggregated metrics for a specific method or function across multiple invocations.
+ * Tracks execution count, timing information, and references to all log events for this method.
+ */
+export class Metric {
+  /** The name of the method or function */
+  name: string;
+  /** The type of the log event (e.g., METHOD_ENTRY, CONSTRUCTOR_ENTRY) */
+  type;
+  /** The number of times this method was invoked */
+  count = 0;
+  /** Total execution time across all invocations in nanoseconds (excludes recursive double-counting) */
+  totalTime = 0;
+  /** Self time (time excluding child calls) across all invocations in nanoseconds */
+  selfTime = 0;
+  /** The namespace or package containing this method */
+  namespace;
+  /** Array of all log events corresponding to this method's invocations */
+  nodes: LogEvent[] = [];
+
+  constructor(node: LogEvent) {
+    this.name = node.text;
+    this.type = node.type;
+    this.namespace = node.namespace;
+  }
+}
+
+/**
+ * Groups log events by method name and namespace, aggregating metrics for each unique method.
+ * Handles recursive calls by tracking the call stack to avoid double-counting execution time.
+ *
+ * @param root - The root log event containing the execution tree to analyze
+ * @returns An array of Metric objects, one per unique method (namespace + name combination)
+ *
+ * @example
+ * ```typescript
+ * const metrics = group(rootLogEvent);
+ * // Returns [
+ * //   { name: "processData", count: 5, totalTime: 1000000, selfTime: 500000, ... },
+ * //   { name: "validateInput", count: 3, totalTime: 200000, selfTime: 200000, ... }
+ * // ]
+ * ```
+ */
+export function group(root: LogEvent) {
+  const methodMap: Map<string, Metric> = new Map();
+  const keyStack = new Multiset<string>();
+
+  for (const child of root.children) {
+    addNodeToMap(methodMap, child, keyStack);
+  }
+  return Array.from(methodMap.values());
+}
+
+/**
+ * Recursively processes a log event node and its children, aggregating metrics by method identity.
+ * Uses a multiset to track the current call stack and prevent double-counting of recursive invocations.
+ *
+ * @param map - Map storing aggregated metrics, keyed by namespace + method name
+ * @param node - The current log event node to process
+ * @param keyStack - Multiset tracking the current call stack to detect recursive calls
+ *
+ * @remarks
+ * - Skips nodes with no duration and no children (leaf nodes with no execution time)
+ * - Uses namespace + name as the unique key for grouping methods
+ * - For recursive calls (same method appearing multiple times in the call stack),
+ *   only the outermost invocation's totalTime is counted to avoid double-counting
+ * - selfTime is always accumulated regardless of recursion
+ */
+function addNodeToMap(map: Map<string, Metric>, node: LogEvent, keyStack: Multiset<string>) {
+  const { self, total } = node.duration;
+  // Exclude nodes without a duration and no children
+  if (!total && !node.children.length) {
+    return;
+  }
+
+  // We want to process all nodes even if duration is 0 so that the count is accurate e.g we could have many method calls of 0 duraion (even if unlikely)
+  const key = node.namespace + node.text;
+  let metric = map.get(key);
+  if (!metric) {
+    metric = new Metric(node);
+    map.set(key, metric);
+  }
+  ++metric.count;
+
+  // Only add totalTime if this key is not already on the stack (avoids double counting)
+  if (!keyStack.has(key)) {
+    metric.totalTime += total;
+  }
+
+  metric.selfTime += self;
+  metric.nodes.push(node);
+
+  keyStack.add(key);
+  for (const child of node.children) {
+    addNodeToMap(map, child, keyStack);
+  }
+  keyStack.remove(key);
+}
+
+/**
+ * A slimmed down multiset (bag) data structure that allows duplicate elements and tracks their count.
+ * Provides O(1) add, remove, and has operations.
+ * Note: This could easily be extended to a full multiset implementation and count() functione etc if needed in the future.
+ */
+export class Multiset<T> {
+  private map: Map<T, number> = new Map();
+
+  /**
+   * Adds an element to the multiset.
+   * @param element - The element to add
+   * @returns The new count of this element
+   */
+  add(element: T): number {
+    const count = (this.map.get(element) ?? 0) + 1;
+    this.map.set(element, count);
+    return count;
+  }
+
+  /**
+   * Removes one occurrence of an element from the multiset.
+   * @param element - The element to remove
+   * @returns True if an element was removed, false if element was not in the multiset
+   */
+  remove(element: T): boolean {
+    const count = this.map.get(element);
+    if (count === undefined) {
+      return false;
+    }
+
+    if (count === 1) {
+      this.map.delete(element);
+    } else {
+      this.map.set(element, count - 1);
+    }
+    return true;
+  }
+
+  /**
+   * Checks if the multiset contains at least one occurrence of an element.
+   * @param element - The element to check
+   * @returns True if the element is in the multiset
+   */
+  has(element: T): boolean {
+    return this.map.has(element);
+  }
+}


### PR DESCRIPTION
# 📝 PR Overview

This prevents double-counting when multiple nodes from the same call chain are present in the filtered set.

For each node, walks up the parent chain to check if any ancestor is also in the node set. Only nodes without ancestors contribute their totalTime to the sum.

## 🧩 Type of change (check all applicable)

- [x] 🐛 Bug fix - something not working as expected
- [ ] ✨ New feature – adds new functionality
- [ ] ♻️ Refactor - internal changes with no user impact
- [ ] ⚡ Performance Improvement
- [ ] 📝 Documentation - README or documentation site changes
- [ ] 🔧 Chore - dev tooling, CI, config
- [ ] 💥 Breaking change

## 📷 Screenshots / gifs / video [optional]

_Show off your UI changes._

## 🔗 Related Issues

fixes #
resolves #
closes #
related #

## ✅ Tests added?

- [ ] 👍 yes
- [ ] 🙅 no, not needed
- [x] 🙋 no, I need help

## 📚 Docs updated?

- [ ] 🔖 README.md
- [ ] 🔖 CHANGELOG.md
- [ ] 📖 help site
- [x] 🙅 not needed

## Anything else we need to know? [optional]
