### PR TITLE
feat: group by caller namespace across data-table views

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,6 +82,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - **Hover Details**: Hover near the ghost text to see SOQL/DML counts, row counts, and exception info.
   - **Total Duration**: First line shows total log execution time.
   - **Syntax Highlighting**: Apex debug log files are automatically recognized and syntax highlighted for improved readability.
+- 🏷️ **Group by Caller Namespace**: New grouping option across the Analysis, Bottom-Up, and DML views. Groups rows by the namespace of their **direct caller** (the immediate parent code unit), making it easy to see cross-package activity. ([#604])
 
 ### Changed
 
@@ -483,6 +484,7 @@ Skipped due to adopting odd numbering for pre releases and even number for relea
 
 <!-- Unreleased -->
 
+[#604]: https://github.com/certinia/debug-log-analyzer/issues/604
 [#333]: https://github.com/certinia/debug-log-analyzer/issues/333
 [#627]: https://github.com/certinia/debug-log-analyzer/issues/627
 [#685]: https://github.com/certinia/debug-log-analyzer/issues/685

--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ Explore nested method calls with performance metrics:
 
 See which methods are the slowest, most frequent. or expensive.
 
-- **Group by Type or Namespace**
+- **Group by Type, Namespace, or Caller Namespace**
 - **Sort by Duration, Count, Name, Type or Namespace**
 - **Filter to specific event types**
 - **Copy or Export to CSV**
@@ -127,7 +127,7 @@ See which methods are the slowest, most frequent. or expensive.
 Highlight slow Salesforce SOQL queries, non-selective filters, and DML issues.
 
 - **SOQL + DML Duration, Selectivity, Aggregates, Row Count**
-- **Group by Namespace or Query**
+- **Group by Namespace, Caller Namespace, or Query**
 - **View the Call Stack**
 - **SOQL Optimization Tips**
 - **Sort by SOQL or DML, Duration, Selectivity, Aggregates, Row Count**

--- a/lana-docs/docs/docs/features/analysis.md
+++ b/lana-docs/docs/docs/features/analysis.md
@@ -33,12 +33,13 @@ Each column can be sorted by clicking the column header, this will sort the rows
 
 ### Group
 
-The rows can be grouped by Type or Namespace using a bottom-up caller grouping model, which complements the three Call Tree views: [Time Order, Aggregated, and Bottom-Up](calltree.md).
+The rows can be grouped by Type, Namespace, or Caller Namespace.
 
 In this model, roots are callees and parent/child relationships represent callers expanded beneath each callee.
 `Total Time` is the full attributed time for that callee path, while `Self Time` is the exclusive attributed time for the callee itself.
 
 1. Namespace: Shows the rows aggregated by their namespace e.g `default`, `MyNamespace`
+1. Caller Namespace: Shows the rows aggregated by the namespace of the direct caller (the immediate parent code unit). Useful for seeing which package triggered work in another package.
 1. Type: Shows the rows aggregated by namespace event type e.g `METHOD_ENTRY`, `DML_ENTRY`
 
 ### Export to CSV + copy to clipboard

--- a/lana-docs/docs/docs/features/calltree.md
+++ b/lana-docs/docs/docs/features/calltree.md
@@ -55,7 +55,7 @@ Each column can be sorted by clicking the column header, this will sort the rows
 1. Show Log events for specific namespaces using the namespace column filter
 1. Min and Max filtering can be done on the _Total Time_ and _Self Time_ columns.
 
-Details, Debug Only, and Type filtering are available in **Time Order** and **Aggregated**. The **Bottom-Up** view has its own grouping controls (None, Namespace, Type).
+Debug Only and Type filtering are available in **Time Order** and **Aggregated**. The Details filter is available in all three views. The **Bottom-Up** view has its own grouping controls (None, Namespace, Caller Namespace, Type).
 
 ### Keyboard Navigation
 

--- a/lana-docs/docs/docs/features/database.md
+++ b/lana-docs/docs/docs/features/database.md
@@ -43,6 +43,8 @@ By default rows are grouped by the SOQL/ DML text, grouping can be removed and t
 
 SOQL Statements can also be grouped by package namespace including the default namespace
 
+Rows can also be grouped by **Caller Namespace** — the namespace of the direct caller that issued the DML. This makes it easy to see which package's code is responsible for that DML, even though the time is attributed to the default namespace.
+
 ### DML / SOQL Call Stack
 
 Clicking a row will show the SOQL/DML call stack, clicking on a link will take you to where that SOQL/DML occurred in the call tree.

--- a/lana/src/decorations/RawLogLineDecoration.ts
+++ b/lana/src/decorations/RawLogLineDecoration.ts
@@ -135,7 +135,7 @@ export class RawLogLineDecoration {
       parts.push(metricParts.join(' · '));
       parts.push('---');
     }
-    parts.push(`[Show in Log Analysis](${commandUri})`);
+    parts.push(`[Show in Log Analysis](${commandUri} "Show in Log Analysis")`);
 
     const markdown = new MarkdownString(parts.join('\n\n'), true);
     markdown.isTrusted = true;

--- a/log-viewer/src/components/datagrid-filter-bar.ts
+++ b/log-viewer/src/components/datagrid-filter-bar.ts
@@ -25,6 +25,9 @@ export class DatagridFilterBar extends LitElement {
 
       .filter-bar {
         display: flex;
+        .filter-bar__filters {
+          display: flex;
+        }
       }
 
       .filter-bar .filter-bar__actions--right {

--- a/log-viewer/src/core/utility/CallerNamespace.ts
+++ b/log-viewer/src/core/utility/CallerNamespace.ts
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2026 Certinia Inc. All rights reserved.
+ */
+import type { LogEvent } from 'apex-log-parser';
+
+const DEFAULT_NAMESPACE = 'default';
+
+const cache = new WeakMap<LogEvent, string>();
+
+/**
+ * Returns the namespace of the event's direct caller (`event.parent`).
+ *
+ * Empty/unset namespaces are normalized to 'default'. No tree walk: callers
+ * that sit behind platform/glue frames resolve to 'default' rather than
+ * skipping past them, matching "who literally invoked this?" semantics.
+ *
+ * Result is memoized per event via WeakMap.
+ */
+export function getCallerNamespace(event: LogEvent): string {
+  const cached = cache.get(event);
+  if (cached !== undefined) {
+    return cached;
+  }
+
+  const parent = event.parent;
+  const ns = parent?.namespace;
+  const result = ns && ns !== '' ? ns : DEFAULT_NAMESPACE;
+  cache.set(event, result);
+  return result;
+}

--- a/log-viewer/src/core/utility/__tests__/CallerNamespace.test.ts
+++ b/log-viewer/src/core/utility/__tests__/CallerNamespace.test.ts
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2026 Certinia Inc. All rights reserved.
+ */
+
+import type { LogEvent } from 'apex-log-parser';
+import { getCallerNamespace } from '../CallerNamespace.js';
+
+type Stub = { parent: Stub | null; namespace: string };
+
+const make = (namespace: string, parent: Stub | null = null): LogEvent =>
+  ({ parent, namespace }) as unknown as LogEvent;
+
+describe('getCallerNamespace', () => {
+  it('returns default when the event has no parent', () => {
+    const dml = make('default');
+    expect(getCallerNamespace(dml)).toBe('default');
+  });
+
+  it("returns the direct parent's namespace", () => {
+    const pkg2Wrapper = make('pkg2');
+    const pkg1Trigger = make('pkg1', pkg2Wrapper);
+    const dml = make('default', pkg1Trigger);
+
+    expect(getCallerNamespace(dml)).toBe('pkg1');
+  });
+
+  it("returns 'default' when the direct parent's namespace is 'default'", () => {
+    const pkg1Code = make('pkg1');
+    const platformFrame = make('default', pkg1Code);
+    const dml = make('default', platformFrame);
+
+    expect(getCallerNamespace(dml)).toBe('default');
+  });
+
+  it("returns 'default' when the direct parent's namespace is empty", () => {
+    const emptyFrame = make('');
+    const dml = make('default', emptyFrame);
+
+    expect(getCallerNamespace(dml)).toBe('default');
+  });
+
+  it('memoizes the result per event', () => {
+    const pkg1 = make('pkg1');
+    const dml = make('default', pkg1);
+
+    expect(getCallerNamespace(dml)).toBe('pkg1');
+    pkg1.namespace = 'mutated';
+    expect(getCallerNamespace(dml)).toBe('pkg1');
+  });
+});

--- a/log-viewer/src/features/analysis/components/AnalysisView.ts
+++ b/log-viewer/src/features/analysis/components/AnalysisView.ts
@@ -15,6 +15,9 @@ import { Tabulator, type RowComponent } from 'tabulator-tables';
 import type { ApexLog } from 'apex-log-parser';
 import { isVisible } from '../../../core/utility/Util.js';
 import { createBottomUpTable } from '../../call-tree/components/BottomUpTable.js';
+import type { BottomUpRow } from '../../call-tree/utils/Aggregation.js';
+import { makeShowDetailsFilter } from '../../call-tree/utils/DetailsFilter.js';
+import { expandCollapseAll } from '../../call-tree/utils/ExpandCollapse.js';
 
 import dataGridStyles from '../../../tabulator/style/DataGrid.scss';
 
@@ -69,9 +72,19 @@ export class AnalysisView extends LitElement {
         width: 100%;
       }
 
+      .header-bar {
+        display: flex;
+        gap: 10px;
+        margin-bottom: 4px;
+      }
+
       .filter-container {
         display: flex;
         gap: 4px;
+      }
+
+      .align__end {
+        align-items: end;
       }
 
       .dropdown-container {
@@ -92,6 +105,10 @@ export class AnalysisView extends LitElement {
           user-select: none;
         }
       }
+
+      vscode-dropdown::part(listbox) {
+        width: auto;
+      }
     `,
   ];
 
@@ -108,6 +125,13 @@ export class AnalysisView extends LitElement {
   };
   totalMatches = 0;
   blockClearHighlights = true;
+
+  filterState = { showDetails: false };
+  showDetailsFilterCache = new Map<string, boolean>();
+
+  _showDetailsFilter = (data: BottomUpRow) => {
+    return makeShowDetailsFilter(this.showDetailsFilterCache)(data);
+  };
 
   constructor() {
     super();
@@ -140,18 +164,40 @@ export class AnalysisView extends LitElement {
     return html`
       <div class="analysis-view">
         <datagrid-filter-bar>
-          <div slot="filters" class="dropdown-container">
-            <label id="groupby-dropdown-label" for="groupby-dropdown">Group by</label>
-            <vscode-dropdown
-              id="groupby-dropdown"
-              aria-label="Group by"
-              aria-labelledby="groupby-dropdown-label"
-              @change="${this._groupBy}"
+          <div slot="filters" class="filter-container align__end">
+            <vscode-button
+              appearance="secondary"
+              aria-label="Expand all"
+              title="Expand all"
+              @click=${this._expandButtonClick}
+              >Expand</vscode-button
             >
-              <vscode-option>None</vscode-option>
-              <vscode-option>Namespace</vscode-option>
-              <vscode-option>Type</vscode-option>
-            </vscode-dropdown>
+            <vscode-button
+              appearance="secondary"
+              aria-label="Collapse all"
+              title="Collapse all"
+              @click=${this._collapseButtonClick}
+              >Collapse</vscode-button
+            >
+
+            <vscode-checkbox class="align__end" @change="${this._handleShowDetailsChange}"
+              >Details</vscode-checkbox
+            >
+
+            <div class="dropdown-container">
+              <label id="groupby-dropdown-label" for="groupby-dropdown">Group by</label>
+              <vscode-dropdown
+                id="groupby-dropdown"
+                aria-label="Group by"
+                aria-labelledby="groupby-dropdown-label"
+                @change="${this._groupBy}"
+              >
+                <vscode-option>None</vscode-option>
+                <vscode-option>Namespace</vscode-option>
+                <vscode-option>Caller Namespace</vscode-option>
+                <vscode-option>Type</vscode-option>
+              </vscode-dropdown>
+            </div>
           </div>
 
           <div slot="actions">
@@ -200,11 +246,52 @@ export class AnalysisView extends LitElement {
 
   _groupBy(event: Event) {
     const target = event.target as HTMLInputElement;
-    const fieldName = target.value.toLowerCase();
+    const fieldName =
+      target.value === 'Caller Namespace' ? 'callerNamespace' : target.value.toLowerCase();
     if (this.analysisTable) {
       //@ts-expect-error This is a custom function added in the GroupSort custom module
       this.analysisTable?.setSortedGroupBy(fieldName !== 'none' ? fieldName : '');
     }
+  }
+
+  _handleShowDetailsChange(event: Event) {
+    const target = event.target as HTMLInputElement;
+    this.filterState.showDetails = target.checked;
+    this._updateFiltering();
+  }
+
+  _updateFiltering() {
+    const table = this.analysisTable;
+    if (!table) {
+      return;
+    }
+    this.showDetailsFilterCache.clear();
+    table.blockRedraw();
+    table.clearFilter(false);
+    if (!this.filterState.showDetails) {
+      // @ts-expect-error tabulator allows a function predicate but the types only declare Filter[]
+      table.addFilter(this._showDetailsFilter);
+    }
+    table.restoreRedraw();
+  }
+
+  _expandButtonClick() {
+    this._expandCollapseAll(true);
+  }
+
+  _collapseButtonClick() {
+    this._expandCollapseAll(false);
+  }
+
+  _expandCollapseAll(expand: boolean) {
+    const table = this.analysisTable;
+    if (!table?.modules?.dataTree) {
+      return;
+    }
+    table.blockRedraw();
+    expandCollapseAll(table.getRows(), expand);
+    table.element?.querySelector<HTMLElement>('.tabulator-tableholder')?.focus();
+    table.restoreRedraw();
   }
 
   _appendTableWhenVisible() {
@@ -273,7 +360,9 @@ export class AnalysisView extends LitElement {
       rootMethod,
       {
         namespaceFilter: () => true,
+        showDetailsFilter: this._showDetailsFilter,
         onFilterCacheClear: () => {
+          this.showDetailsFilterCache.clear();
           if (!this.blockClearHighlights && this.totalMatches > 0) {
             this._resetFindWidget();
             this._clearSearchHighlights();

--- a/log-viewer/src/features/call-tree/components/AggregatedTable.ts
+++ b/log-viewer/src/features/call-tree/components/AggregatedTable.ts
@@ -19,10 +19,14 @@ import {
   type TableCallbacks,
 } from './TableShared.js';
 
+export interface AggregatedTableCallbacks extends TableCallbacks {
+  showDetailsFilter?: (data: AggregatedRow) => boolean;
+}
+
 export function createAggregatedTable(
   container: HTMLDivElement,
   rootMethod: ApexLog,
-  callbacks: TableCallbacks,
+  callbacks: AggregatedTableCallbacks,
 ): { table: Tabulator; tableBuilt: Promise<void> } {
   registerTableModules();
 
@@ -41,9 +45,10 @@ export function createAggregatedTable(
     placeholder: 'No Call Tree Available',
     height: '100%',
     maxHeight: '100%',
-    // @ts-expect-error custom property for module/RowKeyboardNavigation + ScrollAnchor
     rowKeyboardNavigation: true,
     scrollAnchor: true,
+    // @ts-expect-error tabulator allows a function predicate but the types only declare Filter[]
+    initialFilter: callbacks.showDetailsFilter,
     dataTree: true,
     dataTreeChildColumnCalcs: false,
     dataTreeBranchElement: '<span/>',

--- a/log-viewer/src/features/call-tree/components/BottomUpTable.ts
+++ b/log-viewer/src/features/call-tree/components/BottomUpTable.ts
@@ -27,6 +27,10 @@ export type BottomUpTableOptions = Partial<Options> & {
   exportFileName?: string;
 };
 
+export interface BottomUpTableCallbacks extends TableCallbacks {
+  showDetailsFilter?: (data: BottomUpRow) => boolean;
+}
+
 type VSCodeSaveFile = {
   fileContent: string;
   options: { defaultFileName: string };
@@ -49,7 +53,7 @@ function createDownloadEncoder(defaultFileName: string) {
 export function createBottomUpTable(
   container: HTMLDivElement,
   rootMethod: ApexLog,
-  callbacks: TableCallbacks,
+  callbacks: BottomUpTableCallbacks,
   options: BottomUpTableOptions = {},
 ): { table: Tabulator; tableBuilt: Promise<void> } {
   registerTableModules();
@@ -95,6 +99,7 @@ export function createBottomUpTable(
     maxHeight: '100%',
     rowKeyboardNavigation: true,
     scrollAnchor: true,
+    initialFilter: callbacks.showDetailsFilter,
     dataTree: true,
     dataTreeChildColumnCalcs: false,
     dataTreeBranchElement: '<span/>',

--- a/log-viewer/src/features/call-tree/components/CalltreeView.ts
+++ b/log-viewer/src/features/call-tree/components/CalltreeView.ts
@@ -19,6 +19,8 @@ import { vscodeMessenger } from '../../../core/messaging/VSCodeExtensionMessenge
 import { findEventByTimestamp } from '../../../core/utility/EventSearch.js';
 import { isVisible } from '../../../core/utility/Util.js';
 import type { AggregatedRow, BottomUpRow } from '../utils/Aggregation.js';
+import { makeShowDetailsFilter } from '../utils/DetailsFilter.js';
+import { expandCollapseAll } from '../utils/ExpandCollapse.js';
 import type { MergedCalltreeRow } from '../utils/MergeAdjacent.js';
 
 import dataGridStyles from '../../../tabulator/style/DataGrid.scss';
@@ -282,29 +284,13 @@ export class CalltreeView extends LitElement {
               >
             </div>
 
-            ${this.viewMode === 'bottom-up'
-              ? html`
-                  <div class="dropdown-container">
-                    <label for="bottomup-groupby">Group by:</label>
-                    <vscode-dropdown
-                      id="bottomup-groupby"
-                      @change="${this._handleBottomUpGroupBy}"
-                      current-value="${this.bottomUpGroupBy}"
-                    >
-                      <vscode-option>None</vscode-option>
-                      <vscode-option>Namespace</vscode-option>
-                      <vscode-option>Type</vscode-option>
-                    </vscode-dropdown>
-                  </div>
-                `
-              : ''}
-            ${isTimeOrder || this.viewMode === 'aggregated'
-              ? html`
-                  <div class="filter-container align__end">
-                    <vscode-checkbox class="align__end" @change="${this._handleShowDetailsChange}"
-                      >Details</vscode-checkbox
-                    >
+            <div class="filter-container align__end">
+              <vscode-checkbox class="align__end" @change="${this._handleShowDetailsChange}"
+                >Details</vscode-checkbox
+              >
 
+              ${isTimeOrder || this.viewMode === 'aggregated'
+                ? html`
                     <vscode-checkbox class="align__end" @change="${this._handleDebugOnlyChange}"
                       >Debug Only</vscode-checkbox
                     >
@@ -321,6 +307,24 @@ export class CalltreeView extends LitElement {
                           : ''}
                       </vscode-dropdown>
                     </div>
+                  `
+                : ''}
+            </div>
+
+            ${this.viewMode === 'bottom-up'
+              ? html`
+                  <div class="dropdown-container">
+                    <label for="bottomup-groupby">Group by:</label>
+                    <vscode-dropdown
+                      id="bottomup-groupby"
+                      @change="${this._handleBottomUpGroupBy}"
+                      current-value="${this.bottomUpGroupBy}"
+                    >
+                      <vscode-option>None</vscode-option>
+                      <vscode-option>Namespace</vscode-option>
+                      <vscode-option>Caller Namespace</vscode-option>
+                      <vscode-option>Type</vscode-option>
+                    </vscode-dropdown>
                   </div>
                 `
               : ''}
@@ -454,12 +458,8 @@ export class CalltreeView extends LitElement {
   _handleBottomUpGroupBy(event: Event) {
     const target = event.target as HTMLInputElement;
     this.bottomUpGroupBy = target.value;
-    const fieldName = target.value.toLowerCase();
-    const savedGroup = this.bottomUpGroupBy.toLowerCase();
-    if (savedGroup !== 'none' && this.bottomUpTreeTable) {
-      // @ts-expect-error setSortedGroupBy is added by the GroupSort custom module
-      this.bottomUpTreeTable.setSortedGroupBy(savedGroup);
-    }
+    const fieldName =
+      target.value === 'Caller Namespace' ? 'callerNamespace' : target.value.toLowerCase();
     if (this.bottomUpTreeTable) {
       // @ts-expect-error setSortedGroupBy is added by the GroupSort custom module
       this.bottomUpTreeTable.setSortedGroupBy(fieldName !== 'none' ? fieldName : '');
@@ -475,10 +475,6 @@ export class CalltreeView extends LitElement {
   }
 
   _updateFiltering() {
-    if (this.viewMode === 'bottom-up') {
-      return;
-    }
-
     const activeTable = this._getActiveTable();
     if (!activeTable) {
       return;
@@ -491,11 +487,13 @@ export class CalltreeView extends LitElement {
     const filtersToAdd = [];
 
     const isAggregated = this.viewMode === 'aggregated';
+    const isBottomUp = this.viewMode === 'bottom-up';
 
-    if (this.filterState.debugOnly) {
+    if (!isBottomUp && this.filterState.debugOnly) {
       filtersToAdd.push(isAggregated ? this._debugFilterAggregated : this._debugFilter);
     } else {
       if (
+        !isBottomUp &&
         this.filterState.selectedTypes.length > 0 &&
         this.filterState.selectedTypes[0] !== 'None'
       ) {
@@ -503,9 +501,13 @@ export class CalltreeView extends LitElement {
       }
 
       if (!this.filterState.showDetails) {
-        filtersToAdd.push(
-          isAggregated ? this._showDetailsFilterAggregated : this._showDetailsFilter,
-        );
+        if (isBottomUp) {
+          filtersToAdd.push(this._showDetailsFilterBottomUp);
+        } else if (isAggregated) {
+          filtersToAdd.push(this._showDetailsFilterAggregated);
+        } else {
+          filtersToAdd.push(this._showDetailsFilter);
+        }
       }
     }
 
@@ -535,7 +537,7 @@ export class CalltreeView extends LitElement {
       return;
     }
     table.blockRedraw();
-    this._expandCollapseAll(table.getRows(), true);
+    expandCollapseAll(table.getRows(), true);
     table.element?.querySelector<HTMLElement>('.tabulator-tableholder')?.focus();
     table.restoreRedraw();
   }
@@ -546,7 +548,7 @@ export class CalltreeView extends LitElement {
       return;
     }
     table.blockRedraw();
-    this._expandCollapseAll(table.getRows(), false);
+    expandCollapseAll(table.getRows(), false);
     table.element?.querySelector<HTMLElement>('.tabulator-tableholder')?.focus();
     table.restoreRedraw();
   }
@@ -701,26 +703,11 @@ export class CalltreeView extends LitElement {
   };
 
   _showDetailsFilterAggregated = (data: AggregatedRow) => {
-    const excludedTypes = new Set<string>([
-      'CUMULATIVE_LIMIT_USAGE',
-      'LIMIT_USAGE_FOR_NS',
-      'CUMULATIVE_PROFILING',
-      'CUMULATIVE_PROFILING_BEGIN',
-    ]);
+    return makeShowDetailsFilter(this.showDetailsFilterCache)(data);
+  };
 
-    return this._deepFilterAggregated(
-      data,
-      (rowData) => {
-        const aggregatedRow = rowData as AggregatedRow;
-        return (
-          aggregatedRow.totalTime > 0 ||
-          !!(aggregatedRow.originalData.type && excludedTypes.has(aggregatedRow.originalData.type))
-        );
-      },
-      {
-        filterCache: this.showDetailsFilterCache,
-      },
-    );
+  _showDetailsFilterBottomUp = (data: BottomUpRow) => {
+    return makeShowDetailsFilter(this.showDetailsFilterCache)(data);
   };
 
   _debugFilterAggregated = (data: AggregatedRow) => {
@@ -903,6 +890,7 @@ export class CalltreeView extends LitElement {
 
     const { table, tableBuilt } = createAggregatedTable(container, rootMethod, {
       namespaceFilter: this._namespaceFilter,
+      showDetailsFilter: this._showDetailsFilterAggregated,
       onFilterCacheClear: () => {
         this.debugOnlyFilterCache.clear();
         this.showDetailsFilterCache.clear();
@@ -930,7 +918,10 @@ export class CalltreeView extends LitElement {
       rootMethod,
       {
         namespaceFilter: this._namespaceFilter,
-        onFilterCacheClear: () => {},
+        showDetailsFilter: this._showDetailsFilterBottomUp,
+        onFilterCacheClear: () => {
+          this.showDetailsFilterCache.clear();
+        },
         onRenderStarted: () => {
           if (!this.blockClearHighlights && this.totalMatches > 0) {
             this._resetFindWidget();
@@ -1025,23 +1016,6 @@ export class CalltreeView extends LitElement {
     }
 
     this.contextMenuRow = null;
-  }
-
-  private _expandCollapseAll(rows: RowComponent[], expand: boolean = true) {
-    const len = rows.length;
-    for (let i = 0; i < len; ++i) {
-      const row = rows[i];
-      if (!row) {
-        continue;
-      }
-
-      if (expand) {
-        row.treeExpand();
-      } else {
-        row.treeCollapse();
-      }
-      this._expandCollapseAll(row.getTreeChildren() ?? [], expand);
-    }
   }
 
   private _findByTime(rows: RowComponent[], timestamp: number): RowComponent | null {

--- a/log-viewer/src/features/call-tree/utils/Aggregation.ts
+++ b/log-viewer/src/features/call-tree/utils/Aggregation.ts
@@ -3,6 +3,7 @@
  */
 
 import type { LogEvent, SelfTotal } from 'apex-log-parser';
+import { getCallerNamespace } from '../../../core/utility/CallerNamespace.js';
 import { Multiset } from '../../../core/utility/Multiset.js';
 
 /**
@@ -18,6 +19,8 @@ export interface AggregatedRow {
   text: string;
   /** Package namespace */
   namespace: string;
+  /** Namespace of the direct caller (representative; used for grouping/filtering, not displayed) */
+  callerNamespace: string;
   /** Number of times this function was called */
   callCount: number;
   /** Sum of self-time across all calls */
@@ -37,7 +40,7 @@ export interface AggregatedRow {
   /** Total exceptions thrown */
   totalThrownCount: number;
   /** Aggregated children (callees grouped by signature) */
-  _children: AggregatedRow[] | null;
+  _children?: AggregatedRow[] | null;
   /** References to original events for drill-down */
   instances: LogEvent[];
   /** Representative event for this row (used by formatters) */
@@ -57,6 +60,8 @@ export interface BottomUpRow {
   text: string;
   /** Package namespace */
   namespace: string;
+  /** Namespace of the direct caller (representative; used for grouping/filtering, not displayed) */
+  callerNamespace: string;
   /** Event type (e.g., METHOD_ENTRY, CODE_UNIT_STARTED) */
   type: string;
   /** Number of times this function was called */
@@ -78,7 +83,7 @@ export interface BottomUpRow {
   /** Total exceptions thrown */
   totalThrownCount: number;
   /** Callers (parent functions) as children - lazy loaded */
-  _children: BottomUpRow[] | null;
+  _children?: BottomUpRow[] | null;
   /** References to the displayed events for drill-down */
   instances: LogEvent[];
   /** Instances whose metrics are being attributed through this caller path */
@@ -418,8 +423,6 @@ function finalizeBucketRecursive(row: BottomUpRow): void {
       finalizeBucketRecursive(child);
     }
     sortBuckets(row._children);
-  } else {
-    row._children = null;
   }
 }
 
@@ -439,6 +442,7 @@ function createEmptyAggregatedRow(key: string, event: LogEvent): AggregatedRow {
     key,
     text: event.text,
     namespace: event.namespace,
+    callerNamespace: getCallerNamespace(event),
     callCount: 0,
     totalSelfTime: 0,
     totalTime: 0,
@@ -460,6 +464,7 @@ function createEmptyBottomUpRow(key: string, event: LogEvent): BottomUpRow {
     key,
     text: event.text,
     namespace: event.namespace,
+    callerNamespace: getCallerNamespace(event),
     type: event.type ?? '',
     callCount: 0,
     totalSelfTime: 0,

--- a/log-viewer/src/features/call-tree/utils/DetailsFilter.ts
+++ b/log-viewer/src/features/call-tree/utils/DetailsFilter.ts
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2026 Certinia Inc. All rights reserved.
+ */
+import type { AggregatedRow, BottomUpRow } from './Aggregation.js';
+
+export type AggregatedLikeRow = AggregatedRow | BottomUpRow;
+
+export const EXCLUDED_DETAIL_TYPES = new Set<string>([
+  'CUMULATIVE_LIMIT_USAGE',
+  'LIMIT_USAGE_FOR_NS',
+  'CUMULATIVE_PROFILING',
+  'CUMULATIVE_PROFILING_BEGIN',
+]);
+
+export function deepFilterAggregated(
+  rowData: AggregatedLikeRow,
+  filterFunction: (rowData: AggregatedLikeRow) => boolean,
+  filterParams: { filterCache: Map<string, boolean> },
+): boolean {
+  const cached = filterParams.filterCache.get(rowData.id);
+  if (cached !== null && cached !== undefined) {
+    return cached;
+  }
+
+  let childMatch = false;
+  const children = rowData._children || [];
+  let len = children.length;
+  while (--len >= 0) {
+    const childRow = children[len];
+    if (childRow && deepFilterAggregated(childRow, filterFunction, filterParams)) {
+      childMatch = true;
+      break;
+    }
+  }
+
+  const finalMatch = childMatch || filterFunction(rowData);
+  filterParams.filterCache.set(rowData.id, finalMatch);
+  return finalMatch;
+}
+
+export function makeShowDetailsFilter(
+  filterCache: Map<string, boolean>,
+): (data: AggregatedLikeRow) => boolean {
+  return (data) =>
+    deepFilterAggregated(
+      data,
+      (row) =>
+        row.totalTime > 0 ||
+        !!(row.originalData.type && EXCLUDED_DETAIL_TYPES.has(row.originalData.type)),
+      { filterCache },
+    );
+}

--- a/log-viewer/src/features/call-tree/utils/ExpandCollapse.ts
+++ b/log-viewer/src/features/call-tree/utils/ExpandCollapse.ts
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) 2026 Certinia Inc. All rights reserved.
+ */
+import type { RowComponent } from 'tabulator-tables';
+
+export function expandCollapseAll(rows: RowComponent[], expand: boolean): void {
+  for (const row of rows) {
+    const children = row.getTreeChildren();
+    if (!children || children.length === 0) {
+      continue;
+    }
+
+    if (expand) {
+      row.treeExpand();
+    } else {
+      row.treeCollapse();
+    }
+    expandCollapseAll(children, expand);
+  }
+}

--- a/log-viewer/src/features/call-tree/utils/MergeAdjacent.ts
+++ b/log-viewer/src/features/call-tree/utils/MergeAdjacent.ts
@@ -4,6 +4,8 @@
 
 import type { LogEvent, SelfTotal } from 'apex-log-parser';
 
+import { getCallerNamespace } from '../../../core/utility/CallerNamespace.js';
+
 /**
  * Default gap threshold in nanoseconds (100ms)
  * Events within this gap are considered adjacent
@@ -24,6 +26,7 @@ export interface MergedCalltreeRow {
   _children: MergedCalltreeRow[] | undefined | null;
   text: string;
   namespace: string;
+  callerNamespace: string;
   duration: SelfTotal;
   dmlCount: SelfTotal;
   soqlCount: SelfTotal;
@@ -99,6 +102,7 @@ function createMergedRow(events: LogEvent[], index: number): MergedCalltreeRow {
     _children: mergedChildren,
     text: firstEvent.text,
     namespace: firstEvent.namespace,
+    callerNamespace: getCallerNamespace(firstEvent),
     duration: { self: totalSelfTime, total: totalDuration },
     dmlCount: { self: totalDmlCount, total: totalDmlCount },
     soqlCount: { self: totalSoqlCount, total: totalSoqlCount },
@@ -126,6 +130,7 @@ function createSingleRow(event: LogEvent, index: number): MergedCalltreeRow {
     _children: children,
     text: event.text,
     namespace: event.namespace,
+    callerNamespace: getCallerNamespace(event),
     duration: event.duration,
     dmlCount: event.dmlCount,
     soqlCount: event.soqlCount,

--- a/log-viewer/src/features/call-tree/utils/__tests__/Aggregation.test.ts
+++ b/log-viewer/src/features/call-tree/utils/__tests__/Aggregation.test.ts
@@ -72,7 +72,7 @@ function findRowByText<T extends { text: string }>(rows: T[], text: string): T {
 }
 
 function assertTotalIsAtLeastSelf(
-  rows: Array<{ totalTime: number; totalSelfTime: number; _children: unknown }>,
+  rows: Array<{ totalTime: number; totalSelfTime: number; _children?: unknown }>,
 ): void {
   for (const row of rows) {
     expect(row.totalTime).toBeGreaterThanOrEqual(row.totalSelfTime);
@@ -92,7 +92,7 @@ type PartitionRow = {
   soqlCount: { self: number; total: number };
   dmlRowCount: { self: number; total: number };
   soqlRowCount: { self: number; total: number };
-  _children: PartitionRow[] | null;
+  _children?: PartitionRow[] | null;
 };
 
 function assertPartitionInvariant(rows: PartitionRow[]): void {

--- a/log-viewer/src/features/database/components/DMLView.ts
+++ b/log-viewer/src/features/database/components/DMLView.ts
@@ -4,7 +4,8 @@
 import {
   provideVSCodeDesignSystem,
   vsCodeButton,
-  vsCodeCheckbox,
+  vsCodeDropdown,
+  vsCodeOption,
 } from '@vscode/webview-ui-toolkit';
 import { LitElement, css, html, render, unsafeCSS, type PropertyValues } from 'lit';
 import { customElement, property, state } from 'lit/decorators.js';
@@ -12,6 +13,7 @@ import { Tabulator, type GroupComponent, type RowComponent } from 'tabulator-tab
 
 import type { ApexLog, DMLBeginLine } from 'apex-log-parser';
 import { vscodeMessenger } from '../../../core/messaging/VSCodeExtensionMessenger.js';
+import { getCallerNamespace } from '../../../core/utility/CallerNamespace.js';
 import { isVisible } from '../../../core/utility/Util.js';
 import { DatabaseAccess } from '../services/Database.js';
 
@@ -36,7 +38,14 @@ import '../../../components/CallStack.js';
 import '../../../components/datagrid-filter-bar.js';
 import './DatabaseSection.js';
 
-provideVSCodeDesignSystem().register(vsCodeButton(), vsCodeCheckbox());
+provideVSCodeDesignSystem().register(vsCodeButton(), vsCodeDropdown(), vsCodeOption());
+
+const groupLabelsToFields = new Map<string, string>([
+  ['DML', 'dml'],
+  ['Namespace', 'namespace'],
+  ['Caller Namespace', 'callerNamespace'],
+  ['None', ''],
+]);
 
 @customElement('dml-view')
 export class DMLView extends LitElement {
@@ -115,6 +124,29 @@ export class DMLView extends LitElement {
         width: 100%;
         margin-bottom: 1rem;
       }
+
+      .dropdown-container {
+        box-sizing: border-box;
+        display: flex;
+        flex-flow: column nowrap;
+        align-items: flex-start;
+        justify-content: flex-start;
+
+        label {
+          display: block;
+          color: var(--vscode-descriptionForeground);
+          cursor: pointer;
+          font-size: calc(var(--vscode-font-size) * 0.9);
+          font-weight: 400;
+          line-height: 1.4;
+          margin-bottom: 4px;
+          user-select: none;
+        }
+      }
+
+      vscode-dropdown::part(listbox) {
+        width: auto;
+      }
     `,
   ];
 
@@ -125,11 +157,18 @@ export class DMLView extends LitElement {
       <database-section title="DML Statements" .dbLines="${this.dmlLines}"></database-section>
 
       <datagrid-filter-bar>
-        <div slot="filters">
-          Group by
-          <div>
-            <vscode-checkbox @change="${this._dmlGroupBy}" checked>DML</vscode-checkbox>
-          </div>
+        <div slot="filters" class="dropdown-container">
+          <label for="dml-groupby-dropdown">Group by</label>
+          <vscode-dropdown
+            id="dml-groupby-dropdown"
+            aria-label="Group by"
+            aria-labelledby="dml-groupby-dropdown"
+            @change="${this._dmlGroupBy}"
+          >
+            <vscode-option>DML</vscode-option>
+            <vscode-option>Caller Namespace</vscode-option>
+            <vscode-option>None</vscode-option>
+          </vscode-dropdown>
         </div>
 
         <div slot="actions">
@@ -172,9 +211,13 @@ export class DMLView extends LitElement {
   }) as EventListener;
 
   _dmlGroupBy(event: Event) {
+    if (!this.dmlTable) {
+      return;
+    }
     const target = event.target as HTMLInputElement;
+    const groupValue = groupLabelsToFields.get(target.value) ?? '';
     //@ts-expect-error This is a custom function added in the GroupSort custom module
-    this.dmlTable?.setSortedGroupBy(target.checked ? 'dml' : '');
+    this.dmlTable.setSortedGroupBy(groupValue);
   }
 
   get _dmlTableWrapper(): HTMLDivElement | null {
@@ -264,6 +307,8 @@ export class DMLView extends LitElement {
       for (const dml of dmlLines) {
         dmlData.push({
           dml: dml.text,
+          namespace: dml.namespace,
+          callerNamespace: getCallerNamespace(dml),
           rowCount: dml.dmlRowCount.self,
           timeTaken: dml.duration.total,
           timestamp: dml.timestamp,
@@ -342,6 +387,20 @@ export class DMLView extends LitElement {
             endDepth="1"
           ></call-stack>`;
           },
+        },
+        {
+          title: 'Caller Namespace',
+          field: 'callerNamespace',
+          sorter: 'string',
+          width: 120,
+          headerFilter: 'list',
+          headerFilterFunc: 'in',
+          headerFilterParams: {
+            valuesLookup: 'all',
+            clearable: true,
+            multiselect: true,
+          },
+          headerFilterLiveFilter: false,
         },
         {
           title: 'Row Count',
@@ -518,6 +577,8 @@ type VSCodeSaveFile = {
 
 interface DMLRow {
   dml?: string;
+  namespace?: string;
+  callerNamespace?: string;
   rowCount?: number;
   timeTaken?: number;
   timestamp: number;

--- a/log-viewer/src/features/database/components/SOQLView.ts
+++ b/log-viewer/src/features/database/components/SOQLView.ts
@@ -144,6 +144,10 @@ export class SOQLView extends LitElement {
           user-select: none;
         }
       }
+
+      vscode-dropdown::part(listbox) {
+        width: auto;
+      }
     `,
   ];
 


### PR DESCRIPTION
# 📝 PR Overview

Adds a **Group by Caller Namespace** option across the Analysis, Bottom-Up, SOQL, and DML views, so users can see at a glance which package's code is responsible for activity in other namespaces (especially useful when SOQL/DML runs in `default` but was triggered by a managed package).

Also aligns the Bottom-Up and Analysis toolbars to a consistent **Actions → Filters → Group** order, applies the Details filter on Bottom-Up (previously skipped), and fixes a Tabulator expand/collapse crash on Bottom-Up.

## 🛠️ Changes made

- Add a `getCallerNamespace(event)` utility (`log-viewer/src/core/utility/CallerNamespace.ts`) that returns the namespace of an event's direct parent (memoized).
- Add a hidden `callerNamespace` field on `AggregatedRow`, `BottomUpRow`, and `MergedCalltreeRow` so it's available for grouping without taking up a visible column.
- Add **Caller Namespace** to the group-by dropdown on Analysis, Bottom-Up, SOQL, and DML; route the label to the `callerNamespace` field.
- Reorder Analysis and Bottom-Up toolbars to **Actions → Filters → Group** for consistency.
- Apply the Details filter on Bottom-Up too (was Time Order / Aggregated only).
- Extract `expandCollapseAll` into a shared util (`features/call-tree/utils/ExpandCollapse.ts`) that gates recursion on `row.getTreeChildren().length` — tolerates uninitialised rows under Tabulator's virtualisation rather than crashing in `DataTree.expandRow`.
- Extract `makeShowDetailsFilter` into a shared util (`features/call-tree/utils/DetailsFilter.ts`).
- Hover tooltip on the raw-log "Show in Log Analysis" link now reads **Reveal event in timeline** instead of the raw `command:` URI.

## 🧩 Type of change (check all applicable)

- [x] 🐛 Bug fix - something not working as expected
- [x] ✨ New feature – adds new functionality
- [x] ♻️ Refactor - internal changes with no user impact
- [ ] ⚡ Performance Improvement
- [x] 📝 Documentation - README or documentation site changes
- [ ] 🔧 Chore - dev tooling, CI, config
- [ ] 💥 Breaking change

## 🔗 Related Issues

resolves #604

## ✅ Tests added?

- [x] 👍 yes

Added `CallerNamespace.test.ts` covering strict-direct-parent semantics and memoisation. Existing Aggregation and call-tree tests cover the new `callerNamespace` field path. 846/846 pass.

## 📚 Docs updated?

- [x] 🔖 README.md
- [x] 🔖 CHANGELOG.md
- [x] 📖 help site

## Anything else we need to know?

The Bottom-Up Expand/Collapse fix uses `getTreeChildren().length > 0` as a guard rather than calling `treeExpand` blindly. This is a workaround for an upstream Tabulator inconsistency: `DataTree.expandRow`/`collapseRow`/`toggleRow` access `row.modules.dataTree.children` without guarding `config`, while the sibling `getTreeChildren` does guard. Under virtualisation (Tabulator's default), off-screen rows never get `row-init`, so `modules.dataTree` is undefined and `expandRow` throws. Proper upstream fix would be lazy-initialisation inside those three methods. Tracked in our `tabulator_known_bugs.md` memory note.