### PR TITLE
chore: use absolute siteUrl for favicon and head links

### DIFF
--- a/lana-docs-site/docusaurus.config.ts
+++ b/lana-docs-site/docusaurus.config.ts
@@ -4,10 +4,10 @@ import { themes as prismThemes } from 'prism-react-renderer';
 
 const organizationName = 'certinia';
 const projectName = 'debug-log-analyzer';
-const siteUrl = `https://${organizationName}.github.io`;
+const prodUrl = `https://${organizationName}.github.io`;
+const siteUrl = `${prodUrl}/${projectName}`;
 
-//certinia.github.io/debug-log-analyzer/favicon.svg
-https: const config: Config = {
+const config: Config = {
   future: {
     v4: true,
     // eslint-disable-next-line @typescript-eslint/naming-convention
@@ -17,7 +17,7 @@ https: const config: Config = {
   tagline:
     'blazing-fast VS Code extension for Salesforce. Visualize and debug Apex logs with interactive flame charts, dynamic call trees, and detailed SOQL/DML breakdowns. Identify performance bottlenecks, gain deep transaction insights and optimize slow Apex.',
   // Set the production url of your site here
-  url: siteUrl,
+  url: prodUrl,
   // Set the /<baseUrl>/ pathname under which your site is served
   // For GitHub pages deployment, it is often '/<projectName>/'
   baseUrl: `/${projectName}/`,


### PR DESCRIPTION
# 📝 PR Overview

chore: use absolute siteUrl for favicon and head links

Replace relative favicon paths with `${siteUrl}/...` and set config.url to use the siteUrl constant so favicons and head links resolve correctly when the site is hosted on GitHub Pages.

## 🧩 Type of change (check all applicable)

- [ ] 🐛 Bug fix - something not working as expected
- [ ] ✨ New feature – adds new functionality
- [ ] ♻️ Refactor - internal changes with no user impact
- [ ] ⚡ Performance Improvement
- [X] 📝 Documentation - README or documentation site changes
- [ ] 🔧 Chore - dev tooling, CI, config
- [ ] 💥 Breaking change

## 📷 Screenshots / gifs / video [optional]

_Show off your UI changes._

## 🔗 Related Issues

fixes #
resolves #
closes #
related #

## ✅ Tests added?

- [ ] 👍 yes
- [x] 🙅 no, not needed
- [ ] 🙋 no, I need help

## 📚 Docs updated?

- [ ] 🔖 README.md
- [ ] 🔖 CHANGELOG.md
- [x] 📖 help site
- [ ] 🙅 not needed

## Anything else we need to know? [optional]
