### PR TITLE
feat: add aggregated and bottom-up call tree views

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     - Markers for errors, skipped lines, and truncation
     - Click to navigate to Call Tree (now on key press of `J` or `Cmd/Ctrl+Click`)
   - **Legacy Support**: Toggle the legacy timeline anytime via **Settings -> Apex Log Analyzer -> Timeline -> Legacy**.
+- 🌲 **Call Tree Views**: Detailed **Time Order**, **Aggregated**, and **Bottom-Up** views. ([#333])
+  - **Time Order**: Chronological call stack for frame-by-frame execution flow.
+  - **Aggregated**: Groups repeated calls to surface the highest-impact methods quickly.
+  - **Bottom-Up**: Starts from callees and expands to callers, with optional grouping by Namespace or Type.
+  - **Go to Source**: Click method names to open source from **Time Order**, **Aggregated**, and **Bottom-Up** when symbols are available.
+  - **Analysis Alignment**: Analysis now uses the same bottom-up table model for consistent caller attribution.
 - 📄 **Raw Log Navigation**: Seamless navigation between raw log files and the log analysis. ([#204])
   - **Show in Raw Log**: Right-click timeline or call tree frames → "Show in Log File" to jump to the corresponding line.
   - **Show in Log Analysis**: Click the hover link on raw log lines to navigate back to the log analysis.
@@ -477,6 +483,7 @@ Skipped due to adopting odd numbering for pre releases and even number for relea
 
 <!-- Unreleased -->
 
+[#333]: https://github.com/certinia/debug-log-analyzer/issues/333
 [#627]: https://github.com/certinia/debug-log-analyzer/issues/627
 [#685]: https://github.com/certinia/debug-log-analyzer/issues/685
 [#98]: https://github.com/certinia/debug-log-analyzer/issues/98

--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ Also: Frame Selection & Navigation, Dynamic Frame Labels, Adaptive Frame Detail,
 Explore nested method calls with performance metrics:
 
 - **Metrics**: Self Time, Total Time, SOQL/DML/Thrown Counts, SOQL/DML/Rows
+- **Views**: Use Time Order for sequence, Aggregated for repeated hot paths, Bottom-Up for caller attribution
 - **Filter by Namespace, Type or Duration**
 - **Toggle Debug-Only + Detail Events**
 - **Keyboard Navigation**

--- a/lana-docs/docs/docs/features/analysis.md
+++ b/lana-docs/docs/docs/features/analysis.md
@@ -18,7 +18,7 @@ hide_title: true
 
 ## 🧠 Analysis
 
-Analyze Salesforce debug logs with detailed metrics on method calls, including Self Time, Total Time, Count, Name, and Type. Easily sort, filter, and group log events by namespace or type, and export or copy results for efficient troubleshooting and performance optimization.
+Analyze Salesforce debug logs with detailed metrics on method calls, including Self Time, Total Time, Count, Name, and Type. Easily sort, filter, and group log events by namespace or type, and export or copy results for efficient troubleshooting and performance optimization. The Analysis table uses a bottom-up caller grouping model, where each method is shown as a root with its direct callers as children.
 
 ![Analysis view screenshot showing method call metrics such as Self Time, Total Time, Count, Name, and Type](https://raw.githubusercontent.com/certinia/debug-log-analyzer/main/lana/assets/v1.18/lana-analysis.png)
 
@@ -33,7 +33,10 @@ Each column can be sorted by clicking the column header, this will sort the rows
 
 ### Group
 
-The rows can be grouped by Type or Namespace
+The rows can be grouped by Type or Namespace using a bottom-up caller grouping model, which complements the three Call Tree views: [Time Order, Aggregated, and Bottom-Up](calltree.md).
+
+In this model, roots are callees and parent/child relationships represent callers expanded beneath each callee.
+`Total Time` is the full attributed time for that callee path, while `Self Time` is the exclusive attributed time for the callee itself.
 
 1. Namespace: Shows the rows aggregated by their namespace e.g `default`, `MyNamespace`
 1. Type: Shows the rows aggregated by namespace event type e.g `METHOD_ENTRY`, `DML_ENTRY`

--- a/lana-docs/docs/docs/features/calltree.md
+++ b/lana-docs/docs/docs/features/calltree.md
@@ -25,6 +25,21 @@ The Call Tree helps efficently visualize and navigate the call stack in Salesfro
 
 Each row shows event type, details such as method signature, self and total time as well as aggregated DML, SOQL, Throws and Row counts.
 
+### View Modes
+
+The Call Tree supports three separate views, toggled via the toolbar:
+
+1. **Time Order** (default)
+   Displays the call stack in chronological execution order.
+   Best when you want to follow the exact sequence of events from top to bottom.
+1. **Aggregated**
+   Groups repeated method paths so repeated executions are combined.
+   Best when you want a condensed hotspot view without reviewing every individual frame occurrence.
+1. **Bottom-Up**
+   Starts with each callee as the root and expands into callers.
+   In this view, roots are callees and expanded rows are caller context.
+   Best when you want to find which methods are hogging the most time and see the different caller paths that led to them.
+
 ### Go to Code
 
 Clicking the link in the event column will open the corresponding file and line, if that file exists in the current workspace.
@@ -39,6 +54,8 @@ Each column can be sorted by clicking the column header, this will sort the rows
 1. Show only debug statements using the Debug Only filter.
 1. Show Log events for specific namespaces using the namespace column filter
 1. Min and Max filtering can be done on the _Total Time_ and _Self Time_ columns.
+
+Details, Debug Only, and Type filtering are available in **Time Order** and **Aggregated**. The **Bottom-Up** view has its own grouping controls (None, Namespace, Type).
 
 ### Keyboard Navigation
 

--- a/lana-docs/docs/docs/features/features.md
+++ b/lana-docs/docs/docs/features/features.md
@@ -19,6 +19,6 @@ hide_title: true
 
 import DocCardList from '@theme/DocCardList';
 
-Explore the Apex Log Analyzer for Salesforce debug logs features including interactive timelines, detailed call trees, in-depth analysis, database insights, and powerful search capabilities to streamline your debugging and performance tuning.
+Explore the Apex Log Analyzer for Salesforce debug logs features including interactive timelines, detailed Time Order, Aggregated, and Bottom-Up call trees, in-depth analysis, database insights, and powerful search capabilities to streamline your debugging and performance tuning.
 
 <DocCardList />

--- a/log-viewer/src/core/utility/Multiset.ts
+++ b/log-viewer/src/core/utility/Multiset.ts
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2026 Certinia Inc. All rights reserved.
+ */
+
+/**
+ * A slimmed down multiset (bag) data structure that allows duplicate elements and tracks their count.
+ * Provides O(1) add, remove, and has operations.
+ * Note: This could easily be extended to a full multiset implementation and count() function etc if needed in the future.
+ */
+export class Multiset<T> {
+  private map: Map<T, number> = new Map();
+
+  /**
+   * Adds an element to the multiset.
+   * @param element - The element to add
+   * @returns The new count of this element
+   */
+  add(element: T): number {
+    const count = (this.map.get(element) ?? 0) + 1;
+    this.map.set(element, count);
+    return count;
+  }
+
+  /**
+   * Removes one occurrence of an element from the multiset.
+   * @param element - The element to remove
+   * @returns True if an element was removed, false if element was not in the multiset
+   */
+  remove(element: T): boolean {
+    const count = this.map.get(element);
+    if (count === undefined) {
+      return false;
+    }
+
+    if (count === 1) {
+      this.map.delete(element);
+    } else {
+      this.map.set(element, count - 1);
+    }
+    return true;
+  }
+
+  /**
+   * Checks if the multiset contains at least one occurrence of an element.
+   * @param element - The element to check
+   * @returns True if the element is in the multiset
+   */
+  has(element: T): boolean {
+    return this.map.has(element);
+  }
+}

--- a/log-viewer/src/features/analysis/components/AnalysisView.ts
+++ b/log-viewer/src/features/analysis/components/AnalysisView.ts
@@ -94,11 +94,13 @@ export class AnalysisView extends LitElement {
 
         label {
           display: block;
-          color: var(--vscode-foreground);
+          color: var(--vscode-descriptionForeground);
           cursor: pointer;
-          font-size: var(--vscode-font-size);
-          line-height: normal;
-          margin-bottom: 2px;
+          font-size: calc(var(--vscode-font-size) * 0.9);
+          font-weight: 400;
+          line-height: 1.4;
+          margin-bottom: 4px;
+          user-select: none;
         }
       }
     `,
@@ -150,8 +152,13 @@ export class AnalysisView extends LitElement {
       <div class="analysis-view">
         <datagrid-filter-bar>
           <div slot="filters" class="dropdown-container">
-            <label for="groupby-dropdown"><strong>Group by</strong></label>
-            <vscode-dropdown id="groupby-dropdown" @change="${this._groupBy}">
+            <label id="groupby-dropdown-label" for="groupby-dropdown">Group by</label>
+            <vscode-dropdown
+              id="groupby-dropdown"
+              aria-label="Group by"
+              aria-labelledby="groupby-dropdown-label"
+              @change="${this._groupBy}"
+            >
               <vscode-option>None</vscode-option>
               <vscode-option>Namespace</vscode-option>
               <vscode-option>Type</vscode-option>

--- a/log-viewer/src/features/analysis/components/AnalysisView.ts
+++ b/log-viewer/src/features/analysis/components/AnalysisView.ts
@@ -10,23 +10,12 @@ import {
 } from '@vscode/webview-ui-toolkit';
 import { LitElement, css, html, unsafeCSS, type PropertyValues } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
-import { Tabulator, type GlobalTooltipOption, type RowComponent } from 'tabulator-tables';
+import { Tabulator, type RowComponent } from 'tabulator-tables';
 
 import type { ApexLog } from 'apex-log-parser';
-import { vscodeMessenger } from '../../../core/messaging/VSCodeExtensionMessenger.js';
-import { formatDuration, isVisible } from '../../../core/utility/Util.js';
-import { sumRootNodesOnly } from '../services/CallStackSum.js';
-import { group } from '../services/RowGrouper.js';
+import { isVisible } from '../../../core/utility/Util.js';
+import { createBottomUpTable } from '../../call-tree/components/BottomUpTable.js';
 
-// Tabulator custom modules, imports + styles
-import NumberAccessor from '../../../tabulator/dataaccessor/Number.js';
-import { progressFormatterMS } from '../../../tabulator/format/ProgressMS.js';
-import { GroupCalcs } from '../../../tabulator/groups/GroupCalcs.js';
-import { GroupSort } from '../../../tabulator/groups/GroupSort.js';
-import * as CommonModules from '../../../tabulator/module/CommonModules.js';
-import { Find } from '../../../tabulator/module/Find.js';
-import { RowKeyboardNavigation } from '../../../tabulator/module/RowKeyboardNavigation.js';
-import { RowNavigation } from '../../../tabulator/module/RowNavigation.js';
 import dataGridStyles from '../../../tabulator/style/DataGrid.scss';
 
 // styles
@@ -279,165 +268,34 @@ export class AnalysisView extends LitElement {
       return;
     }
 
-    Tabulator.registerModule(Object.values(CommonModules));
-    Tabulator.registerModule([RowKeyboardNavigation, RowNavigation, Find, GroupCalcs, GroupSort]);
-
-    const durationFormatterParams = { totalValue: rootMethod.duration.total };
-    const tooltipContent: GlobalTooltipOption = (_event, cell, _onRender) => {
-      return formatDuration(cell.getValue());
-    };
-
-    this.analysisTable = new Tabulator(this._tableWrapper, {
-      rowKeyboardNavigation: true,
-      selectableRows: 'highlight',
-      data: group(rootMethod),
-      layout: 'fitColumns',
-      placeholder: 'No Analysis Available',
-      columnCalcs: 'table',
-      clipboard: true,
-      downloadEncoder: function (fileContents: string, mimeType) {
-        const vscodeHost = vscodeMessenger.getVsCodeAPI();
-        if (vscodeHost) {
-          vscodeMessenger.send<VSCodeSaveFile>('saveFile', {
-            fileContent: fileContents,
-            options: {
-              defaultFileName: 'analysis.csv',
-            },
-          });
-          return false;
-        }
-
-        return new Blob([fileContents], { type: mimeType });
+    const { table, tableBuilt } = createBottomUpTable(
+      this._tableWrapper,
+      rootMethod,
+      {
+        namespaceFilter: () => true,
+        onFilterCacheClear: () => {
+          if (!this.blockClearHighlights && this.totalMatches > 0) {
+            this._resetFindWidget();
+            this._clearSearchHighlights();
+          }
+        },
+        onRenderStarted: () => {
+          if (!this.blockClearHighlights && this.totalMatches > 0) {
+            this._resetFindWidget();
+            this._clearSearchHighlights();
+          }
+        },
       },
-      dataTree: true, // temporary: fixes a disappearing table issue when scroll is dragged (needs fix in Tabulator)
-      downloadRowRange: 'all',
-      downloadConfig: {
-        columnHeaders: true,
-        columnGroups: true,
-        rowGroups: true,
-        columnCalcs: false,
-        dataTree: true,
+      {
+        placeholder: 'No Analysis Available',
+        selectableRows: 'highlight',
+        enableClipboardAndDownload: true,
+        exportFileName: 'analysis.csv',
       },
-      //@ts-expect-error types need update array is valid
-      keybindings: { copyToClipboard: ['ctrl + 67', 'meta + 67'] },
-      clipboardCopyRowRange: 'all',
-      height: '100%',
-      maxHeight: '100%',
-      groupCalcs: true,
-      groupSort: true,
-      groupClosedShowCalcs: true,
-      groupStartOpen: false,
-      groupToggleElement: 'header',
-      columnDefaults: {
-        title: 'default',
-        resizable: true,
-        headerSortStartingDir: 'desc',
-        headerTooltip: true,
-        headerWordWrap: true,
-      },
-      tooltipDelay: 100,
-      initialSort: [{ column: 'selfTime', dir: 'desc' }],
-      headerSortElement: function (column, dir) {
-        switch (dir) {
-          case 'asc':
-            return "<div class='sort-by--top'></div>";
-            break;
-          case 'desc':
-            return "<div class='sort-by--bottom'></div>";
-            break;
-          default:
-            return "<div class='sort-by'><div class='sort-by--top'></div><div class='sort-by--bottom'></div></div>";
-        }
-      },
-      columns: [
-        {
-          title: 'Name',
-          field: 'name',
-          formatter: 'textarea',
-          headerSortStartingDir: 'asc',
-          sorter: 'string',
-          headerSortTristate: true,
-          cssClass: 'datagrid-code-text',
-          bottomCalc: () => {
-            return 'Total';
-          },
-          widthGrow: 5,
-        },
-        {
-          title: 'Namespace',
-          field: 'namespace',
-          headerSortStartingDir: 'desc',
-          width: 150,
-          sorter: 'string',
-          tooltip: true,
-          headerFilter: 'list',
-          headerFilterFunc: 'in',
-          headerFilterParams: {
-            valuesLookup: 'all',
-            clearable: true,
-            multiselect: true,
-          },
-          headerFilterLiveFilter: false,
-        },
-        {
-          title: 'Type',
-          field: 'type',
-          headerSortStartingDir: 'asc',
-          width: 150,
-          sorter: 'string',
-          tooltip: true,
-        },
-        {
-          title: 'Count',
-          field: 'count',
-          sorter: 'number',
-          cssClass: 'number-cell',
-          width: 65,
-          hozAlign: 'right',
-          headerHozAlign: 'right',
-          bottomCalc: 'sum',
-        },
-        {
-          title: 'Total Time (ms)',
-          field: 'totalTime',
-          sorter: 'number',
-          width: 165,
-          hozAlign: 'right',
-          headerHozAlign: 'right',
-          bottomCalc: sumRootNodesOnly,
-          bottomCalcFormatter: progressFormatterMS,
-          bottomCalcFormatterParams: durationFormatterParams,
-          formatter: progressFormatterMS,
-          formatterParams: durationFormatterParams,
-          accessorDownload: NumberAccessor,
-          tooltip: tooltipContent,
-        },
-        {
-          title: 'Self Time (ms)',
-          field: 'selfTime',
-          sorter: 'number',
-          width: 165,
-          hozAlign: 'right',
-          headerHozAlign: 'right',
-          bottomCalc: 'sum',
-          bottomCalcFormatter: progressFormatterMS,
-          bottomCalcFormatterParams: durationFormatterParams,
-          formatter: progressFormatterMS,
-          formatterParams: durationFormatterParams,
-          accessorDownload: NumberAccessor,
-          tooltip: tooltipContent,
-        },
-      ],
-    });
+    );
+    this.analysisTable = table;
 
     this.analysisTable.on('dataSorted', () => {
-      if (!this.blockClearHighlights && this.totalMatches > 0) {
-        this._resetFindWidget();
-        this._clearSearchHighlights();
-      }
-    });
-
-    this.analysisTable.on('dataFiltered', () => {
       if (!this.blockClearHighlights && this.totalMatches > 0) {
         this._resetFindWidget();
         this._clearSearchHighlights();
@@ -450,6 +308,8 @@ export class AnalysisView extends LitElement {
         this._clearSearchHighlights();
       }
     });
+
+    await tableBuilt;
   }
 
   _resetFindWidget() {
@@ -465,12 +325,5 @@ export class AnalysisView extends LitElement {
     this.totalMatches = 0;
   }
 }
-
-type VSCodeSaveFile = {
-  fileContent: string;
-  options: {
-    defaultFileName: string;
-  };
-};
 
 type FindEvt = CustomEvent<{ text: string; count: number; options: { matchCase: boolean } }>;

--- a/log-viewer/src/features/analysis/services/CallStackSum.ts
+++ b/log-viewer/src/features/analysis/services/CallStackSum.ts
@@ -6,33 +6,17 @@ import type { LogEvent } from 'apex-log-parser';
 import type { Metric } from '../../analysis/services/RowGrouper.js';
 
 /**
- * Calculates the sum of total execution time for root nodes only (nodes without ancestors in the set).
- * This prevents double-counting when multiple nodes from the same call chain are present in the filtered set.
+ * Sums `duration.total` over the union of `eventGroups`, counting each event only
+ * when no ancestor of that event is also in the union. This prevents double-counting
+ * when multiple events from the same call chain are present in the filtered set.
  *
- * For each node, walks up the parent chain to check if any ancestor is also in the node set.
- * Only nodes without ancestors contribute their totalTime to the sum.
- *
- * @param _values - Unused parameter (required by Tabulator's calc function signature)
- * @param data - Array of Metric objects containing the nodes to sum
- * @param _calcParams - Unused parameter (required by Tabulator's calc function signature)
- * @returns The sum of totalTime in nanoseconds for all root nodes (nodes without ancestors in the set)
- *
- * @example
- * ```typescript
- * // If we have nodes: A -> B -> C and the filtered set contains [B, C]
- * // Only B's time is counted (C is excluded because B is its ancestor)
- * const total = sumRootNodesOnly([], [metricB, metricC], {});
- * ```
- *
- * @remarks
- * This function is designed as a Tabulator column calc function, hence the unused parameters.
- * It's used to calculate accurate totals in analysis tables where filtered results may include
- * nodes from the same call stack.
+ * Used by both AnalysisView (rows = `Metric` with `nodes`) and BottomUpTable (rows
+ * = `BottomUpRow` with `instances`).
  */
-export function sumRootNodesOnly(_values: number[], data: Metric[], _calcParams: unknown) {
+export function sumDurationTotalForRootEvents(eventGroups: Iterable<LogEvent[]>): number {
   const allNodes = new Set<LogEvent>();
-  for (const row of data) {
-    for (const node of row.nodes) {
+  for (const group of eventGroups) {
+    for (const node of group) {
       allNodes.add(node);
     }
   }
@@ -56,4 +40,12 @@ export function sumRootNodesOnly(_values: number[], data: Metric[], _calcParams:
   }
 
   return total;
+}
+
+/**
+ * Tabulator `bottomCalc` adapter for AnalysisView: passes each `Metric.nodes` array
+ * to {@link sumDurationTotalForRootEvents}. See that helper for the algorithm.
+ */
+export function sumRootNodesOnly(_values: number[], data: Metric[], _calcParams: unknown): number {
+  return sumDurationTotalForRootEvents(data.map((row) => row.nodes));
 }

--- a/log-viewer/src/features/analysis/services/RowGrouper.ts
+++ b/log-viewer/src/features/analysis/services/RowGrouper.ts
@@ -3,6 +3,7 @@
  */
 
 import type { LogEvent } from 'apex-log-parser';
+import { Multiset } from '../../../core/utility/Multiset.js';
 
 /**
  * Represents aggregated metrics for a specific method or function across multiple invocations.
@@ -74,79 +75,35 @@ export function group(root: LogEvent) {
  */
 function addNodeToMap(map: Map<string, Metric>, node: LogEvent, keyStack: Multiset<string>) {
   const { self, total } = node.duration;
-  // Exclude nodes without a duration and no children
-  if (!total && !node.children.length) {
-    return;
-  }
 
-  // We want to process all nodes even if duration is 0 so that the count is accurate e.g we could have many method calls of 0 duraion (even if unlikely)
-  const key = node.namespace + node.text;
-  let metric = map.get(key);
+  // Bucket by type + namespace + text so events of different types (e.g. CODE_UNIT_STARTED
+  // vs METHOD_ENTRY) for the same name appear as distinct metrics. The recursion-detection
+  // stack key is type-less so a CODE_UNIT_STARTED parent and a METHOD_ENTRY recursive child
+  // of the same method are still recognised as the same call stack and totalTime is not
+  // double-counted.
+  const bucketKey = (node.type ?? '') + '|' + node.namespace + '|' + node.text;
+  const stackKey = node.namespace + '|' + node.text;
+  let metric = map.get(bucketKey);
   if (!metric) {
     metric = new Metric(node);
-    map.set(key, metric);
+    map.set(bucketKey, metric);
   }
   ++metric.count;
 
   // Only add totalTime if this key is not already on the stack (avoids double counting)
-  if (!keyStack.has(key)) {
+  if (!keyStack.has(stackKey)) {
     metric.totalTime += total;
   }
 
   metric.selfTime += self;
   metric.nodes.push(node);
 
-  keyStack.add(key);
+  keyStack.add(stackKey);
   for (const child of node.children) {
     addNodeToMap(map, child, keyStack);
   }
-  keyStack.remove(key);
+  keyStack.remove(stackKey);
 }
 
-/**
- * A slimmed down multiset (bag) data structure that allows duplicate elements and tracks their count.
- * Provides O(1) add, remove, and has operations.
- * Note: This could easily be extended to a full multiset implementation and count() functione etc if needed in the future.
- */
-export class Multiset<T> {
-  private map: Map<T, number> = new Map();
-
-  /**
-   * Adds an element to the multiset.
-   * @param element - The element to add
-   * @returns The new count of this element
-   */
-  add(element: T): number {
-    const count = (this.map.get(element) ?? 0) + 1;
-    this.map.set(element, count);
-    return count;
-  }
-
-  /**
-   * Removes one occurrence of an element from the multiset.
-   * @param element - The element to remove
-   * @returns True if an element was removed, false if element was not in the multiset
-   */
-  remove(element: T): boolean {
-    const count = this.map.get(element);
-    if (count === undefined) {
-      return false;
-    }
-
-    if (count === 1) {
-      this.map.delete(element);
-    } else {
-      this.map.set(element, count - 1);
-    }
-    return true;
-  }
-
-  /**
-   * Checks if the multiset contains at least one occurrence of an element.
-   * @param element - The element to check
-   * @returns True if the element is in the multiset
-   */
-  has(element: T): boolean {
-    return this.map.has(element);
-  }
-}
+// Re-export Multiset for backwards compatibility
+export { Multiset } from '../../../core/utility/Multiset.js';

--- a/log-viewer/src/features/analysis/services/__tests__/CallStackSum.test.ts
+++ b/log-viewer/src/features/analysis/services/__tests__/CallStackSum.test.ts
@@ -1,0 +1,81 @@
+import type { LogEvent } from 'apex-log-parser';
+
+import { sumDurationTotalForRootEvents, sumRootNodesOnly } from '../CallStackSum.js';
+import type { Metric } from '../RowGrouper.js';
+
+type EventOptions = {
+  text: string;
+  total: number;
+  parent?: LogEvent | null;
+};
+
+let nextTimestamp = 1;
+
+function createEvent(options: EventOptions): LogEvent {
+  const event = {
+    parent: options.parent ?? null,
+    children: [],
+    type: 'METHOD_ENTRY' as LogEvent['type'],
+    text: options.text,
+    namespace: 'default',
+    timestamp: nextTimestamp++,
+    duration: { self: 0, total: options.total },
+    dmlRowCount: { self: 0, total: 0 },
+    soqlRowCount: { self: 0, total: 0 },
+    soslRowCount: { self: 0, total: 0 },
+    dmlCount: { self: 0, total: 0 },
+    soqlCount: { self: 0, total: 0 },
+    soslCount: { self: 0, total: 0 },
+    totalThrownCount: 0,
+  } as unknown as LogEvent;
+
+  if (options.parent) {
+    options.parent.children.push(event);
+  }
+
+  return event;
+}
+
+describe('sumDurationTotalForRootEvents', () => {
+  beforeEach(() => {
+    nextTimestamp = 1;
+  });
+
+  it('counts each call-stack root once and skips events whose ancestors are visible', () => {
+    // ParentA(80) → LeafA(80); ParentB(30) → LeafB(30).
+    // Naive sum = 80+30+80+30 = 220 (double-counts).
+    // Root-only sum picks ParentA and ParentB; leaves are excluded because their parents
+    // are in the visible set.
+    const parentA = createEvent({ text: 'ParentA', total: 80 });
+    const leafA = createEvent({ text: 'Leaf', total: 80, parent: parentA });
+    const parentB = createEvent({ text: 'ParentB', total: 30 });
+    const leafB = createEvent({ text: 'Leaf', total: 30, parent: parentB });
+
+    expect(sumDurationTotalForRootEvents([[parentA], [parentB], [leafA, leafB]])).toBe(110);
+  });
+
+  it('sums every event when none share an ancestor in the visible set', () => {
+    const a = createEvent({ text: 'Top1', total: 50 });
+    const b = createEvent({ text: 'Top2', total: 70 });
+    expect(sumDurationTotalForRootEvents([[a], [b]])).toBe(120);
+  });
+
+  it('returns 0 for an empty input', () => {
+    expect(sumDurationTotalForRootEvents([])).toBe(0);
+  });
+});
+
+describe('sumRootNodesOnly (Metric adapter)', () => {
+  beforeEach(() => {
+    nextTimestamp = 1;
+  });
+
+  it('extracts Metric.nodes and applies the root-only sum', () => {
+    const parent = createEvent({ text: 'parent', total: 100 });
+    const child = createEvent({ text: 'child', total: 60, parent });
+
+    const metricParent = { nodes: [parent] } as unknown as Metric;
+    const metricChild = { nodes: [child] } as unknown as Metric;
+    expect(sumRootNodesOnly([], [metricParent, metricChild], {})).toBe(100);
+  });
+});

--- a/log-viewer/src/features/analysis/services/__tests__/RowGrouper.test.ts
+++ b/log-viewer/src/features/analysis/services/__tests__/RowGrouper.test.ts
@@ -1,0 +1,148 @@
+import type { LogEvent } from 'apex-log-parser';
+
+import { group } from '../RowGrouper.js';
+
+type EventOptions = {
+  text: string;
+  self: number;
+  total: number;
+  parent?: LogEvent | null;
+  type?: string;
+  namespace?: string;
+  dmlSelf?: number;
+  dmlTotal?: number;
+  soqlSelf?: number;
+  soqlTotal?: number;
+  thrown?: number;
+};
+
+let nextTimestamp = 1;
+
+function createEvent(options: EventOptions): LogEvent {
+  const event = {
+    logParser: null,
+    parent: options.parent ?? null,
+    children: [],
+    type: (options.type ?? 'METHOD_ENTRY') as LogEvent['type'],
+    logLine: '',
+    text: options.text,
+    acceptsText: false,
+    isExit: false,
+    isParent: false,
+    isTruncated: false,
+    nextLineIsExit: false,
+    lineNumber: null,
+    namespace: options.namespace ?? 'default',
+    hasValidSymbols: true,
+    suffix: null,
+    discontinuity: false,
+    timestamp: nextTimestamp++,
+    exitStamp: null,
+    category: '',
+    debugCategory: '',
+    debugLevel: '',
+    cpuType: '',
+    duration: { self: options.self, total: options.total },
+    dmlRowCount: { self: 0, total: 0 },
+    soqlRowCount: { self: 0, total: 0 },
+    soslRowCount: { self: 0, total: 0 },
+    dmlCount: { self: options.dmlSelf ?? 0, total: options.dmlTotal ?? 0 },
+    soqlCount: { self: options.soqlSelf ?? 0, total: options.soqlTotal ?? 0 },
+    soslCount: { self: 0, total: 0 },
+    totalThrownCount: options.thrown ?? 0,
+    exitTypes: [],
+  } as unknown as LogEvent;
+
+  if (options.parent) {
+    options.parent.children.push(event);
+  }
+
+  return event;
+}
+
+describe('RowGrouper.group', () => {
+  beforeEach(() => {
+    nextTimestamp = 1;
+  });
+
+  it('includes zero-time leaves so DML/SOQL/exception counts and call counts roll up', () => {
+    const root = createEvent({ text: 'LOG_ROOT', self: 0, total: 0, type: 'EXECUTION_STARTED' });
+    createEvent({
+      text: 'LimitOnly',
+      self: 0,
+      total: 0,
+      parent: root,
+      dmlSelf: 1,
+      dmlTotal: 1,
+      thrown: 1,
+    });
+
+    const metrics = group(root);
+    const limitOnly = metrics.find((m) => m.name === 'LimitOnly');
+    if (!limitOnly) throw new Error('LimitOnly metric missing');
+    expect(limitOnly.count).toBe(1);
+    expect(limitOnly.totalTime).toBe(0);
+    expect(limitOnly.selfTime).toBe(0);
+    expect(limitOnly.nodes).toHaveLength(1);
+  });
+
+  it('keeps different entry types as separate metrics for the same name+namespace', () => {
+    const root = createEvent({ text: 'LOG_ROOT', self: 0, total: 0, type: 'EXECUTION_STARTED' });
+    createEvent({ text: 'foo', self: 5, total: 5, parent: root, type: 'CODE_UNIT_STARTED' });
+    createEvent({ text: 'foo', self: 7, total: 7, parent: root, type: 'METHOD_ENTRY' });
+
+    const metrics = group(root);
+    const fooMetrics = metrics.filter((m) => m.name === 'foo');
+    expect(fooMetrics).toHaveLength(2);
+    const codeUnit = fooMetrics.find((m) => m.type === 'CODE_UNIT_STARTED');
+    const methodEntry = fooMetrics.find((m) => m.type === 'METHOD_ENTRY');
+    expect(codeUnit?.selfTime).toBe(5);
+    expect(methodEntry?.selfTime).toBe(7);
+  });
+
+  it('does not double-count totalTime across same-name recursion regardless of entry type', () => {
+    const root = createEvent({ text: 'LOG_ROOT', self: 0, total: 0, type: 'EXECUTION_STARTED' });
+    // CODE_UNIT_STARTED foo (total=100) → METHOD_ENTRY foo (total=80) → METHOD_ENTRY foo (total=50).
+    // The two METHOD_ENTRY recursive calls are nested inside CODE_UNIT_STARTED foo. Recursion
+    // detection is type-less, so the inner totalTimes must NOT be added to the METHOD_ENTRY bucket.
+    const outer = createEvent({
+      text: 'foo',
+      self: 20,
+      total: 100,
+      parent: root,
+      type: 'CODE_UNIT_STARTED',
+    });
+    const inner = createEvent({ text: 'foo', self: 30, total: 80, parent: outer });
+    createEvent({ text: 'foo', self: 50, total: 50, parent: inner });
+
+    const metrics = group(root);
+    const fooMetrics = metrics.filter((m) => m.name === 'foo');
+    expect(fooMetrics).toHaveLength(2);
+    const codeUnit = fooMetrics.find((m) => m.type === 'CODE_UNIT_STARTED');
+    const methodEntry = fooMetrics.find((m) => m.type === 'METHOD_ENTRY');
+    if (!codeUnit || !methodEntry) throw new Error('Missing metric');
+
+    // CODE_UNIT outer is the outermost — gets total=100. The inner METHOD_ENTRY frames are on
+    // the call stack via the type-less stack key, so neither contributes total to the
+    // METHOD_ENTRY bucket.
+    expect(codeUnit.totalTime).toBe(100);
+    expect(methodEntry.totalTime).toBe(0);
+
+    // selfTime accumulates regardless of recursion.
+    expect(codeUnit.selfTime).toBe(20);
+    expect(methodEntry.selfTime).toBe(80);
+  });
+
+  it('separates metrics by namespace even when name and type match', () => {
+    const root = createEvent({ text: 'LOG_ROOT', self: 0, total: 0, type: 'EXECUTION_STARTED' });
+    createEvent({ text: 'doWork', self: 10, total: 10, parent: root, namespace: 'default' });
+    createEvent({ text: 'doWork', self: 15, total: 15, parent: root, namespace: 'pkg' });
+
+    const metrics = group(root);
+    const namespaces = metrics
+      .filter((m) => m.name === 'doWork')
+      .map((m) => m.namespace)
+      .sort();
+    expect(namespaces).toEqual(['default', 'pkg']);
+  });
+});

--- a/log-viewer/src/features/call-tree/components/AggregatedTable.ts
+++ b/log-viewer/src/features/call-tree/components/AggregatedTable.ts
@@ -154,6 +154,10 @@ export function createAggregatedTable(
         },
         hozAlign: 'right',
         headerHozAlign: 'right',
+        tooltip(_event, cell, _onRender) {
+          const maxDmlStatements = rootMethod.governorLimits.dmlStatements.limit;
+          return cell.getValue() + (maxDmlStatements > 0 ? '/' + maxDmlStatements : '');
+        },
       },
       {
         title: 'SOQL Count',
@@ -177,6 +181,72 @@ export function createAggregatedTable(
         },
         hozAlign: 'right',
         headerHozAlign: 'right',
+        tooltip(_event, cell, _onRender) {
+          const maxSoql = rootMethod.governorLimits.soqlQueries.limit;
+          return cell.getValue() + (maxSoql > 0 ? '/' + maxSoql : '');
+        },
+      },
+      {
+        title: 'Throws Count',
+        field: 'totalThrownCount',
+        sorter: 'number',
+        cssClass: 'number-cell',
+        width: 60,
+        hozAlign: 'right',
+        headerHozAlign: 'right',
+        bottomCalc: 'sum',
+      },
+      {
+        title: 'DML Rows',
+        field: 'dmlRowCount.total',
+        sorter: 'number',
+        cssClass: 'number-cell',
+        width: 60,
+        bottomCalc: 'sum',
+        bottomCalcFormatter: progressFormatter,
+        bottomCalcFormatterParams: {
+          precision: 0,
+          totalValue: rootMethod.governorLimits.dmlRows.limit,
+          showPercentageText: false,
+        },
+        formatter: progressFormatter,
+        formatterParams: {
+          precision: 0,
+          totalValue: rootMethod.governorLimits.dmlRows.limit,
+          showPercentageText: false,
+        },
+        hozAlign: 'right',
+        headerHozAlign: 'right',
+        tooltip(_event, cell, _onRender) {
+          const maxDmlRows = rootMethod.governorLimits.dmlRows.limit;
+          return cell.getValue() + (maxDmlRows > 0 ? '/' + maxDmlRows : '');
+        },
+      },
+      {
+        title: 'SOQL Rows',
+        field: 'soqlRowCount.total',
+        sorter: 'number',
+        cssClass: 'number-cell',
+        width: 60,
+        bottomCalc: 'sum',
+        bottomCalcFormatter: progressFormatter,
+        bottomCalcFormatterParams: {
+          precision: 0,
+          totalValue: rootMethod.governorLimits.queryRows.limit,
+          showPercentageText: false,
+        },
+        formatter: progressFormatter,
+        formatterParams: {
+          precision: 0,
+          totalValue: rootMethod.governorLimits.queryRows.limit,
+          showPercentageText: false,
+        },
+        hozAlign: 'right',
+        headerHozAlign: 'right',
+        tooltip(_event, cell, _onRender) {
+          const maxQueryRows = rootMethod.governorLimits.queryRows.limit;
+          return cell.getValue() + (maxQueryRows > 0 ? '/' + maxQueryRows : '');
+        },
       },
       {
         title: 'Total Time (ms)',

--- a/log-viewer/src/features/call-tree/components/AggregatedTable.ts
+++ b/log-viewer/src/features/call-tree/components/AggregatedTable.ts
@@ -224,22 +224,6 @@ export function createAggregatedTable(
         headerFilterLiveFilter: false,
         tooltip: (_event, cell) => formatDuration(cell.getValue()),
       },
-      {
-        title: 'Avg Self (ms)',
-        field: 'avgSelfTime',
-        sorter: 'number',
-        headerSortTristate: true,
-        width: 110,
-        minWidth: 90,
-        hozAlign: 'right',
-        headerHozAlign: 'right',
-        formatter: progressFormatterMS,
-        formatterParams: {
-          precision: 2,
-          totalValue: rootMethod.duration.total,
-        },
-        tooltip: (_event, cell) => formatDuration(cell.getValue()),
-      },
     ],
   });
   tableRef.current = table;

--- a/log-viewer/src/features/call-tree/components/AggregatedTable.ts
+++ b/log-viewer/src/features/call-tree/components/AggregatedTable.ts
@@ -1,0 +1,259 @@
+/*
+ * Copyright (c) 2024 Certinia Inc. All rights reserved.
+ */
+import type { ApexLog } from 'apex-log-parser';
+import { Tabulator } from 'tabulator-tables';
+
+import { vscodeMessenger } from '../../../core/messaging/VSCodeExtensionMessenger.js';
+import { formatDuration } from '../../../core/utility/Util.js';
+import MinMaxEditor from '../../../tabulator/editors/MinMax.js';
+import { minMaxTreeFilter } from '../../../tabulator/filters/MinMax.js';
+import { progressFormatter } from '../../../tabulator/format/Progress.js';
+import { progressFormatterMS } from '../../../tabulator/format/ProgressMS.js';
+import { toAggregatedCallTree, type AggregatedRow } from '../utils/Aggregation.js';
+import { makeSumSelfTimeAllVisible } from '../utils/BottomCalcs.js';
+import {
+  commonColumnDefaults,
+  headerSortElement,
+  registerTableModules,
+  type TableCallbacks,
+} from './TableShared.js';
+
+export function createAggregatedTable(
+  container: HTMLDivElement,
+  rootMethod: ApexLog,
+  callbacks: TableCallbacks,
+): Tabulator {
+  registerTableModules();
+
+  const namespaceFilterCache = new Map<string, boolean>();
+  const totalTimeFilterCache = new Map<string, boolean>();
+  const selfTimeFilterCache = new Map<string, boolean>();
+
+  let childIndent: number | undefined;
+
+  const tableRef: { current: Tabulator | undefined } = { current: undefined };
+  const selfTimeBottomCalc = makeSumSelfTimeAllVisible(() => tableRef.current);
+
+  const table = new Tabulator(container, {
+    data: toAggregatedCallTree(rootMethod.children),
+    layout: 'fitColumns',
+    placeholder: 'No Call Tree Available',
+    height: '100%',
+    maxHeight: '100%',
+    // @ts-expect-error custom property for module/RowKeyboardNavigation + MiddleRowFocus
+    rowKeyboardNavigation: true,
+    middleRowFocus: true,
+    dataTree: true,
+    dataTreeChildColumnCalcs: false,
+    dataTreeBranchElement: '<span/>',
+    tooltipDelay: 100,
+    selectableRows: 1,
+    headerSortElement,
+    columnCalcs: 'both',
+    columnDefaults: commonColumnDefaults,
+    columns: [
+      {
+        title: 'Name',
+        field: 'text',
+        headerSortTristate: true,
+        bottomCalc: () => 'Total',
+        cssClass: 'datagrid-textarea datagrid-code-text',
+        formatter: (cell) => {
+          const cellElem = cell.getElement();
+          const row = cell.getRow();
+          // @ts-expect-error: _row is private
+          const dataTree = row._row.modules.dataTree;
+          const treeLevel = dataTree?.index ?? 0;
+          childIndent ??= row.getTable().options.dataTreeChildIndent || 0;
+          const levelIndent = treeLevel * childIndent;
+          cellElem.style.paddingLeft = `${levelIndent + 4}px`;
+          cellElem.style.textIndent = `-${levelIndent}px`;
+
+          const rowData = cell.getData() as AggregatedRow;
+          const elem = document.createElement('span');
+          const firstInstance = rowData.instances[0];
+
+          if (firstInstance?.hasValidSymbols) {
+            const link = document.createElement('a');
+            link.setAttribute('href', '#!');
+            link.textContent = rowData.text;
+            elem.appendChild(link);
+          } else {
+            const textSpan = document.createElement('span');
+            textSpan.textContent = rowData.text;
+            elem.appendChild(textSpan);
+          }
+
+          return elem;
+        },
+        variableHeight: true,
+        cellClick: (e, cell) => {
+          const { type } = window.getSelection() ?? {};
+          if (type === 'Range') {
+            return;
+          }
+
+          if (!(e.target as HTMLElement).matches('a')) {
+            return;
+          }
+          const rowData = cell.getData() as AggregatedRow;
+          const firstInstance = rowData.instances[0];
+          if (firstInstance?.hasValidSymbols) {
+            vscodeMessenger.send<string>('openType', rowData.text);
+          }
+        },
+        widthGrow: 5,
+      },
+      {
+        title: 'Namespace',
+        field: 'namespace',
+        sorter: 'string',
+        width: 100,
+        minWidth: 80,
+        headerFilter: 'list',
+        headerFilterFunc: callbacks.namespaceFilter,
+        headerFilterFuncParams: { filterCache: namespaceFilterCache },
+        headerFilterParams: {
+          values: rootMethod.namespaces,
+          clearable: true,
+          multiselect: true,
+        },
+        headerFilterLiveFilter: false,
+      },
+      {
+        title: 'Calls',
+        field: 'callCount',
+        sorter: 'number',
+        cssClass: 'number-cell',
+        width: 70,
+        minWidth: 60,
+        hozAlign: 'right',
+        headerHozAlign: 'right',
+        bottomCalc: 'sum',
+      },
+      {
+        title: 'DML Count',
+        field: 'dmlCount.total',
+        sorter: 'number',
+        cssClass: 'number-cell',
+        width: 70,
+        minWidth: 60,
+        bottomCalc: 'sum',
+        bottomCalcFormatter: progressFormatter,
+        bottomCalcFormatterParams: {
+          precision: 0,
+          totalValue: rootMethod.governorLimits.dmlStatements.limit,
+          showPercentageText: false,
+        },
+        formatter: progressFormatter,
+        formatterParams: {
+          precision: 0,
+          totalValue: rootMethod.governorLimits.dmlStatements.limit,
+          showPercentageText: false,
+        },
+        hozAlign: 'right',
+        headerHozAlign: 'right',
+      },
+      {
+        title: 'SOQL Count',
+        field: 'soqlCount.total',
+        sorter: 'number',
+        cssClass: 'number-cell',
+        width: 70,
+        minWidth: 60,
+        bottomCalc: 'sum',
+        bottomCalcFormatter: progressFormatter,
+        bottomCalcFormatterParams: {
+          precision: 0,
+          totalValue: rootMethod.governorLimits.soqlQueries.limit,
+          showPercentageText: false,
+        },
+        formatter: progressFormatter,
+        formatterParams: {
+          precision: 0,
+          totalValue: rootMethod.governorLimits.soqlQueries.limit,
+          showPercentageText: false,
+        },
+        hozAlign: 'right',
+        headerHozAlign: 'right',
+      },
+      {
+        title: 'Total Time (ms)',
+        field: 'totalTime',
+        sorter: 'number',
+        headerSortTristate: true,
+        width: 150,
+        minWidth: 120,
+        hozAlign: 'right',
+        headerHozAlign: 'right',
+        formatter: progressFormatterMS,
+        formatterParams: {
+          precision: 2,
+          totalValue: rootMethod.duration.total,
+        },
+        bottomCalcFormatter: progressFormatterMS,
+        bottomCalc: 'sum',
+        bottomCalcFormatterParams: { precision: 2, totalValue: rootMethod.duration.total },
+        headerFilter: MinMaxEditor,
+        headerFilterFunc: minMaxTreeFilter,
+        headerFilterFuncParams: { columnName: 'totalTime', filterCache: totalTimeFilterCache },
+        headerFilterLiveFilter: false,
+        tooltip: (_event, cell) => formatDuration(cell.getValue()),
+      },
+      {
+        title: 'Self Time (ms)',
+        field: 'totalSelfTime',
+        sorter: 'number',
+        headerSortTristate: true,
+        width: 150,
+        minWidth: 120,
+        hozAlign: 'right',
+        headerHozAlign: 'right',
+        formatter: progressFormatterMS,
+        formatterParams: {
+          precision: 2,
+          totalValue: rootMethod.duration.total,
+        },
+        bottomCalcFormatter: progressFormatterMS,
+        bottomCalc: selfTimeBottomCalc,
+        bottomCalcFormatterParams: { precision: 2, totalValue: rootMethod.duration.total },
+        headerFilter: MinMaxEditor,
+        headerFilterFunc: minMaxTreeFilter,
+        headerFilterFuncParams: { columnName: 'totalSelfTime', filterCache: selfTimeFilterCache },
+        headerFilterLiveFilter: false,
+        tooltip: (_event, cell) => formatDuration(cell.getValue()),
+      },
+      {
+        title: 'Avg Self (ms)',
+        field: 'avgSelfTime',
+        sorter: 'number',
+        headerSortTristate: true,
+        width: 110,
+        minWidth: 90,
+        hozAlign: 'right',
+        headerHozAlign: 'right',
+        formatter: progressFormatterMS,
+        formatterParams: {
+          precision: 2,
+          totalValue: rootMethod.duration.total,
+        },
+        tooltip: (_event, cell) => formatDuration(cell.getValue()),
+      },
+    ],
+  });
+  tableRef.current = table;
+
+  table.on('dataFiltered', () => {
+    namespaceFilterCache.clear();
+    totalTimeFilterCache.clear();
+    selfTimeFilterCache.clear();
+    callbacks.onFilterCacheClear();
+  });
+
+  table.on('renderStarted', () => {
+    callbacks.onRenderStarted();
+  });
+
+  return table;
+}

--- a/log-viewer/src/features/call-tree/components/AggregatedTable.ts
+++ b/log-viewer/src/features/call-tree/components/AggregatedTable.ts
@@ -23,7 +23,7 @@ export function createAggregatedTable(
   container: HTMLDivElement,
   rootMethod: ApexLog,
   callbacks: TableCallbacks,
-): Tabulator {
+): { table: Tabulator; tableBuilt: Promise<void> } {
   registerTableModules();
 
   const namespaceFilterCache = new Map<string, boolean>();
@@ -309,5 +309,11 @@ export function createAggregatedTable(
     callbacks.onRenderStarted();
   });
 
-  return table;
+  const tableBuilt = new Promise<void>((resolve) => {
+    table.on('tableBuilt', () => {
+      resolve();
+    });
+  });
+
+  return { table, tableBuilt };
 }

--- a/log-viewer/src/features/call-tree/components/BottomUpTable.ts
+++ b/log-viewer/src/features/call-tree/components/BottomUpTable.ts
@@ -2,7 +2,7 @@
  * Copyright (c) 2024 Certinia Inc. All rights reserved.
  */
 import type { ApexLog, LogEventType } from 'apex-log-parser';
-import { Tabulator } from 'tabulator-tables';
+import { Tabulator, type Options } from 'tabulator-tables';
 
 import { vscodeMessenger } from '../../../core/messaging/VSCodeExtensionMessenger.js';
 import { formatDuration } from '../../../core/utility/Util.js';
@@ -22,10 +22,35 @@ import {
 
 import { createCalltreeNameFormatter } from './CalltreeNameFormatter.js';
 
+export type BottomUpTableOptions = Partial<Options> & {
+  enableClipboardAndDownload?: boolean;
+  exportFileName?: string;
+};
+
+type VSCodeSaveFile = {
+  fileContent: string;
+  options: { defaultFileName: string };
+};
+
+function createDownloadEncoder(defaultFileName: string) {
+  return function (fileContents: string, mimeType: string) {
+    const vscodeHost = vscodeMessenger.getVsCodeAPI();
+    if (vscodeHost) {
+      vscodeMessenger.send<VSCodeSaveFile>('saveFile', {
+        fileContent: fileContents,
+        options: { defaultFileName },
+      });
+      return false;
+    }
+    return new Blob([fileContents], { type: mimeType });
+  };
+}
+
 export function createBottomUpTable(
   container: HTMLDivElement,
   rootMethod: ApexLog,
   callbacks: TableCallbacks,
+  options: BottomUpTableOptions = {},
 ): { table: Tabulator; tableBuilt: Promise<void> } {
   registerTableModules();
   Tabulator.registerModule([GroupCalcs, GroupSort]);
@@ -39,20 +64,43 @@ export function createBottomUpTable(
     _calcParams: unknown,
   ): number => sumDurationTotalForRootEvents(data.map((row) => row.instances));
 
-  const table = new Tabulator(container, {
+  const { enableClipboardAndDownload, exportFileName, ...tabulatorOptionOverrides } = options;
+
+  // @ts-expect-error tabulator typings are behind runtime support for keybindings
+  const clipboardAndDownloadOptions: Partial<Options> = enableClipboardAndDownload
+    ? {
+        clipboard: true,
+        clipboardCopyConfig: {
+          dataTree: false,
+        },
+        downloadEncoder: createDownloadEncoder(exportFileName ?? 'analysis.csv'),
+        downloadRowRange: 'all',
+        downloadConfig: {
+          columnHeaders: true,
+          columnGroups: true,
+          rowGroups: true,
+          columnCalcs: false,
+          dataTree: true,
+        },
+        clipboardCopyRowRange: 'all',
+        keybindings: { copyToClipboard: ['ctrl + 67', 'meta + 67'] },
+      }
+    : {};
+
+  const tabulatorOptions = {
     data: toBottomUpTree(rootMethod.children),
     layout: 'fitColumns',
-    placeholder: 'No Call Tree Available',
+    placeholder: options.placeholder ?? 'No Call Tree Available',
     height: '100%',
     maxHeight: '100%',
-    // @ts-expect-error custom property for module/RowKeyboardNavigation + MiddleRowFocus
     rowKeyboardNavigation: true,
     middleRowFocus: true,
     dataTree: true,
     dataTreeChildColumnCalcs: false,
     dataTreeBranchElement: '<span/>',
     tooltipDelay: 100,
-    selectableRows: 1,
+    selectableRows: options.selectableRows ?? 1,
+    ...clipboardAndDownloadOptions,
     initialSort: [{ column: 'totalSelfTime', dir: 'desc' }],
     headerSortElement,
     columnCalcs: 'table',
@@ -62,6 +110,10 @@ export function createBottomUpTable(
     groupStartOpen: false,
     groupToggleElement: 'header',
     columnDefaults: commonColumnDefaults,
+  } as Options;
+
+  const table = new Tabulator(container, {
+    ...tabulatorOptions,
     columns: [
       {
         title: 'Name',
@@ -167,6 +219,7 @@ export function createBottomUpTable(
         tooltip: (_event, cell) => formatDuration(cell.getValue()),
       },
     ],
+    ...tabulatorOptionOverrides,
   });
 
   table.on('dataFiltered', () => {

--- a/log-viewer/src/features/call-tree/components/BottomUpTable.ts
+++ b/log-viewer/src/features/call-tree/components/BottomUpTable.ts
@@ -9,6 +9,8 @@ import { formatDuration } from '../../../core/utility/Util.js';
 import MinMaxEditor from '../../../tabulator/editors/MinMax.js';
 import MinMaxFilter from '../../../tabulator/filters/MinMax.js';
 import { progressFormatterMS } from '../../../tabulator/format/ProgressMS.js';
+import { GroupCalcs } from '../../../tabulator/groups/GroupCalcs.js';
+import { GroupSort } from '../../../tabulator/groups/GroupSort.js';
 import { sumDurationTotalForRootEvents } from '../../analysis/services/CallStackSum.js';
 import { toBottomUpTree, type BottomUpRow } from '../utils/Aggregation.js';
 import {
@@ -26,6 +28,7 @@ export function createBottomUpTable(
   callbacks: TableCallbacks,
 ): Tabulator {
   registerTableModules();
+  Tabulator.registerModule([GroupCalcs, GroupSort]);
 
   const excludedTypes = new Set<LogEventType>(['SOQL_EXECUTE_BEGIN', 'DML_BEGIN']);
   const nameFormatter = createCalltreeNameFormatter(excludedTypes);
@@ -52,7 +55,12 @@ export function createBottomUpTable(
     selectableRows: 1,
     initialSort: [{ column: 'totalSelfTime', dir: 'desc' }],
     headerSortElement,
-    columnCalcs: 'both',
+    columnCalcs: 'table',
+    groupCalcs: true,
+    groupSort: true,
+    groupClosedShowCalcs: true,
+    groupStartOpen: false,
+    groupToggleElement: 'header',
     columnDefaults: commonColumnDefaults,
     columns: [
       {

--- a/log-viewer/src/features/call-tree/components/BottomUpTable.ts
+++ b/log-viewer/src/features/call-tree/components/BottomUpTable.ts
@@ -26,7 +26,7 @@ export function createBottomUpTable(
   container: HTMLDivElement,
   rootMethod: ApexLog,
   callbacks: TableCallbacks,
-): Tabulator {
+): { table: Tabulator; tableBuilt: Promise<void> } {
   registerTableModules();
   Tabulator.registerModule([GroupCalcs, GroupSort]);
 
@@ -177,5 +177,11 @@ export function createBottomUpTable(
     callbacks.onRenderStarted();
   });
 
-  return table;
+  const tableBuilt = new Promise<void>((resolve) => {
+    table.on('tableBuilt', () => {
+      resolve();
+    });
+  });
+
+  return { table, tableBuilt };
 }

--- a/log-viewer/src/features/call-tree/components/BottomUpTable.ts
+++ b/log-viewer/src/features/call-tree/components/BottomUpTable.ts
@@ -1,0 +1,173 @@
+/*
+ * Copyright (c) 2024 Certinia Inc. All rights reserved.
+ */
+import type { ApexLog, LogEventType } from 'apex-log-parser';
+import { Tabulator } from 'tabulator-tables';
+
+import { vscodeMessenger } from '../../../core/messaging/VSCodeExtensionMessenger.js';
+import { formatDuration } from '../../../core/utility/Util.js';
+import MinMaxEditor from '../../../tabulator/editors/MinMax.js';
+import MinMaxFilter from '../../../tabulator/filters/MinMax.js';
+import { progressFormatterMS } from '../../../tabulator/format/ProgressMS.js';
+import { sumDurationTotalForRootEvents } from '../../analysis/services/CallStackSum.js';
+import { toBottomUpTree, type BottomUpRow } from '../utils/Aggregation.js';
+import {
+  commonColumnDefaults,
+  headerSortElement,
+  registerTableModules,
+  type TableCallbacks,
+} from './TableShared.js';
+
+import { createCalltreeNameFormatter } from './CalltreeNameFormatter.js';
+
+export function createBottomUpTable(
+  container: HTMLDivElement,
+  rootMethod: ApexLog,
+  callbacks: TableCallbacks,
+): Tabulator {
+  registerTableModules();
+
+  const excludedTypes = new Set<LogEventType>(['SOQL_EXECUTE_BEGIN', 'DML_BEGIN']);
+  const nameFormatter = createCalltreeNameFormatter(excludedTypes);
+
+  const totalTimeBottomCalc = (
+    _values: number[],
+    data: BottomUpRow[],
+    _calcParams: unknown,
+  ): number => sumDurationTotalForRootEvents(data.map((row) => row.instances));
+
+  const table = new Tabulator(container, {
+    data: toBottomUpTree(rootMethod.children),
+    layout: 'fitColumns',
+    placeholder: 'No Call Tree Available',
+    height: '100%',
+    maxHeight: '100%',
+    // @ts-expect-error custom property for module/RowKeyboardNavigation + MiddleRowFocus
+    rowKeyboardNavigation: true,
+    middleRowFocus: true,
+    dataTree: true,
+    dataTreeChildColumnCalcs: false,
+    dataTreeBranchElement: '<span/>',
+    tooltipDelay: 100,
+    selectableRows: 1,
+    initialSort: [{ column: 'totalSelfTime', dir: 'desc' }],
+    headerSortElement,
+    columnCalcs: 'both',
+    columnDefaults: commonColumnDefaults,
+    columns: [
+      {
+        title: 'Name',
+        field: 'text',
+        headerSortTristate: true,
+        bottomCalc: () => 'Total',
+        cssClass: 'datagrid-textarea datagrid-code-text',
+        formatter: nameFormatter,
+        variableHeight: true,
+        cellClick: (e, cell) => {
+          const { type } = window.getSelection() ?? {};
+          if (type === 'Range') {
+            return;
+          }
+
+          if (!(e.target as HTMLElement).matches('a')) {
+            return;
+          }
+          const rowData = cell.getData() as BottomUpRow;
+          const firstInstance = rowData.instances[0];
+          if (firstInstance?.hasValidSymbols) {
+            vscodeMessenger.send<string>('openType', rowData.text);
+          }
+        },
+        widthGrow: 5,
+      },
+      {
+        title: 'Namespace',
+        field: 'namespace',
+        sorter: 'string',
+        width: 100,
+        minWidth: 80,
+        headerFilter: 'list',
+        headerFilterFunc: 'in',
+        headerFilterParams: {
+          values: rootMethod.namespaces,
+          clearable: true,
+          multiselect: true,
+        },
+        headerFilterLiveFilter: false,
+      },
+      {
+        title: 'Type',
+        field: 'type',
+        headerSortStartingDir: 'asc',
+        width: 150,
+        sorter: 'string',
+        tooltip: true,
+      },
+      {
+        title: 'Count',
+        field: 'callCount',
+        sorter: 'number',
+        cssClass: 'number-cell',
+        width: 65,
+        minWidth: 60,
+        hozAlign: 'right',
+        headerHozAlign: 'right',
+        bottomCalc: 'sum',
+      },
+      {
+        title: 'Total Time (ms)',
+        field: 'totalTime',
+        sorter: 'number',
+        headerSortTristate: true,
+        width: 165,
+        minWidth: 120,
+        hozAlign: 'right',
+        headerHozAlign: 'right',
+        formatter: progressFormatterMS,
+        formatterParams: {
+          precision: 2,
+          totalValue: rootMethod.duration.total,
+        },
+        bottomCalcFormatter: progressFormatterMS,
+        bottomCalc: totalTimeBottomCalc,
+        bottomCalcFormatterParams: { precision: 2, totalValue: rootMethod.duration.total },
+        headerFilter: MinMaxEditor,
+        headerFilterFunc: MinMaxFilter,
+        headerFilterLiveFilter: false,
+        tooltip: (_event, cell) => formatDuration(cell.getValue()),
+      },
+      {
+        title: 'Self Time (ms)',
+        field: 'totalSelfTime',
+        sorter: 'number',
+        headerSortTristate: true,
+        width: 165,
+        minWidth: 120,
+        hozAlign: 'right',
+        headerHozAlign: 'right',
+        formatter: progressFormatterMS,
+        formatterParams: {
+          precision: 2,
+          totalValue: rootMethod.duration.total,
+        },
+        bottomCalcFormatter: progressFormatterMS,
+        bottomCalc: 'sum',
+        bottomCalcFormatterParams: { precision: 2, totalValue: rootMethod.duration.total },
+        headerFilter: MinMaxEditor,
+        headerFilterFunc: MinMaxFilter,
+        headerFilterLiveFilter: false,
+        tooltip: (_event, cell) => formatDuration(cell.getValue()),
+      },
+    ],
+  });
+
+  table.on('dataFiltered', () => {
+    callbacks.onFilterCacheClear();
+  });
+
+  table.on('renderStarted', () => {
+    callbacks.onRenderStarted();
+  });
+
+  return table;
+}

--- a/log-viewer/src/features/call-tree/components/CalltreeNameFormatter.ts
+++ b/log-viewer/src/features/call-tree/components/CalltreeNameFormatter.ts
@@ -18,12 +18,17 @@ export function createCalltreeNameFormatter(excludedTypes: Set<LogEventType>) {
     // @ts-expect-error _row is private to tabulator but is the only way to get the tree level in a formatter
     const treeLevel: number = row._row.modules.dataTree?.index ?? 0;
     const levelIndent = treeLevel * childIndent;
-
-    const cellElem = cell.getElement();
-    cellElem.style.paddingLeft = `${levelIndent + 4}px`;
-    cellElem.style.textIndent = `-${levelIndent}px`;
+    if (levelIndent) {
+      const cellElem = cell.getElement();
+      cellElem.style.paddingLeft = `${levelIndent + 4}px`;
+      cellElem.style.textIndent = `-${levelIndent}px`;
+    }
 
     const { originalData: node } = cell.getData() as { originalData: LogEvent };
+    if (!node) {
+      return document.createTextNode(cell.getValue()) as unknown as HTMLElement;
+    }
+
     if (node.hasValidSymbols) {
       const link = document.createElement('a');
       link.setAttribute('href', '#!');

--- a/log-viewer/src/features/call-tree/components/CalltreeNameFormatter.ts
+++ b/log-viewer/src/features/call-tree/components/CalltreeNameFormatter.ts
@@ -12,16 +12,18 @@ export function createCalltreeNameFormatter(excludedTypes: Set<LogEventType>) {
     _formatterParams: object,
     _onRendered: EmptyCallback,
   ): string | HTMLElement {
-    const data = cell.getData() as { originalData: LogEvent; treeLevel: number };
-    const { originalData: node, treeLevel } = data;
     // @ts-expect-error this.table is added by tabulator when the formatter is called, but isn't in the types for some reason
     childIndent ??= this.table.options.dataTreeChildIndent ?? 9;
+    const row = cell.getRow();
+    // @ts-expect-error _row is private to tabulator but is the only way to get the tree level in a formatter
+    const treeLevel: number = row._row.modules.dataTree?.index ?? 0;
     const levelIndent = treeLevel * childIndent;
 
     const cellElem = cell.getElement();
     cellElem.style.paddingLeft = `${levelIndent + 4}px`;
     cellElem.style.textIndent = `-${levelIndent}px`;
 
+    const { originalData: node } = cell.getData() as { originalData: LogEvent };
     if (node.hasValidSymbols) {
       const link = document.createElement('a');
       link.setAttribute('href', '#!');

--- a/log-viewer/src/features/call-tree/components/CalltreeView.ts
+++ b/log-viewer/src/features/call-tree/components/CalltreeView.ts
@@ -3,6 +3,7 @@
  */
 import {
   provideVSCodeDesignSystem,
+  vsCodeButton,
   vsCodeCheckbox,
   vsCodeDropdown,
   vsCodeOption,
@@ -10,26 +11,17 @@ import {
 import { css, html, LitElement, unsafeCSS, type PropertyValues } from 'lit';
 import { customElement, property, state } from 'lit/decorators.js';
 import { repeat } from 'lit/directives/repeat.js';
-import { Tabulator, type RowComponent } from 'tabulator-tables';
+import { type RowComponent, type Tabulator } from 'tabulator-tables';
 
-import type { ApexLog, LogEvent, LogEventType } from 'apex-log-parser';
+import type { ApexLog, LogEvent } from 'apex-log-parser';
 import { eventBus } from '../../../core/events/EventBus.js';
 import { vscodeMessenger } from '../../../core/messaging/VSCodeExtensionMessenger.js';
 import { findEventByTimestamp } from '../../../core/utility/EventSearch.js';
-import { formatDuration, isVisible } from '../../../core/utility/Util.js';
+import { isVisible } from '../../../core/utility/Util.js';
+import type { AggregatedRow, BottomUpRow } from '../utils/Aggregation.js';
+import type { MergedCalltreeRow } from '../utils/MergeAdjacent.js';
 
-// Tabulator custom modules, imports + styles
-import MinMaxEditor from '../../../tabulator/editors/MinMax.js';
-import MinMaxFilter from '../../../tabulator/filters/MinMax.js';
-import { progressFormatter } from '../../../tabulator/format/Progress.js';
-import { progressFormatterMS } from '../../../tabulator/format/ProgressMS.js';
-import * as CommonModules from '../../../tabulator/module/CommonModules.js';
-import { Find } from '../../../tabulator/module/Find.js';
-import { MiddleRowFocus } from '../../../tabulator/module/MiddleRowFocus.js';
-import { RowKeyboardNavigation } from '../../../tabulator/module/RowKeyboardNavigation.js';
-import { RowNavigation } from '../../../tabulator/module/RowNavigation.js';
 import dataGridStyles from '../../../tabulator/style/DataGrid.scss';
-import { createCalltreeNameFormatter } from './CalltreeNameFormatter.js';
 
 // styles
 import { globalStyles } from '../../../styles/global.styles.js';
@@ -39,7 +31,21 @@ import '../../../components/ContextMenu.js';
 import type { ContextMenu } from '../../../components/ContextMenu.js';
 import '../../../components/GridSkeleton.js';
 
-provideVSCodeDesignSystem().register(vsCodeCheckbox(), vsCodeDropdown(), vsCodeOption());
+// Table creation functions
+import { createAggregatedTable } from './AggregatedTable.js';
+import { createBottomUpTable } from './BottomUpTable.js';
+import { createTimeOrderTable } from './TimeOrderTable.js';
+
+import codiconStyles from '../../../styles/codicon.css';
+
+provideVSCodeDesignSystem().register(
+  vsCodeButton(),
+  vsCodeCheckbox(),
+  vsCodeDropdown(),
+  vsCodeOption(),
+);
+
+type ViewMode = 'time-order' | 'aggregated' | 'bottom-up';
 
 @customElement('call-tree-view')
 export class CalltreeView extends LitElement {
@@ -48,6 +54,12 @@ export class CalltreeView extends LitElement {
 
   @state()
   isVisible = false;
+
+  @state()
+  viewMode: ViewMode = 'time-order';
+
+  aggregatedTreeTable: Tabulator | null = null;
+  bottomUpTreeTable: Tabulator | null = null;
 
   filterState: { showDetails: boolean; debugOnly: boolean; selectedTypes: string[] } = {
     showDetails: false,
@@ -74,7 +86,7 @@ export class CalltreeView extends LitElement {
   rootMethod: ApexLog | null = null;
 
   private contextMenu: ContextMenu | null = null;
-  private contextMenuRow: CalltreeRow | null = null;
+  private contextMenuRow: MergedCalltreeRow | null = null;
 
   get _callTreeTableWrapper(): HTMLDivElement | null {
     return (this.tableContainer = this.renderRoot?.querySelector('#call-tree-table') ?? null);
@@ -117,6 +129,7 @@ export class CalltreeView extends LitElement {
 
   static styles = [
     unsafeCSS(dataGridStyles),
+    unsafeCSS(codiconStyles),
     globalStyles,
     css`
       :host {
@@ -139,12 +152,6 @@ export class CalltreeView extends LitElement {
         width: 100%;
         min-height: 0;
         min-width: 0;
-      }
-
-      #call-tree-table {
-        display: inline-block;
-        height: 100%;
-        width: 100%;
       }
 
       .header-bar {
@@ -185,16 +192,68 @@ export class CalltreeView extends LitElement {
       .align__end {
         align-items: end;
       }
+
+      .view-mode-buttons {
+        display: flex;
+        gap: 0;
+        align-self: flex-end;
+      }
+
+      .view-mode-buttons vscode-button {
+        height: 26px;
+      }
+
+      .view-mode-buttons vscode-button::part(control) {
+        border-radius: 0;
+        min-width: auto;
+        padding: 0 8px;
+        height: 100%;
+      }
+
+      .view-mode-buttons vscode-button:first-child::part(control) {
+        border-radius: 2px 0 0 2px;
+      }
+
+      .view-mode-buttons vscode-button:last-child::part(control) {
+        border-radius: 0 2px 2px 0;
+      }
+
+      #call-tree-table,
+      #aggregated-tree-table,
+      #bottom-up-tree-table {
+        display: inline-block;
+        height: 100%;
+        width: 100%;
+      }
     `,
   ];
 
   render() {
     const skeleton = !this.timelineRoot ? html`<grid-skeleton></grid-skeleton>` : '';
+    const isTimeOrder = this.viewMode === 'time-order';
 
     return html`
       <div id="call-tree-container">
         <div>
           <div class="header-bar">
+            <div class="view-mode-buttons" role="radiogroup" aria-label="View mode">
+              <vscode-button
+                appearance="${this.viewMode === 'time-order' ? '' : 'secondary'}"
+                @click="${() => this._setViewMode('time-order')}"
+                >Time Order</vscode-button
+              >
+              <vscode-button
+                appearance="${this.viewMode === 'aggregated' ? '' : 'secondary'}"
+                @click="${() => this._setViewMode('aggregated')}"
+                >Aggregated</vscode-button
+              >
+              <vscode-button
+                appearance="${this.viewMode === 'bottom-up' ? '' : 'secondary'}"
+                @click="${() => this._setViewMode('bottom-up')}"
+                >Bottom-Up</vscode-button
+              >
+            </div>
+
             <div class="filter-container align__end">
               <vscode-button appearance="secondary" @click="${this._expandButtonClick}"
                 >Expand</vscode-button
@@ -204,37 +263,42 @@ export class CalltreeView extends LitElement {
               >
             </div>
 
-            <div class="filter-section">
-              <strong>Filter</strong>
-              <div class="filter-container align__end">
-                <vscode-checkbox class="align__end" @change="${this._handleShowDetailsChange}"
-                  >Details</vscode-checkbox
-                >
+            ${isTimeOrder
+              ? html`
+                  <div class="filter-container align__end">
+                    <vscode-checkbox class="align__end" @change="${this._handleShowDetailsChange}"
+                      >Details</vscode-checkbox
+                    >
 
-                <vscode-checkbox class="align__end" @change="${this._handleDebugOnlyChange}"
-                  >Debug Only</vscode-checkbox
-                >
+                    <vscode-checkbox class="align__end" @change="${this._handleDebugOnlyChange}"
+                      >Debug Only</vscode-checkbox
+                    >
 
-                <div class="dropdown-container">
-                  <label for="types">Type:</label>
-                  <vscode-dropdown @change="${this._handleTypeFilter}">
-                    <vscode-option>None</vscode-option>
-                    ${this.isVisible
-                      ? repeat(
-                          this._getAllTypes(this.timelineRoot?.children ?? []),
-                          (type, _index) => html`<vscode-option>${type}</vscode-option>`,
-                        )
-                      : ''}
-                  </vscode-dropdown>
-                </div>
-              </div>
-            </div>
+                    <div class="dropdown-container">
+                      <label for="types">Type:</label>
+                      <vscode-dropdown @change="${this._handleTypeFilter}">
+                        <vscode-option>None</vscode-option>
+                        ${this.isVisible
+                          ? repeat(
+                              this._getAllTypes(this.timelineRoot?.children ?? []),
+                              (type, _index) => html`<vscode-option>${type}</vscode-option>`,
+                            )
+                          : ''}
+                      </vscode-dropdown>
+                    </div>
+                  </div>
+                `
+              : ''}
           </div>
         </div>
 
         <div id="call-tree-table-container">
           ${skeleton}
-          <div id="call-tree-table"></div>
+          ${this.viewMode === 'time-order'
+            ? html`<div id="call-tree-table"></div>`
+            : this.viewMode === 'aggregated'
+              ? html`<div id="aggregated-tree-table"></div>`
+              : html`<div id="bottom-up-tree-table"></div>`}
         </div>
         <context-menu @menu-select="${this._handleContextMenuSelect}"></context-menu>
       </div>
@@ -281,6 +345,55 @@ export class CalltreeView extends LitElement {
     this._updateFiltering();
   }
 
+  _setViewMode(newMode: ViewMode) {
+    if (newMode === this.viewMode) {
+      return;
+    }
+
+    this._destroyCurrentTable();
+    this.viewMode = newMode;
+
+    this.updateComplete.then(() => {
+      if (!this.rootMethod) {
+        return;
+      }
+
+      if (this.viewMode === 'time-order') {
+        const container = this.renderRoot?.querySelector('#call-tree-table') as HTMLDivElement;
+        if (container) {
+          this._renderCallTree(container, this.rootMethod);
+        }
+      } else if (this.viewMode === 'aggregated') {
+        const container = this.renderRoot?.querySelector(
+          '#aggregated-tree-table',
+        ) as HTMLDivElement;
+        if (container) {
+          this._renderAggregatedTree(container, this.rootMethod);
+        }
+      } else if (this.viewMode === 'bottom-up') {
+        const container = this.renderRoot?.querySelector('#bottom-up-tree-table') as HTMLDivElement;
+        if (container) {
+          this._renderBottomUpTree(container, this.rootMethod);
+        }
+      }
+    });
+  }
+
+  private _destroyCurrentTable(): void {
+    if (this.calltreeTable) {
+      this.calltreeTable.destroy();
+      this.calltreeTable = null;
+    }
+    if (this.aggregatedTreeTable) {
+      this.aggregatedTreeTable.destroy();
+      this.aggregatedTreeTable = null;
+    }
+    if (this.bottomUpTreeTable) {
+      this.bottomUpTreeTable.destroy();
+      this.bottomUpTreeTable = null;
+    }
+  }
+
   _handleTypeFilter(event: CustomEvent<{ selectedOptions: [{ value: string }] }>) {
     this.filterState.selectedTypes = [];
     event.detail.selectedOptions.forEach((element) => {
@@ -290,13 +403,12 @@ export class CalltreeView extends LitElement {
   }
 
   _updateFiltering() {
-    if (!this.calltreeTable) {
+    const activeTable = this._getActiveTable();
+    if (!activeTable) {
       return;
     }
     const filtersToAdd = [];
 
-    // if debug only we want to show everything and apply the debug only filter.
-    // So we make sure this will be the only filter applied
     if (this.filterState.debugOnly) {
       filtersToAdd.push(this._debugFilter);
     } else {
@@ -312,33 +424,46 @@ export class CalltreeView extends LitElement {
       }
     }
 
-    this.calltreeTable.blockRedraw();
-    this.calltreeTable.clearFilter(false);
+    activeTable.blockRedraw();
+    activeTable.clearFilter(false);
     filtersToAdd.forEach((filter) => {
       // @ts-expect-error valid
-      this.calltreeTable.addFilter(filter);
+      activeTable.addFilter(filter);
     });
-    this.calltreeTable.restoreRedraw();
+    activeTable.restoreRedraw();
+  }
+
+  private _getActiveTable(): Tabulator | null {
+    switch (this.viewMode) {
+      case 'time-order':
+        return this.calltreeTable;
+      case 'aggregated':
+        return this.aggregatedTreeTable;
+      case 'bottom-up':
+        return this.bottomUpTreeTable;
+    }
   }
 
   _expandButtonClick() {
-    if (!this.calltreeTable?.modules?.dataTree) {
+    const table = this._getActiveTable();
+    if (!table?.modules?.dataTree) {
       return;
     }
-    this.calltreeTable.blockRedraw();
-    this._expandCollapseAll(this.calltreeTable.getRows(), true);
-    this.calltreeTable.element?.querySelector<HTMLElement>('.tabulator-tableholder')?.focus();
-    this.calltreeTable.restoreRedraw();
+    table.blockRedraw();
+    this._expandCollapseAll(table.getRows(), true);
+    table.element?.querySelector<HTMLElement>('.tabulator-tableholder')?.focus();
+    table.restoreRedraw();
   }
 
   _collapseButtonClick() {
-    if (!this.calltreeTable?.modules?.dataTree) {
+    const table = this._getActiveTable();
+    if (!table?.modules?.dataTree) {
       return;
     }
-    this.calltreeTable.blockRedraw();
-    this._expandCollapseAll(this.calltreeTable.getRows(), false);
-    this.calltreeTable.element?.querySelector<HTMLElement>('.tabulator-tableholder')?.focus();
-    this.calltreeTable.restoreRedraw();
+    table.blockRedraw();
+    this._expandCollapseAll(table.getRows(), false);
+    table.element?.querySelector<HTMLElement>('.tabulator-tableholder')?.focus();
+    table.restoreRedraw();
   }
 
   _appendTableWhenVisible() {
@@ -356,10 +481,21 @@ export class CalltreeView extends LitElement {
   }
 
   async _goToRow(timestamp: number) {
-    if (!this._callTreeTableWrapper || !this.rootMethod) {
+    if (!this.rootMethod) {
       return;
     }
     document.dispatchEvent(new CustomEvent('show-tab', { detail: { tabid: 'tree-tab' } }));
+
+    if (this.viewMode !== 'time-order') {
+      this._destroyCurrentTable();
+      this.viewMode = 'time-order';
+      await this.updateComplete;
+    }
+
+    if (!this._callTreeTableWrapper) {
+      return;
+    }
+
     await this._renderCallTree(this._callTreeTableWrapper, this.rootMethod);
     if (!this.calltreeTable) {
       return;
@@ -371,7 +507,8 @@ export class CalltreeView extends LitElement {
   }
 
   async _find(e: CustomEvent<{ text: string; count: number; options: { matchCase: boolean } }>) {
-    const isTableVisible = !!this.calltreeTable?.element?.clientHeight;
+    const activeTable = this._getActiveTable();
+    const isTableVisible = !!activeTable?.element?.clientHeight;
     if (!isTableVisible && !this.totalMatches) {
       return;
     }
@@ -390,7 +527,7 @@ export class CalltreeView extends LitElement {
     if (newSearch || clearHighlights) {
       this.blockClearHighlights = true;
       //@ts-expect-error This is a custom function added in by Find custom module
-      const result = await this.calltreeTable.find(this.findArgs);
+      const result = await activeTable.find(this.findArgs);
       this.blockClearHighlights = false;
       this.totalMatches = result.totalMatches;
       this.findMap = result.matchIndexes;
@@ -402,30 +539,20 @@ export class CalltreeView extends LitElement {
       }
     }
 
-    // Highlight the current row and reset the previous or next depending on whether we are stepping forward or back.
     if (this.totalMatches <= 0 || !isTableVisible) {
       return;
     }
     this.blockClearHighlights = true;
     const currentRow = this.findMap[this.findArgs.count];
     //@ts-expect-error This is a custom function added in by Find custom module
-    await this.calltreeTable.setCurrentMatch(this.findArgs.count, currentRow, {
+    await activeTable.setCurrentMatch(this.findArgs.count, currentRow, {
       scrollIfVisible: false,
       focusRow: false,
     });
     this.blockClearHighlights = false;
   }
 
-  _highlight(inputString: string, substring: string) {
-    const regex = new RegExp(substring, 'gi');
-    const resultString = inputString.replace(
-      regex,
-      '<span style="background-color:yellow;border:1px solid lightgrey">$&</span>',
-    );
-    return resultString;
-  }
-
-  _showDetailsFilter = (data: CalltreeRow) => {
+  _showDetailsFilter = (data: MergedCalltreeRow) => {
     const excludedTypes = new Set<string>([
       'CUMULATIVE_LIMIT_USAGE',
       'LIMIT_USAGE_FOR_NS',
@@ -450,7 +577,7 @@ export class CalltreeView extends LitElement {
     );
   };
 
-  _debugFilter = (data: CalltreeRow) => {
+  _debugFilter = (data: MergedCalltreeRow) => {
     const debugValues = new Set<string>([
       'USER_DEBUG',
       'DATAWEAVE_USER_DEBUG',
@@ -473,7 +600,7 @@ export class CalltreeView extends LitElement {
     );
   };
 
-  _typeFilter = (data: CalltreeRow) => {
+  _typeFilter = (data: MergedCalltreeRow) => {
     return this._deepFilter(
       data,
       (rowData) => {
@@ -491,18 +618,30 @@ export class CalltreeView extends LitElement {
 
   _namespaceFilter = (
     selectedNamespaces: string[],
-    namespace: string,
-    data: CalltreeRow,
-    filterParams: { columnName: string; filterCache: Map<string, boolean> },
+    _namespace: string,
+    data: MergedCalltreeRow | AggregatedRow | BottomUpRow,
+    filterParams: { filterCache: Map<string, boolean> },
   ) => {
     if (selectedNamespaces.length === 0) {
       return true;
     }
 
-    return this._deepFilter(
-      data,
+    if ('originalData' in data) {
+      return this._deepFilter(
+        data as MergedCalltreeRow,
+        (rowData) => {
+          return selectedNamespaces.includes(rowData.originalData.namespace || '');
+        },
+        {
+          filterCache: filterParams.filterCache,
+        },
+      );
+    }
+
+    return this._deepFilterAggregated(
+      data as AggregatedRow | BottomUpRow,
       (rowData) => {
-        return selectedNamespaces.includes(rowData.originalData.namespace || '');
+        return selectedNamespaces.includes(rowData.namespace || '');
       },
       {
         filterCache: filterParams.filterCache,
@@ -510,9 +649,42 @@ export class CalltreeView extends LitElement {
     );
   };
 
+  private _deepFilterAggregated(
+    rowData: AggregatedRow | BottomUpRow,
+    filterFunction: (rowData: AggregatedRow | BottomUpRow) => boolean,
+    filterParams: { filterCache: Map<string, boolean> },
+  ): boolean {
+    const cachedMatch = filterParams.filterCache.get(rowData.id);
+    if (cachedMatch !== null && cachedMatch !== undefined) {
+      return cachedMatch;
+    }
+
+    let childMatch = false;
+    const children = rowData._children || [];
+    let len = children.length;
+    while (--len >= 0) {
+      const childRow = children[len];
+      if (childRow) {
+        const match = this._deepFilterAggregated(childRow, filterFunction, filterParams);
+
+        if (match) {
+          childMatch = true;
+          break;
+        }
+      }
+    }
+
+    filterParams.filterCache.set(rowData.id, childMatch);
+    if (childMatch) {
+      return true;
+    }
+
+    return filterFunction(rowData);
+  }
+
   private _deepFilter(
-    rowData: CalltreeRow,
-    filterFunction: (rowData: CalltreeRow) => boolean,
+    rowData: MergedCalltreeRow,
+    filterFunction: (rowData: MergedCalltreeRow) => boolean,
     filterParams: { filterCache: Map<string, boolean> },
   ): boolean {
     const cachedMatch = filterParams.filterCache.get(rowData.id);
@@ -548,8 +720,6 @@ export class CalltreeView extends LitElement {
     rootMethod: ApexLog,
   ): Promise<void> {
     if (this.calltreeTable) {
-      // Ensure the table is fully visible before attempting to do things e.g go to rows.
-      // Otherwise there are visible rendering issues.
       await new Promise((resolve, reject) => {
         const visibilityObserver = new IntersectionObserver(
           (entries, observer) => {
@@ -569,302 +739,66 @@ export class CalltreeView extends LitElement {
       return new Promise((resolve) => setTimeout(resolve));
     }
 
-    return new Promise((resolve) => {
-      Tabulator.registerModule(Object.values(CommonModules));
-      Tabulator.registerModule([RowKeyboardNavigation, RowNavigation, MiddleRowFocus, Find]);
-
-      const selfTimeFilterCache = new Map<string, boolean>();
-      const totalTimeFilterCache = new Map<string, boolean>();
-      const namespaceFilterCache = new Map<string, boolean>();
-
-      const excludedTypes = new Set<LogEventType>(['SOQL_EXECUTE_BEGIN', 'DML_BEGIN']);
-      const governorLimits = rootMethod.governorLimits;
-
-      const nameFormatter = createCalltreeNameFormatter(excludedTypes);
-      this.calltreeTable = new Tabulator(callTreeTableContainer, {
-        data: this._toCallTree(rootMethod.children),
-        layout: 'fitColumns',
-        placeholder: 'No Call Tree Available',
-        height: '100%',
-        maxHeight: '100%',
-        //  custom property for datagrid/module/RowKeyboardNavigation
-        rowKeyboardNavigation: true,
-        //  custom property for module/MiddleRowFocus
-        middleRowFocus: true,
-        dataTree: true,
-        dataTreeChildColumnCalcs: true, // todo: fix
-        dataTreeBranchElement: '<span/>',
-        tooltipDelay: 100,
-        selectableRows: 1,
-        // @ts-expect-error it is possible to pass a function to intitialFilter the types need updating
-        initialFilter: this._showDetailsFilter,
-        headerSortElement: function (column, dir) {
-          switch (dir) {
-            case 'asc':
-              return "<div class='sort-by--top'></div>";
-              break;
-            case 'desc':
-              return "<div class='sort-by--bottom'></div>";
-              break;
-            default:
-              return "<div class='sort-by'><div class='sort-by--top'></div><div class='sort-by--bottom'></div></div>";
-          }
-        },
-        columnCalcs: 'both',
-        columnDefaults: {
-          title: 'default',
-          resizable: true,
-          headerSortStartingDir: 'desc',
-          headerTooltip: true,
-          headerWordWrap: true,
-        },
-        columns: [
-          {
-            title: 'Name',
-            field: 'text',
-            headerSortTristate: true,
-            bottomCalc: () => {
-              return 'Total';
-            },
-            cssClass: 'datagrid-textarea datagrid-code-text',
-            formatter: nameFormatter,
-            variableHeight: true,
-            cellClick: (e, cell) => {
-              const { type } = window.getSelection() ?? {};
-              if (type === 'Range') {
-                return;
-              }
-
-              if (!(e.target as HTMLElement).matches('a')) {
-                return;
-              }
-              const node = (cell.getData() as CalltreeRow).originalData;
-              if (node.hasValidSymbols) {
-                vscodeMessenger.send<string>('openType', node.text);
-              }
-            },
-            widthGrow: 5,
-          },
-          {
-            title: 'Namespace',
-            field: 'namespace',
-            sorter: 'string',
-            width: 100,
-            headerFilter: 'list',
-            headerFilterFunc: this._namespaceFilter,
-            headerFilterFuncParams: { filterCache: namespaceFilterCache },
-            headerFilterParams: {
-              values: rootMethod.namespaces,
-              clearable: true,
-              multiselect: true,
-            },
-            headerFilterLiveFilter: false,
-          },
-          {
-            title: 'DML Count',
-            field: 'dmlCount.total',
-            sorter: 'number',
-            cssClass: 'number-cell',
-            width: 60,
-            bottomCalc: 'max',
-            bottomCalcFormatter: progressFormatter,
-            bottomCalcFormatterParams: {
-              precision: 0,
-              totalValue: governorLimits.dmlStatements.limit,
-              showPercentageText: false,
-            },
-            formatter: progressFormatter,
-            formatterParams: {
-              precision: 0,
-              totalValue: governorLimits.dmlStatements.limit,
-              showPercentageText: false,
-            },
-            hozAlign: 'right',
-            headerHozAlign: 'right',
-            tooltip(_event, cell, _onRender) {
-              const maxDmlStatements = governorLimits.dmlStatements.limit;
-              return cell.getValue() + (maxDmlStatements > 0 ? '/' + maxDmlStatements : '');
-            },
-          },
-          {
-            title: 'SOQL Count',
-            field: 'soqlCount.total',
-            sorter: 'number',
-            cssClass: 'number-cell',
-            width: 60,
-            bottomCalc: 'max',
-            bottomCalcFormatter: progressFormatter,
-            bottomCalcFormatterParams: {
-              precision: 0,
-              totalValue: governorLimits.soqlQueries.limit,
-              showPercentageText: false,
-            },
-            formatter: progressFormatter,
-            formatterParams: {
-              precision: 0,
-              totalValue: governorLimits.soqlQueries.limit,
-              showPercentageText: false,
-            },
-            hozAlign: 'right',
-            headerHozAlign: 'right',
-            tooltip(_event, cell, _onRender) {
-              const maxSoql = governorLimits.soqlQueries.limit;
-              return cell.getValue() + (maxSoql > 0 ? '/' + maxSoql : '');
-            },
-          },
-          {
-            title: 'Throws Count',
-            field: 'totalThrownCount',
-            sorter: 'number',
-            cssClass: 'number-cell',
-            width: 60,
-            hozAlign: 'right',
-            headerHozAlign: 'right',
-            bottomCalc: 'max',
-          },
-          {
-            title: 'DML Rows',
-            field: 'dmlRowCount.total',
-            sorter: 'number',
-            cssClass: 'number-cell',
-            width: 60,
-            bottomCalc: 'max',
-            bottomCalcFormatter: progressFormatter,
-            bottomCalcFormatterParams: {
-              precision: 0,
-              totalValue: governorLimits.dmlRows.limit,
-              showPercentageText: false,
-            },
-            formatter: progressFormatter,
-            formatterParams: {
-              precision: 0,
-              totalValue: governorLimits.dmlRows.limit,
-              showPercentageText: false,
-            },
-            hozAlign: 'right',
-            headerHozAlign: 'right',
-            tooltip(_event, cell, _onRender) {
-              const maxDmlRows = governorLimits.dmlRows.limit;
-              return cell.getValue() + (maxDmlRows > 0 ? '/' + maxDmlRows : '');
-            },
-          },
-          {
-            title: 'SOQL Rows',
-            field: 'soqlRowCount.total',
-            sorter: 'number',
-            cssClass: 'number-cell',
-            width: 60,
-            bottomCalc: 'max',
-            bottomCalcFormatter: progressFormatter,
-            bottomCalcFormatterParams: {
-              precision: 0,
-              totalValue: governorLimits.queryRows.limit,
-              showPercentageText: false,
-            },
-            formatter: progressFormatter,
-            formatterParams: {
-              precision: 0,
-              totalValue: governorLimits.queryRows.limit,
-              showPercentageText: false,
-            },
-            hozAlign: 'right',
-            headerHozAlign: 'right',
-            tooltip(_event, cell, _onRender) {
-              const maxQueryRows = governorLimits.queryRows.limit;
-              return cell.getValue() + (maxQueryRows > 0 ? '/' + maxQueryRows : '');
-            },
-          },
-          {
-            title: 'Total Time (ms)',
-            field: 'duration.total',
-            sorter: 'number',
-            headerSortTristate: true,
-            width: 150,
-            hozAlign: 'right',
-            headerHozAlign: 'right',
-            formatter: progressFormatterMS,
-            formatterParams: {
-              precision: 2,
-              totalValue: rootMethod.duration.total,
-            },
-            bottomCalcFormatter: progressFormatterMS,
-            bottomCalc: 'max',
-            bottomCalcFormatterParams: { precision: 2, totalValue: rootMethod.duration.total },
-            headerFilter: MinMaxEditor,
-            headerFilterFunc: MinMaxFilter,
-            headerFilterFuncParams: { columnName: 'duration', filterCache: totalTimeFilterCache },
-            headerFilterLiveFilter: false,
-            tooltip(_event, cell, _onRender) {
-              return formatDuration(cell.getValue());
-            },
-          },
-          {
-            title: 'Self Time (ms)',
-            field: 'duration.self',
-            sorter: 'number',
-            headerSortTristate: true,
-            width: 150,
-            hozAlign: 'right',
-            headerHozAlign: 'right',
-            bottomCalc: 'sum',
-            bottomCalcFormatterParams: { precision: 2, totalValue: rootMethod.duration.total },
-            bottomCalcFormatter: progressFormatterMS,
-            formatter: progressFormatterMS,
-            formatterParams: {
-              precision: 2,
-              totalValue: rootMethod.duration.total,
-            },
-            headerFilter: MinMaxEditor,
-            headerFilterFunc: MinMaxFilter,
-            headerFilterFuncParams: {
-              columnName: 'duration.self',
-              filterCache: selfTimeFilterCache,
-            },
-            headerFilterLiveFilter: false,
-            tooltip(_event, cell, _onRender) {
-              return formatDuration(cell.getValue());
-            },
-          },
-        ],
-      });
-
-      this.calltreeTable.on('dataFiltered', () => {
-        totalTimeFilterCache.clear();
-        selfTimeFilterCache.clear();
-        namespaceFilterCache.clear();
+    const { table, tableBuilt } = createTimeOrderTable(callTreeTableContainer, rootMethod, {
+      showDetailsFilter: this._showDetailsFilter,
+      namespaceFilter: this._namespaceFilter,
+      onFilterCacheClear: () => {
         this.debugOnlyFilterCache.clear();
         this.showDetailsFilterCache.clear();
         this.typeFilterCache.clear();
-      });
-
-      this.calltreeTable.on('dataSorted', () => {
+      },
+      onRenderStarted: () => {
         if (!this.blockClearHighlights && this.totalMatches > 0) {
           this._resetFindWidget();
           this._clearSearchHighlights();
         }
-      });
-
-      this.calltreeTable.on('dataFiltered', () => {
-        if (!this.blockClearHighlights && this.totalMatches > 0) {
-          this._resetFindWidget();
-          this._clearSearchHighlights();
-        }
-      });
-
-      // Custom context menu handler using Tabulator's rowContext event
-      this.calltreeTable.on('rowContext', (e: UIEvent, row: RowComponent) => {
-        // If user has selected text, allow browser's native context menu
+      },
+      onContextMenu: (e, row) => {
         if (window.getSelection()?.type === 'Range') {
           return;
         }
         e.preventDefault();
         const mouseEvent = e as MouseEvent;
         this._showRowContextMenu(row, mouseEvent.clientX, mouseEvent.clientY);
-      });
+      },
+    });
+    this.calltreeTable = table;
+    return tableBuilt;
+  }
 
-      this.calltreeTable.on('tableBuilt', () => {
-        resolve();
-      });
+  private _renderAggregatedTree(container: HTMLDivElement, rootMethod: ApexLog): void {
+    if (this.aggregatedTreeTable) {
+      this.aggregatedTreeTable.destroy();
+      this.aggregatedTreeTable = null;
+    }
+
+    this.aggregatedTreeTable = createAggregatedTable(container, rootMethod, {
+      namespaceFilter: this._namespaceFilter,
+      onFilterCacheClear: () => {},
+      onRenderStarted: () => {
+        if (!this.blockClearHighlights && this.totalMatches > 0) {
+          this._resetFindWidget();
+          this._clearSearchHighlights();
+        }
+      },
+    });
+  }
+
+  private _renderBottomUpTree(container: HTMLDivElement, rootMethod: ApexLog): void {
+    if (this.bottomUpTreeTable) {
+      this.bottomUpTreeTable.destroy();
+      this.bottomUpTreeTable = null;
+    }
+
+    this.bottomUpTreeTable = createBottomUpTable(container, rootMethod, {
+      namespaceFilter: this._namespaceFilter,
+      onFilterCacheClear: () => {},
+      onRenderStarted: () => {
+        if (!this.blockClearHighlights && this.totalMatches > 0) {
+          this._resetFindWidget();
+          this._clearSearchHighlights();
+        }
+      },
     });
   }
 
@@ -875,8 +809,9 @@ export class CalltreeView extends LitElement {
   private _clearSearchHighlights() {
     this.findArgs.text = '';
     this.findArgs.count = 0;
+    const activeTable = this._getActiveTable();
     //@ts-expect-error This is a custom function added in by Find custom module
-    this.calltreeTable.clearFindHighlights();
+    activeTable?.clearFindHighlights();
     this.findMap = {};
     this.totalMatches = 0;
   }
@@ -886,24 +821,21 @@ export class CalltreeView extends LitElement {
       return;
     }
 
-    const rowData = row.getData() as CalltreeRow;
+    const rowData = row.getData() as MergedCalltreeRow;
     this.contextMenuRow = rowData;
 
     const items: { id: string; label: string; separator?: boolean; shortcut?: string }[] = [];
 
-    // 1. Navigation actions (go elsewhere)
     items.push({ id: 'show-in-timeline', label: 'Show in Timeline' });
 
     if (rowData.originalData.hasValidSymbols) {
       items.push({ id: 'go-to-source', label: 'Go to Source' });
     }
 
-    // 2. View actions (show related content)
     if (rowData.originalData.timestamp) {
       items.push({ id: 'show-in-log', label: 'Show in Log File' });
     }
 
-    // 3. Separator + Copy actions
     items.push(
       { id: 'separator-1', label: '', separator: true },
       { id: 'copy-name', label: 'Copy Name' },
@@ -960,60 +892,19 @@ export class CalltreeView extends LitElement {
     }
   }
 
-  private _toCallTree(nodes: LogEvent[], treeLevel = 0): CalltreeRow[] | undefined {
-    const len = nodes.length;
-    if (!len) {
-      return undefined;
-    }
-
-    const results: CalltreeRow[] = [];
-    for (let i = 0; i < len; ++i) {
-      const node = nodes[i];
-      if (!node) {
-        continue;
-      }
-      const children = node.children.length ? this._toCallTree(node.children, treeLevel + 1) : null;
-      results.push({
-        id: node.timestamp + '-' + i,
-        originalData: node,
-        _children: children,
-        text: node.text,
-        treeLevel,
-        namespace: node.namespace,
-        duration: node.duration,
-        dmlCount: node.dmlCount,
-        soqlCount: node.soqlCount,
-        dmlRowCount: node.dmlRowCount,
-        soqlRowCount: node.soqlRowCount,
-        totalThrownCount: node.totalThrownCount,
-      });
-    }
-    return results;
-  }
-
-  /**
-   * Find a row by timestamp using the shared binary search utility.
-   * First finds the target LogEvent, then locates the corresponding row.
-   */
   private _findByTime(rows: RowComponent[], timestamp: number): RowComponent | null {
     if (!rows?.length || !this.rootMethod?.children) {
       return null;
     }
 
-    // Use shared utility to find the target event
     const result = findEventByTimestamp(this.rootMethod.children, timestamp);
     if (!result) {
       return null;
     }
 
-    // Find the row matching the found event
     return this._findRowByEvent(rows, result.event);
   }
 
-  /**
-   * Find the RowComponent that contains the specified LogEvent.
-   * Uses binary search since rows are sorted by timestamp.
-   */
   private _findRowByEvent(rows: RowComponent[], targetEvent: LogEvent): RowComponent | null {
     let start = 0;
     let end = rows.length - 1;
@@ -1025,14 +916,13 @@ export class CalltreeView extends LitElement {
         break;
       }
 
-      const rowEvent = (row.getData() as CalltreeRow).originalData as LogEvent;
+      const rowEvent = (row.getData() as MergedCalltreeRow).originalData as LogEvent;
       const endTime = rowEvent.exitStamp ?? rowEvent.timestamp;
 
       if (rowEvent.timestamp === targetEvent.timestamp) {
         return row;
       }
 
-      // Check if target is within this row's time range (i.e., in children)
       if (targetEvent.timestamp >= rowEvent.timestamp && targetEvent.timestamp <= endTime) {
         const childResult = this._findRowByEvent(row.getTreeChildren() ?? [], targetEvent);
         return childResult ?? row;
@@ -1048,23 +938,6 @@ export class CalltreeView extends LitElement {
     return null;
   }
 }
-
-interface CalltreeRow {
-  id: string;
-  originalData: LogEvent;
-  _children: CalltreeRow[] | undefined | null;
-  text: string;
-  treeLevel: number;
-  duration: CountTotals;
-  namespace: string;
-  dmlCount: CountTotals;
-  soqlCount: CountTotals;
-  dmlRowCount: CountTotals;
-  soqlRowCount: CountTotals;
-  totalThrownCount: number;
-}
-
-type CountTotals = { self: number; total: number };
 
 export async function goToRow(timestamp: number) {
   document.dispatchEvent(

--- a/log-viewer/src/features/call-tree/components/CalltreeView.ts
+++ b/log-viewer/src/features/call-tree/components/CalltreeView.ts
@@ -174,15 +174,17 @@ export class CalltreeView extends LitElement {
         flex-flow: column nowrap;
         align-items: flex-start;
         justify-content: flex-start;
-      }
 
-      .dropdown-container label {
-        display: block;
-        color: var(--vscode-foreground);
-        cursor: pointer;
-        font-size: var(--vscode-font-size);
-        line-height: normal;
-        margin-bottom: 2px;
+        label {
+          display: block;
+          color: var(--vscode-descriptionForeground);
+          cursor: pointer;
+          font-size: calc(var(--vscode-font-size) * 0.9);
+          font-weight: 400;
+          line-height: 1.4;
+          margin-bottom: 4px;
+          user-select: none;
+        }
       }
 
       vscode-dropdown::part(listbox) {
@@ -225,6 +227,15 @@ export class CalltreeView extends LitElement {
         height: 100%;
         width: 100%;
       }
+
+      .table-host {
+        height: 100%;
+        width: 100%;
+      }
+
+      .table-host.is-hidden {
+        display: none;
+      }
     `,
   ];
 
@@ -263,6 +274,18 @@ export class CalltreeView extends LitElement {
               >
             </div>
 
+            ${this.viewMode === 'bottom-up'
+              ? html`
+                  <div class="dropdown-container">
+                    <label for="bottomup-groupby">Group by:</label>
+                    <vscode-dropdown id="bottomup-groupby" @change="${this._handleBottomUpGroupBy}">
+                      <vscode-option>None</vscode-option>
+                      <vscode-option>Namespace</vscode-option>
+                      <vscode-option>Type</vscode-option>
+                    </vscode-dropdown>
+                  </div>
+                `
+              : ''}
             ${isTimeOrder
               ? html`
                   <div class="filter-container align__end">
@@ -294,11 +317,15 @@ export class CalltreeView extends LitElement {
 
         <div id="call-tree-table-container">
           ${skeleton}
-          ${this.viewMode === 'time-order'
-            ? html`<div id="call-tree-table"></div>`
-            : this.viewMode === 'aggregated'
-              ? html`<div id="aggregated-tree-table"></div>`
-              : html`<div id="bottom-up-tree-table"></div>`}
+          <div class="table-host ${this.viewMode === 'time-order' ? '' : 'is-hidden'}">
+            <div id="call-tree-table"></div>
+          </div>
+          <div class="table-host ${this.viewMode === 'aggregated' ? '' : 'is-hidden'}">
+            <div id="aggregated-tree-table"></div>
+          </div>
+          <div class="table-host ${this.viewMode === 'bottom-up' ? '' : 'is-hidden'}">
+            <div id="bottom-up-tree-table"></div>
+          </div>
         </div>
         <context-menu @menu-select="${this._handleContextMenuSelect}"></context-menu>
       </div>
@@ -350,32 +377,41 @@ export class CalltreeView extends LitElement {
       return;
     }
 
-    this._destroyCurrentTable();
     this.viewMode = newMode;
 
-    this.updateComplete.then(() => {
+    this.updateComplete.then(async () => {
       if (!this.rootMethod) {
         return;
       }
 
       if (this.viewMode === 'time-order') {
-        const container = this.renderRoot?.querySelector('#call-tree-table') as HTMLDivElement;
-        if (container) {
-          this._renderCallTree(container, this.rootMethod);
+        if (!this.calltreeTable) {
+          const container = this.renderRoot?.querySelector<HTMLDivElement>('#call-tree-table');
+          if (container) {
+            await this._renderCallTree(container, this.rootMethod);
+          }
         }
       } else if (this.viewMode === 'aggregated') {
-        const container = this.renderRoot?.querySelector(
-          '#aggregated-tree-table',
-        ) as HTMLDivElement;
-        if (container) {
-          this._renderAggregatedTree(container, this.rootMethod);
+        if (!this.aggregatedTreeTable) {
+          const container =
+            this.renderRoot?.querySelector<HTMLDivElement>('#aggregated-tree-table');
+          if (container) {
+            this._renderAggregatedTree(container, this.rootMethod);
+          }
         }
       } else if (this.viewMode === 'bottom-up') {
-        const container = this.renderRoot?.querySelector('#bottom-up-tree-table') as HTMLDivElement;
-        if (container) {
-          this._renderBottomUpTree(container, this.rootMethod);
+        if (!this.bottomUpTreeTable) {
+          const container = this.renderRoot?.querySelector<HTMLDivElement>('#bottom-up-tree-table');
+          if (container) {
+            this._renderBottomUpTree(container, this.rootMethod);
+          }
         }
       }
+
+      // const activeTable = this._getActiveTable();
+      // if (activeTable) {
+      //   requestAnimationFrame(() => activeTable.redraw(true));
+      // }
     });
   }
 
@@ -391,6 +427,15 @@ export class CalltreeView extends LitElement {
     if (this.bottomUpTreeTable) {
       this.bottomUpTreeTable.destroy();
       this.bottomUpTreeTable = null;
+    }
+  }
+
+  _handleBottomUpGroupBy(event: Event) {
+    const target = event.target as HTMLInputElement;
+    const fieldName = target.value.toLowerCase();
+    if (this.bottomUpTreeTable) {
+      // @ts-expect-error setSortedGroupBy is added by the GroupSort custom module
+      this.bottomUpTreeTable.setSortedGroupBy(fieldName !== 'none' ? fieldName : '');
     }
   }
 
@@ -487,7 +532,6 @@ export class CalltreeView extends LitElement {
     document.dispatchEvent(new CustomEvent('show-tab', { detail: { tabid: 'tree-tab' } }));
 
     if (this.viewMode !== 'time-order') {
-      this._destroyCurrentTable();
       this.viewMode = 'time-order';
       await this.updateComplete;
     }

--- a/log-viewer/src/features/call-tree/components/CalltreeView.ts
+++ b/log-viewer/src/features/call-tree/components/CalltreeView.ts
@@ -87,6 +87,7 @@ export class CalltreeView extends LitElement {
 
   private contextMenu: ContextMenu | null = null;
   private contextMenuRow: MergedCalltreeRow | null = null;
+  private viewSwitchEpoch = 0;
 
   get _callTreeTableWrapper(): HTMLDivElement | null {
     return (this.tableContainer = this.renderRoot?.querySelector('#call-tree-table') ?? null);
@@ -111,6 +112,7 @@ export class CalltreeView extends LitElement {
     document.removeEventListener('lv-find', this._findEvt);
     document.removeEventListener('lv-find-match', this._findEvt);
     document.removeEventListener('lv-find-close', this._findEvt);
+    this._destroyCurrentTable();
   }
 
   updated(changedProperties: PropertyValues): void {
@@ -152,6 +154,7 @@ export class CalltreeView extends LitElement {
         width: 100%;
         min-height: 0;
         min-width: 0;
+        position: relative;
       }
 
       .header-bar {
@@ -231,10 +234,14 @@ export class CalltreeView extends LitElement {
       .table-host {
         height: 100%;
         width: 100%;
+        position: absolute;
+        inset: 0;
       }
 
       .table-host.is-hidden {
-        display: none;
+        visibility: hidden;
+        opacity: 0;
+        pointer-events: none;
       }
     `,
   ];
@@ -372,47 +379,40 @@ export class CalltreeView extends LitElement {
     this._updateFiltering();
   }
 
-  _setViewMode(newMode: ViewMode) {
+  async _setViewMode(newMode: ViewMode): Promise<void> {
     if (newMode === this.viewMode) {
       return;
     }
 
+    const switchEpoch = ++this.viewSwitchEpoch;
     this.viewMode = newMode;
+    await this.updateComplete;
+    await this._waitForNextFrame();
 
-    this.updateComplete.then(async () => {
-      if (!this.rootMethod) {
-        return;
+    if (switchEpoch !== this.viewSwitchEpoch || !this.rootMethod) {
+      return;
+    }
+
+    if (this.viewMode === 'time-order') {
+      const container = this.renderRoot?.querySelector<HTMLDivElement>('#call-tree-table');
+      if (container) {
+        await this._renderCallTree(container, this.rootMethod);
       }
-
-      if (this.viewMode === 'time-order') {
-        if (!this.calltreeTable) {
-          const container = this.renderRoot?.querySelector<HTMLDivElement>('#call-tree-table');
-          if (container) {
-            await this._renderCallTree(container, this.rootMethod);
-          }
-        }
-      } else if (this.viewMode === 'aggregated') {
-        if (!this.aggregatedTreeTable) {
-          const container =
-            this.renderRoot?.querySelector<HTMLDivElement>('#aggregated-tree-table');
-          if (container) {
-            this._renderAggregatedTree(container, this.rootMethod);
-          }
-        }
-      } else if (this.viewMode === 'bottom-up') {
-        if (!this.bottomUpTreeTable) {
-          const container = this.renderRoot?.querySelector<HTMLDivElement>('#bottom-up-tree-table');
-          if (container) {
-            this._renderBottomUpTree(container, this.rootMethod);
-          }
-        }
+    } else if (this.viewMode === 'aggregated') {
+      const container = this.renderRoot?.querySelector<HTMLDivElement>('#aggregated-tree-table');
+      if (container) {
+        await this._renderAggregatedTree(container, this.rootMethod);
       }
+    } else if (this.viewMode === 'bottom-up') {
+      const container = this.renderRoot?.querySelector<HTMLDivElement>('#bottom-up-tree-table');
+      if (container) {
+        await this._renderBottomUpTree(container, this.rootMethod);
+      }
+    }
 
-      // const activeTable = this._getActiveTable();
-      // if (activeTable) {
-      //   requestAnimationFrame(() => activeTable.redraw(true));
-      // }
-    });
+    if (switchEpoch !== this.viewSwitchEpoch) {
+      return;
+    }
   }
 
   private _destroyCurrentTable(): void {
@@ -520,7 +520,7 @@ export class CalltreeView extends LitElement {
     isVisible(this).then((isVisible) => {
       this.isVisible = isVisible;
       if (this.rootMethod && this._callTreeTableWrapper) {
-        this._renderCallTree(this._callTreeTableWrapper, this.rootMethod);
+        void this._renderCallTree(this._callTreeTableWrapper, this.rootMethod);
       }
     });
   }
@@ -764,23 +764,8 @@ export class CalltreeView extends LitElement {
     rootMethod: ApexLog,
   ): Promise<void> {
     if (this.calltreeTable) {
-      await new Promise((resolve, reject) => {
-        const visibilityObserver = new IntersectionObserver(
-          (entries, observer) => {
-            const entry = entries[0];
-            const visible = entry?.isIntersecting && entry?.intersectionRatio > 0;
-            if (visible) {
-              resolve(true);
-              observer.disconnect();
-            } else {
-              reject();
-            }
-          },
-          { threshold: 1 },
-        );
-        visibilityObserver.observe(callTreeTableContainer);
-      });
-      return new Promise((resolve) => setTimeout(resolve));
+      await this._waitForNextFrame();
+      return;
     }
 
     const { table, tableBuilt } = createTimeOrderTable(callTreeTableContainer, rootMethod, {
@@ -807,16 +792,19 @@ export class CalltreeView extends LitElement {
       },
     });
     this.calltreeTable = table;
-    return tableBuilt;
+    await tableBuilt;
   }
 
-  private _renderAggregatedTree(container: HTMLDivElement, rootMethod: ApexLog): void {
+  private async _renderAggregatedTree(
+    container: HTMLDivElement,
+    rootMethod: ApexLog,
+  ): Promise<void> {
     if (this.aggregatedTreeTable) {
-      this.aggregatedTreeTable.destroy();
-      this.aggregatedTreeTable = null;
+      await this._waitForNextFrame();
+      return;
     }
 
-    this.aggregatedTreeTable = createAggregatedTable(container, rootMethod, {
+    const { table, tableBuilt } = createAggregatedTable(container, rootMethod, {
       namespaceFilter: this._namespaceFilter,
       onFilterCacheClear: () => {},
       onRenderStarted: () => {
@@ -826,15 +814,17 @@ export class CalltreeView extends LitElement {
         }
       },
     });
+    this.aggregatedTreeTable = table;
+    await tableBuilt;
   }
 
-  private _renderBottomUpTree(container: HTMLDivElement, rootMethod: ApexLog): void {
+  private async _renderBottomUpTree(container: HTMLDivElement, rootMethod: ApexLog): Promise<void> {
     if (this.bottomUpTreeTable) {
-      this.bottomUpTreeTable.destroy();
-      this.bottomUpTreeTable = null;
+      await this._waitForNextFrame();
+      return;
     }
 
-    this.bottomUpTreeTable = createBottomUpTable(container, rootMethod, {
+    const { table, tableBuilt } = createBottomUpTable(container, rootMethod, {
       namespaceFilter: this._namespaceFilter,
       onFilterCacheClear: () => {},
       onRenderStarted: () => {
@@ -843,6 +833,14 @@ export class CalltreeView extends LitElement {
           this._clearSearchHighlights();
         }
       },
+    });
+    this.bottomUpTreeTable = table;
+    await tableBuilt;
+  }
+
+  private _waitForNextFrame(): Promise<void> {
+    return new Promise((resolve) => {
+      requestAnimationFrame(() => resolve());
     });
   }
 

--- a/log-viewer/src/features/call-tree/components/CalltreeView.ts
+++ b/log-viewer/src/features/call-tree/components/CalltreeView.ts
@@ -66,6 +66,7 @@ export class CalltreeView extends LitElement {
     debugOnly: false,
     selectedTypes: [],
   };
+  bottomUpGroupBy = 'None';
   debugOnlyFilterCache = new Map<string, boolean>();
   showDetailsFilterCache = new Map<string, boolean>();
   typeFilterCache = new Map<string, boolean>();
@@ -285,7 +286,11 @@ export class CalltreeView extends LitElement {
               ? html`
                   <div class="dropdown-container">
                     <label for="bottomup-groupby">Group by:</label>
-                    <vscode-dropdown id="bottomup-groupby" @change="${this._handleBottomUpGroupBy}">
+                    <vscode-dropdown
+                      id="bottomup-groupby"
+                      @change="${this._handleBottomUpGroupBy}"
+                      current-value="${this.bottomUpGroupBy}"
+                    >
                       <vscode-option>None</vscode-option>
                       <vscode-option>Namespace</vscode-option>
                       <vscode-option>Type</vscode-option>
@@ -448,7 +453,13 @@ export class CalltreeView extends LitElement {
 
   _handleBottomUpGroupBy(event: Event) {
     const target = event.target as HTMLInputElement;
+    this.bottomUpGroupBy = target.value;
     const fieldName = target.value.toLowerCase();
+    const savedGroup = this.bottomUpGroupBy.toLowerCase();
+    if (savedGroup !== 'none' && this.bottomUpTreeTable) {
+      // @ts-expect-error setSortedGroupBy is added by the GroupSort custom module
+      this.bottomUpTreeTable.setSortedGroupBy(savedGroup);
+    }
     if (this.bottomUpTreeTable) {
       // @ts-expect-error setSortedGroupBy is added by the GroupSort custom module
       this.bottomUpTreeTable.setSortedGroupBy(fieldName !== 'none' ? fieldName : '');

--- a/log-viewer/src/features/call-tree/components/CalltreeView.ts
+++ b/log-viewer/src/features/call-tree/components/CalltreeView.ts
@@ -293,7 +293,7 @@ export class CalltreeView extends LitElement {
                   </div>
                 `
               : ''}
-            ${isTimeOrder
+            ${isTimeOrder || this.viewMode === 'aggregated'
               ? html`
                   <div class="filter-container align__end">
                     <vscode-checkbox class="align__end" @change="${this._handleShowDetailsChange}"
@@ -384,6 +384,20 @@ export class CalltreeView extends LitElement {
       return;
     }
 
+    // Reset search when switching views
+    if (this.totalMatches > 0 || this.findArgs.text !== '') {
+      const oldTable = this._getActiveTable();
+      this._resetFindWidget();
+      if (oldTable) {
+        //@ts-expect-error This is a custom function added in by Find custom module
+        oldTable.clearFindHighlights();
+      }
+      this.findArgs.text = '';
+      this.findArgs.count = 0;
+      this.findMap = {};
+      this.totalMatches = 0;
+    }
+
     const switchEpoch = ++this.viewSwitchEpoch;
     this.viewMode = newMode;
     await this.updateComplete;
@@ -397,11 +411,13 @@ export class CalltreeView extends LitElement {
       const container = this.renderRoot?.querySelector<HTMLDivElement>('#call-tree-table');
       if (container) {
         await this._renderCallTree(container, this.rootMethod);
+        this._updateFiltering();
       }
     } else if (this.viewMode === 'aggregated') {
       const container = this.renderRoot?.querySelector<HTMLDivElement>('#aggregated-tree-table');
       if (container) {
         await this._renderAggregatedTree(container, this.rootMethod);
+        this._updateFiltering();
       }
     } else if (this.viewMode === 'bottom-up') {
       const container = this.renderRoot?.querySelector<HTMLDivElement>('#bottom-up-tree-table');
@@ -448,24 +464,37 @@ export class CalltreeView extends LitElement {
   }
 
   _updateFiltering() {
+    if (this.viewMode === 'bottom-up') {
+      return;
+    }
+
     const activeTable = this._getActiveTable();
     if (!activeTable) {
       return;
     }
+
+    this.debugOnlyFilterCache.clear();
+    this.showDetailsFilterCache.clear();
+    this.typeFilterCache.clear();
+
     const filtersToAdd = [];
 
+    const isAggregated = this.viewMode === 'aggregated';
+
     if (this.filterState.debugOnly) {
-      filtersToAdd.push(this._debugFilter);
+      filtersToAdd.push(isAggregated ? this._debugFilterAggregated : this._debugFilter);
     } else {
       if (
         this.filterState.selectedTypes.length > 0 &&
         this.filterState.selectedTypes[0] !== 'None'
       ) {
-        filtersToAdd.push(this._typeFilter);
+        filtersToAdd.push(isAggregated ? this._typeFilterAggregated : this._typeFilter);
       }
 
       if (!this.filterState.showDetails) {
-        filtersToAdd.push(this._showDetailsFilter);
+        filtersToAdd.push(
+          isAggregated ? this._showDetailsFilterAggregated : this._showDetailsFilter,
+        );
       }
     }
 
@@ -660,6 +689,69 @@ export class CalltreeView extends LitElement {
     );
   };
 
+  _showDetailsFilterAggregated = (data: AggregatedRow) => {
+    const excludedTypes = new Set<string>([
+      'CUMULATIVE_LIMIT_USAGE',
+      'LIMIT_USAGE_FOR_NS',
+      'CUMULATIVE_PROFILING',
+      'CUMULATIVE_PROFILING_BEGIN',
+    ]);
+
+    return this._deepFilterAggregated(
+      data,
+      (rowData) => {
+        const aggregatedRow = rowData as AggregatedRow;
+        return (
+          aggregatedRow.totalTime > 0 ||
+          !!(aggregatedRow.originalData.type && excludedTypes.has(aggregatedRow.originalData.type))
+        );
+      },
+      {
+        filterCache: this.showDetailsFilterCache,
+      },
+    );
+  };
+
+  _debugFilterAggregated = (data: AggregatedRow) => {
+    const debugValues = new Set<string>([
+      'USER_DEBUG',
+      'DATAWEAVE_USER_DEBUG',
+      'USER_DEBUG_FINER',
+      'USER_DEBUG_FINEST',
+      'USER_DEBUG_FINE',
+      'USER_DEBUG_DEBUG',
+      'USER_DEBUG_INFO',
+      'USER_DEBUG_WARN',
+      'USER_DEBUG_ERROR',
+    ]);
+    return this._deepFilterAggregated(
+      data,
+      (rowData) => {
+        const logLine = (rowData as AggregatedRow).originalData;
+        return !!(logLine.type && debugValues.has(logLine.type));
+      },
+      {
+        filterCache: this.debugOnlyFilterCache,
+      },
+    );
+  };
+
+  _typeFilterAggregated = (data: AggregatedRow) => {
+    return this._deepFilterAggregated(
+      data,
+      (rowData) => {
+        const logLine = (rowData as AggregatedRow).originalData;
+        if (!logLine.type) {
+          return false;
+        }
+        return this.filterState.selectedTypes.includes(logLine.type);
+      },
+      {
+        filterCache: this.typeFilterCache,
+      },
+    );
+  };
+
   _namespaceFilter = (
     selectedNamespaces: string[],
     _namespace: string,
@@ -718,12 +810,9 @@ export class CalltreeView extends LitElement {
       }
     }
 
-    filterParams.filterCache.set(rowData.id, childMatch);
-    if (childMatch) {
-      return true;
-    }
-
-    return filterFunction(rowData);
+    const finalMatch = childMatch || filterFunction(rowData);
+    filterParams.filterCache.set(rowData.id, finalMatch);
+    return finalMatch;
   }
 
   private _deepFilter(
@@ -751,12 +840,9 @@ export class CalltreeView extends LitElement {
       }
     }
 
-    filterParams.filterCache.set(rowData.id, childMatch);
-    if (childMatch) {
-      return true;
-    }
-
-    return filterFunction(rowData);
+    const finalMatch = childMatch || filterFunction(rowData);
+    filterParams.filterCache.set(rowData.id, finalMatch);
+    return finalMatch;
   }
 
   private async _renderCallTree(
@@ -806,7 +892,11 @@ export class CalltreeView extends LitElement {
 
     const { table, tableBuilt } = createAggregatedTable(container, rootMethod, {
       namespaceFilter: this._namespaceFilter,
-      onFilterCacheClear: () => {},
+      onFilterCacheClear: () => {
+        this.debugOnlyFilterCache.clear();
+        this.showDetailsFilterCache.clear();
+        this.typeFilterCache.clear();
+      },
       onRenderStarted: () => {
         if (!this.blockClearHighlights && this.totalMatches > 0) {
           this._resetFindWidget();
@@ -824,16 +914,25 @@ export class CalltreeView extends LitElement {
       return;
     }
 
-    const { table, tableBuilt } = createBottomUpTable(container, rootMethod, {
-      namespaceFilter: this._namespaceFilter,
-      onFilterCacheClear: () => {},
-      onRenderStarted: () => {
-        if (!this.blockClearHighlights && this.totalMatches > 0) {
-          this._resetFindWidget();
-          this._clearSearchHighlights();
-        }
+    const { table, tableBuilt } = createBottomUpTable(
+      container,
+      rootMethod,
+      {
+        namespaceFilter: this._namespaceFilter,
+        onFilterCacheClear: () => {},
+        onRenderStarted: () => {
+          if (!this.blockClearHighlights && this.totalMatches > 0) {
+            this._resetFindWidget();
+            this._clearSearchHighlights();
+          }
+        },
       },
-    });
+      {
+        selectableRows: 'highlight',
+        enableClipboardAndDownload: true,
+        exportFileName: 'bottom-up.csv',
+      },
+    );
     this.bottomUpTreeTable = table;
     await tableBuilt;
   }

--- a/log-viewer/src/features/call-tree/components/TableShared.ts
+++ b/log-viewer/src/features/call-tree/components/TableShared.ts
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2024 Certinia Inc. All rights reserved.
+ */
+import { Tabulator } from 'tabulator-tables';
+
+import * as CommonModules from '../../../tabulator/module/CommonModules.js';
+import { Find } from '../../../tabulator/module/Find.js';
+import { MiddleRowFocus } from '../../../tabulator/module/MiddleRowFocus.js';
+import { RowKeyboardNavigation } from '../../../tabulator/module/RowKeyboardNavigation.js';
+import { RowNavigation } from '../../../tabulator/module/RowNavigation.js';
+import type { AggregatedRow, BottomUpRow } from '../utils/Aggregation.js';
+import type { MergedCalltreeRow } from '../utils/MergeAdjacent.js';
+
+export interface TableCallbacks {
+  namespaceFilter: (
+    selectedNamespaces: string[],
+    namespace: string,
+    data: MergedCalltreeRow | AggregatedRow | BottomUpRow,
+    filterParams: { filterCache: Map<string, boolean> },
+  ) => boolean;
+  onFilterCacheClear: () => void;
+  onRenderStarted: () => void;
+}
+
+export function registerTableModules(): void {
+  Tabulator.registerModule(Object.values(CommonModules));
+  Tabulator.registerModule([RowKeyboardNavigation, RowNavigation, MiddleRowFocus, Find]);
+}
+
+export function headerSortElement(_column: unknown, dir: string): string {
+  switch (dir) {
+    case 'asc':
+      return "<div class='sort-by--top'></div>";
+    case 'desc':
+      return "<div class='sort-by--bottom'></div>";
+    default:
+      return "<div class='sort-by'><div class='sort-by--top'></div><div class='sort-by--bottom'></div></div>";
+  }
+}
+
+export const commonColumnDefaults = {
+  title: 'default',
+  resizable: true,
+  headerSortStartingDir: 'desc' as const,
+  headerTooltip: true,
+  headerWordWrap: true,
+};

--- a/log-viewer/src/features/call-tree/components/TimeOrderTable.ts
+++ b/log-viewer/src/features/call-tree/components/TimeOrderTable.ts
@@ -1,0 +1,307 @@
+/*
+ * Copyright (c) 2024 Certinia Inc. All rights reserved.
+ */
+import type { ApexLog, LogEventType } from 'apex-log-parser';
+import { Tabulator, type RowComponent } from 'tabulator-tables';
+
+import { vscodeMessenger } from '../../../core/messaging/VSCodeExtensionMessenger.js';
+import { formatDuration } from '../../../core/utility/Util.js';
+import MinMaxEditor from '../../../tabulator/editors/MinMax.js';
+import { minMaxTreeFilter } from '../../../tabulator/filters/MinMax.js';
+import { progressFormatter } from '../../../tabulator/format/Progress.js';
+import { progressFormatterMS } from '../../../tabulator/format/ProgressMS.js';
+import { makeSumSelfTimeAllVisible } from '../utils/BottomCalcs.js';
+import { toUnmergedCallTree, type MergedCalltreeRow } from '../utils/MergeAdjacent.js';
+import { createCalltreeNameFormatter } from './CalltreeNameFormatter.js';
+import {
+  commonColumnDefaults,
+  headerSortElement,
+  registerTableModules,
+  type TableCallbacks,
+} from './TableShared.js';
+
+export interface TimeOrderCallbacks extends TableCallbacks {
+  showDetailsFilter: (data: MergedCalltreeRow) => boolean;
+  onContextMenu: (e: UIEvent, row: RowComponent) => void;
+}
+
+export function createTimeOrderTable(
+  container: HTMLDivElement,
+  rootMethod: ApexLog,
+  callbacks: TimeOrderCallbacks,
+): { table: Tabulator; tableBuilt: Promise<void> } {
+  registerTableModules();
+
+  const selfTimeFilterCache = new Map<string, boolean>();
+  const totalTimeFilterCache = new Map<string, boolean>();
+  const namespaceFilterCache = new Map<string, boolean>();
+
+  const excludedTypes = new Set<LogEventType>(['SOQL_EXECUTE_BEGIN', 'DML_BEGIN']);
+  const governorLimits = rootMethod.governorLimits;
+
+  const tableData = toUnmergedCallTree(rootMethod.children);
+  const nameFormatter = createCalltreeNameFormatter(excludedTypes);
+
+  const tableRef: { current: Tabulator | undefined } = { current: undefined };
+  const selfTimeBottomCalc = makeSumSelfTimeAllVisible(() => tableRef.current);
+
+  const table = new Tabulator(container, {
+    data: tableData,
+    layout: 'fitColumns',
+    placeholder: 'No Call Tree Available',
+    height: '100%',
+    maxHeight: '100%',
+    persistence: true,
+    //  custom property for datagrid/module/RowKeyboardNavigation
+    rowKeyboardNavigation: true,
+    //  custom property for module/MiddleRowFocus
+    middleRowFocus: true,
+    dataTree: true,
+    dataTreeChildColumnCalcs: false,
+    dataTreeBranchElement: '<span/>',
+    tooltipDelay: 100,
+    selectableRows: 1,
+    // @ts-expect-error it is possible to pass a function to intitialFilter the types need updating
+    initialFilter: callbacks.showDetailsFilter,
+    headerSortElement,
+    columnCalcs: 'both',
+    columnDefaults: commonColumnDefaults,
+    columns: [
+      {
+        title: 'Name',
+        field: 'text',
+        headerSortTristate: true,
+        bottomCalc: () => 'Total',
+        cssClass: 'datagrid-textarea datagrid-code-text',
+        formatter: nameFormatter,
+        variableHeight: true,
+        cellClick: (e, cell) => {
+          const { type } = window.getSelection() ?? {};
+          if (type === 'Range') {
+            return;
+          }
+
+          if (!(e.target as HTMLElement).matches('a')) {
+            return;
+          }
+          const node = (cell.getData() as MergedCalltreeRow).originalData;
+          if (node.hasValidSymbols) {
+            vscodeMessenger.send<string>('openType', node.text);
+          }
+        },
+        widthGrow: 5,
+      },
+      {
+        title: 'Namespace',
+        field: 'namespace',
+        sorter: 'string',
+        width: 100,
+        minWidth: 80,
+        headerFilter: 'list',
+        headerFilterFunc: callbacks.namespaceFilter,
+        headerFilterFuncParams: { filterCache: namespaceFilterCache },
+        headerFilterParams: {
+          values: rootMethod.namespaces,
+          clearable: true,
+          multiselect: true,
+        },
+        headerFilterLiveFilter: false,
+      },
+      {
+        title: 'DML Count',
+        field: 'dmlCount.total',
+        sorter: 'number',
+        cssClass: 'number-cell',
+        width: 70,
+        minWidth: 60,
+        bottomCalc: 'max',
+        bottomCalcFormatter: progressFormatter,
+        bottomCalcFormatterParams: {
+          precision: 0,
+          totalValue: governorLimits.dmlStatements.limit,
+          showPercentageText: false,
+        },
+        formatter: progressFormatter,
+        formatterParams: {
+          precision: 0,
+          totalValue: governorLimits.dmlStatements.limit,
+          showPercentageText: false,
+        },
+        hozAlign: 'right',
+        headerHozAlign: 'right',
+        tooltip(_event, cell, _onRender) {
+          const maxDmlStatements = governorLimits.dmlStatements.limit;
+          return cell.getValue() + (maxDmlStatements > 0 ? '/' + maxDmlStatements : '');
+        },
+      },
+      {
+        title: 'SOQL Count',
+        field: 'soqlCount.total',
+        sorter: 'number',
+        cssClass: 'number-cell',
+        width: 70,
+        minWidth: 60,
+        bottomCalc: 'max',
+        bottomCalcFormatter: progressFormatter,
+        bottomCalcFormatterParams: {
+          precision: 0,
+          totalValue: governorLimits.soqlQueries.limit,
+          showPercentageText: false,
+        },
+        formatter: progressFormatter,
+        formatterParams: {
+          precision: 0,
+          totalValue: governorLimits.soqlQueries.limit,
+          showPercentageText: false,
+        },
+        hozAlign: 'right',
+        headerHozAlign: 'right',
+        tooltip(_event, cell, _onRender) {
+          const maxSoql = governorLimits.soqlQueries.limit;
+          return cell.getValue() + (maxSoql > 0 ? '/' + maxSoql : '');
+        },
+      },
+      {
+        title: 'Throws Count',
+        field: 'totalThrownCount',
+        sorter: 'number',
+        cssClass: 'number-cell',
+        width: 60,
+        hozAlign: 'right',
+        headerHozAlign: 'right',
+        bottomCalc: 'max',
+      },
+      {
+        title: 'DML Rows',
+        field: 'dmlRowCount.total',
+        sorter: 'number',
+        cssClass: 'number-cell',
+        width: 60,
+        bottomCalc: 'max',
+        bottomCalcFormatter: progressFormatter,
+        bottomCalcFormatterParams: {
+          precision: 0,
+          totalValue: governorLimits.dmlRows.limit,
+          showPercentageText: false,
+        },
+        formatter: progressFormatter,
+        formatterParams: {
+          precision: 0,
+          totalValue: governorLimits.dmlRows.limit,
+          showPercentageText: false,
+        },
+        hozAlign: 'right',
+        headerHozAlign: 'right',
+        tooltip(_event, cell, _onRender) {
+          const maxDmlRows = governorLimits.dmlRows.limit;
+          return cell.getValue() + (maxDmlRows > 0 ? '/' + maxDmlRows : '');
+        },
+      },
+      {
+        title: 'SOQL Rows',
+        field: 'soqlRowCount.total',
+        sorter: 'number',
+        cssClass: 'number-cell',
+        width: 60,
+        bottomCalc: 'max',
+        bottomCalcFormatter: progressFormatter,
+        bottomCalcFormatterParams: {
+          precision: 0,
+          totalValue: governorLimits.queryRows.limit,
+          showPercentageText: false,
+        },
+        formatter: progressFormatter,
+        formatterParams: {
+          precision: 0,
+          totalValue: governorLimits.queryRows.limit,
+          showPercentageText: false,
+        },
+        hozAlign: 'right',
+        headerHozAlign: 'right',
+        tooltip(_event, cell, _onRender) {
+          const maxQueryRows = governorLimits.queryRows.limit;
+          return cell.getValue() + (maxQueryRows > 0 ? '/' + maxQueryRows : '');
+        },
+      },
+      {
+        title: 'Total Time (ms)',
+        field: 'duration.total',
+        sorter: 'number',
+        headerSortTristate: true,
+        width: 150,
+        hozAlign: 'right',
+        headerHozAlign: 'right',
+        formatter: progressFormatterMS,
+        formatterParams: {
+          precision: 2,
+          totalValue: rootMethod.duration.total,
+        },
+        bottomCalcFormatter: progressFormatterMS,
+        bottomCalc: 'sum',
+        bottomCalcFormatterParams: { precision: 2, totalValue: rootMethod.duration.total },
+        headerFilter: MinMaxEditor,
+        headerFilterFunc: minMaxTreeFilter,
+        headerFilterFuncParams: { columnName: 'duration.total', filterCache: totalTimeFilterCache },
+        headerFilterLiveFilter: false,
+        tooltip(_event, cell, _onRender) {
+          return formatDuration(cell.getValue());
+        },
+      },
+      {
+        title: 'Self Time (ms)',
+        field: 'duration.self',
+        sorter: 'number',
+        headerSortTristate: true,
+        width: 150,
+        hozAlign: 'right',
+        headerHozAlign: 'right',
+        bottomCalc: selfTimeBottomCalc,
+        bottomCalcFormatterParams: { precision: 2, totalValue: rootMethod.duration.total },
+        bottomCalcFormatter: progressFormatterMS,
+        formatter: progressFormatterMS,
+        formatterParams: {
+          precision: 2,
+          totalValue: rootMethod.duration.total,
+        },
+        headerFilter: MinMaxEditor,
+        headerFilterFunc: minMaxTreeFilter,
+        headerFilterFuncParams: {
+          columnName: 'duration.self',
+          filterCache: selfTimeFilterCache,
+        },
+        headerFilterLiveFilter: false,
+        tooltip(_event, cell, _onRender) {
+          return formatDuration(cell.getValue());
+        },
+      },
+    ],
+  });
+  tableRef.current = table;
+
+  table.on('dataFiltered', () => {
+    totalTimeFilterCache.clear();
+    selfTimeFilterCache.clear();
+    namespaceFilterCache.clear();
+    callbacks.onFilterCacheClear();
+  });
+
+  table.on('dataSorted', () => {
+    callbacks.onRenderStarted();
+  });
+
+  table.on('dataFiltered', () => {
+    callbacks.onRenderStarted();
+  });
+
+  table.on('rowContext', (e: UIEvent, row: RowComponent) => {
+    callbacks.onContextMenu(e, row);
+  });
+
+  const tableBuilt = new Promise<void>((resolve) => {
+    table.on('tableBuilt', () => {
+      resolve();
+    });
+  });
+
+  return { table, tableBuilt };
+}

--- a/log-viewer/src/features/call-tree/components/TimeOrderTable.ts
+++ b/log-viewer/src/features/call-tree/components/TimeOrderTable.ts
@@ -113,7 +113,7 @@ export function createTimeOrderTable(
         cssClass: 'number-cell',
         width: 70,
         minWidth: 60,
-        bottomCalc: 'max',
+        bottomCalc: 'sum',
         bottomCalcFormatter: progressFormatter,
         bottomCalcFormatterParams: {
           precision: 0,
@@ -140,7 +140,7 @@ export function createTimeOrderTable(
         cssClass: 'number-cell',
         width: 70,
         minWidth: 60,
-        bottomCalc: 'max',
+        bottomCalc: 'sum',
         bottomCalcFormatter: progressFormatter,
         bottomCalcFormatterParams: {
           precision: 0,
@@ -168,7 +168,7 @@ export function createTimeOrderTable(
         width: 60,
         hozAlign: 'right',
         headerHozAlign: 'right',
-        bottomCalc: 'max',
+        bottomCalc: 'sum',
       },
       {
         title: 'DML Rows',
@@ -176,7 +176,7 @@ export function createTimeOrderTable(
         sorter: 'number',
         cssClass: 'number-cell',
         width: 60,
-        bottomCalc: 'max',
+        bottomCalc: 'sum',
         bottomCalcFormatter: progressFormatter,
         bottomCalcFormatterParams: {
           precision: 0,
@@ -202,7 +202,7 @@ export function createTimeOrderTable(
         sorter: 'number',
         cssClass: 'number-cell',
         width: 60,
-        bottomCalc: 'max',
+        bottomCalc: 'sum',
         bottomCalcFormatter: progressFormatter,
         bottomCalcFormatterParams: {
           precision: 0,

--- a/log-viewer/src/features/call-tree/components/TimeOrderTable.ts
+++ b/log-viewer/src/features/call-tree/components/TimeOrderTable.ts
@@ -51,7 +51,6 @@ export function createTimeOrderTable(
     placeholder: 'No Call Tree Available',
     height: '100%',
     maxHeight: '100%',
-    persistence: true,
     //  custom property for datagrid/module/RowKeyboardNavigation
     rowKeyboardNavigation: true,
     //  custom property for module/MiddleRowFocus

--- a/log-viewer/src/features/call-tree/utils/Aggregation.ts
+++ b/log-viewer/src/features/call-tree/utils/Aggregation.ts
@@ -1,0 +1,490 @@
+/*
+ * Copyright (c) 2024 Certinia Inc. All rights reserved.
+ */
+
+import type { LogEvent, SelfTotal } from 'apex-log-parser';
+import { Multiset } from '../../../core/utility/Multiset.js';
+
+/**
+ * Represents a row in the aggregated call tree view.
+ * All calls to the same function signature are merged, with children also aggregated.
+ */
+export interface AggregatedRow {
+  /** Unique identifier for the row */
+  id: string;
+  /** Unique grouping key for this function signature */
+  key: string;
+  /** Display name */
+  text: string;
+  /** Package namespace */
+  namespace: string;
+  /** Number of times this function was called */
+  callCount: number;
+  /** Sum of self-time across all calls */
+  totalSelfTime: number;
+  /** Sum of total-time across all calls */
+  totalTime: number;
+  /** Average self-time per call */
+  avgSelfTime: number;
+  /** Total DML count */
+  dmlCount: SelfTotal;
+  /** Total SOQL count */
+  soqlCount: SelfTotal;
+  /** Total DML rows */
+  dmlRowCount: SelfTotal;
+  /** Total SOQL rows */
+  soqlRowCount: SelfTotal;
+  /** Total exceptions thrown */
+  totalThrownCount: number;
+  /** Aggregated children (callees grouped by signature) */
+  _children: AggregatedRow[] | null;
+  /** References to original events for drill-down */
+  instances: LogEvent[];
+  /** Representative event for this row (used by formatters) */
+  originalData: LogEvent;
+}
+
+/**
+ * Represents a row in the bottom-up tree view.
+ * Functions sorted by self-time, with callers (parents) as children.
+ */
+export interface BottomUpRow {
+  /** Unique identifier for the row */
+  id: string;
+  /** Unique grouping key for this function signature */
+  key: string;
+  /** Display name */
+  text: string;
+  /** Package namespace */
+  namespace: string;
+  /** Event type (e.g., METHOD_ENTRY, CODE_UNIT_STARTED) */
+  type: string;
+  /** Number of times this function was called */
+  callCount: number;
+  /** Sum of self-time across all calls */
+  totalSelfTime: number;
+  /** Sum of total-time across all calls */
+  totalTime: number;
+  /** Average self-time per call */
+  avgSelfTime: number;
+  /** Total DML count */
+  dmlCount: SelfTotal;
+  /** Total SOQL count */
+  soqlCount: SelfTotal;
+  /** Total DML rows */
+  dmlRowCount: SelfTotal;
+  /** Total SOQL rows */
+  soqlRowCount: SelfTotal;
+  /** Total exceptions thrown */
+  totalThrownCount: number;
+  /** Callers (parent functions) as children - lazy loaded */
+  _children: BottomUpRow[] | null;
+  /** References to the displayed events for drill-down */
+  instances: LogEvent[];
+  /** Instances whose metrics are being attributed through this caller path */
+  contributionInstances: LogEvent[];
+  /** Representative event for this row (used by formatters) */
+  originalData: LogEvent;
+}
+
+/**
+ * Generates a unique key for grouping events by signature.
+ * Includes event type so different entry types (e.g. CODE_UNIT_STARTED vs METHOD_ENTRY)
+ * are displayed as separate rows. Field order (type|namespace|text) is the shared
+ * canonical bucket-key shape used by aggregated, bottom-up, and analysis views.
+ */
+export function getEventKey(event: LogEvent): string {
+  return `${event.type ?? ''}|${event.namespace}|${event.text}`;
+}
+
+/**
+ * Generates a key for call-stack tracking to detect recursive calls.
+ * Excludes event type so the same method is recognised regardless of entry type
+ * (e.g. CODE_UNIT_STARTED at the top level, METHOD_ENTRY for recursive calls).
+ * Matches the approach used by the analysis view's RowGrouper.
+ */
+function getStackKey(event: LogEvent): string {
+  return `${event.namespace}|${event.text}`;
+}
+
+/**
+ * Creates an aggregated call tree where all calls to the same function signature
+ * are merged together, with aggregated metrics.
+ * Uses Multiset call-stack tracking to prevent double-counting of recursive calls.
+ */
+export function toAggregatedCallTree(rootChildren: LogEvent[]): AggregatedRow[] {
+  if (rootChildren.length === 0) {
+    return [];
+  }
+
+  // Group root-level events by signature with call stack tracking
+  const rootMap = new Map<string, AggregatedRow>();
+  const keyStack = new Multiset<string>();
+
+  for (const event of rootChildren) {
+    // Process every event so callCount/DML/SOQL/exception counts roll up even
+    // when the event has no timing contribution.
+    const key = getEventKey(event);
+    let row = rootMap.get(key);
+
+    if (!row) {
+      row = createEmptyAggregatedRow(key, event);
+      rootMap.set(key, row);
+    }
+
+    const stackKey = getStackKey(event);
+    addEventToAggregatedRowWithStack(row, event, stackKey, keyStack);
+  }
+
+  // Recursively aggregate children for each row
+  for (const row of rootMap.values()) {
+    const firstInstance = row.instances[0];
+    const stackKey = firstInstance ? getStackKey(firstInstance) : row.key;
+    row._children = aggregateChildrenRecursive(row.instances, stackKey);
+    calculateAverages(row);
+  }
+
+  // Sort by total time descending
+  return Array.from(rootMap.values()).sort((a, b) => b.totalTime - a.totalTime);
+}
+
+/**
+ * Recursively aggregates children of all instances.
+ * Tracks the parent key to detect recursive calls within the same aggregation context.
+ */
+function aggregateChildrenRecursive(
+  instances: LogEvent[],
+  parentStackKey: string,
+): AggregatedRow[] | null {
+  const childMap = new Map<string, AggregatedRow>();
+  // Create a new stack for each aggregation level, starting with the parent stack key
+  const keyStack = new Multiset<string>();
+  keyStack.add(parentStackKey);
+
+  for (const instance of instances) {
+    for (const child of instance.children) {
+      const key = getEventKey(child);
+      let row = childMap.get(key);
+
+      if (!row) {
+        row = createEmptyAggregatedRow(key, child);
+        childMap.set(key, row);
+      }
+
+      const stackKey = getStackKey(child);
+      addEventToAggregatedRowWithStack(row, child, stackKey, keyStack);
+    }
+  }
+
+  if (childMap.size === 0) {
+    return null;
+  }
+
+  // Recursively aggregate children using stack key for recursion tracking
+  for (const row of childMap.values()) {
+    const firstInstance = row.instances[0];
+    const stackKey = firstInstance ? getStackKey(firstInstance) : row.key;
+    row._children = aggregateChildrenRecursive(row.instances, stackKey);
+    calculateAverages(row);
+  }
+
+  // Sort by total time descending
+  return Array.from(childMap.values()).sort((a, b) => b.totalTime - a.totalTime);
+}
+
+/**
+ * Adds an event to an aggregated row, using call stack tracking to prevent
+ * double-counting of totalTime for recursive calls.
+ */
+function addEventToAggregatedRowWithStack(
+  row: AggregatedRow,
+  event: LogEvent,
+  stackKey: string,
+  keyStack: Multiset<string>,
+): void {
+  row.callCount++;
+  row.totalSelfTime += event.duration.self; // Always add self time
+
+  // Only add totalTime if this method is not already on the stack (avoids recursive double-counting)
+  // Uses stackKey (text+namespace, no type) so CODE_UNIT_STARTED and METHOD_ENTRY for the same
+  // method are recognised as the same function in the call stack.
+  if (!keyStack.has(stackKey)) {
+    row.totalTime += event.duration.total;
+  }
+
+  row.dmlCount.self += event.dmlCount.self;
+  row.dmlCount.total += event.dmlCount.total;
+  row.soqlCount.self += event.soqlCount.self;
+  row.soqlCount.total += event.soqlCount.total;
+  row.dmlRowCount.self += event.dmlRowCount.self;
+  row.dmlRowCount.total += event.dmlRowCount.total;
+  row.soqlRowCount.self += event.soqlRowCount.self;
+  row.soqlRowCount.total += event.soqlRowCount.total;
+  row.totalThrownCount += event.totalThrownCount;
+  row.instances.push(event);
+}
+
+/**
+ * Converts top-down call trees into bottom-up call trees.
+ *
+ * Bottom-up roots are callees; children are reversed callers.
+ * For every metric pair M.self/M.total (for example time, soqlRows), values are
+ * attributed once using deepest active frame assignment and then bucketed by
+ * reversed caller path. At every node, child partitions must sum to parent for
+ * both self and total. Totals are non-overlapping and recursion-safe.
+ *
+ * Algorithm (see BOTTOM_UP_CALL_TREE_SPEC.md):
+ *   1. Compute per-frame attributed totals. For every frame F with name R,
+ *      attr(F) = F.total - Σ T for each nearest same-name descendant T. The DFS
+ *      maintains Map<name, deepest-active-frame> and subtracts descendant totals
+ *      from their nearest same-name ancestor on entry.
+ *   2. For every frame F with F.duration.self > 0, walk its ancestor chain and
+ *      insert F into a trie keyed by [F.name, F.parent.name, F.grandparent.name, …].
+ *      At every prefix, accumulate F.self (bucket.self) and attr(F) (bucket.total)
+ *      plus the matching metric pairs.
+ *   3. Finalize averages and sort deterministically (totalSelfTime desc, name asc).
+ */
+export function toBottomUpTree(rootChildren: LogEvent[]): BottomUpRow[] {
+  if (rootChildren.length === 0) {
+    return [];
+  }
+
+  const attributionMap = computeFrameAttribution(rootChildren);
+  const rootBuckets = new Map<string, BottomUpRow>();
+
+  for (const frame of attributionMap.keys()) {
+    // Insert every frame so callCount and DML/SOQL/exception attributions roll up
+    // even for frames whose self-time contribution is zero.
+    insertFrameIntoTrie(frame, attributionMap, rootBuckets);
+  }
+
+  return finalizeBuckets(rootBuckets);
+}
+
+type FrameAttribution = {
+  totalTime: number;
+  dmlTotal: number;
+  soqlTotal: number;
+  dmlRowTotal: number;
+  soqlRowTotal: number;
+  thrownTotal: number;
+};
+
+/**
+ * Walks the top-down tree tracking the deepest active same-name ancestor per name.
+ * For each event E, if there is already an active frame A with the same name,
+ * subtract E's totals from A's attribution — because E's subtree belongs to E's
+ * own bucket, not A's. Every visited event receives an attribution entry whose
+ * initial values equal the event's own totals; same-name descendants trim those
+ * down to the non-overlapping slice attributable to this frame alone.
+ */
+function computeFrameAttribution(rootChildren: LogEvent[]): Map<LogEvent, FrameAttribution> {
+  const attributionMap = new Map<LogEvent, FrameAttribution>();
+  const activeByName = new Map<string, LogEvent>();
+
+  const visit = (node: LogEvent): void => {
+    const key = getStackKey(node);
+    const nearestSameName = activeByName.get(key);
+
+    getOrInitAttribution(attributionMap, node);
+
+    if (nearestSameName) {
+      const nearestAttr = getOrInitAttribution(attributionMap, nearestSameName);
+      nearestAttr.totalTime -= node.duration.total;
+      nearestAttr.dmlTotal -= node.dmlCount.total;
+      nearestAttr.soqlTotal -= node.soqlCount.total;
+      nearestAttr.dmlRowTotal -= node.dmlRowCount.total;
+      nearestAttr.soqlRowTotal -= node.soqlRowCount.total;
+      nearestAttr.thrownTotal -= node.totalThrownCount;
+    }
+
+    activeByName.set(key, node);
+    for (const child of node.children) {
+      visit(child);
+    }
+    if (nearestSameName) {
+      activeByName.set(key, nearestSameName);
+    } else {
+      activeByName.delete(key);
+    }
+  };
+
+  for (const child of rootChildren) {
+    visit(child);
+  }
+
+  return attributionMap;
+}
+
+function getOrInitAttribution(
+  map: Map<LogEvent, FrameAttribution>,
+  frame: LogEvent,
+): FrameAttribution {
+  const existing = map.get(frame);
+  if (existing) {
+    return existing;
+  }
+  const entry: FrameAttribution = {
+    totalTime: frame.duration.total,
+    dmlTotal: frame.dmlCount.total,
+    soqlTotal: frame.soqlCount.total,
+    dmlRowTotal: frame.dmlRowCount.total,
+    soqlRowTotal: frame.soqlRowCount.total,
+    thrownTotal: frame.totalThrownCount,
+  };
+  map.set(frame, entry);
+  return entry;
+}
+
+/**
+ * Inserts a frame into the bucket trie at every prefix of its ancestor chain.
+ * Depth 0 is the root bucket (keyed by the frame's own name); deeper buckets are
+ * keyed by each successive ancestor's name. The frame's attributed metrics are
+ * added at every prefix — the partition invariant (children sum to parent) is
+ * preserved because each frame contributes its own self / attr exactly once per
+ * depth and the child buckets partition the parent by ancestor identity.
+ */
+function insertFrameIntoTrie(
+  frame: LogEvent,
+  attributionMap: Map<LogEvent, FrameAttribution>,
+  rootBuckets: Map<string, BottomUpRow>,
+): void {
+  const attribution = getOrInitAttribution(attributionMap, frame);
+  const rootKey = getEventKey(frame);
+  let bucket = rootBuckets.get(rootKey);
+  if (!bucket) {
+    bucket = createEmptyBottomUpRow(rootKey, frame);
+    rootBuckets.set(rootKey, bucket);
+  }
+  accumulateContribution(bucket, frame, frame, attribution);
+
+  let ancestor = frame.parent;
+  let parentBucket = bucket;
+  while (ancestor && ancestor.text !== 'LOG_ROOT') {
+    const ancestorKey = getEventKey(ancestor);
+    const existingChildren = parentBucket._children ?? [];
+    let childBucket = existingChildren.find((candidate) => candidate.key === ancestorKey);
+    if (!childBucket) {
+      childBucket = createEmptyBottomUpRow(ancestorKey, ancestor);
+      existingChildren.push(childBucket);
+      parentBucket._children = existingChildren;
+    }
+    accumulateContribution(childBucket, frame, ancestor, attribution);
+    parentBucket = childBucket;
+    ancestor = ancestor.parent;
+  }
+}
+
+function accumulateContribution(
+  bucket: BottomUpRow,
+  frame: LogEvent,
+  displayEvent: LogEvent,
+  attribution: FrameAttribution,
+): void {
+  bucket.callCount++;
+  bucket.totalSelfTime += frame.duration.self;
+  bucket.totalTime += attribution.totalTime;
+  bucket.dmlCount.self += frame.dmlCount.self;
+  bucket.dmlCount.total += attribution.dmlTotal;
+  bucket.soqlCount.self += frame.soqlCount.self;
+  bucket.soqlCount.total += attribution.soqlTotal;
+  bucket.dmlRowCount.self += frame.dmlRowCount.self;
+  bucket.dmlRowCount.total += attribution.dmlRowTotal;
+  bucket.soqlRowCount.self += frame.soqlRowCount.self;
+  bucket.soqlRowCount.total += attribution.soqlRowTotal;
+  bucket.totalThrownCount += attribution.thrownTotal;
+  bucket.instances.push(displayEvent);
+  bucket.contributionInstances.push(frame);
+}
+
+/**
+ * Walks the bucket trie computing averages and applying deterministic ordering
+ * (primary metric total-self desc, then name asc) at every level. Empty child
+ * arrays are collapsed to null so Tabulator's dataTree renders a leaf indicator.
+ */
+function finalizeBuckets(rootBuckets: Map<string, BottomUpRow>): BottomUpRow[] {
+  const roots = Array.from(rootBuckets.values());
+  for (const row of roots) {
+    finalizeBucketRecursive(row);
+  }
+  sortBuckets(roots);
+  return roots;
+}
+
+function finalizeBucketRecursive(row: BottomUpRow): void {
+  calculateBottomUpAverages(row);
+  if (row._children && row._children.length > 0) {
+    for (const child of row._children) {
+      finalizeBucketRecursive(child);
+    }
+    sortBuckets(row._children);
+  } else {
+    row._children = null;
+  }
+}
+
+function sortBuckets(rows: BottomUpRow[]): void {
+  rows.sort((a, b) => {
+    const delta = b.totalSelfTime - a.totalSelfTime;
+    if (delta !== 0) {
+      return delta;
+    }
+    return a.text.localeCompare(b.text);
+  });
+}
+
+function createEmptyAggregatedRow(key: string, event: LogEvent): AggregatedRow {
+  return {
+    id: `agg-${key}-${Date.now()}-${Math.random().toString(36).slice(2, 9)}`,
+    key,
+    text: event.text,
+    namespace: event.namespace,
+    callCount: 0,
+    totalSelfTime: 0,
+    totalTime: 0,
+    avgSelfTime: 0,
+    dmlCount: { self: 0, total: 0 },
+    soqlCount: { self: 0, total: 0 },
+    dmlRowCount: { self: 0, total: 0 },
+    soqlRowCount: { self: 0, total: 0 },
+    totalThrownCount: 0,
+    _children: null,
+    instances: [],
+    originalData: event,
+  };
+}
+
+function createEmptyBottomUpRow(key: string, event: LogEvent): BottomUpRow {
+  return {
+    id: `bu-${key}-${Date.now()}-${Math.random().toString(36).slice(2, 9)}`,
+    key,
+    text: event.text,
+    namespace: event.namespace,
+    type: event.type ?? '',
+    callCount: 0,
+    totalSelfTime: 0,
+    totalTime: 0,
+    avgSelfTime: 0,
+    dmlCount: { self: 0, total: 0 },
+    soqlCount: { self: 0, total: 0 },
+    dmlRowCount: { self: 0, total: 0 },
+    soqlRowCount: { self: 0, total: 0 },
+    totalThrownCount: 0,
+    _children: null,
+    instances: [],
+    contributionInstances: [],
+    originalData: event,
+  };
+}
+
+function calculateAverages(row: AggregatedRow): void {
+  if (row.callCount > 0) {
+    row.avgSelfTime = row.totalSelfTime / row.callCount;
+  }
+}
+
+function calculateBottomUpAverages(row: BottomUpRow): void {
+  if (row.callCount > 0) {
+    row.avgSelfTime = row.totalSelfTime / row.callCount;
+  }
+}

--- a/log-viewer/src/features/call-tree/utils/BottomCalcs.ts
+++ b/log-viewer/src/features/call-tree/utils/BottomCalcs.ts
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2026 Certinia Inc. All rights reserved.
+ */
+
+import type { RowComponent, Tabulator } from 'tabulator-tables';
+
+import type { AggregatedRow, BottomUpRow } from './Aggregation.js';
+import { type MergedCalltreeRow } from './MergeAdjacent.js';
+
+type CalltreeRowUnion = MergedCalltreeRow | AggregatedRow | BottomUpRow;
+
+interface InternalRow {
+  getComponent(): RowComponent;
+  getData(): CalltreeRowUnion;
+}
+
+interface DataTreeModule {
+  getFilteredTreeChildren(row: InternalRow): InternalRow[];
+}
+
+interface RowComponentInternal extends RowComponent {
+  _getSelf(): InternalRow;
+}
+
+type TabulatorInternals = Tabulator & {
+  modules: { dataTree?: DataTreeModule };
+};
+
+function getRowSelfTime(row: CalltreeRowUnion): number {
+  if ('duration' in row) {
+    return row.duration.self;
+  }
+  return row.totalSelfTime;
+}
+
+/**
+ * Top-down self-time bottom calc factory: sums self-time across every row that
+ * currently passes the table's filters, regardless of whether its parent
+ * branch is expanded.
+ *
+ * Tabulator's public `RowComponent.getTreeChildren()` ignores filters, and
+ * `getRows('active')` only walks expanded branches. To get an accurate sum we
+ * reach into `table.modules.dataTree.getFilteredTreeChildren(internalRow)`,
+ * which applies the active filters to a row's tree children. The internal Row
+ * is obtained via `RowComponent._getSelf()`.
+ */
+export function makeSumSelfTimeAllVisible(getTable: () => Tabulator | undefined) {
+  return (_values: number[], _data: CalltreeRowUnion[], _calcParams: unknown): number => {
+    const table = getTable() as TabulatorInternals | undefined;
+    const dataTree = table?.modules.dataTree;
+    if (!table || !dataTree) {
+      return 0;
+    }
+
+    let total = 0;
+    const walk = (rows: InternalRow[]): void => {
+      for (const row of rows) {
+        total += getRowSelfTime(row.getData());
+        walk(dataTree.getFilteredTreeChildren(row));
+      }
+    };
+
+    const topLevel = table.getRows('active') as RowComponentInternal[];
+    walk(topLevel.map((rc) => rc._getSelf()));
+    return total;
+  };
+}

--- a/log-viewer/src/features/call-tree/utils/MergeAdjacent.ts
+++ b/log-viewer/src/features/call-tree/utils/MergeAdjacent.ts
@@ -1,0 +1,207 @@
+/*
+ * Copyright (c) 2026 Certinia Inc. All rights reserved.
+ */
+
+import type { LogEvent, SelfTotal } from 'apex-log-parser';
+
+/**
+ * Default gap threshold in nanoseconds (100ms)
+ * Events within this gap are considered adjacent
+ */
+const DEFAULT_GAP_THRESHOLD_NS = 100_000_000;
+
+/**
+ * Minimum percentage of total merged duration for dynamic gap threshold
+ */
+const GAP_THRESHOLD_PERCENTAGE = 0.01; // 1%
+
+/**
+ * Represents a row in the call tree with potential merging
+ */
+export interface MergedCalltreeRow {
+  id: string;
+  originalData: LogEvent;
+  _children: MergedCalltreeRow[] | undefined | null;
+  text: string;
+  namespace: string;
+  duration: SelfTotal;
+  dmlCount: SelfTotal;
+  soqlCount: SelfTotal;
+  dmlRowCount: SelfTotal;
+  soqlRowCount: SelfTotal;
+  totalThrownCount: number;
+  /** Whether this row represents merged events */
+  isMerged: boolean;
+  /** Number of events merged into this row (alias for mergeCount) */
+  callCount: number;
+  /** Number of events merged into this row */
+  mergeCount: number;
+  /** Original events for expansion (only populated for merged rows) */
+  mergedEvents: LogEvent[];
+  /** Duration statistics for merged rows */
+  durationRange?: { min: number; max: number; avg: number };
+  /** Average self time per call */
+  avgSelfTime: number;
+}
+
+/**
+ * Generates a signature key for matching adjacent events
+ * Events with the same key can be merged if adjacent
+ */
+export function getSignatureKey(event: LogEvent): string {
+  return `${event.type ?? ''}|${event.text}|${event.lineNumber ?? ''}|${event.namespace}`;
+}
+
+/**
+ * Determines if two events are close enough to be considered adjacent
+ */
+function isWithinGapThreshold(
+  event1: LogEvent,
+  event2: LogEvent,
+  thresholdNs: number = DEFAULT_GAP_THRESHOLD_NS,
+): boolean {
+  const event1End = event1.exitStamp ?? event1.timestamp;
+  const gap = event2.timestamp - event1End;
+  return gap >= 0 && gap <= thresholdNs;
+}
+
+/**
+ * Creates a merged row from a group of adjacent events
+ */
+function createMergedRow(events: LogEvent[], index: number): MergedCalltreeRow {
+  const firstEvent = events[0]!;
+  const totalDuration = events.reduce((sum, e) => sum + e.duration.total, 0);
+  const totalSelfTime = events.reduce((sum, e) => sum + e.duration.self, 0);
+  const totalDmlCount = events.reduce((sum, e) => sum + e.dmlCount.total, 0);
+  const totalSoqlCount = events.reduce((sum, e) => sum + e.soqlCount.total, 0);
+  const totalDmlRowCount = events.reduce((sum, e) => sum + e.dmlRowCount.total, 0);
+  const totalSoqlRowCount = events.reduce((sum, e) => sum + e.soqlRowCount.total, 0);
+  const totalThrownCount = events.reduce((sum, e) => sum + e.totalThrownCount, 0);
+
+  const durations = events.map((e) => e.duration.total);
+  const minDuration = Math.min(...durations);
+  const maxDuration = Math.max(...durations);
+  const avgDuration = totalDuration / events.length;
+
+  // Create merged children from all events' children
+  const allChildren: LogEvent[] = [];
+  for (const event of events) {
+    allChildren.push(...event.children);
+  }
+  const mergedChildren = allChildren.length > 0 ? toMergedCallTree(allChildren) : null;
+
+  const callCount = events.length;
+  const avgSelfTime = callCount > 0 ? totalSelfTime / callCount : 0;
+
+  return {
+    id: `merged-${firstEvent.timestamp}-${index}`,
+    originalData: firstEvent,
+    _children: mergedChildren,
+    text: firstEvent.text,
+    namespace: firstEvent.namespace,
+    duration: { self: totalSelfTime, total: totalDuration },
+    dmlCount: { self: totalDmlCount, total: totalDmlCount },
+    soqlCount: { self: totalSoqlCount, total: totalSoqlCount },
+    dmlRowCount: { self: totalDmlRowCount, total: totalDmlRowCount },
+    soqlRowCount: { self: totalSoqlRowCount, total: totalSoqlRowCount },
+    totalThrownCount,
+    isMerged: true,
+    callCount,
+    mergeCount: callCount,
+    mergedEvents: events,
+    durationRange: { min: minDuration, max: maxDuration, avg: avgDuration },
+    avgSelfTime,
+  };
+}
+
+/**
+ * Creates a non-merged row from a single event
+ */
+function createSingleRow(event: LogEvent, index: number): MergedCalltreeRow {
+  const children = event.children.length > 0 ? toMergedCallTree(event.children) : null;
+
+  return {
+    id: `${event.timestamp}-${index}`,
+    originalData: event,
+    _children: children,
+    text: event.text,
+    namespace: event.namespace,
+    duration: event.duration,
+    dmlCount: event.dmlCount,
+    soqlCount: event.soqlCount,
+    dmlRowCount: event.dmlRowCount,
+    soqlRowCount: event.soqlRowCount,
+    totalThrownCount: event.totalThrownCount,
+    isMerged: false,
+    callCount: 1,
+    mergeCount: 1,
+    mergedEvents: [],
+    avgSelfTime: event.duration.self,
+  };
+}
+
+/**
+ * Converts log events to call tree rows with adjacent event merging
+ */
+export function toMergedCallTree(nodes: LogEvent[]): MergedCalltreeRow[] | undefined {
+  const len = nodes.length;
+  if (!len) {
+    return undefined;
+  }
+
+  const results: MergedCalltreeRow[] = [];
+  let i = 0;
+
+  while (i < len) {
+    const currentEvent = nodes[i]!;
+    const currentKey = getSignatureKey(currentEvent);
+
+    // Look for adjacent events with the same signature
+    const adjacentGroup: LogEvent[] = [currentEvent];
+    let j = i + 1;
+
+    while (j < len) {
+      const nextEvent = nodes[j]!;
+      const nextKey = getSignatureKey(nextEvent);
+
+      // Check if same signature and within gap threshold
+      if (
+        nextKey === currentKey &&
+        isWithinGapThreshold(adjacentGroup[adjacentGroup.length - 1]!, nextEvent)
+      ) {
+        adjacentGroup.push(nextEvent);
+        j++;
+      } else {
+        break;
+      }
+    }
+
+    // Only merge if we have at least 2 adjacent events
+    if (adjacentGroup.length >= 2) {
+      results.push(createMergedRow(adjacentGroup, results.length));
+    } else {
+      results.push(createSingleRow(currentEvent, results.length));
+    }
+
+    i = j;
+  }
+
+  return results;
+}
+
+/**
+ * Converts log events to call tree rows without merging (regular view)
+ */
+export function toUnmergedCallTree(nodes: LogEvent[]): MergedCalltreeRow[] | undefined {
+  const len = nodes.length;
+  if (!len) {
+    return undefined;
+  }
+
+  const results: MergedCalltreeRow[] = [];
+  for (let i = 0; i < len; ++i) {
+    const node = nodes[i]!;
+    results.push(createSingleRow(node, i));
+  }
+  return results;
+}

--- a/log-viewer/src/features/call-tree/utils/__tests__/Aggregation.test.ts
+++ b/log-viewer/src/features/call-tree/utils/__tests__/Aggregation.test.ts
@@ -1,0 +1,901 @@
+import type { LogEvent } from 'apex-log-parser';
+
+import { toAggregatedCallTree, toBottomUpTree } from '../Aggregation.js';
+
+type EventOptions = {
+  text: string;
+  self: number;
+  total: number;
+  parent?: LogEvent | null;
+  type?: string;
+  dmlSelf?: number;
+  dmlTotal?: number;
+  soqlSelf?: number;
+  soqlTotal?: number;
+  dmlRowSelf?: number;
+  dmlRowTotal?: number;
+  soqlRowSelf?: number;
+  soqlRowTotal?: number;
+  thrown?: number;
+};
+
+let nextTimestamp = 1;
+
+function createEvent(options: EventOptions): LogEvent {
+  const event = {
+    logParser: null,
+    parent: options.parent ?? null,
+    children: [],
+    type: (options.type ?? 'METHOD_ENTRY') as LogEvent['type'],
+    logLine: '',
+    text: options.text,
+    acceptsText: false,
+    isExit: false,
+    isParent: false,
+    isTruncated: false,
+    nextLineIsExit: false,
+    lineNumber: null,
+    namespace: 'default',
+    hasValidSymbols: true,
+    suffix: null,
+    discontinuity: false,
+    timestamp: nextTimestamp++,
+    exitStamp: null,
+    category: '',
+    debugCategory: '',
+    debugLevel: '',
+    cpuType: '',
+    duration: { self: options.self, total: options.total },
+    dmlRowCount: { self: options.dmlRowSelf ?? 0, total: options.dmlRowTotal ?? 0 },
+    soqlRowCount: { self: options.soqlRowSelf ?? 0, total: options.soqlRowTotal ?? 0 },
+    soslRowCount: { self: 0, total: 0 },
+    dmlCount: { self: options.dmlSelf ?? 0, total: options.dmlTotal ?? 0 },
+    soqlCount: { self: options.soqlSelf ?? 0, total: options.soqlTotal ?? 0 },
+    soslCount: { self: 0, total: 0 },
+    totalThrownCount: options.thrown ?? 0,
+    exitTypes: [],
+  } as unknown as LogEvent;
+
+  if (options.parent) {
+    options.parent.children.push(event);
+  }
+
+  return event;
+}
+
+function findRowByText<T extends { text: string }>(rows: T[], text: string): T {
+  const row = rows.find((candidate) => candidate.text === text);
+  if (!row) {
+    throw new Error(`Unable to find row for ${text}`);
+  }
+  return row;
+}
+
+function assertTotalIsAtLeastSelf(
+  rows: Array<{ totalTime: number; totalSelfTime: number; _children: unknown }>,
+): void {
+  for (const row of rows) {
+    expect(row.totalTime).toBeGreaterThanOrEqual(row.totalSelfTime);
+    if (Array.isArray(row._children)) {
+      assertTotalIsAtLeastSelf(
+        row._children as Array<{ totalTime: number; totalSelfTime: number; _children: unknown }>,
+      );
+    }
+  }
+}
+
+type PartitionRow = {
+  text: string;
+  totalTime: number;
+  totalSelfTime: number;
+  dmlCount: { self: number; total: number };
+  soqlCount: { self: number; total: number };
+  dmlRowCount: { self: number; total: number };
+  soqlRowCount: { self: number; total: number };
+  _children: PartitionRow[] | null;
+};
+
+function assertPartitionInvariant(rows: PartitionRow[]): void {
+  for (const row of rows) {
+    if (!row._children || row._children.length === 0) {
+      continue;
+    }
+    const totals = row._children.reduce(
+      (acc, child) => ({
+        totalTime: acc.totalTime + child.totalTime,
+        totalSelfTime: acc.totalSelfTime + child.totalSelfTime,
+        dmlSelf: acc.dmlSelf + child.dmlCount.self,
+        dmlTotal: acc.dmlTotal + child.dmlCount.total,
+        soqlSelf: acc.soqlSelf + child.soqlCount.self,
+        soqlTotal: acc.soqlTotal + child.soqlCount.total,
+        dmlRowSelf: acc.dmlRowSelf + child.dmlRowCount.self,
+        dmlRowTotal: acc.dmlRowTotal + child.dmlRowCount.total,
+        soqlRowSelf: acc.soqlRowSelf + child.soqlRowCount.self,
+        soqlRowTotal: acc.soqlRowTotal + child.soqlRowCount.total,
+      }),
+      {
+        totalTime: 0,
+        totalSelfTime: 0,
+        dmlSelf: 0,
+        dmlTotal: 0,
+        soqlSelf: 0,
+        soqlTotal: 0,
+        dmlRowSelf: 0,
+        dmlRowTotal: 0,
+        soqlRowSelf: 0,
+        soqlRowTotal: 0,
+      },
+    );
+    expect(totals.totalTime).toBeCloseTo(row.totalTime, 6);
+    expect(totals.totalSelfTime).toBeCloseTo(row.totalSelfTime, 6);
+    expect(totals.dmlSelf).toBeCloseTo(row.dmlCount.self, 6);
+    expect(totals.dmlTotal).toBeCloseTo(row.dmlCount.total, 6);
+    expect(totals.soqlSelf).toBeCloseTo(row.soqlCount.self, 6);
+    expect(totals.soqlTotal).toBeCloseTo(row.soqlCount.total, 6);
+    expect(totals.dmlRowSelf).toBeCloseTo(row.dmlRowCount.self, 6);
+    expect(totals.dmlRowTotal).toBeCloseTo(row.dmlRowCount.total, 6);
+    expect(totals.soqlRowSelf).toBeCloseTo(row.soqlRowCount.self, 6);
+    expect(totals.soqlRowTotal).toBeCloseTo(row.soqlRowCount.total, 6);
+    assertPartitionInvariant(row._children);
+  }
+}
+
+function sumTraceSelfTime(events: LogEvent[]): number {
+  let total = 0;
+  for (const event of events) {
+    if (event.duration.self > 0) {
+      total += event.duration.self;
+    }
+    total += sumTraceSelfTime(event.children);
+  }
+  return total;
+}
+
+describe('toBottomUpTree', () => {
+  beforeEach(() => {
+    nextTimestamp = 1;
+  });
+
+  it('attributes caller rows using the current node contribution, not the caller event metrics', () => {
+    const root = createEvent({ text: 'LOG_ROOT', self: 0, total: 0, type: 'EXECUTION_STARTED' });
+    const parentA = createEvent({
+      text: 'ParentA',
+      self: 5,
+      total: 15,
+      parent: root,
+      dmlSelf: 9,
+      dmlTotal: 12,
+      thrown: 4,
+    });
+    createEvent({
+      text: 'Child',
+      self: 10,
+      total: 10,
+      parent: parentA,
+      dmlSelf: 1,
+      dmlTotal: 2,
+      soqlSelf: 3,
+      soqlTotal: 5,
+      dmlRowSelf: 7,
+      dmlRowTotal: 8,
+      soqlRowSelf: 11,
+      soqlRowTotal: 13,
+      thrown: 1,
+    });
+
+    const parentB = createEvent({
+      text: 'ParentB',
+      self: 8,
+      total: 28,
+      parent: root,
+      dmlSelf: 15,
+      dmlTotal: 18,
+      thrown: 6,
+    });
+    createEvent({
+      text: 'Child',
+      self: 20,
+      total: 20,
+      parent: parentB,
+      dmlSelf: 2,
+      dmlTotal: 4,
+      soqlSelf: 6,
+      soqlTotal: 10,
+      dmlRowSelf: 14,
+      dmlRowTotal: 16,
+      soqlRowSelf: 22,
+      soqlRowTotal: 26,
+      thrown: 2,
+    });
+
+    const rows = toBottomUpTree(root.children);
+    const childRow = findRowByText(rows, 'Child');
+    expect(childRow).toMatchObject({
+      totalSelfTime: 30,
+      totalTime: 30,
+      dmlCount: { self: 3, total: 6 },
+      soqlCount: { self: 9, total: 15 },
+      dmlRowCount: { self: 21, total: 24 },
+      soqlRowCount: { self: 33, total: 39 },
+      totalThrownCount: 3,
+    });
+
+    const callers = childRow._children ?? [];
+    const callerA = findRowByText(callers, 'ParentA');
+    const callerB = findRowByText(callers, 'ParentB');
+
+    expect(callerA.instances.map((instance) => instance.text)).toEqual(['ParentA']);
+    expect(callerA).toMatchObject({
+      totalSelfTime: 10,
+      totalTime: 10,
+      dmlCount: { self: 1, total: 2 },
+      soqlCount: { self: 3, total: 5 },
+      dmlRowCount: { self: 7, total: 8 },
+      soqlRowCount: { self: 11, total: 13 },
+      totalThrownCount: 1,
+    });
+
+    expect(callerB.instances.map((instance) => instance.text)).toEqual(['ParentB']);
+    expect(callerB).toMatchObject({
+      totalSelfTime: 20,
+      totalTime: 20,
+      dmlCount: { self: 2, total: 4 },
+      soqlCount: { self: 6, total: 10 },
+      dmlRowCount: { self: 14, total: 16 },
+      soqlRowCount: { self: 22, total: 26 },
+      totalThrownCount: 2,
+    });
+  });
+
+  it('shows every frame at the root including zero-self wrappers and keeps path totals when grouping callers', () => {
+    const root = createEvent({ text: 'LOG_ROOT', self: 0, total: 0, type: 'EXECUTION_STARTED' });
+
+    const parentA = createEvent({ text: 'ParentA', self: 5, total: 85, parent: root });
+    const methodFromA = createEvent({
+      text: 'MethodB',
+      self: 20,
+      total: 80,
+      parent: parentA,
+      dmlSelf: 1,
+      dmlTotal: 3,
+    });
+    createEvent({ text: 'LeafC', self: 60, total: 60, parent: methodFromA });
+
+    const parentB = createEvent({ text: 'ParentB', self: 10, total: 40, parent: root });
+    createEvent({
+      text: 'MethodB',
+      self: 30,
+      total: 30,
+      parent: parentB,
+      dmlSelf: 2,
+      dmlTotal: 5,
+    });
+
+    const zeroSelfWrapper = createEvent({
+      text: 'ZeroSelfWrapper',
+      self: 0,
+      total: 40,
+      parent: root,
+    });
+    createEvent({ text: 'WrappedLeaf', self: 40, total: 40, parent: zeroSelfWrapper });
+
+    const rows = toBottomUpTree(root.children);
+
+    expect(rows.some((row) => row.text === 'ZeroSelfWrapper')).toBe(true);
+    expect(rows.some((row) => row.text === 'WrappedLeaf')).toBe(true);
+
+    const methodRow = findRowByText(rows, 'MethodB');
+    expect(methodRow).toMatchObject({
+      totalSelfTime: 50,
+      totalTime: 110,
+      dmlCount: { self: 3, total: 8 },
+    });
+
+    const callers = methodRow._children ?? [];
+    expect(findRowByText(callers, 'ParentA')).toMatchObject({
+      totalSelfTime: 20,
+      totalTime: 80,
+      dmlCount: { self: 1, total: 3 },
+    });
+    expect(findRowByText(callers, 'ParentB')).toMatchObject({
+      totalSelfTime: 30,
+      totalTime: 30,
+      dmlCount: { self: 2, total: 5 },
+    });
+  });
+
+  it('accumulates global totals at root and attributes splits to caller rows', () => {
+    const root = createEvent({ text: 'LOG_ROOT', self: 60, total: 100, type: 'EXECUTION_STARTED' });
+
+    const parentA = createEvent({ text: 'ParentA', self: 10, total: 80, parent: root });
+    createEvent({
+      text: 'HotMethod',
+      self: 40,
+      total: 80,
+      parent: parentA,
+      dmlSelf: 4,
+      dmlTotal: 8,
+      soqlSelf: 2,
+      soqlTotal: 6,
+      dmlRowSelf: 20,
+      dmlRowTotal: 30,
+      soqlRowSelf: 10,
+      soqlRowTotal: 18,
+      thrown: 4,
+    });
+
+    const parentB = createEvent({ text: 'ParentB', self: 15, total: 70, parent: root });
+    createEvent({
+      text: 'HotMethod',
+      self: 35,
+      total: 70,
+      parent: parentB,
+      dmlSelf: 3,
+      dmlTotal: 7,
+      soqlSelf: 4,
+      soqlTotal: 5,
+      dmlRowSelf: 15,
+      dmlRowTotal: 25,
+      soqlRowSelf: 12,
+      soqlRowTotal: 16,
+      thrown: 3,
+    });
+
+    const rows = toBottomUpTree(root.children);
+    const hotMethod = findRowByText(rows, 'HotMethod');
+
+    expect(hotMethod.callCount).toBe(2);
+    expect(hotMethod.totalSelfTime).toBe(75);
+    expect(hotMethod.totalTime).toBe(150);
+    expect(hotMethod.dmlCount).toEqual({ self: 7, total: 15 });
+    expect(hotMethod.soqlCount).toEqual({ self: 6, total: 11 });
+    expect(hotMethod.dmlRowCount).toEqual({ self: 35, total: 55 });
+    expect(hotMethod.soqlRowCount).toEqual({ self: 22, total: 34 });
+    expect(hotMethod.totalThrownCount).toBe(7);
+
+    const callers = hotMethod._children ?? [];
+    const callerA = findRowByText(callers, 'ParentA');
+    const callerB = findRowByText(callers, 'ParentB');
+
+    expect(callerA.callCount).toBe(1);
+    expect(callerB.callCount).toBe(1);
+    expect(callerA.totalTime + callerB.totalTime).toBeCloseTo(hotMethod.totalTime, 6);
+    expect(callerA.totalSelfTime + callerB.totalSelfTime).toBeCloseTo(hotMethod.totalSelfTime, 6);
+  });
+
+  it('keeps events with different entry types as separate root rows for the same name', () => {
+    const root = createEvent({ text: 'LOG_ROOT', self: 0, total: 0, type: 'EXECUTION_STARTED' });
+    createEvent({ text: 'MyMethod', self: 10, total: 10, parent: root, type: 'CODE_UNIT_STARTED' });
+    createEvent({ text: 'MyMethod', self: 15, total: 15, parent: root, type: 'METHOD_ENTRY' });
+
+    const rows = toBottomUpTree(root.children);
+
+    const myMethodRows = rows.filter((r) => r.text === 'MyMethod');
+    expect(myMethodRows).toHaveLength(2);
+    const codeUnitRow = myMethodRows.find((r) => r.type === 'CODE_UNIT_STARTED');
+    const methodEntryRow = myMethodRows.find((r) => r.type === 'METHOD_ENTRY');
+    if (!codeUnitRow || !methodEntryRow) throw new Error('Expected both type rows');
+    expect(codeUnitRow.callCount).toBe(1);
+    expect(codeUnitRow.totalSelfTime).toBe(10);
+    expect(codeUnitRow.totalTime).toBe(10);
+    expect(methodEntryRow.callCount).toBe(1);
+    expect(methodEntryRow.totalSelfTime).toBe(15);
+    expect(methodEntryRow.totalTime).toBe(15);
+  });
+
+  it('keeps caller rows with different entry types separate for the same name', () => {
+    const root = createEvent({ text: 'LOG_ROOT', self: 0, total: 0, type: 'EXECUTION_STARTED' });
+    const parentA = createEvent({
+      text: 'ParentMethod',
+      self: 10,
+      total: 20,
+      parent: root,
+      type: 'CODE_UNIT_STARTED',
+    });
+    createEvent({ text: 'Leaf', self: 5, total: 5, parent: parentA });
+
+    const parentB = createEvent({
+      text: 'ParentMethod',
+      self: 15,
+      total: 25,
+      parent: root,
+      type: 'METHOD_ENTRY',
+    });
+    createEvent({ text: 'Leaf', self: 7, total: 7, parent: parentB });
+
+    const rows = toBottomUpTree(root.children);
+
+    const leafRow = findRowByText(rows, 'Leaf');
+    const callerRows = leafRow._children ?? [];
+    const parentMethodRows = callerRows.filter((row) => row.text === 'ParentMethod');
+
+    expect(parentMethodRows).toHaveLength(2);
+    const codeUnitCaller = parentMethodRows.find((r) => r.type === 'CODE_UNIT_STARTED');
+    const methodEntryCaller = parentMethodRows.find((r) => r.type === 'METHOD_ENTRY');
+    if (!codeUnitCaller || !methodEntryCaller) throw new Error('Expected both caller type rows');
+    expect(codeUnitCaller.callCount).toBe(1);
+    expect(codeUnitCaller.totalSelfTime).toBe(5);
+    expect(codeUnitCaller.totalTime).toBe(5);
+    expect(methodEntryCaller.callCount).toBe(1);
+    expect(methodEntryCaller.totalSelfTime).toBe(7);
+    expect(methodEntryCaller.totalTime).toBe(7);
+  });
+
+  it('uses only the outermost recursive call for totalTime, but sums all self times', () => {
+    const root = createEvent({ text: 'LOG_ROOT', self: 0, total: 1000, type: 'EXECUTION_STARTED' });
+    const caller = createEvent({ text: 'Outer', self: 100, total: 1000, parent: root });
+    const rec1 = createEvent({ text: 'Search', self: 50, total: 900, parent: caller });
+    const rec2 = createEvent({ text: 'Search', self: 50, total: 800, parent: rec1 });
+    createEvent({ text: 'Search', self: 50, total: 700, parent: rec2 });
+
+    const rows = toBottomUpTree(root.children);
+
+    const searchRow = rows.find((r) => r.text === 'Search');
+    if (!searchRow) throw new Error('Search row not found');
+
+    expect(searchRow.callCount).toBe(3);
+    expect(searchRow.totalSelfTime).toBe(150);
+    expect(searchRow.totalTime).toBe(900);
+  });
+
+  it('recursive self-caller row uses only outermost entry total and maintains self ≤ total', () => {
+    const root = createEvent({ text: 'LOG_ROOT', self: 0, total: 1000, type: 'EXECUTION_STARTED' });
+    const outer = createEvent({ text: 'Outer', self: 100, total: 1000, parent: root });
+    const rec1 = createEvent({ text: 'Search', self: 50, total: 900, parent: outer });
+    const rec2 = createEvent({ text: 'Search', self: 50, total: 800, parent: rec1 });
+    createEvent({ text: 'Search', self: 50, total: 700, parent: rec2 });
+
+    const rows = toBottomUpTree(root.children);
+
+    const searchRow = rows.find((r) => r.text === 'Search');
+    if (!searchRow) throw new Error('Search row not found');
+
+    const callerRows = searchRow._children ?? [];
+    const selfCallerRow = callerRows.find((r) => r.text === 'Search');
+    if (!selfCallerRow) throw new Error('Self-caller row not found');
+
+    expect(selfCallerRow.totalTime).toBe(800);
+    expect(selfCallerRow.totalSelfTime).toBeLessThanOrEqual(selfCallerRow.totalTime);
+  });
+
+  it('renders recursive self-callers one level at a time until the real stack is exhausted', () => {
+    const root = createEvent({ text: 'LOG_ROOT', self: 0, total: 1000, type: 'EXECUTION_STARTED' });
+    const outer = createEvent({ text: 'Outer', self: 100, total: 1000, parent: root });
+    const rec1 = createEvent({ text: 'Search', self: 50, total: 900, parent: outer });
+    const rec2 = createEvent({ text: 'Search', self: 50, total: 800, parent: rec1 });
+    createEvent({ text: 'Search', self: 50, total: 700, parent: rec2 });
+
+    const rows = toBottomUpTree(root.children);
+
+    const searchRow = findRowByText(rows, 'Search');
+    const callerRows = searchRow._children ?? [];
+    const selfCallerRow = findRowByText(callerRows, 'Search');
+
+    expect(selfCallerRow.totalTime).toBe(800);
+    expect(selfCallerRow.totalSelfTime).toBe(100);
+
+    const nestedCallerRows = selfCallerRow._children ?? [];
+    const nestedSelfCallerRow = findRowByText(nestedCallerRows, 'Search');
+    expect(nestedCallerRows.some((row) => row.text === 'Outer')).toBe(true);
+    expect(nestedSelfCallerRow.totalTime).toBe(700);
+    expect(nestedSelfCallerRow.totalSelfTime).toBe(50);
+
+    const terminalCallerRows = nestedSelfCallerRow._children ?? [];
+    expect(terminalCallerRows.some((row) => row.text === 'Search')).toBe(false);
+    expect(terminalCallerRows.some((row) => row.text === 'Outer')).toBe(true);
+  });
+
+  it('attributes each recursive caller level to the matching immediate parent window', () => {
+    const root = createEvent({ text: 'LOG_ROOT', self: 0, total: 1200, type: 'EXECUTION_STARTED' });
+    const outer = createEvent({ text: 'Outer', self: 80, total: 1200, parent: root });
+    const rec1 = createEvent({ text: 'Search', self: 40, total: 900, parent: outer });
+    const rec2 = createEvent({ text: 'Search', self: 30, total: 600, parent: rec1 });
+    createEvent({ text: 'Search', self: 20, total: 300, parent: rec2 });
+
+    const rows = toBottomUpTree(root.children);
+    const rootSearchRow = findRowByText(rows, 'Search');
+    const firstRecursiveCaller = findRowByText(rootSearchRow._children ?? [], 'Search');
+    const secondRecursiveCaller = findRowByText(firstRecursiveCaller._children ?? [], 'Search');
+
+    expect(rootSearchRow.totalTime).toBe(900);
+    expect(rootSearchRow.totalSelfTime).toBe(90);
+    expect(firstRecursiveCaller.totalTime).toBe(600);
+    expect(firstRecursiveCaller.totalSelfTime).toBe(50);
+    expect(secondRecursiveCaller.totalTime).toBe(300);
+    expect(secondRecursiveCaller.totalSelfTime).toBe(20);
+  });
+
+  it('does not double-count DML/SOQL totals for recursive calls', () => {
+    const root = createEvent({ text: 'LOG_ROOT', self: 0, total: 1000, type: 'EXECUTION_STARTED' });
+    const outer = createEvent({ text: 'Outer', self: 100, total: 1000, parent: root });
+    // rec1 is the outermost recursive Search — its totals are the canonical scope
+    const rec1 = createEvent({
+      text: 'Search',
+      self: 50,
+      total: 900,
+      parent: outer,
+      dmlTotal: 10,
+      dmlSelf: 2,
+      soqlTotal: 6,
+      soqlSelf: 1,
+      dmlRowTotal: 100,
+      dmlRowSelf: 20,
+      soqlRowTotal: 50,
+      soqlRowSelf: 5,
+      thrown: 3,
+    });
+    const rec2 = createEvent({
+      text: 'Search',
+      self: 50,
+      total: 800,
+      parent: rec1,
+      dmlTotal: 8,
+      dmlSelf: 2,
+      soqlTotal: 5,
+      soqlSelf: 1,
+      dmlRowTotal: 80,
+      dmlRowSelf: 20,
+      soqlRowTotal: 40,
+      soqlRowSelf: 5,
+      thrown: 2,
+    });
+    createEvent({
+      text: 'Search',
+      self: 50,
+      total: 700,
+      parent: rec2,
+      dmlTotal: 5,
+      dmlSelf: 2,
+      soqlTotal: 3,
+      soqlSelf: 1,
+      dmlRowTotal: 50,
+      dmlRowSelf: 20,
+      soqlRowTotal: 20,
+      soqlRowSelf: 5,
+      thrown: 1,
+    });
+
+    const rows = toBottomUpTree(root.children);
+
+    const searchRow = rows.find((r) => r.text === 'Search');
+    if (!searchRow) throw new Error('Search row not found');
+
+    // totalTime uses outermost only (rec1.total = 900) — already tested separately
+    expect(searchRow.totalTime).toBe(900);
+    // self sums all three invocations
+    expect(searchRow.totalSelfTime).toBe(150);
+
+    // *.total metrics must apply the same outermost-only rule as totalTime
+    // rec1 is the outermost, so only its totals count
+    expect(searchRow.dmlCount.self).toBe(6); // 2+2+2 — all self invocations sum
+    expect(searchRow.dmlCount.total).toBe(10); // outermost only
+    expect(searchRow.soqlCount.self).toBe(3);
+    expect(searchRow.soqlCount.total).toBe(6); // outermost only
+    expect(searchRow.dmlRowCount.self).toBe(60); // 20+20+20
+    expect(searchRow.dmlRowCount.total).toBe(100); // outermost only
+    expect(searchRow.soqlRowCount.self).toBe(15);
+    expect(searchRow.soqlRowCount.total).toBe(50); // outermost only
+    expect(searchRow.totalThrownCount).toBe(3); // outermost only
+  });
+
+  it('keeps totalTime greater than or equal to totalSelfTime for all bottom-up rows', () => {
+    const root = createEvent({ text: 'LOG_ROOT', self: 0, total: 1000, type: 'EXECUTION_STARTED' });
+
+    const constructor = createEvent({ text: 'Constructor', self: 20, total: 200, parent: root });
+    createEvent({
+      text: 'buildNode',
+      self: 25,
+      total: 140,
+      parent: constructor,
+      type: 'CODE_UNIT_STARTED',
+    });
+    createEvent({
+      text: 'buildNode',
+      self: 15,
+      total: 60,
+      parent: constructor,
+      type: 'METHOD_ENTRY',
+    });
+
+    const service = createEvent({ text: 'Service', self: 40, total: 700, parent: root });
+    const search1 = createEvent({ text: 'buildNode', self: 17, total: 500, parent: service });
+    const search2 = createEvent({ text: 'buildNode', self: 11, total: 300, parent: search1 });
+    createEvent({ text: 'buildNode', self: 9, total: 120, parent: search2 });
+
+    const rows = toBottomUpTree(root.children);
+
+    assertTotalIsAtLeastSelf(rows);
+    const buildNodeRows = rows.filter((row) => row.text === 'buildNode');
+    // Different entry types are now bucketed separately: CODE_UNIT_STARTED + METHOD_ENTRY.
+    expect(buildNodeRows).toHaveLength(2);
+  });
+
+  it('shows each unique method exactly once at root even with mixed entry types and recursion', () => {
+    const root = createEvent({ text: 'LOG_ROOT', self: 0, total: 400, type: 'EXECUTION_STARTED' });
+
+    const topLevel = createEvent({
+      text: 'search',
+      self: 10,
+      total: 300,
+      parent: root,
+      type: 'CODE_UNIT_STARTED',
+    });
+    const recursive = createEvent({
+      text: 'search',
+      self: 8,
+      total: 220,
+      parent: topLevel,
+      type: 'METHOD_ENTRY',
+    });
+    createEvent({ text: 'search', self: 7, total: 140, parent: recursive, type: 'METHOD_ENTRY' });
+    createEvent({ text: 'helper', self: 20, total: 20, parent: topLevel, type: 'METHOD_ENTRY' });
+
+    const rows = toBottomUpTree(root.children);
+
+    const uniqueKeys = new Set(rows.map((row) => row.key));
+    expect(uniqueKeys.size).toBe(rows.length);
+
+    // CODE_UNIT_STARTED + METHOD_ENTRY are now bucketed separately by type.
+    const searchRows = rows.filter((row) => row.text === 'search');
+    expect(searchRows).toHaveLength(2);
+    expect(searchRows.find((r) => r.type === 'CODE_UNIT_STARTED')).toBeDefined();
+    expect(searchRows.find((r) => r.type === 'METHOD_ENTRY')).toBeDefined();
+  });
+
+  it('keeps bottom-up root self-time budget equal to full trace self-time', () => {
+    const root = createEvent({ text: 'LOG_ROOT', self: 0, total: 500, type: 'EXECUTION_STARTED' });
+
+    const a = createEvent({ text: 'A', self: 30, total: 250, parent: root });
+    const b = createEvent({ text: 'B', self: 20, total: 200, parent: a });
+    createEvent({ text: 'B', self: 15, total: 120, parent: b });
+    createEvent({ text: 'C', self: 25, total: 25, parent: b });
+    createEvent({ text: 'D', self: 40, total: 40, parent: root });
+
+    const rows = toBottomUpTree(root.children);
+    const rootSelfBudget = rows.reduce((sum, row) => sum + row.totalSelfTime, 0);
+    const traceSelfBudget = sumTraceSelfTime(root.children);
+
+    expect(rootSelfBudget).toBe(traceSelfBudget);
+  });
+
+  it('matches worked example A (pure recursion) from BOTTOM_UP_CALL_TREE_SPEC.md', () => {
+    const root = createEvent({ text: 'LOG_ROOT', self: 0, total: 0, type: 'EXECUTION_STARTED' });
+    const outer = createEvent({ text: 'Outer', self: 100, total: 1000, parent: root });
+    const r1 = createEvent({ text: 'recursive', self: 10, total: 35, parent: outer });
+    const r2 = createEvent({ text: 'recursive', self: 8, total: 25, parent: r1 });
+    createEvent({ text: 'recursive', self: 17, total: 17, parent: r2 });
+
+    const rows = toBottomUpTree(root.children);
+
+    const recursive = findRowByText(rows, 'recursive');
+    expect(recursive.totalSelfTime).toBe(35);
+    expect(recursive.totalTime).toBe(35);
+
+    const level1 = recursive._children ?? [];
+    const level1Outer = findRowByText(level1, 'Outer');
+    const level1Recursive = findRowByText(level1, 'recursive');
+    expect(level1Outer).toMatchObject({ totalSelfTime: 10, totalTime: 10 });
+    expect(level1Recursive).toMatchObject({ totalSelfTime: 25, totalTime: 25 });
+
+    const level2 = level1Recursive._children ?? [];
+    const level2Outer = findRowByText(level2, 'Outer');
+    const level2Recursive = findRowByText(level2, 'recursive');
+    expect(level2Outer).toMatchObject({ totalSelfTime: 8, totalTime: 8 });
+    expect(level2Recursive).toMatchObject({ totalSelfTime: 17, totalTime: 17 });
+
+    const level3 = level2Recursive._children ?? [];
+    const level3Outer = findRowByText(level3, 'Outer');
+    expect(level3Outer).toMatchObject({ totalSelfTime: 17, totalTime: 17 });
+    expect(level3Outer._children).toBeNull();
+  });
+
+  it('matches worked example B (other / sub other) from BOTTOM_UP_CALL_TREE_SPEC.md', () => {
+    const root = createEvent({ text: 'LOG_ROOT', self: 0, total: 0, type: 'EXECUTION_STARTED' });
+    const outer = createEvent({ text: 'Outer', self: 0, total: 25, parent: root });
+    const other = createEvent({ text: 'other', self: 10, total: 25, parent: outer });
+    createEvent({ text: 'sub other', self: 6, total: 6, parent: other });
+    createEvent({ text: 'sub other', self: 9, total: 9, parent: other });
+
+    const rows = toBottomUpTree(root.children);
+
+    const subOther = findRowByText(rows, 'sub other');
+    expect(subOther).toMatchObject({ totalSelfTime: 15, totalTime: 15, callCount: 2 });
+
+    const otherCaller = findRowByText(subOther._children ?? [], 'other');
+    expect(otherCaller).toMatchObject({ totalSelfTime: 15, totalTime: 15 });
+
+    const outerCaller = findRowByText(otherCaller._children ?? [], 'Outer');
+    expect(outerCaller).toMatchObject({ totalSelfTime: 15, totalTime: 15 });
+
+    const otherRow = findRowByText(rows, 'other');
+    expect(otherRow).toMatchObject({ totalSelfTime: 10, totalTime: 25 });
+    const otherOuter = findRowByText(otherRow._children ?? [], 'Outer');
+    expect(otherOuter).toMatchObject({ totalSelfTime: 10, totalTime: 25 });
+  });
+
+  it('matches worked example C (nested Search) from top-down-to-bottom-up-example.md', () => {
+    const root = createEvent({ text: 'LOG_ROOT', self: 0, total: 0, type: 'EXECUTION_STARTED' });
+    const outer = createEvent({ text: 'Outer', self: 100, total: 1000, parent: root });
+
+    // First Search branch: Search > Search > { method > sub method, Search > { method > sub method, Search }, function }
+    const s1 = createEvent({ text: 'Search', self: 20, total: 810, parent: outer });
+    const s2 = createEvent({ text: 'Search', self: 70, total: 790, parent: s1 });
+    const method1 = createEvent({ text: 'method', self: 30, total: 200, parent: s2 });
+    createEvent({ text: 'sub method', self: 170, total: 170, parent: method1 });
+    const s3 = createEvent({ text: 'Search', self: 30, total: 350, parent: s2 });
+    const method2 = createEvent({ text: 'method', self: 60, total: 180, parent: s3 });
+    createEvent({ text: 'sub method', self: 120, total: 120, parent: method2 });
+    createEvent({ text: 'Search', self: 140, total: 140, parent: s3 });
+    createEvent({ text: 'function', self: 170, total: 170, parent: s2 });
+
+    // Sibling Search directly under Outer
+    createEvent({ text: 'Search', self: 30, total: 30, parent: outer });
+
+    const rows = toBottomUpTree(root.children);
+
+    const search = findRowByText(rows, 'Search');
+    expect(search).toMatchObject({ totalSelfTime: 290, totalTime: 840 });
+
+    const searchOuter = findRowByText(search._children ?? [], 'Outer');
+    expect(searchOuter).toMatchObject({ totalSelfTime: 50, totalTime: 50 });
+
+    const searchSearch = findRowByText(search._children ?? [], 'Search');
+    expect(searchSearch).toMatchObject({ totalSelfTime: 240, totalTime: 790 });
+
+    const ssOuter = findRowByText(searchSearch._children ?? [], 'Outer');
+    expect(ssOuter).toMatchObject({ totalSelfTime: 70, totalTime: 440 });
+
+    const sss = findRowByText(searchSearch._children ?? [], 'Search');
+    expect(sss).toMatchObject({ totalSelfTime: 170, totalTime: 350 });
+
+    const sssOuter = findRowByText(sss._children ?? [], 'Outer');
+    expect(sssOuter).toMatchObject({ totalSelfTime: 30, totalTime: 210 });
+
+    const ssss = findRowByText(sss._children ?? [], 'Search');
+    expect(ssss).toMatchObject({ totalSelfTime: 140, totalTime: 140 });
+
+    const ssssOuter = findRowByText(ssss._children ?? [], 'Outer');
+    expect(ssssOuter).toMatchObject({ totalSelfTime: 140, totalTime: 140 });
+
+    const method = findRowByText(rows, 'method');
+    expect(method).toMatchObject({ totalSelfTime: 90, totalTime: 380 });
+
+    const subMethod = findRowByText(rows, 'sub method');
+    expect(subMethod).toMatchObject({ totalSelfTime: 290, totalTime: 290 });
+
+    const fn = findRowByText(rows, 'function');
+    expect(fn).toMatchObject({ totalSelfTime: 170, totalTime: 170 });
+
+    assertPartitionInvariant(rows);
+  });
+
+  it('partitions every metric pair (time, dml, soql, dmlRow, soqlRow) at every level', () => {
+    const root = createEvent({ text: 'LOG_ROOT', self: 0, total: 0, type: 'EXECUTION_STARTED' });
+    const outer = createEvent({ text: 'Outer', self: 10, total: 200, parent: root });
+    const s1 = createEvent({
+      text: 'Search',
+      self: 20,
+      total: 150,
+      parent: outer,
+      dmlSelf: 1,
+      dmlTotal: 6,
+      soqlSelf: 2,
+      soqlTotal: 8,
+      dmlRowSelf: 5,
+      dmlRowTotal: 15,
+      soqlRowSelf: 3,
+      soqlRowTotal: 12,
+    });
+    const s2 = createEvent({
+      text: 'Search',
+      self: 30,
+      total: 100,
+      parent: s1,
+      dmlSelf: 2,
+      dmlTotal: 4,
+      soqlSelf: 1,
+      soqlTotal: 5,
+      dmlRowSelf: 4,
+      dmlRowTotal: 8,
+      soqlRowSelf: 2,
+      soqlRowTotal: 6,
+    });
+    createEvent({
+      text: 'Search',
+      self: 40,
+      total: 40,
+      parent: s2,
+      dmlSelf: 1,
+      dmlTotal: 1,
+      soqlSelf: 1,
+      soqlTotal: 1,
+      dmlRowSelf: 2,
+      dmlRowTotal: 2,
+      soqlRowSelf: 1,
+      soqlRowTotal: 1,
+    });
+    createEvent({
+      text: 'Search',
+      self: 50,
+      total: 50,
+      parent: outer,
+      dmlSelf: 3,
+      dmlTotal: 3,
+      soqlSelf: 4,
+      soqlTotal: 4,
+      dmlRowSelf: 7,
+      dmlRowTotal: 7,
+      soqlRowSelf: 5,
+      soqlRowTotal: 5,
+    });
+
+    const rows = toBottomUpTree(root.children);
+    assertPartitionInvariant(rows);
+
+    const search = findRowByText(rows, 'Search');
+    // Global: no bottom-up row may exceed the outermost totals of any metric.
+    expect(search.totalTime).toBeLessThanOrEqual(outer.duration.total);
+  });
+
+  it('expands methods to callers (parents), not callees (children)', () => {
+    const root = createEvent({ text: 'LOG_ROOT', self: 0, total: 300, type: 'EXECUTION_STARTED' });
+
+    const callerA = createEvent({ text: 'CallerA', self: 10, total: 120, parent: root });
+    const methodBFromA = createEvent({ text: 'MethodB', self: 25, total: 100, parent: callerA });
+    createEvent({ text: 'LeafD', self: 35, total: 35, parent: methodBFromA });
+
+    const callerC = createEvent({ text: 'CallerC', self: 12, total: 90, parent: root });
+    createEvent({ text: 'MethodB', self: 30, total: 70, parent: callerC });
+
+    const rows = toBottomUpTree(root.children);
+    const methodB = findRowByText(rows, 'MethodB');
+    const callers = methodB._children ?? [];
+
+    const callerNames = callers.map((row) => row.text).sort();
+    expect(callerNames).toEqual(['CallerA', 'CallerC']);
+    expect(callers.some((row) => row.text === 'LeafD')).toBe(false);
+  });
+
+  it('includes zero-time frames so DML/SOQL/exception counts and callCount roll up', () => {
+    const root = createEvent({ text: 'LOG_ROOT', self: 0, total: 0, type: 'EXECUTION_STARTED' });
+    // Frame with no timing but a DML and a thrown exception — must still contribute.
+    createEvent({
+      text: 'LimitOnly',
+      self: 0,
+      total: 0,
+      parent: root,
+      dmlSelf: 1,
+      dmlTotal: 1,
+      thrown: 1,
+    });
+
+    const rows = toBottomUpTree(root.children);
+    const limitOnly = findRowByText(rows, 'LimitOnly');
+    expect(limitOnly.callCount).toBe(1);
+    expect(limitOnly.dmlCount.self).toBe(1);
+    expect(limitOnly.totalThrownCount).toBe(1);
+  });
+});
+
+describe('toAggregatedCallTree', () => {
+  beforeEach(() => {
+    nextTimestamp = 1;
+  });
+
+  it('includes zero-time frames so DML/SOQL/exception counts and callCount roll up', () => {
+    const root = createEvent({ text: 'LOG_ROOT', self: 0, total: 0, type: 'EXECUTION_STARTED' });
+    createEvent({
+      text: 'LimitOnly',
+      self: 0,
+      total: 0,
+      parent: root,
+      soqlSelf: 2,
+      soqlTotal: 2,
+    });
+
+    const rows = toAggregatedCallTree(root.children);
+    const limitOnly = findRowByText(rows, 'LimitOnly');
+    expect(limitOnly.callCount).toBe(1);
+    expect(limitOnly.soqlCount.self).toBe(2);
+  });
+});

--- a/log-viewer/src/features/call-tree/utils/__tests__/BottomCalcs.test.ts
+++ b/log-viewer/src/features/call-tree/utils/__tests__/BottomCalcs.test.ts
@@ -1,0 +1,84 @@
+import type { Tabulator } from 'tabulator-tables';
+
+import { makeSumSelfTimeAllVisible } from '../BottomCalcs.js';
+
+interface FakeRow<TData = unknown> {
+  data: TData;
+  children: FakeRow<TData>[];
+}
+
+interface InternalRowLike {
+  getData(): unknown;
+  __children: FakeRow[];
+}
+
+function toInternalRow(row: FakeRow): InternalRowLike {
+  return {
+    getData: () => row.data,
+    __children: row.children,
+  };
+}
+
+function fakeTable(rootRows: FakeRow[]): Tabulator {
+  const internalRows = rootRows.map(toInternalRow);
+  return {
+    getRows: () =>
+      internalRows.map((ir) => ({
+        _getSelf: () => ir,
+      })),
+    modules: {
+      dataTree: {
+        getFilteredTreeChildren: (row: InternalRowLike) => row.__children.map(toInternalRow),
+      },
+    },
+  } as unknown as Tabulator;
+}
+
+describe('bottomCalcs', () => {
+  it('makeSumSelfTimeAllVisible sums self time for every visible row in the filtered tree', () => {
+    const tree: FakeRow[] = [
+      {
+        data: { totalSelfTime: 10 },
+        children: [
+          { data: { totalSelfTime: 40 }, children: [] },
+          { data: { totalSelfTime: 5 }, children: [] },
+        ],
+      },
+      {
+        data: { totalSelfTime: 20 },
+        children: [{ data: { totalSelfTime: 10 }, children: [] }],
+      },
+    ];
+    const calc = makeSumSelfTimeAllVisible(() => fakeTable(tree));
+    expect(calc([], [], {})).toBe(10 + 40 + 5 + 20 + 10);
+  });
+
+  it('makeSumSelfTimeAllVisible excludes children filtered out of the tree', () => {
+    const fullTree: FakeRow[] = [
+      {
+        data: { totalSelfTime: 10 },
+        children: [
+          { data: { totalSelfTime: 40 }, children: [] },
+          { data: { totalSelfTime: 5 }, children: [] },
+        ],
+      },
+    ];
+    const filteredTree: FakeRow[] = [
+      {
+        data: { totalSelfTime: 10 },
+        children: [{ data: { totalSelfTime: 5 }, children: [] }],
+      },
+    ];
+
+    const fullCalc = makeSumSelfTimeAllVisible(() => fakeTable(fullTree));
+    const filteredCalc = makeSumSelfTimeAllVisible(() => fakeTable(filteredTree));
+
+    expect(fullCalc([], [], {})).toBe(55);
+    expect(filteredCalc([], [], {})).toBe(15);
+  });
+
+  it('makeSumSelfTimeAllVisible returns 0 before the table is available', () => {
+    const calc = makeSumSelfTimeAllVisible(() => undefined);
+    expect(calc([], [], {})).toBe(0);
+  });
+});

--- a/log-viewer/src/features/database/components/DMLView.ts
+++ b/log-viewer/src/features/database/components/DMLView.ts
@@ -126,7 +126,7 @@ export class DMLView extends LitElement {
 
       <datagrid-filter-bar>
         <div slot="filters">
-          <strong>Group by</strong>
+          Group by
           <div>
             <vscode-checkbox @change="${this._dmlGroupBy}" checked>DML</vscode-checkbox>
           </div>

--- a/log-viewer/src/features/database/components/SOQLView.ts
+++ b/log-viewer/src/features/database/components/SOQLView.ts
@@ -135,11 +135,13 @@ export class SOQLView extends LitElement {
 
         label {
           display: block;
-          color: var(--vscode-foreground);
+          color: var(--vscode-descriptionForeground);
           cursor: pointer;
-          font-size: var(--vscode-font-size);
-          line-height: normal;
-          margin-bottom: 2px;
+          font-size: calc(var(--vscode-font-size) * 0.9);
+          font-weight: 400;
+          line-height: 1.4;
+          margin-bottom: 4px;
+          user-select: none;
         }
       }
     `,
@@ -152,8 +154,13 @@ export class SOQLView extends LitElement {
 
       <datagrid-filter-bar>
         <div slot="filters" class="dropdown-container">
-          <label for="soql-groupby-dropdown"><strong>Group by</strong></label>
-          <vscode-dropdown id="soql-groupby-dropdown" @change="${this._soqlGroupBy}">
+          <label for="soql-groupby-dropdown">Group by</label>
+          <vscode-dropdown
+            id="soql-groupby-dropdown"
+            aria-label="Group by"
+            aria-labelledby="soql-groupby-dropdown"
+            @change="${this._soqlGroupBy}"
+          >
             <vscode-option>SOQL</vscode-option>
             <vscode-option>Namespace</vscode-option>
             <vscode-option>None</vscode-option>

--- a/log-viewer/src/tabulator/filters/MinMax.ts
+++ b/log-viewer/src/tabulator/filters/MinMax.ts
@@ -2,36 +2,47 @@
  * Copyright (c) 2022 Certinia Inc. All rights reserved.
  */
 
-export default function (
-  filterVal: { start: number | null; end: number | null },
-  rowVal: number,
-  rowData: { _children: []; id: number },
-  filterParams: { columnName: string; filterCache: Map<number, boolean> },
-): boolean {
+type FilterRange = { start: number | null; end: number | null };
+
+type RowWithChildren = { _children?: unknown[]; id: number | string };
+
+const NS_PER_MS = 1_000_000;
+
+export default function (filterVal: FilterRange, rowVal: number): boolean {
   if (!('start' in filterVal) || !('end' in filterVal)) {
     return false;
   }
-
-  return deepFilter(filterVal, rowVal, rowData, filterParams);
+  return inRange(filterVal, rowVal);
 }
 
+export const minMaxTreeFilter = (
+  filterVal: FilterRange,
+  rowVal: number,
+  rowData: RowWithChildren,
+  filterParams: { columnName: string; filterCache: Map<number | string, boolean> },
+): boolean => {
+  if (!('start' in filterVal) || !('end' in filterVal)) {
+    return false;
+  }
+  return deepFilter(filterVal, rowVal, rowData, filterParams);
+};
+
 function deepFilter(
-  headerValue: { start: number | null; end: number | null },
+  headerValue: FilterRange,
   rowValue: number,
-  rowData: { _children: []; id: number },
-  filterParams: { columnName: string; filterCache: Map<number, boolean> },
+  rowData: RowWithChildren,
+  filterParams: { columnName: string; filterCache: Map<number | string, boolean> },
 ): boolean {
-  const cachedMatch = filterParams.filterCache.get(rowData.id);
-  if (cachedMatch !== null && cachedMatch !== undefined) {
-    return cachedMatch;
+  const cached = filterParams.filterCache.get(rowData.id);
+  if (cached !== undefined) {
+    return cached;
   }
 
-  const columnName = filterParams.columnName;
+  const { columnName } = filterParams;
   let childMatch = false;
-  for (const childRow of rowData._children || []) {
-    const match = deepFilter(headerValue, childRow[columnName], childRow, filterParams);
-
-    if (match) {
+  for (const childRow of (rowData._children ?? []) as RowWithChildren[]) {
+    const childVal = getByPath(childRow, columnName);
+    if (typeof childVal === 'number' && deepFilter(headerValue, childVal, childRow, filterParams)) {
       childMatch = true;
       break;
     }
@@ -42,16 +53,37 @@ function deepFilter(
     return true;
   }
 
-  const rowVal = +(rowValue / 1000000).toFixed(3);
-  const min = headerValue.start;
-  const max = headerValue.end;
-  if (min && max) {
+  return inRange(headerValue, rowValue);
+}
+
+function inRange(range: FilterRange, value: number): boolean {
+  const rowVal = +(value / NS_PER_MS).toFixed(3);
+  const { start: min, end: max } = range;
+  if (min !== null && max !== null) {
     return rowVal >= min && rowVal <= max;
-  } else if (min) {
+  }
+  if (min !== null) {
     return rowVal >= min;
-  } else if (max) {
+  }
+  if (max !== null) {
     return rowVal <= max;
   }
-
   return true;
+}
+
+function getByPath(obj: unknown, path: string): unknown {
+  if (obj === null || obj === undefined) {
+    return undefined;
+  }
+  if (!path.includes('.')) {
+    return (obj as Record<string, unknown>)[path];
+  }
+  let cur: unknown = obj;
+  for (const key of path.split('.')) {
+    if (cur === null || cur === undefined || typeof cur !== 'object') {
+      return undefined;
+    }
+    cur = (cur as Record<string, unknown>)[key];
+  }
+  return cur;
 }

--- a/log-viewer/src/tabulator/filters/__tests__/MinMax.test.ts
+++ b/log-viewer/src/tabulator/filters/__tests__/MinMax.test.ts
@@ -1,0 +1,77 @@
+import minMaxFilter, { minMaxTreeFilter } from '../MinMax.js';
+
+const NS = 1_000_000;
+
+describe('minMaxFilter (core, non-recursive)', () => {
+  it('matches when value is within [start, end] (ms)', () => {
+    expect(minMaxFilter({ start: 1, end: 10 }, 5 * NS)).toBe(true);
+  });
+
+  it('rejects when value is below start', () => {
+    expect(minMaxFilter({ start: 5, end: null }, 1 * NS)).toBe(false);
+  });
+
+  it('rejects when value is above end', () => {
+    expect(minMaxFilter({ start: null, end: 5 }, 10 * NS)).toBe(false);
+  });
+
+  it('passes everything when both bounds are null', () => {
+    expect(minMaxFilter({ start: null, end: null }, 0)).toBe(true);
+  });
+
+  it('does NOT recurse into _children', () => {
+    // even if a descendant would match, the row itself must match
+    const row = { _children: [{ totalTime: 5 * NS }], totalTime: 0, id: 1 };
+    // core filter takes only filterVal + rowVal; passing rowVal=0 → out of [1,10]
+    expect(minMaxFilter({ start: 1, end: 10 }, row.totalTime)).toBe(false);
+  });
+});
+
+describe('minMaxTreeFilter (recursive)', () => {
+  it('matches a row when its own value is in range', () => {
+    const cache = new Map<number, boolean>();
+    const row = { id: 1, totalTime: 5 * NS };
+    expect(
+      minMaxTreeFilter({ start: 1, end: 10 }, row.totalTime, row, {
+        columnName: 'totalTime',
+        filterCache: cache,
+      }),
+    ).toBe(true);
+  });
+
+  it('matches a parent whose own value is out of range but a child is in range', () => {
+    const cache = new Map<number, boolean>();
+    const child = { id: 2, totalTime: 5 * NS };
+    const parent = { id: 1, totalTime: 0, _children: [child] };
+    expect(
+      minMaxTreeFilter({ start: 1, end: 10 }, parent.totalTime, parent, {
+        columnName: 'totalTime',
+        filterCache: cache,
+      }),
+    ).toBe(true);
+  });
+
+  it('rejects when neither row nor descendants match', () => {
+    const cache = new Map<number, boolean>();
+    const child = { id: 2, totalTime: 0 };
+    const parent = { id: 1, totalTime: 0, _children: [child] };
+    expect(
+      minMaxTreeFilter({ start: 1, end: 10 }, parent.totalTime, parent, {
+        columnName: 'totalTime',
+        filterCache: cache,
+      }),
+    ).toBe(false);
+  });
+
+  it('supports dotted column paths (e.g. duration.self)', () => {
+    const cache = new Map<number, boolean>();
+    const child = { id: 2, duration: { total: 0, self: 5 * NS } };
+    const parent = { id: 1, duration: { total: 0, self: 0 }, _children: [child] };
+    expect(
+      minMaxTreeFilter({ start: 1, end: 10 }, parent.duration.self, parent, {
+        columnName: 'duration.self',
+        filterCache: cache,
+      }),
+    ).toBe(true);
+  });
+});

--- a/log-viewer/src/tabulator/format/ProgressComponent.ts
+++ b/log-viewer/src/tabulator/format/ProgressComponent.ts
@@ -16,10 +16,8 @@ export function progressComponent(
 
   const roundedValue = (value || 0).toFixed(precision);
 
-  if (totalValue !== undefined && totalValue !== null) {
-    const showPercent = showPercentageText ?? true;
-    const percentComplete =
-      totalValue !== 0 ? (Math.round((value / totalValue) * 100) / 100) * 100 : 0;
+  if (totalValue !== null && totalValue !== undefined) {
+    const percentComplete = totalValue !== 0 ? Math.round((value / totalValue) * 100) : 0;
 
     const wrapper = document.createElement('div');
     wrapper.className = 'progress-wrapper';
@@ -38,7 +36,7 @@ export function progressComponent(
     valueSpan.textContent = roundedValue;
     textEl.appendChild(valueSpan);
 
-    if (showPercent) {
+    if (showPercentageText) {
       const pctSpan = document.createElement('span');
       pctSpan.className = 'progress-bar__text__percent';
       pctSpan.textContent = `(${percentComplete.toFixed(2)}%)`;

--- a/log-viewer/src/tabulator/module/MiddleRowFocus.ts
+++ b/log-viewer/src/tabulator/module/MiddleRowFocus.ts
@@ -60,7 +60,7 @@ export class MiddleRowFocus extends Module {
     }
 
     let rowToScrollTo: RowComponent | null = row;
-    if (rowToScrollTo) {
+    if (rowToScrollTo?.getData) {
       const displayRows = this.table.rowManager.getDisplayRows();
       //@ts-expect-error This is private to tabulator, but we have no other choice atm.
       const internalRow = rowToScrollTo._getSelf();

--- a/log-viewer/src/tabulator/style/DataGrid.scss
+++ b/log-viewer/src/tabulator/style/DataGrid.scss
@@ -47,11 +47,9 @@ $footerActiveColor: #d00 !default; //footer bottom active text color
   .tabulator-tableholder {
     overflow-x: hidden;
     overflow-anchor: none;
-    will-change: transform;
     .tabulator-table {
       display: block;
       background-color: default;
-      content-visibility: auto;
     }
   }
 


### PR DESCRIPTION
# 📝 PR Overview

Adds aggregated and bottom-up call tree views, aligns analysis table behavior with the new call tree tables, and updates related docs so log analysis workflows are consistent and easier to use.

## 🛠️ Changes made

- Add aggregated, bottom-up, and time-order call tree table implementations with shared aggregation utilities
- Refactor call tree and analysis views to share table behavior, filtering, grouping, and persistence logic
- Add tests for aggregation, row grouping, min/max filtering, and bottom calculation behavior
- Update README, changelog, and docs for the new analysis and call tree functionality

## 🧩 Type of change (check all applicable)

- [ ] 🐛 Bug fix - something not working as expected
- [x] ✨ New feature – adds new functionality
- [x] ♻️ Refactor - internal changes with no user impact
- [ ] ⚡ Performance Improvement
- [x] 📝 Documentation - README or documentation site changes
- [ ] 🔧 Chore - dev tooling, CI, config
- [ ] 💥 Breaking change

## 📷 Screenshots / gifs / video [optional]
<img width="1674" height="1209" alt="image" src="https://github.com/user-attachments/assets/46d18649-114a-4280-960d-19bec83c5f6a" />

<img width="1669" height="1206" alt="image" src="https://github.com/user-attachments/assets/57d39e06-eed1-4ae3-aef2-5fe9da688b13" />

## 🔗 Related Issues

fixes #
resolves #333
closes #
related #

## ✅ Tests added?

- [x] 👍 yes
- [ ] 🙅 no, not needed
- [ ] 🙋 no, I need help

## 📚 Docs updated?

- [x] 🔖 README.md
- [x] 🔖 CHANGELOG.md
- [x] 📖 help site
- [ ] 🙅 not needed

## Anything else we need to know? [optional]

The branch also includes internal table and filter refactors that support the new call tree views and keep analysis behavior aligned.
