### PR TITLE
chore(dependabot): change versioning strategy to auto

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,4 +4,4 @@ updates:
     directory: '/'
     schedule:
       interval: 'daily' # Check the npm registry for updates every day (weekdays)
-    versioning-strategy: increase
+    versioning-strategy: auto


### PR DESCRIPTION
# 📝 PR Overview

change versioning strategy to auto
We do not want auto increase out side of version specific in semver range. 

We could add a separate section to do that. So we get safe updates and major in separate PRs e.g

```
version: 2
updates:
  - package-ecosystem: "npm"
    directory: "/"
    schedule:
      interval: "daily"
    versioning-strategy: "auto"   # respects semver

  - package-ecosystem: "npm"
    directory: "/"
    schedule:
      interval: "weekly"          # check major updates less frequently
      versioning-strategy:  increase 
```

## 🧩 Type of change (check all applicable)

- [ ] 🐛 Bug fix - something not working as expected
- [ ] ✨ New feature – adds new functionality
- [ ] ♻️ Refactor - internal changes with no user impact
- [ ] ⚡ Performance Improvement
- [ ] 📝 Documentation - README or documentation site changes
- [X] 🔧 Chore - dev tooling, CI, config
- [ ] 💥 Breaking change

## 📷 Screenshots / gifs / video [optional]

_Show off your UI changes._

## 🔗 Related Issues

fixes #
resolves #
closes #
related #

## ✅ Tests added?

- [ ] 👍 yes
- [x] 🙅 no, not needed
- [ ] 🙋 no, I need help

## 📚 Docs updated?

- [ ] 🔖 README.md
- [ ] 🔖 CHANGELOG.md
- [ ] 📖 help site
- [x] 🙅 not needed

## Anything else we need to know? [optional]
