### PR TITLE
fix(MiddleRowFocus): preserve scroll anchor across table operations

### DIFF
--- a/log-viewer/src/tabulator/module/MiddleRowFocus.ts
+++ b/log-viewer/src/tabulator/module/MiddleRowFocus.ts
@@ -17,7 +17,24 @@ export class MiddleRowFocus extends Module {
   static moduleName = 'middleRowFocus';
 
   tableHolder: HTMLElement | null = null;
+  private tableEl: HTMLElement | null = null;
   middleRow: RowComponent | null = null;
+  private pendingFilterRaf: number | null = null;
+
+  // Single tree toggle: skip the next renderComplete recenter so scrollTop stays put.
+  // Bulk toggle (expand-all / collapse-all): the second toggle in the synchronous burst
+  // clears the skip flag, so the recenter runs as before.
+  private skipNextRender = false;
+  private toggleSeenInBurst = false;
+
+  // Boundary anchoring: when the user is at the top or bottom of the scroll range
+  // before an operation, recentering on the middle row pushes them away from the
+  // edge they were at. Capture the boundary at snapshot time and restore it
+  // (scrollTop = 0 / scrollHeight - clientHeight) instead of centering.
+  private static readonly boundaryThresholdPx = 10;
+  private wasAtTop = false;
+  private wasAtBottom = false;
+
   constructor(table: Tabulator) {
     super(table);
     this.registerTableOption(middleRowFocusOption, false);
@@ -28,30 +45,128 @@ export class MiddleRowFocus extends Module {
     if (this.options(middleRowFocusOption)) {
       this.tableHolder = this.table.element.querySelector('.tabulator-tableholder');
 
-      this.table.on('dataTreeRowExpanded', () => {
-        this._clearFocusRow();
-      });
+      this.table.on('dataTreeRowExpanded', () => this._onTreeToggle());
+      this.table.on('dataTreeRowCollapsed', () => this._onTreeToggle());
 
-      this.table.on('dataTreeRowCollapsed', () => {
-        this._clearFocusRow();
-      });
+      // Sort resets scrollTop before renderStarted fires, so capture the anchor here
+      // (pre-sort) instead. The renderStarted handler below is a no-op once middleRow
+      // is set — see the !this.middleRow guard.
+      this.table.on('dataSorting', () => this._captureAnchor());
 
-      this.table.on('renderStarted', () => {
-        if (this.table && this.tableHolder && !this.middleRow) {
-          this.middleRow = this._findMiddleVisibleRow(this.tableHolder);
+      this.table.on('renderStarted', () => this._captureAnchor());
+
+      // Tabulator bug workaround: rerenderRows on filter can leave .tabulator-table's
+      // paddingTop inflated when the pre-filter vDomTop/vDomBottom point past the
+      // post-filter row count. Detect and zero on the next frame after the render.
+      // See tabulator-virtual-scroll-fixes.md "Fix 7" for the upstream patch.
+      this.table.on('dataFiltered', () => {
+        if (this.pendingFilterRaf !== null) {
+          cancelAnimationFrame(this.pendingFilterRaf);
         }
+        this.pendingFilterRaf = requestAnimationFrame(() => {
+          this.pendingFilterRaf = null;
+          this._resetStaleTopPadding();
+        });
       });
 
       this.table.on('renderComplete', async () => {
-        const rowToScrollTo = this.middleRow;
-        this._scrollToRow(rowToScrollTo);
-        this.middleRow = null;
+        if (this.skipNextRender) {
+          this.skipNextRender = false;
+          this._clearAnchor();
+        } else {
+          this._restoreAnchor();
+        }
+        this.toggleSeenInBurst = false;
       });
     }
   }
 
-  private _clearFocusRow() {
+  /**
+   * Capture the user's scroll anchor: the row at the visual middle and whether
+   * the user was at the top / bottom edge. Idempotent within one operation —
+   * subsequent calls are no-ops once an anchor is already set.
+   */
+  private _captureAnchor() {
+    if (!this.tableHolder || this.middleRow) {
+      return;
+    }
+    const holder = this.tableHolder;
+    const max = Math.max(0, holder.scrollHeight - holder.clientHeight);
+    this.wasAtTop = holder.scrollTop <= MiddleRowFocus.boundaryThresholdPx;
+    this.wasAtBottom = max - holder.scrollTop <= MiddleRowFocus.boundaryThresholdPx;
+    this.middleRow = this._findMiddleVisibleRow(holder);
+  }
+
+  /**
+   * Restore the captured anchor. Boundary cases (was-at-top / was-at-bottom) snap
+   * to the edge so we don't push the user off it. Mid-table centers on middleRow.
+   */
+  private _restoreAnchor() {
+    const holder = this.tableHolder;
+    if (!holder) {
+      this._clearAnchor();
+      return;
+    }
+    if (this.wasAtTop) {
+      holder.scrollTop = 0;
+    } else if (this.wasAtBottom) {
+      holder.scrollTop = Math.max(0, holder.scrollHeight - holder.clientHeight);
+    } else {
+      this._scrollToRow(this.middleRow);
+    }
+    this._clearAnchor();
+  }
+
+  private _clearAnchor() {
     this.middleRow = null;
+    this.wasAtTop = false;
+    this.wasAtBottom = false;
+  }
+
+  /**
+   * Tabulator bug workaround: after a filter, rerenderRows() (`tabulator_esm.mjs`,
+   * line ~25265) iterates pre-filter `vDomTop..vDomBottom` against the post-filter
+   * `rows()` array. The resulting `topOffset` flows into `_virtualRenderFill` and
+   * inflates `vDomTopPad` → `paddingTop` on `.tabulator-table` → blank strip across
+   * the top of the holder. We detect the symptom (`scrollTop < paddingTop`, which
+   * implies more empty space above the rendered window than the user has scrolled
+   * past) and reset the padding plus Tabulator's internal `vDomTopPad` so future
+   * renders are coherent.
+   */
+  private _resetStaleTopPadding() {
+    if (!this.tableHolder) {
+      return;
+    }
+    if (!this.tableEl) {
+      this.tableEl = this.tableHolder.querySelector('.tabulator-table');
+    }
+    const tableEl = this.tableEl;
+    if (!tableEl) {
+      return;
+    }
+    const paddingTop = parseFloat(tableEl.style.paddingTop) || 0;
+    const scrollTop = this.tableHolder.scrollTop;
+    if (paddingTop > 0 && scrollTop < paddingTop) {
+      tableEl.style.paddingTop = '0px';
+      const renderer = this.table.rowManager?.renderer as Record<string, unknown> | undefined;
+      if (renderer) {
+        renderer.vDomTopPad = 0;
+      }
+    }
+  }
+
+  private _onTreeToggle() {
+    if (!this.toggleSeenInBurst) {
+      // First toggle in this burst: assume single, arm the skip.
+      this.toggleSeenInBurst = true;
+      this.skipNextRender = true;
+    } else {
+      // A second toggle arrived synchronously => it's a bulk operation; let the
+      // existing recenter run so the user's middle row stays in view.
+      this.skipNextRender = false;
+    }
+    // Clear the anchor so renderStarted captures fresh (with up-to-date boundary flags).
+    this._clearAnchor();
   }
 
   private _scrollToRow(row: RowComponent | null) {

--- a/log-viewer/src/tabulator/module/__mocks__/tabulator-tables.ts
+++ b/log-viewer/src/tabulator/module/__mocks__/tabulator-tables.ts
@@ -1,0 +1,7 @@
+// __mocks__/tabulator-tables.ts
+export class Module {
+  constructor(table?: any) {
+    // this.table = table;
+  }
+  registerTableOption() {}
+}

--- a/log-viewer/src/tabulator/module/__tests__/MiddleRowFocus.test.ts
+++ b/log-viewer/src/tabulator/module/__tests__/MiddleRowFocus.test.ts
@@ -1,0 +1,334 @@
+import { describe, expect, it, jest } from '@jest/globals';
+import { MiddleRowFocus } from '../MiddleRowFocus';
+
+function rect(top: number, height: number) {
+  return {
+    top,
+    bottom: top + height,
+    left: 0,
+    right: 0,
+    width: 0,
+    height,
+    x: 0,
+    y: top,
+    toJSON: () => ({}),
+  };
+}
+
+function makeRow(top: number, height = 20) {
+  return {
+    getElement: () => ({ getBoundingClientRect: () => rect(top, height) }),
+  };
+}
+
+function makeBareTable() {
+  const handlers: Record<string, ((...args: unknown[]) => void)[]> = {};
+  return {
+    handlers,
+    on: jest.fn((evt: string, fn: (...args: unknown[]) => void) => {
+      (handlers[evt] ??= []).push(fn);
+    }),
+    element: { querySelector: jest.fn() },
+    getRows: jest.fn(() => []),
+    rowManager: { getDisplayRows: () => [] },
+    scrollToRow: jest.fn(() => Promise.resolve()),
+  };
+}
+
+function setup() {
+  const table = makeBareTable();
+  const plugin = new MiddleRowFocus(table as never);
+  (plugin as unknown as { table: typeof table }).table = table;
+  (plugin as unknown as { options: () => boolean }).options = () => true;
+  plugin.initialize();
+  return { plugin, table };
+}
+
+describe('MiddleRowFocus', () => {
+  it('returns the row whose cumulative visible height first crosses half of the holder height', () => {
+    // holder height 100, target 50. r1 contributes 30 (running 30), r2 contributes 30
+    // (running 60 — first row at/over 50), r3 never reached.
+    const r1 = makeRow(0, 30);
+    const r2 = makeRow(30, 30);
+    const r3 = makeRow(60, 30);
+    const holder = { getBoundingClientRect: () => rect(0, 100) };
+
+    const table = {
+      on: jest.fn(),
+      element: { querySelector: jest.fn() },
+      getRows: jest.fn((type?: string) => {
+        if (type === 'visible') return [r1, r2, r3];
+        return [];
+      }),
+    };
+
+    const plugin = new MiddleRowFocus(table as never);
+    (plugin as unknown as { table: typeof table }).table = table;
+
+    const found = (
+      plugin as unknown as { _findMiddleVisibleRow: (h: unknown) => unknown }
+    )._findMiddleVisibleRow(holder);
+    expect(found).toBe(r2);
+    // r3 should never be reached.
+    void r3;
+  });
+
+  it('skips the recenter on a single tree toggle (preserves scrollTop)', () => {
+    const { table, plugin } = setup();
+
+    table.handlers.dataTreeRowExpanded?.[0]?.();
+    expect((plugin as unknown as { skipNextRender: boolean }).skipNextRender).toBe(true);
+
+    // Pretend Tabulator runs its render cycle.
+    table.handlers.renderStarted?.[0]?.();
+    table.handlers.renderComplete?.[0]?.();
+
+    // No scroll attempted; flag cleared.
+    expect(table.scrollToRow).not.toHaveBeenCalled();
+    expect((plugin as unknown as { skipNextRender: boolean }).skipNextRender).toBe(false);
+  });
+
+  it('captures the middle row in dataSorting (before Tabulator resets scrollTop)', () => {
+    // Build a table with a holder + visible rows so dataSorting can run
+    // _findMiddleVisibleRow successfully.
+    const r1 = makeRow(0, 30);
+    const r2 = makeRow(30, 30);
+    const r3 = makeRow(60, 30);
+    const holder = { getBoundingClientRect: () => rect(0, 100) };
+    const handlers: Record<string, ((...args: unknown[]) => void)[]> = {};
+    const table = {
+      handlers,
+      on: jest.fn((evt: string, fn: (...args: unknown[]) => void) => {
+        (handlers[evt] ??= []).push(fn);
+      }),
+      element: { querySelector: jest.fn(() => holder) },
+      getRows: jest.fn((type?: string) => {
+        if (type === 'visible') return [r1, r2, r3];
+        return [];
+      }),
+      rowManager: { getDisplayRows: () => [] },
+      scrollToRow: jest.fn(() => Promise.resolve()),
+    };
+
+    const plugin = new MiddleRowFocus(table as never);
+    (plugin as unknown as { table: typeof table }).table = table;
+    (plugin as unknown as { options: () => boolean }).options = () => true;
+    plugin.initialize();
+
+    // Sort starts — pre-sort middle row should be captured now (= r2).
+    handlers.dataSorting?.[0]?.();
+    expect((plugin as unknown as { middleRow: unknown }).middleRow).toBe(r2);
+
+    // Tabulator now rebuilds DOM with sorted rows in a different order. If our
+    // dataSorting capture didn't happen, renderStarted would capture the wrong
+    // row. Simulate that by changing the visible set and firing renderStarted —
+    // the guard `!this.middleRow` should make this a no-op.
+    (table.getRows as jest.Mock).mockImplementation((...args: unknown[]) => {
+      if (args[0] === 'visible') return [r3, r2, r1]; // reversed
+      return [];
+    });
+    handlers.renderStarted?.[0]?.();
+    expect((plugin as unknown as { middleRow: unknown }).middleRow).toBe(r2);
+  });
+
+  it('zeros stale paddingTop after filter when scrollTop is less than paddingTop', () => {
+    // Build a holder containing a .tabulator-table child whose style.paddingTop
+    // simulates the inflated value Tabulator's rerenderRows leaves behind.
+    const tableEl = { style: { paddingTop: '120px' } };
+    const holder = {
+      scrollTop: 0,
+      querySelector: jest.fn((sel: string) => (sel === '.tabulator-table' ? tableEl : null)),
+    };
+    const handlers: Record<string, ((...args: unknown[]) => void)[]> = {};
+    const renderer: Record<string, unknown> = { vDomTopPad: 120 };
+    const table = {
+      handlers,
+      on: jest.fn((evt: string, fn: (...args: unknown[]) => void) => {
+        (handlers[evt] ??= []).push(fn);
+      }),
+      element: { querySelector: jest.fn(() => holder) },
+      getRows: jest.fn(() => []),
+      rowManager: { renderer, getDisplayRows: () => [] },
+      scrollToRow: jest.fn(() => Promise.resolve()),
+    };
+
+    const plugin = new MiddleRowFocus(table as never);
+    (plugin as unknown as { table: typeof table }).table = table;
+    (plugin as unknown as { options: () => boolean }).options = () => true;
+    plugin.initialize();
+
+    // Drive the workaround directly (rAF-free) — same code path the rAF schedules.
+    (plugin as unknown as { _resetStaleTopPadding: () => void })._resetStaleTopPadding();
+
+    expect(tableEl.style.paddingTop).toBe('0px');
+    expect(renderer.vDomTopPad).toBe(0);
+  });
+
+  it('captures wasAtTop when the user is at the scroll top', () => {
+    const r1 = makeRow(0, 20);
+    const r2 = makeRow(20, 20);
+    const holder = {
+      scrollTop: 0,
+      scrollHeight: 1000,
+      clientHeight: 100,
+      getBoundingClientRect: () => rect(0, 100),
+    };
+    const handlers: Record<string, ((...args: unknown[]) => void)[]> = {};
+    const table = {
+      handlers,
+      on: jest.fn((evt: string, fn: (...args: unknown[]) => void) => {
+        (handlers[evt] ??= []).push(fn);
+      }),
+      element: { querySelector: jest.fn(() => holder) },
+      getRows: jest.fn((type?: string) => (type === 'visible' ? [r1, r2] : [])),
+      rowManager: { getDisplayRows: () => [] },
+      scrollToRow: jest.fn(() => Promise.resolve()),
+    };
+    const plugin = new MiddleRowFocus(table as never);
+    (plugin as unknown as { table: typeof table }).table = table;
+    (plugin as unknown as { options: () => boolean }).options = () => true;
+    plugin.initialize();
+
+    handlers.renderStarted?.[0]?.();
+
+    expect((plugin as unknown as { wasAtTop: boolean }).wasAtTop).toBe(true);
+    expect((plugin as unknown as { wasAtBottom: boolean }).wasAtBottom).toBe(false);
+  });
+
+  it('captures wasAtBottom when the user is at the scroll bottom', () => {
+    const r1 = makeRow(0, 20);
+    const r2 = makeRow(20, 20);
+    // scrollHeight 1000, clientHeight 100 → max scrollTop = 900.
+    const holder = {
+      scrollTop: 900,
+      scrollHeight: 1000,
+      clientHeight: 100,
+      getBoundingClientRect: () => rect(0, 100),
+    };
+    const handlers: Record<string, ((...args: unknown[]) => void)[]> = {};
+    const table = {
+      handlers,
+      on: jest.fn((evt: string, fn: (...args: unknown[]) => void) => {
+        (handlers[evt] ??= []).push(fn);
+      }),
+      element: { querySelector: jest.fn(() => holder) },
+      getRows: jest.fn((type?: string) => (type === 'visible' ? [r1, r2] : [])),
+      rowManager: { getDisplayRows: () => [] },
+      scrollToRow: jest.fn(() => Promise.resolve()),
+    };
+    const plugin = new MiddleRowFocus(table as never);
+    (plugin as unknown as { table: typeof table }).table = table;
+    (plugin as unknown as { options: () => boolean }).options = () => true;
+    plugin.initialize();
+
+    handlers.renderStarted?.[0]?.();
+
+    expect((plugin as unknown as { wasAtBottom: boolean }).wasAtBottom).toBe(true);
+    expect((plugin as unknown as { wasAtTop: boolean }).wasAtTop).toBe(false);
+  });
+
+  it('on renderComplete with wasAtTop, snaps scrollTop to 0 instead of centering', () => {
+    const holder: { scrollTop: number; scrollHeight: number; clientHeight: number } = {
+      scrollTop: 0,
+      scrollHeight: 1000,
+      clientHeight: 100,
+    };
+    const handlers: Record<string, ((...args: unknown[]) => void)[]> = {};
+    const table = {
+      handlers,
+      on: jest.fn((evt: string, fn: (...args: unknown[]) => void) => {
+        (handlers[evt] ??= []).push(fn);
+      }),
+      element: { querySelector: jest.fn(() => holder) },
+      getRows: jest.fn(() => []),
+      rowManager: { getDisplayRows: () => [] },
+      scrollToRow: jest.fn(() => Promise.resolve()),
+    };
+    const plugin = new MiddleRowFocus(table as never);
+    (plugin as unknown as { table: typeof table }).table = table;
+    (plugin as unknown as { options: () => boolean }).options = () => true;
+    plugin.initialize();
+
+    // Simulate post-snapshot state where wasAtTop is set.
+    (plugin as unknown as { wasAtTop: boolean }).wasAtTop = true;
+    holder.scrollTop = 200; // pretend Tabulator moved scrollTop during render
+    handlers.renderComplete?.[0]?.();
+
+    expect(holder.scrollTop).toBe(0);
+    expect(table.scrollToRow).not.toHaveBeenCalled();
+  });
+
+  it('on renderComplete with wasAtBottom, snaps scrollTop to max instead of centering', () => {
+    const holder: { scrollTop: number; scrollHeight: number; clientHeight: number } = {
+      scrollTop: 0,
+      scrollHeight: 1000,
+      clientHeight: 100,
+    };
+    const handlers: Record<string, ((...args: unknown[]) => void)[]> = {};
+    const table = {
+      handlers,
+      on: jest.fn((evt: string, fn: (...args: unknown[]) => void) => {
+        (handlers[evt] ??= []).push(fn);
+      }),
+      element: { querySelector: jest.fn(() => holder) },
+      getRows: jest.fn(() => []),
+      rowManager: { getDisplayRows: () => [] },
+      scrollToRow: jest.fn(() => Promise.resolve()),
+    };
+    const plugin = new MiddleRowFocus(table as never);
+    (plugin as unknown as { table: typeof table }).table = table;
+    (plugin as unknown as { options: () => boolean }).options = () => true;
+    plugin.initialize();
+
+    (plugin as unknown as { wasAtBottom: boolean }).wasAtBottom = true;
+    handlers.renderComplete?.[0]?.();
+
+    expect(holder.scrollTop).toBe(900); // 1000 - 100
+    expect(table.scrollToRow).not.toHaveBeenCalled();
+  });
+
+  it('does NOT zero paddingTop when scrollTop has accounted for it (legitimate state)', () => {
+    // Mid-table: scrollTop matches paddingTop, meaning the user has genuinely scrolled
+    // past the rows the padding represents. Mitigation must leave this alone.
+    const tableEl = { style: { paddingTop: '500px' } };
+    const holder = {
+      scrollTop: 500,
+      querySelector: jest.fn((sel: string) => (sel === '.tabulator-table' ? tableEl : null)),
+    };
+    const handlers: Record<string, ((...args: unknown[]) => void)[]> = {};
+    const renderer: Record<string, unknown> = { vDomTopPad: 500 };
+    const table = {
+      handlers,
+      on: jest.fn((evt: string, fn: (...args: unknown[]) => void) => {
+        (handlers[evt] ??= []).push(fn);
+      }),
+      element: { querySelector: jest.fn(() => holder) },
+      getRows: jest.fn(() => []),
+      rowManager: { renderer, getDisplayRows: () => [] },
+      scrollToRow: jest.fn(() => Promise.resolve()),
+    };
+
+    const plugin = new MiddleRowFocus(table as never);
+    (plugin as unknown as { table: typeof table }).table = table;
+    (plugin as unknown as { options: () => boolean }).options = () => true;
+    plugin.initialize();
+
+    (plugin as unknown as { _resetStaleTopPadding: () => void })._resetStaleTopPadding();
+
+    expect(tableEl.style.paddingTop).toBe('500px');
+    expect(renderer.vDomTopPad).toBe(500);
+  });
+
+  it('a second toggle in the same burst clears the skip flag (bulk recenter runs)', () => {
+    const { table, plugin } = setup();
+
+    // Synchronous burst — expand-all.
+    table.handlers.dataTreeRowExpanded?.[0]?.();
+    table.handlers.dataTreeRowExpanded?.[0]?.();
+    table.handlers.dataTreeRowExpanded?.[0]?.();
+
+    // After the first toggle skip was armed; subsequent toggles cleared it.
+    expect((plugin as unknown as { skipNextRender: boolean }).skipNextRender).toBe(false);
+    expect((plugin as unknown as { toggleSeenInBurst: boolean }).toggleSeenInBurst).toBe(true);
+  });
+});


### PR DESCRIPTION
# 📝 PR Overview

Improves row-focus behavior so the user's scroll position is preserved across table operations (sort, filter, single tree toggle) instead of always recentering on the middle visible row.

## 🛠️ Changes made

- Capture scroll anchor on `dataSorting` (Tabulator resets `scrollTop` before `renderStarted`, so the previous capture point lost the pre-sort row).
- Anchor boundaries: when the user is at the top or bottom edge before an operation, restore to that edge instead of centering.
- Single tree toggle: skip the next recenter so `scrollTop` stays put. Bulk toggles (expand-all / collapse-all) detect a synchronous burst and run the recenter as before.
- Workaround for Tabulator filter bug where `rerenderRows` leaves `.tabulator-table` `paddingTop` inflated — detect (`scrollTop < paddingTop`) and zero it plus `vDomTopPad` on the next frame.
- Tests covering middle-row math, sort capture, boundary anchoring, single vs. bulk toggle, and the filter padding mitigation.

## 🧩 Type of change (check all applicable)

- [x] 🐛 Bug fix - something not working as expected
- [ ] ✨ New feature – adds new functionality
- [ ] ♻️ Refactor - internal changes with no user impact
- [ ] ⚡ Performance Improvement
- [ ] 📝 Documentation - README or documentation site changes
- [ ] 🔧 Chore - dev tooling, CI, config
- [ ] 💥 Breaking change

## 📷 Screenshots / gifs / video [optional]

_n/a_

## 🔗 Related Issues

fixes #
resolves #
closes #
related #

## ✅ Tests added?

- [x] 👍 yes
- [ ] 🙅 no, not needed
- [ ] 🙋 no, I need help

## 📚 Docs updated?

- [ ] 🔖 README.md
- [ ] 🔖 CHANGELOG.md
- [ ] 📖 help site
- [x] 🙅 not needed

## Anything else we need to know? [optional]

The filter padding fix is a workaround in `MiddleRowFocus` rather than a direct edit to `tabulator_esm.mjs`. See `tabulator-virtual-scroll-fixes.md` "Fix 7" for the related upstream patch context.