### PR TITLE
refactor(ScrollAnchor): pixel-accurate anchor and rename module

### DIFF
--- a/log-viewer/src/features/call-tree/components/AggregatedTable.ts
+++ b/log-viewer/src/features/call-tree/components/AggregatedTable.ts
@@ -41,9 +41,9 @@ export function createAggregatedTable(
     placeholder: 'No Call Tree Available',
     height: '100%',
     maxHeight: '100%',
-    // @ts-expect-error custom property for module/RowKeyboardNavigation + MiddleRowFocus
+    // @ts-expect-error custom property for module/RowKeyboardNavigation + ScrollAnchor
     rowKeyboardNavigation: true,
-    middleRowFocus: true,
+    scrollAnchor: true,
     dataTree: true,
     dataTreeChildColumnCalcs: false,
     dataTreeBranchElement: '<span/>',

--- a/log-viewer/src/features/call-tree/components/BottomUpTable.ts
+++ b/log-viewer/src/features/call-tree/components/BottomUpTable.ts
@@ -94,7 +94,7 @@ export function createBottomUpTable(
     height: '100%',
     maxHeight: '100%',
     rowKeyboardNavigation: true,
-    middleRowFocus: true,
+    scrollAnchor: true,
     dataTree: true,
     dataTreeChildColumnCalcs: false,
     dataTreeBranchElement: '<span/>',

--- a/log-viewer/src/features/call-tree/components/TableShared.ts
+++ b/log-viewer/src/features/call-tree/components/TableShared.ts
@@ -5,9 +5,9 @@ import { Tabulator } from 'tabulator-tables';
 
 import * as CommonModules from '../../../tabulator/module/CommonModules.js';
 import { Find } from '../../../tabulator/module/Find.js';
-import { MiddleRowFocus } from '../../../tabulator/module/MiddleRowFocus.js';
 import { RowKeyboardNavigation } from '../../../tabulator/module/RowKeyboardNavigation.js';
 import { RowNavigation } from '../../../tabulator/module/RowNavigation.js';
+import { ScrollAnchor } from '../../../tabulator/module/ScrollAnchor.js';
 import type { AggregatedRow, BottomUpRow } from '../utils/Aggregation.js';
 import type { MergedCalltreeRow } from '../utils/MergeAdjacent.js';
 
@@ -24,7 +24,7 @@ export interface TableCallbacks {
 
 export function registerTableModules(): void {
   Tabulator.registerModule(Object.values(CommonModules));
-  Tabulator.registerModule([RowKeyboardNavigation, RowNavigation, MiddleRowFocus, Find]);
+  Tabulator.registerModule([RowKeyboardNavigation, RowNavigation, ScrollAnchor, Find]);
 }
 
 export function headerSortElement(_column: unknown, dir: string): string {

--- a/log-viewer/src/features/call-tree/components/TimeOrderTable.ts
+++ b/log-viewer/src/features/call-tree/components/TimeOrderTable.ts
@@ -53,8 +53,8 @@ export function createTimeOrderTable(
     maxHeight: '100%',
     //  custom property for datagrid/module/RowKeyboardNavigation
     rowKeyboardNavigation: true,
-    //  custom property for module/MiddleRowFocus
-    middleRowFocus: true,
+    //  custom property for module/ScrollAnchor
+    scrollAnchor: true,
     dataTree: true,
     dataTreeChildColumnCalcs: false,
     dataTreeBranchElement: '<span/>',

--- a/log-viewer/src/tabulator/module/ScrollAnchor.ts
+++ b/log-viewer/src/tabulator/module/ScrollAnchor.ts
@@ -6,19 +6,24 @@ import { Module, type RowComponent, type Tabulator } from 'tabulator-tables';
 
 type TimedNodeProp = { originalData: LogEvent };
 
-const middleRowFocusOption = 'middleRowFocus' as const;
+const scrollAnchorOption = 'scrollAnchor' as const;
+
 /**
- * Enable MiddleRowFocus by importing the class and calling
- * Tabulator.registerModule(MiddleRowFocus); before the first instantiation of the table.
- * Then enable by setting middleRowFocus to true in table config.
- * To disable RowNavigation set middleRowFocus to false in table options.
+ * Pixel-accurate scroll anchoring across table re-renders.
+ *
+ * Capture (renderStarted / dataSorting): the middle visible row and its Y offset
+ * inside the holder. Restore (renderComplete, fully synchronous): set scrollTop
+ * so the same row sits at the same pixel — no visible jump.
+ *
+ * Enable by registering the module and setting `scrollAnchor: true` in table options.
  */
-export class MiddleRowFocus extends Module {
-  static moduleName = 'middleRowFocus';
+export class ScrollAnchor extends Module {
+  static moduleName = 'scrollAnchor';
 
   tableHolder: HTMLElement | null = null;
   private tableEl: HTMLElement | null = null;
-  middleRow: RowComponent | null = null;
+  anchorRow: RowComponent | null = null;
+  private anchorOffsetFromHolderTop = 0;
   private pendingFilterRaf: number | null = null;
 
   // Single tree toggle: skip the next renderComplete recenter so scrollTop stays put.
@@ -28,29 +33,28 @@ export class MiddleRowFocus extends Module {
   private toggleSeenInBurst = false;
 
   // Boundary anchoring: when the user is at the top or bottom of the scroll range
-  // before an operation, recentering on the middle row pushes them away from the
-  // edge they were at. Capture the boundary at snapshot time and restore it
-  // (scrollTop = 0 / scrollHeight - clientHeight) instead of centering.
+  // before an operation, recentering pushes them away from the edge they were at.
+  // Capture the boundary at snapshot time and restore it instead of pixel-anchoring.
   private static readonly boundaryThresholdPx = 10;
   private wasAtTop = false;
   private wasAtBottom = false;
 
   constructor(table: Tabulator) {
     super(table);
-    this.registerTableOption(middleRowFocusOption, false);
+    this.registerTableOption(scrollAnchorOption, false);
   }
 
   initialize() {
     // @ts-expect-error not in types
-    if (this.options(middleRowFocusOption)) {
+    if (this.options(scrollAnchorOption)) {
       this.tableHolder = this.table.element.querySelector('.tabulator-tableholder');
 
       this.table.on('dataTreeRowExpanded', () => this._onTreeToggle());
       this.table.on('dataTreeRowCollapsed', () => this._onTreeToggle());
 
       // Sort resets scrollTop before renderStarted fires, so capture the anchor here
-      // (pre-sort) instead. The renderStarted handler below is a no-op once middleRow
-      // is set — see the !this.middleRow guard.
+      // (pre-sort) instead. The renderStarted handler below is a no-op once anchorRow
+      // is set — see the !this.anchorRow guard.
       this.table.on('dataSorting', () => this._captureAnchor());
 
       this.table.on('renderStarted', () => this._captureAnchor());
@@ -69,7 +73,7 @@ export class MiddleRowFocus extends Module {
         });
       });
 
-      this.table.on('renderComplete', async () => {
+      this.table.on('renderComplete', () => {
         if (this.skipNextRender) {
           this.skipNextRender = false;
           this._clearAnchor();
@@ -82,24 +86,34 @@ export class MiddleRowFocus extends Module {
   }
 
   /**
-   * Capture the user's scroll anchor: the row at the visual middle and whether
-   * the user was at the top / bottom edge. Idempotent within one operation —
-   * subsequent calls are no-ops once an anchor is already set.
+   * Capture the user's scroll anchor: the middle visible row, its Y offset inside
+   * the holder, and whether the user was at the top / bottom edge. Idempotent
+   * within one operation — subsequent calls are no-ops once an anchor is set.
    */
   private _captureAnchor() {
-    if (!this.tableHolder || this.middleRow) {
+    if (!this.tableHolder || this.anchorRow) {
       return;
     }
     const holder = this.tableHolder;
     const max = Math.max(0, holder.scrollHeight - holder.clientHeight);
-    this.wasAtTop = holder.scrollTop <= MiddleRowFocus.boundaryThresholdPx;
-    this.wasAtBottom = max - holder.scrollTop <= MiddleRowFocus.boundaryThresholdPx;
-    this.middleRow = this._findMiddleVisibleRow(holder);
+    this.wasAtTop = holder.scrollTop <= ScrollAnchor.boundaryThresholdPx;
+    this.wasAtBottom = max - holder.scrollTop <= ScrollAnchor.boundaryThresholdPx;
+
+    const row = this._findMiddleVisibleRow(holder);
+    this.anchorRow = row;
+    if (row) {
+      const rowRect = row.getElement().getBoundingClientRect();
+      const holderRect = holder.getBoundingClientRect();
+      this.anchorOffsetFromHolderTop = rowRect.top - holderRect.top;
+    } else {
+      this.anchorOffsetFromHolderTop = 0;
+    }
   }
 
   /**
-   * Restore the captured anchor. Boundary cases (was-at-top / was-at-bottom) snap
-   * to the edge so we don't push the user off it. Mid-table centers on middleRow.
+   * Restore the captured anchor synchronously. Boundary cases (was-at-top /
+   * was-at-bottom) snap to the edge. Mid-table sets scrollTop so the anchor row
+   * sits at exactly the same Y pixel it occupied pre-render — no flash.
    */
   private _restoreAnchor() {
     const holder = this.tableHolder;
@@ -112,15 +126,84 @@ export class MiddleRowFocus extends Module {
     } else if (this.wasAtBottom) {
       holder.scrollTop = Math.max(0, holder.scrollHeight - holder.clientHeight);
     } else {
-      this._scrollToRow(this.middleRow);
+      this._anchorPixelAccurate(holder);
     }
     this._clearAnchor();
   }
 
   private _clearAnchor() {
-    this.middleRow = null;
+    this.anchorRow = null;
+    this.anchorOffsetFromHolderTop = 0;
     this.wasAtTop = false;
     this.wasAtBottom = false;
+  }
+
+  /**
+   * Synchronous, pixel-accurate scroll anchor restore.
+   *
+   * 1. Resolve which row to anchor on post-render. If the original anchor row is
+   *    still in the display set, use it. Otherwise fall back to the nearest
+   *    still-active row by timestamp (rows above us could have been added or
+   *    removed; the literal anchor row could have been filtered/collapsed away).
+   * 2. Make sure the row is in the virtual DOM window so its `offsetTop` is
+   *    meaningful — call Tabulator's private `_virtualRenderFill` to refill the
+   *    vDom centered on the row index. Same hook the public `scrollToRow` uses.
+   * 3. Set `scrollTop = rowEl.offsetTop - anchorOffsetFromHolderTop`. Both DOM
+   *    writes happen in the same JS turn as `renderComplete`, so the browser
+   *    paints the corrected scroll position directly — no intermediate frame.
+   */
+  private _anchorPixelAccurate(holder: HTMLElement) {
+    const row = this._resolveAnchorRow();
+    if (!row) {
+      return;
+    }
+
+    const renderer = this.table.rowManager?.renderer as
+      | { rows?: () => unknown[]; _virtualRenderFill?: (index: number, force?: boolean) => void }
+      | undefined;
+
+    // Tabulator's private internal row (Row, not RowComponent) is what the renderer
+    // indexes. We need that index to refill the vDom window around it.
+    // @ts-expect-error _getSelf is private to tabulator, but we have no other choice atm.
+    const internalRow = row._getSelf() as unknown;
+    if (renderer?.rows && renderer._virtualRenderFill) {
+      const rows = renderer.rows();
+      const index = rows.indexOf(internalRow);
+      if (index > -1) {
+        renderer._virtualRenderFill(index, true);
+      }
+    }
+
+    const rowEl = row.getElement();
+    if (!rowEl) {
+      return;
+    }
+    holder.scrollTop = Math.max(0, rowEl.offsetTop - this.anchorOffsetFromHolderTop);
+  }
+
+  /**
+   * Pick the row to anchor on after the render. Prefer the originally captured
+   * row; if it has been filtered/collapsed away, fall back to the nearest active
+   * row by timestamp so the user keeps their place.
+   */
+  private _resolveAnchorRow(): RowComponent | null {
+    const row = this.anchorRow;
+    if (!row) {
+      return null;
+    }
+    const displayRows = this.table.rowManager.getDisplayRows();
+    // @ts-expect-error _getSelf is private to tabulator, but we have no other choice atm.
+    const internalRow = row._getSelf();
+    if (displayRows.indexOf(internalRow) !== -1) {
+      return row;
+    }
+
+    const data = row.getData() as TimedNodeProp;
+    const timestamp = data?.originalData?.timestamp;
+    if (timestamp === undefined) {
+      return null;
+    }
+    return this._findClosestActive(this.table.getRows('active'), timestamp);
   }
 
   /**
@@ -157,46 +240,12 @@ export class MiddleRowFocus extends Module {
 
   private _onTreeToggle() {
     if (!this.toggleSeenInBurst) {
-      // First toggle in this burst: assume single, arm the skip.
       this.toggleSeenInBurst = true;
       this.skipNextRender = true;
     } else {
-      // A second toggle arrived synchronously => it's a bulk operation; let the
-      // existing recenter run so the user's middle row stays in view.
       this.skipNextRender = false;
     }
-    // Clear the anchor so renderStarted captures fresh (with up-to-date boundary flags).
     this._clearAnchor();
-  }
-
-  private _scrollToRow(row: RowComponent | null) {
-    if (!row) {
-      return;
-    }
-
-    let rowToScrollTo: RowComponent | null = row;
-    if (rowToScrollTo?.getData) {
-      const displayRows = this.table.rowManager.getDisplayRows();
-      //@ts-expect-error This is private to tabulator, but we have no other choice atm.
-      const internalRow = rowToScrollTo._getSelf();
-      const canScroll = displayRows.indexOf(internalRow) !== -1;
-      if (!canScroll) {
-        const rowData = rowToScrollTo.getData() as TimedNodeProp;
-        const node = rowData.originalData;
-
-        rowToScrollTo = this._findClosestActive(this.table.getRows('active'), node.timestamp);
-      }
-
-      if (rowToScrollTo) {
-        this.table.scrollToRow(rowToScrollTo, 'center', true).then(() => {
-          setTimeout(() => {
-            rowToScrollTo
-              ?.getElement()
-              .scrollIntoView({ behavior: 'auto', block: 'center', inline: 'start' });
-          });
-        });
-      }
-    }
   }
 
   private _findClosestActive(rows: RowComponent[], timeStamp: number): RowComponent | null {
@@ -207,10 +256,8 @@ export class MiddleRowFocus extends Module {
     let start = 0,
       end = rows.length - 1;
 
-    // Iterate as long as the beginning does not encounter the end.
     const displayRows = this.table.rowManager.getDisplayRows();
     while (start <= end) {
-      // find out the middle index
       const mid = Math.floor((start + end) / 2);
       const row = rows[mid];
 
@@ -221,7 +268,7 @@ export class MiddleRowFocus extends Module {
       const endTime = node.exitStamp ?? node.timestamp;
 
       if (timeStamp === node.timestamp) {
-        //@ts-expect-error This is private to tabulator, but we have no other choice atm.
+        // @ts-expect-error This is private to tabulator, but we have no other choice atm.
         const internalRow = row._getSelf();
         const isActive = displayRows.indexOf(internalRow) !== -1;
         if (isActive) {
@@ -235,9 +282,7 @@ export class MiddleRowFocus extends Module {
           return childMatch;
         }
         return this._findClosestActiveSibling(mid, rows, displayRows);
-      }
-      // Otherwise, look in the left or right half
-      else if (timeStamp > endTime) {
+      } else if (timeStamp > endTime) {
         start = mid + 1;
       } else if (timeStamp < node.timestamp) {
         end = mid - 1;
@@ -263,7 +308,7 @@ export class MiddleRowFocus extends Module {
       if (!previousVisible) {
         continue;
       }
-      //@ts-expect-error This is private to tabulator, but we have no other choice atm.
+      // @ts-expect-error This is private to tabulator, but we have no other choice atm.
       const internalRow = previousVisible._getSelf();
       const isActive = activeRows.indexOf(internalRow) !== -1;
       if (previousVisible && isActive) {
@@ -285,7 +330,7 @@ export class MiddleRowFocus extends Module {
         continue;
       }
 
-      //@ts-expect-error This is private to tabulator, but we have no other choice atm.
+      // @ts-expect-error This is private to tabulator, but we have no other choice atm.
       const internalRow = nextVisible._getSelf();
       const isActive = activeRows.indexOf(internalRow) !== -1;
       if (nextVisible && isActive) {

--- a/log-viewer/src/tabulator/module/ScrollAnchor.ts
+++ b/log-viewer/src/tabulator/module/ScrollAnchor.ts
@@ -1,10 +1,7 @@
 /*
  * Copyright (c) 2024 Certinia Inc. All rights reserved.
  */
-import type { LogEvent } from 'apex-log-parser';
 import { Module, type RowComponent, type Tabulator } from 'tabulator-tables';
-
-type TimedNodeProp = { originalData: LogEvent };
 
 const scrollAnchorOption = 'scrollAnchor' as const;
 
@@ -24,6 +21,7 @@ export class ScrollAnchor extends Module {
   private tableEl: HTMLElement | null = null;
   anchorRow: RowComponent | null = null;
   private anchorOffsetFromHolderTop = 0;
+  private anchorDisplayIndex = -1;
   private pendingFilterRaf: number | null = null;
 
   // Single tree toggle: skip the next renderComplete recenter so scrollTop stays put.
@@ -106,6 +104,8 @@ export class ScrollAnchor extends Module {
       // scrollTop gives the row's Y position inside the holder viewport — same
       // result as paired getBoundingClientRect calls without forcing layout reads.
       this.anchorOffsetFromHolderTop = row.getElement().offsetTop - holder.scrollTop;
+      // @ts-expect-error _getSelf is private to tabulator, but we have no other choice atm.
+      this.anchorDisplayIndex = this.table.rowManager.getDisplayRows().indexOf(row._getSelf());
     }
   }
 
@@ -133,6 +133,7 @@ export class ScrollAnchor extends Module {
   private _clearAnchor() {
     this.anchorRow = null;
     this.anchorOffsetFromHolderTop = 0;
+    this.anchorDisplayIndex = -1;
     this.wasAtTop = false;
     this.wasAtBottom = false;
   }
@@ -173,9 +174,9 @@ export class ScrollAnchor extends Module {
   }
 
   /**
-   * Pick the row to anchor on after the render. Prefer the originally captured
-   * row; if it has been filtered/collapsed away, fall back to the nearest active
-   * row by timestamp so the user keeps their place.
+   * Resolve the anchor row in the post-render display set. If it was filtered
+   * or collapsed away, fall back to the nearest displayed tree ancestor, then
+   * to the row at the captured display-index clamped to the new display length.
    */
   private _resolveAnchorRow(): RowComponent | null {
     const row = this.anchorRow;
@@ -187,11 +188,23 @@ export class ScrollAnchor extends Module {
       return row;
     }
 
-    const timestamp = (row.getData() as TimedNodeProp).originalData?.timestamp;
-    if (timestamp === undefined) {
-      return null;
+    let parent = row.getTreeParent();
+    while (parent) {
+      if (this._isRowActive(parent, displayRows)) {
+        return parent;
+      }
+      parent = parent.getTreeParent();
     }
-    return this._findClosestActive(this.table.getRows('active'), timestamp, displayRows);
+
+    if (this.anchorDisplayIndex >= 0 && displayRows.length > 0) {
+      const idx = Math.min(this.anchorDisplayIndex, displayRows.length - 1);
+      const internalRow = displayRows[idx];
+      if (internalRow) {
+        return (internalRow as unknown as { getComponent: () => RowComponent }).getComponent();
+      }
+    }
+
+    return null;
   }
 
   private _isRowActive(row: RowComponent, displayRows: RowComponent[]): boolean {
@@ -240,104 +253,6 @@ export class ScrollAnchor extends Module {
       this.skipNextRender = false;
     }
     this._clearAnchor();
-  }
-
-  private _findClosestActive(
-    rows: RowComponent[],
-    timeStamp: number,
-    displayRows: RowComponent[] = this.table.rowManager.getDisplayRows(),
-  ): RowComponent | null {
-    if (!rows) {
-      return null;
-    }
-
-    let start = 0,
-      end = rows.length - 1;
-
-    while (start <= end) {
-      const mid = Math.floor((start + end) / 2);
-      const row = rows[mid];
-
-      if (!row) {
-        break;
-      }
-      const node = (row.getData() as TimedNodeProp).originalData;
-      const endTime = node.exitStamp ?? node.timestamp;
-
-      if (timeStamp === node.timestamp) {
-        if (this._isRowActive(row, displayRows)) {
-          return row;
-        }
-
-        return this._findClosestActiveSibling(mid, rows, displayRows);
-      } else if (timeStamp >= node.timestamp && timeStamp <= endTime) {
-        const childMatch = this._findClosestActive(
-          row.getTreeChildren() ?? [],
-          timeStamp,
-          displayRows,
-        );
-        if (childMatch) {
-          return childMatch;
-        }
-        return this._findClosestActiveSibling(mid, rows, displayRows);
-      } else if (timeStamp > endTime) {
-        start = mid + 1;
-      } else if (timeStamp < node.timestamp) {
-        end = mid - 1;
-      } else {
-        return null;
-      }
-    }
-
-    return null;
-  }
-
-  private _findClosestActiveSibling(
-    midIndex: number,
-    rows: RowComponent[],
-    activeRows: RowComponent[],
-  ) {
-    const indexes = [];
-
-    let previousIndex = midIndex;
-    let previousVisible;
-    while (previousIndex >= 0) {
-      previousVisible = rows[previousIndex];
-      if (!previousVisible) {
-        continue;
-      }
-      if (this._isRowActive(previousVisible, activeRows)) {
-        indexes.push(previousIndex);
-        break;
-      }
-
-      previousIndex--;
-    }
-
-    const distanceFromMid = previousIndex > -1 ? midIndex - previousIndex : midIndex;
-
-    const len = rows.length;
-    let nextIndex = midIndex;
-    let nextVisible;
-    while (nextIndex >= 0 && nextIndex !== len && nextIndex - midIndex < distanceFromMid) {
-      nextVisible = rows[nextIndex];
-      if (!nextVisible) {
-        continue;
-      }
-      if (this._isRowActive(nextVisible, activeRows)) {
-        indexes.push(nextIndex);
-        break;
-      }
-      nextIndex++;
-    }
-
-    const closestIndex = indexes.length
-      ? indexes.reduce((a, b) => {
-          return Math.abs(b - midIndex) < Math.abs(a - midIndex) ? b : a;
-        })
-      : null;
-
-    return closestIndex ? rows[closestIndex] || null : null;
   }
 
   private _findMiddleVisibleRow(tableHolder: HTMLElement) {

--- a/log-viewer/src/tabulator/module/ScrollAnchor.ts
+++ b/log-viewer/src/tabulator/module/ScrollAnchor.ts
@@ -102,11 +102,10 @@ export class ScrollAnchor extends Module {
     const row = this._findMiddleVisibleRow(holder);
     this.anchorRow = row;
     if (row) {
-      const rowRect = row.getElement().getBoundingClientRect();
-      const holderRect = holder.getBoundingClientRect();
-      this.anchorOffsetFromHolderTop = rowRect.top - holderRect.top;
-    } else {
-      this.anchorOffsetFromHolderTop = 0;
+      // offsetTop is relative to the offsetParent (.tabulator-table); subtracting
+      // scrollTop gives the row's Y position inside the holder viewport — same
+      // result as paired getBoundingClientRect calls without forcing layout reads.
+      this.anchorOffsetFromHolderTop = row.getElement().offsetTop - holder.scrollTop;
     }
   }
 
@@ -141,16 +140,11 @@ export class ScrollAnchor extends Module {
   /**
    * Synchronous, pixel-accurate scroll anchor restore.
    *
-   * 1. Resolve which row to anchor on post-render. If the original anchor row is
-   *    still in the display set, use it. Otherwise fall back to the nearest
-   *    still-active row by timestamp (rows above us could have been added or
-   *    removed; the literal anchor row could have been filtered/collapsed away).
-   * 2. Make sure the row is in the virtual DOM window so its `offsetTop` is
-   *    meaningful — call Tabulator's private `_virtualRenderFill` to refill the
-   *    vDom centered on the row index. Same hook the public `scrollToRow` uses.
-   * 3. Set `scrollTop = rowEl.offsetTop - anchorOffsetFromHolderTop`. Both DOM
-   *    writes happen in the same JS turn as `renderComplete`, so the browser
-   *    paints the corrected scroll position directly — no intermediate frame.
+   * If the anchor row is outside the post-render virtual DOM window its element
+   * is detached and `offsetTop` is stale. Call Tabulator's private
+   * `_virtualRenderFill` (same hook the public `scrollToRow` uses) to refill the
+   * vDom centered on the row, then set scrollTop in the same JS turn as
+   * renderComplete — the browser paints the corrected position directly.
    */
   private _anchorPixelAccurate(holder: HTMLElement) {
     const row = this._resolveAnchorRow();
@@ -158,26 +152,23 @@ export class ScrollAnchor extends Module {
       return;
     }
 
-    const renderer = this.table.rowManager?.renderer as
-      | { rows?: () => unknown[]; _virtualRenderFill?: (index: number, force?: boolean) => void }
-      | undefined;
-
-    // Tabulator's private internal row (Row, not RowComponent) is what the renderer
-    // indexes. We need that index to refill the vDom window around it.
-    // @ts-expect-error _getSelf is private to tabulator, but we have no other choice atm.
-    const internalRow = row._getSelf() as unknown;
-    if (renderer?.rows && renderer._virtualRenderFill) {
-      const rows = renderer.rows();
-      const index = rows.indexOf(internalRow);
-      if (index > -1) {
-        renderer._virtualRenderFill(index, true);
+    const rowEl = row.getElement();
+    if (!rowEl.isConnected) {
+      const renderer = this.table.rowManager.renderer as Record<string, unknown> | undefined;
+      // @ts-expect-error _getSelf is private to tabulator, but we have no other choice atm.
+      const internalRow = row._getSelf() as unknown;
+      const rendererRows = (renderer?.rows as (() => unknown[]) | undefined)?.();
+      const fill = renderer?._virtualRenderFill as
+        | ((index: number, force?: boolean) => void)
+        | undefined;
+      if (rendererRows && fill) {
+        const index = rendererRows.indexOf(internalRow);
+        if (index > -1) {
+          fill.call(renderer, index, true);
+        }
       }
     }
 
-    const rowEl = row.getElement();
-    if (!rowEl) {
-      return;
-    }
     holder.scrollTop = Math.max(0, rowEl.offsetTop - this.anchorOffsetFromHolderTop);
   }
 
@@ -192,18 +183,21 @@ export class ScrollAnchor extends Module {
       return null;
     }
     const displayRows = this.table.rowManager.getDisplayRows();
-    // @ts-expect-error _getSelf is private to tabulator, but we have no other choice atm.
-    const internalRow = row._getSelf();
-    if (displayRows.indexOf(internalRow) !== -1) {
+    if (this._isRowActive(row, displayRows)) {
       return row;
     }
 
-    const data = row.getData() as TimedNodeProp;
-    const timestamp = data?.originalData?.timestamp;
+    const timestamp = (row.getData() as TimedNodeProp).originalData?.timestamp;
     if (timestamp === undefined) {
       return null;
     }
-    return this._findClosestActive(this.table.getRows('active'), timestamp);
+    return this._findClosestActive(this.table.getRows('active'), timestamp, displayRows);
+  }
+
+  private _isRowActive(row: RowComponent, displayRows: RowComponent[]): boolean {
+    // @ts-expect-error _getSelf is private to tabulator, but we have no other choice atm.
+    const internalRow = row._getSelf();
+    return displayRows.indexOf(internalRow) !== -1;
   }
 
   /**
@@ -248,7 +242,11 @@ export class ScrollAnchor extends Module {
     this._clearAnchor();
   }
 
-  private _findClosestActive(rows: RowComponent[], timeStamp: number): RowComponent | null {
+  private _findClosestActive(
+    rows: RowComponent[],
+    timeStamp: number,
+    displayRows: RowComponent[] = this.table.rowManager.getDisplayRows(),
+  ): RowComponent | null {
     if (!rows) {
       return null;
     }
@@ -256,7 +254,6 @@ export class ScrollAnchor extends Module {
     let start = 0,
       end = rows.length - 1;
 
-    const displayRows = this.table.rowManager.getDisplayRows();
     while (start <= end) {
       const mid = Math.floor((start + end) / 2);
       const row = rows[mid];
@@ -268,16 +265,17 @@ export class ScrollAnchor extends Module {
       const endTime = node.exitStamp ?? node.timestamp;
 
       if (timeStamp === node.timestamp) {
-        // @ts-expect-error This is private to tabulator, but we have no other choice atm.
-        const internalRow = row._getSelf();
-        const isActive = displayRows.indexOf(internalRow) !== -1;
-        if (isActive) {
+        if (this._isRowActive(row, displayRows)) {
           return row;
         }
 
         return this._findClosestActiveSibling(mid, rows, displayRows);
       } else if (timeStamp >= node.timestamp && timeStamp <= endTime) {
-        const childMatch = this._findClosestActive(row.getTreeChildren() ?? [], timeStamp);
+        const childMatch = this._findClosestActive(
+          row.getTreeChildren() ?? [],
+          timeStamp,
+          displayRows,
+        );
         if (childMatch) {
           return childMatch;
         }
@@ -308,10 +306,7 @@ export class ScrollAnchor extends Module {
       if (!previousVisible) {
         continue;
       }
-      // @ts-expect-error This is private to tabulator, but we have no other choice atm.
-      const internalRow = previousVisible._getSelf();
-      const isActive = activeRows.indexOf(internalRow) !== -1;
-      if (previousVisible && isActive) {
+      if (this._isRowActive(previousVisible, activeRows)) {
         indexes.push(previousIndex);
         break;
       }
@@ -329,11 +324,7 @@ export class ScrollAnchor extends Module {
       if (!nextVisible) {
         continue;
       }
-
-      // @ts-expect-error This is private to tabulator, but we have no other choice atm.
-      const internalRow = nextVisible._getSelf();
-      const isActive = activeRows.indexOf(internalRow) !== -1;
-      if (nextVisible && isActive) {
+      if (this._isRowActive(nextVisible, activeRows)) {
         indexes.push(nextIndex);
         break;
       }

--- a/log-viewer/src/tabulator/module/__tests__/ScrollAnchor.test.ts
+++ b/log-viewer/src/tabulator/module/__tests__/ScrollAnchor.test.ts
@@ -325,10 +325,14 @@ describe('ScrollAnchor', () => {
   });
 
   it('captures the anchor offset within the holder for pixel-accurate restore', () => {
-    // Holder top at y=50, anchor row top at y=80 → offset 30. r1 too small to be middle;
-    // r2 covers half-height first.
-    const r1 = makeRow(50, 20);
-    const r2 = makeRow(80, 40);
+    // Anchor row offsetTop=130, holder.scrollTop=100 → captured offset = 30 (the
+    // row's Y position inside the visible holder viewport).
+    const r1 = {
+      getElement: () => ({ offsetTop: 100, getBoundingClientRect: () => rect(50, 20) }),
+    };
+    const r2 = {
+      getElement: () => ({ offsetTop: 130, getBoundingClientRect: () => rect(80, 40) }),
+    };
     const holder = {
       scrollTop: 100,
       scrollHeight: 1000,

--- a/log-viewer/src/tabulator/module/__tests__/ScrollAnchor.test.ts
+++ b/log-viewer/src/tabulator/module/__tests__/ScrollAnchor.test.ts
@@ -16,8 +16,10 @@ function rect(top: number, height: number) {
 }
 
 function makeRow(top: number, height = 20) {
+  const internal = {};
   return {
     getElement: () => ({ getBoundingClientRect: () => rect(top, height) }),
+    _getSelf: () => internal,
   };
 }
 
@@ -327,11 +329,15 @@ describe('ScrollAnchor', () => {
   it('captures the anchor offset within the holder for pixel-accurate restore', () => {
     // Anchor row offsetTop=130, holder.scrollTop=100 → captured offset = 30 (the
     // row's Y position inside the visible holder viewport).
+    const r1Internal = {};
+    const r2Internal = {};
     const r1 = {
       getElement: () => ({ offsetTop: 100, getBoundingClientRect: () => rect(50, 20) }),
+      _getSelf: () => r1Internal,
     };
     const r2 = {
       getElement: () => ({ offsetTop: 130, getBoundingClientRect: () => rect(80, 40) }),
+      _getSelf: () => r2Internal,
     };
     const holder = {
       scrollTop: 100,
@@ -423,5 +429,98 @@ describe('ScrollAnchor', () => {
     expect(renderer._virtualRenderFill).toHaveBeenCalledWith(0, true);
     expect(holder.scrollTop).toBe(470);
     expect(table.scrollToRow).not.toHaveBeenCalled();
+  });
+
+  it('fallback: collapse case walks up getTreeParent to the nearest displayed ancestor', () => {
+    // Anchor row was a child collapsed under a parent. Parent is displayed.
+    const parentInternal = {};
+    const childInternal = {};
+    const parentComponent = {
+      _getSelf: () => parentInternal,
+      getTreeParent: () => false,
+    };
+    const childComponent = {
+      _getSelf: () => childInternal,
+      getTreeParent: () => parentComponent,
+    };
+    const { table, plugin } = setup();
+    table.rowManager.getDisplayRows = () => [parentInternal] as never;
+
+    const p = plugin as unknown as { anchorRow: unknown };
+    p.anchorRow = childComponent;
+
+    const resolved = (
+      plugin as unknown as { _resolveAnchorRow: () => unknown }
+    )._resolveAnchorRow();
+    expect(resolved).toBe(parentComponent);
+  });
+
+  it('fallback: filter case picks the row at the captured display-rows index (clamped)', () => {
+    // Anchor row was at display-index 50 pre-render. Post-render display set has
+    // only 10 rows (filter removed most). Index clamped to 9 (length - 1).
+    const internalRows = Array.from({ length: 10 }, (_, i) => ({ id: i }));
+    const expectedComponent = { mark: 'expected' };
+    (internalRows[9] as unknown as { getComponent: () => unknown }).getComponent = () =>
+      expectedComponent;
+
+    const anchorInternal = {};
+    const anchorComponent = {
+      _getSelf: () => anchorInternal,
+      getTreeParent: () => false,
+    };
+    const { table, plugin } = setup();
+    table.rowManager.getDisplayRows = () => internalRows as never;
+
+    const p = plugin as unknown as { anchorRow: unknown; anchorDisplayIndex: number };
+    p.anchorRow = anchorComponent;
+    p.anchorDisplayIndex = 50;
+
+    const resolved = (
+      plugin as unknown as { _resolveAnchorRow: () => unknown }
+    )._resolveAnchorRow();
+    expect(resolved).toBe(expectedComponent);
+  });
+
+  it('fallback: filter case with exact index returns the row at that index', () => {
+    const internalRows = Array.from({ length: 100 }, (_, i) => ({ id: i }));
+    const expectedComponent = { mark: 'at-30' };
+    (internalRows[30] as unknown as { getComponent: () => unknown }).getComponent = () =>
+      expectedComponent;
+
+    const anchorInternal = {};
+    const anchorComponent = {
+      _getSelf: () => anchorInternal,
+      getTreeParent: () => false,
+    };
+    const { table, plugin } = setup();
+    table.rowManager.getDisplayRows = () => internalRows as never;
+
+    const p = plugin as unknown as { anchorRow: unknown; anchorDisplayIndex: number };
+    p.anchorRow = anchorComponent;
+    p.anchorDisplayIndex = 30;
+
+    const resolved = (
+      plugin as unknown as { _resolveAnchorRow: () => unknown }
+    )._resolveAnchorRow();
+    expect(resolved).toBe(expectedComponent);
+  });
+
+  it('fallback: returns null when no parent is displayed and display rows are empty', () => {
+    const anchorInternal = {};
+    const anchorComponent = {
+      _getSelf: () => anchorInternal,
+      getTreeParent: () => false,
+    };
+    const { table, plugin } = setup();
+    table.rowManager.getDisplayRows = () => [] as never;
+
+    const p = plugin as unknown as { anchorRow: unknown; anchorDisplayIndex: number };
+    p.anchorRow = anchorComponent;
+    p.anchorDisplayIndex = 5;
+
+    const resolved = (
+      plugin as unknown as { _resolveAnchorRow: () => unknown }
+    )._resolveAnchorRow();
+    expect(resolved).toBeNull();
   });
 });

--- a/log-viewer/src/tabulator/module/__tests__/ScrollAnchor.test.ts
+++ b/log-viewer/src/tabulator/module/__tests__/ScrollAnchor.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, jest } from '@jest/globals';
-import { MiddleRowFocus } from '../MiddleRowFocus';
+import { ScrollAnchor } from '../ScrollAnchor';
 
 function rect(top: number, height: number) {
   return {
@@ -37,14 +37,14 @@ function makeBareTable() {
 
 function setup() {
   const table = makeBareTable();
-  const plugin = new MiddleRowFocus(table as never);
+  const plugin = new ScrollAnchor(table as never);
   (plugin as unknown as { table: typeof table }).table = table;
   (plugin as unknown as { options: () => boolean }).options = () => true;
   plugin.initialize();
   return { plugin, table };
 }
 
-describe('MiddleRowFocus', () => {
+describe('ScrollAnchor', () => {
   it('returns the row whose cumulative visible height first crosses half of the holder height', () => {
     // holder height 100, target 50. r1 contributes 30 (running 30), r2 contributes 30
     // (running 60 — first row at/over 50), r3 never reached.
@@ -62,7 +62,7 @@ describe('MiddleRowFocus', () => {
       }),
     };
 
-    const plugin = new MiddleRowFocus(table as never);
+    const plugin = new ScrollAnchor(table as never);
     (plugin as unknown as { table: typeof table }).table = table;
 
     const found = (
@@ -110,30 +110,28 @@ describe('MiddleRowFocus', () => {
       scrollToRow: jest.fn(() => Promise.resolve()),
     };
 
-    const plugin = new MiddleRowFocus(table as never);
+    const plugin = new ScrollAnchor(table as never);
     (plugin as unknown as { table: typeof table }).table = table;
     (plugin as unknown as { options: () => boolean }).options = () => true;
     plugin.initialize();
 
     // Sort starts — pre-sort middle row should be captured now (= r2).
     handlers.dataSorting?.[0]?.();
-    expect((plugin as unknown as { middleRow: unknown }).middleRow).toBe(r2);
+    expect((plugin as unknown as { anchorRow: unknown }).anchorRow).toBe(r2);
 
     // Tabulator now rebuilds DOM with sorted rows in a different order. If our
     // dataSorting capture didn't happen, renderStarted would capture the wrong
     // row. Simulate that by changing the visible set and firing renderStarted —
-    // the guard `!this.middleRow` should make this a no-op.
+    // the guard `!this.anchorRow` should make this a no-op.
     (table.getRows as jest.Mock).mockImplementation((...args: unknown[]) => {
       if (args[0] === 'visible') return [r3, r2, r1]; // reversed
       return [];
     });
     handlers.renderStarted?.[0]?.();
-    expect((plugin as unknown as { middleRow: unknown }).middleRow).toBe(r2);
+    expect((plugin as unknown as { anchorRow: unknown }).anchorRow).toBe(r2);
   });
 
   it('zeros stale paddingTop after filter when scrollTop is less than paddingTop', () => {
-    // Build a holder containing a .tabulator-table child whose style.paddingTop
-    // simulates the inflated value Tabulator's rerenderRows leaves behind.
     const tableEl = { style: { paddingTop: '120px' } };
     const holder = {
       scrollTop: 0,
@@ -152,12 +150,11 @@ describe('MiddleRowFocus', () => {
       scrollToRow: jest.fn(() => Promise.resolve()),
     };
 
-    const plugin = new MiddleRowFocus(table as never);
+    const plugin = new ScrollAnchor(table as never);
     (plugin as unknown as { table: typeof table }).table = table;
     (plugin as unknown as { options: () => boolean }).options = () => true;
     plugin.initialize();
 
-    // Drive the workaround directly (rAF-free) — same code path the rAF schedules.
     (plugin as unknown as { _resetStaleTopPadding: () => void })._resetStaleTopPadding();
 
     expect(tableEl.style.paddingTop).toBe('0px');
@@ -184,7 +181,7 @@ describe('MiddleRowFocus', () => {
       rowManager: { getDisplayRows: () => [] },
       scrollToRow: jest.fn(() => Promise.resolve()),
     };
-    const plugin = new MiddleRowFocus(table as never);
+    const plugin = new ScrollAnchor(table as never);
     (plugin as unknown as { table: typeof table }).table = table;
     (plugin as unknown as { options: () => boolean }).options = () => true;
     plugin.initialize();
@@ -198,7 +195,6 @@ describe('MiddleRowFocus', () => {
   it('captures wasAtBottom when the user is at the scroll bottom', () => {
     const r1 = makeRow(0, 20);
     const r2 = makeRow(20, 20);
-    // scrollHeight 1000, clientHeight 100 → max scrollTop = 900.
     const holder = {
       scrollTop: 900,
       scrollHeight: 1000,
@@ -216,7 +212,7 @@ describe('MiddleRowFocus', () => {
       rowManager: { getDisplayRows: () => [] },
       scrollToRow: jest.fn(() => Promise.resolve()),
     };
-    const plugin = new MiddleRowFocus(table as never);
+    const plugin = new ScrollAnchor(table as never);
     (plugin as unknown as { table: typeof table }).table = table;
     (plugin as unknown as { options: () => boolean }).options = () => true;
     plugin.initialize();
@@ -244,14 +240,13 @@ describe('MiddleRowFocus', () => {
       rowManager: { getDisplayRows: () => [] },
       scrollToRow: jest.fn(() => Promise.resolve()),
     };
-    const plugin = new MiddleRowFocus(table as never);
+    const plugin = new ScrollAnchor(table as never);
     (plugin as unknown as { table: typeof table }).table = table;
     (plugin as unknown as { options: () => boolean }).options = () => true;
     plugin.initialize();
 
-    // Simulate post-snapshot state where wasAtTop is set.
     (plugin as unknown as { wasAtTop: boolean }).wasAtTop = true;
-    holder.scrollTop = 200; // pretend Tabulator moved scrollTop during render
+    holder.scrollTop = 200;
     handlers.renderComplete?.[0]?.();
 
     expect(holder.scrollTop).toBe(0);
@@ -275,7 +270,7 @@ describe('MiddleRowFocus', () => {
       rowManager: { getDisplayRows: () => [] },
       scrollToRow: jest.fn(() => Promise.resolve()),
     };
-    const plugin = new MiddleRowFocus(table as never);
+    const plugin = new ScrollAnchor(table as never);
     (plugin as unknown as { table: typeof table }).table = table;
     (plugin as unknown as { options: () => boolean }).options = () => true;
     plugin.initialize();
@@ -283,13 +278,11 @@ describe('MiddleRowFocus', () => {
     (plugin as unknown as { wasAtBottom: boolean }).wasAtBottom = true;
     handlers.renderComplete?.[0]?.();
 
-    expect(holder.scrollTop).toBe(900); // 1000 - 100
+    expect(holder.scrollTop).toBe(900);
     expect(table.scrollToRow).not.toHaveBeenCalled();
   });
 
   it('does NOT zero paddingTop when scrollTop has accounted for it (legitimate state)', () => {
-    // Mid-table: scrollTop matches paddingTop, meaning the user has genuinely scrolled
-    // past the rows the padding represents. Mitigation must leave this alone.
     const tableEl = { style: { paddingTop: '500px' } };
     const holder = {
       scrollTop: 500,
@@ -308,7 +301,7 @@ describe('MiddleRowFocus', () => {
       scrollToRow: jest.fn(() => Promise.resolve()),
     };
 
-    const plugin = new MiddleRowFocus(table as never);
+    const plugin = new ScrollAnchor(table as never);
     (plugin as unknown as { table: typeof table }).table = table;
     (plugin as unknown as { options: () => boolean }).options = () => true;
     plugin.initialize();
@@ -327,8 +320,104 @@ describe('MiddleRowFocus', () => {
     table.handlers.dataTreeRowExpanded?.[0]?.();
     table.handlers.dataTreeRowExpanded?.[0]?.();
 
-    // After the first toggle skip was armed; subsequent toggles cleared it.
     expect((plugin as unknown as { skipNextRender: boolean }).skipNextRender).toBe(false);
     expect((plugin as unknown as { toggleSeenInBurst: boolean }).toggleSeenInBurst).toBe(true);
+  });
+
+  it('captures the anchor offset within the holder for pixel-accurate restore', () => {
+    // Holder top at y=50, anchor row top at y=80 → offset 30. r1 too small to be middle;
+    // r2 covers half-height first.
+    const r1 = makeRow(50, 20);
+    const r2 = makeRow(80, 40);
+    const holder = {
+      scrollTop: 100,
+      scrollHeight: 1000,
+      clientHeight: 100,
+      getBoundingClientRect: () => rect(50, 100),
+    };
+    const handlers: Record<string, ((...args: unknown[]) => void)[]> = {};
+    const table = {
+      handlers,
+      on: jest.fn((evt: string, fn: (...args: unknown[]) => void) => {
+        (handlers[evt] ??= []).push(fn);
+      }),
+      element: { querySelector: jest.fn(() => holder) },
+      getRows: jest.fn((type?: string) => (type === 'visible' ? [r1, r2] : [])),
+      rowManager: { getDisplayRows: () => [] },
+      scrollToRow: jest.fn(() => Promise.resolve()),
+    };
+    const plugin = new ScrollAnchor(table as never);
+    (plugin as unknown as { table: typeof table }).table = table;
+    (plugin as unknown as { options: () => boolean }).options = () => true;
+    plugin.initialize();
+
+    handlers.renderStarted?.[0]?.();
+
+    expect((plugin as unknown as { anchorRow: unknown }).anchorRow).toBe(r2);
+    expect(
+      (plugin as unknown as { anchorOffsetFromHolderTop: number }).anchorOffsetFromHolderTop,
+    ).toBe(30);
+  });
+
+  it('restores scrollTop synchronously in renderComplete (no awaits, no scrollToRow)', () => {
+    // Pre-render: middle row sat at offset 30 from holder top. Post-render: same row
+    // is at offsetTop 500 inside .tabulator-table → expected scrollTop = 500 - 30 = 470.
+    // Crucially the assertion runs immediately after the renderComplete call — no await,
+    // no rAF, no setTimeout. If the write were async this would still be the old value.
+    const internalRow = { __internal: true };
+    const rowEl = { offsetTop: 500 };
+    const r2: {
+      getElement: () => unknown;
+      getData: () => { originalData: { timestamp: number } };
+      _getSelf: () => unknown;
+    } = {
+      getElement: () => rowEl,
+      getData: () => ({ originalData: { timestamp: 0 } }),
+      _getSelf: () => internalRow,
+    };
+    const holder: {
+      scrollTop: number;
+      scrollHeight: number;
+      clientHeight: number;
+      getBoundingClientRect: () => ReturnType<typeof rect>;
+    } = {
+      scrollTop: 100,
+      scrollHeight: 5000,
+      clientHeight: 100,
+      getBoundingClientRect: () => rect(0, 100),
+    };
+    const renderer = {
+      rows: jest.fn(() => [internalRow]),
+      _virtualRenderFill: jest.fn(),
+    };
+    const handlers: Record<string, ((...args: unknown[]) => void)[]> = {};
+    const table = {
+      handlers,
+      on: jest.fn((evt: string, fn: (...args: unknown[]) => void) => {
+        (handlers[evt] ??= []).push(fn);
+      }),
+      element: { querySelector: jest.fn(() => holder) },
+      getRows: jest.fn(() => []),
+      rowManager: { renderer, getDisplayRows: () => [internalRow] },
+      scrollToRow: jest.fn(() => Promise.resolve()),
+    };
+    const plugin = new ScrollAnchor(table as never);
+    (plugin as unknown as { table: typeof table }).table = table;
+    (plugin as unknown as { options: () => boolean }).options = () => true;
+    plugin.initialize();
+
+    // Manually seed the captured anchor (skip dataSorting/renderStarted to keep test focused).
+    const p = plugin as unknown as {
+      anchorRow: typeof r2;
+      anchorOffsetFromHolderTop: number;
+    };
+    p.anchorRow = r2;
+    p.anchorOffsetFromHolderTop = 30;
+
+    handlers.renderComplete?.[0]?.();
+
+    expect(renderer._virtualRenderFill).toHaveBeenCalledWith(0, true);
+    expect(holder.scrollTop).toBe(470);
+    expect(table.scrollToRow).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
> ⚠️ **Depends on #756 — that PR must merge first.**
> This branch is stacked on `feat-row-focus-improvements` (the head of #756). Targeting `main` for visibility, but >please **merge #756 first** so the diff here resolves to only this PR's changes.
> ✅ It has merged


# 📝 PR Overview

Improvement on top of #756. Three changes layered:

1. Switches the row-focus behaviour from row-centering (which moved the anchor row to the visual middle on every re-render and produced a small visible jump) to **pixel-accurate anchoring** — the same row stays at the same Y pixel in the holder across sort / filter / tree-toggle / data update.
2. **Renames** `MiddleRowFocus` → `ScrollAnchor` to reflect the broader role.
3. Makes the module **data-agnostic** so it can drop into any Tabulator table.

## 🛠️ Changes made

**Pixel-accurate anchoring**
- Capture the anchor row's Y offset inside the holder at snapshot time (`offsetTop - scrollTop`) and restore `scrollTop` synchronously in `renderComplete` so the row sits at exactly the same pixel — eliminates the post-render flash.
- When the anchor row is outside the post-render virtual DOM window, refill the vDom via Tabulator's internal `_virtualRenderFill` (same hook `scrollToRow` uses) before reading `offsetTop`.
- Replace async `scrollToRow` + `setTimeout` + `scrollIntoView` chain with a single synchronous `scrollTop` write.
- Use `offsetTop` instead of paired `getBoundingClientRect` calls to avoid forcing extra layout reads on the hot path.

**Rename**
- `MiddleRowFocus` → `ScrollAnchor` (module name, file, table option `middleRowFocus` → `scrollAnchor`, tests, and call sites in `AggregatedTable`, `BottomUpTable`, `TableShared`, `TimeOrderTable`).

**Data-agnostic fallback** (when the captured anchor row is no longer in the post-render display set)
- Removes the `apex-log-parser` `LogEvent` import and the timestamp-keyed binary search (`_findClosestActive` / `_findClosestActiveSibling`, ~100 lines).
- Replaces it in `_resolveAnchorRow` with two legs using only public Tabulator APIs:
  - **Collapse case** → walk up `getTreeParent()` to the nearest displayed ancestor. Matches the previous "anchor lands on the parent" feel for the call-tree views.
  - **Filter case** → capture the anchor row's index in `getDisplayRows()` pre-render; on restore, use the row at that (clamped) index. Replaces "nearest by timestamp" (only meaningful in time-ordered tables) with "same position in the list" (natural in any sort order).
  - If neither leg yields a row, return null and the restore is a no-op.

Tests added for offset capture, synchronous pixel-accurate restore, both fallback legs, and the exhausted case.

## 🧩 Type of change (check all applicable)

- [ ] 🐛 Bug fix - something not working as expected
- [ ] ✨ New feature – adds new functionality
- [x] ♻️ Refactor - internal changes with no user impact
- [x] ⚡ Performance Improvement
- [ ] 📝 Documentation - README or documentation site changes
- [ ] 🔧 Chore - dev tooling, CI, config
- [ ] 💥 Breaking change

## 📷 Screenshots / gifs / video [optional]

_n/a_

## 🔗 Related Issues

related #756

## ✅ Tests added?

- [x] 👍 yes
- [ ] 🙅 no, not needed
- [ ] 🙋 no, I need help

## 📚 Docs updated?

- [ ] 🔖 README.md
- [ ] 🔖 CHANGELOG.md
- [ ] 📖 help site
- [x] 🙅 not needed

## Anything else we need to know? [optional]

Until #756 lands, the diff against \`main\` here will include #756's commit too. After #756 merges, the diff will collapse to this PR's three refactor commits.