### PR TITLE
perf(call-tree): speed up filtering and rendering on large logs

### DIFF
--- a/SCROLL_ANCHOR_UPSTREAM.md
+++ b/SCROLL_ANCHOR_UPSTREAM.md
@@ -1,0 +1,251 @@
+# ScrollAnchor — upstream Tabulator PR brief
+
+This document is written for an agent preparing an upstream PR to [Tabulator](https://github.com/olifolkerd/tabulator) that adds **pixel-accurate scroll anchoring** as a first-class feature, based on a working downstream module. It maps the existing implementation onto upstream source, names the private APIs that need public equivalents, and separates the symptom-side workarounds from the cause-side fixes that belong in the core.
+
+The reference implementation is a custom Tabulator module that has been shipping in production. The agent does not need to read it to follow this brief — every load-bearing piece of it is described here. References to "the reference module" point at `ScrollAnchor.ts` in the originating repo if you want to cross-check.
+
+**Reference versions**: all `tabulator_esm.mjs` line numbers in this document are pinned to **`tabulator-tables@6.4.0`**. If you're on a different version, grep for the surrounding identifier (e.g. `rerenderRows`, `_virtualRenderFill`) — line numbers drift but the call sites have been stable across recent 6.x releases.
+
+## 1. Goal & user-visible behaviour
+
+The default Tabulator behaviour after a re-render (sort, filter, tree expand/collapse, data update) is to leave `scrollTop` wherever the renderer happened to land. For virtual-scrolled tables this often means the user's row of interest jumps off-screen, or the viewport flashes through an intermediate position before settling. The proposed feature keeps a chosen anchor row at the same Y pixel inside the table holder across every re-render — synchronously, with no perceptible flash.
+
+Behaviours the feature MUST provide:
+
+1. **Pixel-accurate anchor**. The row that was at the visual middle of the holder before a re-render is at the same Y pixel after.
+2. **Boundary snap**. When the user was at the very top or very bottom of the scroll range pre-render, restore to that edge instead of pixel-anchoring — anchoring on a middle row at the edge feels broken because it pushes the user away from the boundary.
+3. **Single tree-toggle is non-disruptive**. Expanding or collapsing one row should not move the user's scroll position at all.
+4. **Bulk tree-toggle still recenters**. Expand-all / collapse-all (multiple synchronous toggles) should anchor the same way as sort / filter, so the user's row stays in view rather than scrolling far off-screen as the row count changes by orders of magnitude.
+5. **Filter does not leave a blank strip**. Tabulator's `rerenderRows` after a filter currently inflates `paddingTop` on `.tabulator-table`; the anchored experience must not show this.
+6. **Anchor row fallback**. When the captured anchor row no longer exists in the post-render display set (filtered out, collapsed under a parent), the feature falls back to the nearest still-displayed row by row identity and keeps the user near where they were.
+
+## 2. Proposed public surface
+
+- **Module name**: `scrollAnchor` (matches downstream).
+- **Table option**: `scrollAnchor: true` toggles the feature on. Default `false` for backwards compatibility.
+- **No per-row API** is needed. The anchor is computed automatically from the visible rows in the holder.
+- **Optional sub-option**: `scrollAnchor: { boundaryThresholdPx: number }` to override the edge-detection threshold (default `10`). Only add this if a non-default is requested during review — the constant works for every downstream case so far.
+
+## 3. Algorithm
+
+Pseudocode, free of Tabulator-specific identifiers, so the contract is reviewable on its own:
+
+```text
+state:
+  anchorRow:        Row | null
+  anchorOffsetFromHolderTop:   number    # row top - holder.scrollTop, captured pre-render
+  wasAtTop:         bool
+  wasAtBottom:      bool
+  skipNextRender:   bool
+  toggleSeenInBurst: bool
+
+state (continued):
+  anchorDisplayIndex: int    # row's index in displayRows pre-render (filter fallback)
+
+on capture-event (sort starting, render starting):
+  if anchorRow is set: return                        # idempotent within one op
+  wasAtTop    = holder.scrollTop <= threshold
+  wasAtBottom = (holder.scrollHeight - holder.clientHeight) - holder.scrollTop <= threshold
+  # When content fits entirely, scrollTop is forced to 0 → wasAtTop is true and
+  # the restore snaps to top. This matches CSS overflow-anchor (which excludes
+  # non-scrollable containers).
+  anchorRow          = findMiddleVisibleRow(holder)
+  anchorOffsetFromHolderTop     = anchorRow.element.offsetTop - holder.scrollTop
+  anchorDisplayIndex = displayRows.indexOf(anchorRow)
+
+on render-complete:
+  if skipNextRender:
+     skipNextRender = false; clear-anchor; return
+  if not anchorRow: return
+  if wasAtTop:       holder.scrollTop = 0
+  elif wasAtBottom:  holder.scrollTop = holder.scrollHeight - holder.clientHeight
+  else:
+     row = resolveAnchorRow(anchorRow)               # fallback if filtered/collapsed
+     if row.element is detached:                     # outside post-render vDom window
+        rendererRefillCenteredOn(row)                # see §5
+     holder.scrollTop = row.element.offsetTop - anchorOffsetFromHolderTop
+  clear-anchor
+  toggleSeenInBurst = false
+
+on tree-toggle (expand or collapse):
+  if not toggleSeenInBurst:                          # first in this synchronous burst
+     toggleSeenInBurst = true; skipNextRender = true # treat as single → don't move
+  else:                                              # bulk burst → second toggle clears skip
+     skipNextRender = false
+  clear-anchor                                       # let the next capture run fresh
+
+findMiddleVisibleRow(holder):
+   target = holder.clientHeight / 2
+   walk visible rows top-to-bottom, summing intersected heights.
+   Partial visibility at the edges is clipped: subtract any portion above
+   the holder top (topDiff) and below the holder bottom (bottomDiff) so
+   the running sum reflects only the on-screen pixels of each row.
+   Return the first row whose cumulative intersected height reaches target,
+   or null if cumulative height never reaches it (in which case content fits
+   the holder; the boundary snap takes precedence anyway).
+
+resolveAnchorRow(row):
+   if row is in current displayRows: return row
+   # Collapse leg: walk up tree parents to nearest displayed ancestor.
+   p = row.getTreeParent()
+   while p:
+      if p in displayRows: return p
+      p = p.getTreeParent()
+   # Filter leg: same position in the new display rows (clamped).
+   if anchorDisplayIndex >= 0 and displayRows.length > 0:
+      idx = min(anchorDisplayIndex, displayRows.length - 1)
+      return displayRows[idx]
+   return null
+```
+
+Restore is **fully synchronous in the `renderComplete` handler** — no `await`, no `setTimeout`, no `requestAnimationFrame`. The browser paints the corrected `scrollTop` directly from the post-render frame; any deferral re-introduces a one-frame flash.
+
+## 4. Required Tabulator hooks
+
+Each entry: hook used, why it's needed, where it fires upstream.
+
+| Hook                                          | Why                                                                                                                                                                                                                                                                                                                   | Upstream emit site (sketch)                                            |
+| --------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------- |
+| `dataSorting`                                 | **Primary capture for sorts.** Sort calls `rowManager.scrollVertical(0)` (or equivalent) before `renderStarted` fires, so by the time `renderStarted` runs, `scrollTop` has been zeroed and `findMiddleVisibleRow` would pick the wrong row. We capture _pre-sort_, while `scrollTop` still reflects the user's view. | Sort module before it triggers `rowManager.refreshActiveData("sort")`. |
+| `renderStarted`                               | **Primary capture for filter / tree toggle / data updates.** `scrollTop` is still valid here for these operations. The handler is a no-op when the anchor was already captured by `dataSorting` (`if (anchorRow) return`).                                                                                            | `RowManager` before each `_virtualRenderFill`.                         |
+| `renderComplete`                              | **Restore site.** Called after the new vDom window is in the DOM. The handler reads `offsetTop` of the post-render anchor row element and writes `scrollTop`.                                                                                                                                                         | `RowManager` after `_virtualRenderFill` finishes.                      |
+| `dataTreeRowExpanded`, `dataTreeRowCollapsed` | **Tree-toggle burst detection.** Used to set `skipNextRender` for single toggles and clear it when a second toggle arrives synchronously (bulk).                                                                                                                                                                      | `DataTree` module on each toggle.                                      |
+| `dataFiltered`                                | **Filter padding fix.** Wraps the symptom-side mitigation described in §6. Schedules the check on `requestAnimationFrame` so it runs after the post-filter render.                                                                                                                                                    | `Filter` module after applying filter.                                 |
+
+If the upstream PR adds a dedicated `RowManager` callback that runs _before_ sort zeros `scrollTop` (e.g. `dataSortInitiated` or `beforeSort`), it can replace `dataSorting` as the capture site cleanly.
+
+**Option-gated subscription**: every subscription above must be installed inside `initialize()` _only when_ `options.scrollAnchor` is truthy. When the option is off (the default), the module attaches no listeners and contributes zero per-render overhead. The reference implementation does exactly this — see `ScrollAnchor.ts:45-83`. Keeping the gate tight is what makes the feature genuinely additive and free for users who don't opt in.
+
+## 5. Private APIs touched & proposed public equivalents
+
+The downstream module accesses three private APIs via `@ts-expect-error` casts. Each must be replaced with a public equivalent before upstream merge.
+
+### 5.1 `row._getSelf()` — internal Row reference from a RowComponent
+
+- **Used at**: `_isRowActive`, `_anchorPixelAccurate` in the reference module — both compare a `RowComponent` against the entries returned by `rowManager.getDisplayRows()` or `renderer.rows()`, which return _internal_ `Row` instances. `RowComponent` and `Row` are not `===` equal, so the comparison requires `_getSelf()`.
+- **Reason**: identity comparison in O(1) array lookup. No data is mutated.
+- **Public equivalent (proposed)**: add `RowComponent.getInternal(): Row` (or an internal-only utility on `RowManager`: `rowManager.includes(component): boolean`). The simplest public surface is the latter — it removes the need to expose `Row` itself and matches what every caller actually wants ("is this component still in the display set?").
+- **Same leak via `rowManager.getDisplayRows()`**: `getDisplayRows()` returns internal `Row` instances, not `RowComponent`s. The reference module uses it at `ScrollAnchor.ts:108` (to capture `anchorDisplayIndex`) and `:186` (to drive the fallback) by comparing against `component._getSelf()`. The same proposed public API resolves both call sites — `rowManager.includes(component)` covers the membership test, and a sibling `rowManager.getDisplayComponents(): RowComponent[]` would let downstream avoid `_getSelf()` entirely.
+
+### 5.2 `renderer._virtualRenderFill(index, force)` — refill the vDom centered on a specific row index
+
+- **Used at**: `_anchorPixelAccurate` when the anchor row's element is detached (`!rowEl.isConnected`) because the post-render vDom window does not include it. Without refilling first, `rowEl.offsetTop` is stale and the resulting `scrollTop` write lands on the wrong row.
+- **Reason**: bring the anchor row's DOM element back online before reading its post-layout offset. The same hook is called by Tabulator's public `scrollToRow` internally, but `scrollToRow` is async and tries to scroll — we want to refill _without_ scrolling because we are about to set `scrollTop` ourselves.
+- **Public equivalent (proposed)**: `rowManager.renderer.ensureRendered(rowIndex: number): void` — synchronously refills the vDom around `rowIndex` with no scroll side-effect. Implementation can be a one-liner that calls the existing `_virtualRenderFill(index, true)`.
+
+### 5.3 `renderer.vDomTopPad` — internal padding state
+
+- **Used at**: `_resetStaleTopPadding` after a filter, to keep Tabulator's internal model in sync with the DOM after we zero `.tabulator-table`'s inline `paddingTop`.
+- **Reason**: if we only reset the DOM style, the next render reads the stale `vDomTopPad` and re-inflates the padding.
+- **Public equivalent**: not needed if the **upstream filter fix in §6 lands** — the bug never occurs, the symptom-side workaround disappears, and `vDomTopPad` stays internal. If the filter fix is deferred, expose `rowManager.renderer.resetTopPadding(): void` as a transitional API.
+
+The upstream patch should reference `tabulator_esm.mjs` line ~25265 (v6.4.0) (the `rerenderRows` site identified in the downstream comment) when locating the bug.
+
+### 5.4 `renderer.rows()` — array of internal Row instances in the current vDom window
+
+- **Used at**: `_anchorPixelAccurate` in the reference module (`ScrollAnchor.ts:161`). We need the index of the anchor's internal Row inside the renderer's view so we can pass it to `_virtualRenderFill`.
+- **Reason**: lookup-only. `_virtualRenderFill(index, force)` takes a numeric index, not a row reference.
+- **Public equivalent (proposed)**: roll this into a higher-level API so callers never need the array directly: `renderer.ensureRendered(row: RowComponent): void`. The renderer does the index lookup internally and refills the vDom around it with no scroll side-effect. Subsumes both §5.2 and §5.4 — callers don't touch indices or internal arrays at all.
+
+## 6. Filter padding fix
+
+### Bug
+
+After a filter, `rerenderRows()` (around `tabulator_esm.mjs:25265`) iterates the **pre-filter** `vDomTop..vDomBottom` indices against the **post-filter** rows array. When the pre-filter window points past the end of the post-filter list, the resulting `topOffset` is large; that flows into `_virtualRenderFill` and inflates `vDomTopPad`, which is written onto `.tabulator-table` as inline `paddingTop`. The user sees a blank strip across the top of the holder until the next interaction.
+
+### Symptom-side detection (downstream module)
+
+Used as a verification heuristic, not the upstream fix:
+
+```text
+if paddingTop > 0 and holder.scrollTop < paddingTop:
+   # there is more empty space above the rendered window than the user has scrolled past
+   .tabulator-table.style.paddingTop = '0px'
+   renderer.vDomTopPad = 0
+```
+
+This runs on `requestAnimationFrame` after `dataFiltered` so the DOM has settled. It is reliable for detection but is a band-aid — it papers over the bad state instead of preventing it.
+
+The reference module stores the pending rAF handle and cancels it before scheduling a new one (`ScrollAnchor.ts:65-71`). Rapid sequential `dataFiltered` events (e.g. typing in a header filter) otherwise queue redundant checks and can race against each other. Once the cause-side fix below lands, the rAF and its cancellation both disappear.
+
+### Cause-side fix (upstream PR)
+
+Inside `rerenderRows`, before the iteration that produces `topOffset`:
+
+```text
+# Clamp the pre-filter window to the post-filter row count.
+postCount = rows.length
+if vDomTop > postCount:    vDomTop    = max(0, postCount - 1)
+if vDomBottom > postCount: vDomBottom = postCount
+```
+
+…or, equivalently, recompute `vDomTop` from the current `scrollTop` and average row height when the pre-filter window is invalid against the new row set. Either prevents `topOffset` from running away.
+
+The PR should include a regression test that filters a long list down to a short list and asserts `parseFloat(table.element.querySelector('.tabulator-table').style.paddingTop)` is `0` after the filter completes.
+
+## 7. Edge cases & rationale
+
+- **Sort vs. other re-renders.** Two capture sites (`dataSorting` + `renderStarted`) exist because sort is the only operation that resets `scrollTop` before render starts. Removing the duplication requires a new pre-sort hook upstream (see §4 note).
+- **Single vs bulk tree toggle.** Synchronous-burst detection (a flag set on the first toggle and cleared on the second within the same JS turn) lets the module distinguish `userClickedOneCaret` from `userPressedExpandAll` without a timer. A timer would be wrong because expand-all and a deliberate two-row click are indistinguishable on the wall clock; the JS event-loop turn is the only reliable separator.
+- **Boundary snap.** Pixel-anchoring at the boundary feels broken: the user was at the bottom and now they're floating in the middle of an empty stretch because the anchor row moved. Snap-to-edge restores the natural feel. Threshold is in pixels (default 10) to tolerate sub-pixel scrollbar values. The `wasAtBottom` restore clamps with `Math.max(0, scrollHeight - clientHeight)` (`ScrollAnchor.ts:126`) so a holder that briefly has `scrollHeight < clientHeight` (post-filter shrinkage) writes `0` rather than a negative scrollTop.
+- **Fits-in-viewport.** When the visible content is shorter than the holder (e.g. an aggressive filter leaves three rows in a 600px holder), the browser forces `scrollTop = 0` — there is nothing to scroll. Both boundary checks evaluate true; `wasAtTop` is checked first in the restore and wins → snap to top. This matches CSS `overflow-anchor`, which excludes non-scrollable containers from anchoring (and is the convention followed by virtual-list libraries like Virtuoso and TanStack Virtual). User-visible behaviour: "filter to a tiny list, then clear the filter → user lands at the top of the unfiltered list." If a future requirement is to return the user to their _pre-filter_ row across a filter→clear round-trip, that requires capturing the anchor before the filter changes the active set (subscribe to `dataFiltering`) — out of scope for this module's current behaviour.
+- **Anchor-row fallback.** When the captured row is no longer in the display set, the feature uses a two-leg, data-agnostic fallback (already implemented in the reference module — no upstream-only work):
+  - **Collapse case** (anchor row is hidden under a now-collapsed ancestor) → walk up `RowComponent.getTreeParent()` to the nearest displayed ancestor. This matches the natural feel of "I see where my row went, it's under this collapsed parent." Public Tabulator API.
+  - **Filter case** (anchor row removed entirely) → capture the anchor row's index in `rowManager.getDisplayRows()` at snapshot time; on restore, use the row at that index in the post-render display set, clamped to `displayRows.length - 1`. Replaces "nearest by timestamp" (which only made sense in time-ordered tables) with "same position in the list" (natural in any sort order).
+  - If neither leg yields a row (no displayed ancestor and empty post-render display set), return `null` and the restore is a no-op for that frame.
+
+## 8. What to drop when going upstream
+
+- **All `@ts-expect-error` casts**. Replaced by the public APIs in §5.
+- **References to the originating repo** (`tabulator-virtual-scroll-fixes.md`, "Fix 7"). The upstream module has no dependency outside Tabulator.
+- **Symptom-side filter padding mitigation** (`_resetStaleTopPadding`, `dataFiltered` rAF). Becomes unnecessary once the cause-side fix in §6 lands; if both ship, drop the workaround.
+
+The reference module is **already domain-agnostic** — it has no `apex-log-parser` import, no `TimedNodeProp`, and no timestamp logic. The fallback strategy in §7 uses only public Tabulator APIs (`getTreeParent()`, `getDisplayRows()`).
+
+## 9. Test contract
+
+Test cases the upstream suite should cover. Each is a starting set, not exhaustive; downstream `ScrollAnchor.test.ts` has them implemented against jest mocks and is a useful reference shape:
+
+1. `findMiddleVisibleRow` returns the row whose cumulative intersected height first crosses half the holder height.
+2. Single tree toggle does not change `scrollTop` and does not call any scroll API.
+3. Bulk tree toggle (≥2 synchronous toggles) clears the skip flag so the recentering path runs.
+4. Sort capture happens in `dataSorting` (not `renderStarted`); confirm by changing the visible row set between the two events and asserting the captured anchor is the pre-sort row.
+5. `wasAtTop` / `wasAtBottom` are captured correctly at boundary scrollTop values.
+6. On `renderComplete`, `wasAtTop` snaps `scrollTop` to `0` and skips pixel-anchoring.
+7. On `renderComplete`, `wasAtBottom` snaps `scrollTop` to `scrollHeight - clientHeight`.
+8. Pixel-accurate restore: pre-render `(rowOffsetTop=A, scrollTop=B) → captured offset=(A-B)`. Post-render `rowOffsetTop=A'` → `scrollTop = A' - (A-B)`. Assert synchronously after the `renderComplete` call (no awaits) — proves the restore is sync.
+9. Filter padding regression (cause-side fix from §6): filter a long list to a short list, assert `.tabulator-table` `paddingTop` is `0` after.
+10. Filter padding **negative case** (symptom-side detection): when `scrollTop >= paddingTop` the user has legitimately scrolled past the padding; assert the detection does **not** clobber it (`ScrollAnchor.test.ts:287`).
+11. Anchor row fallback — collapse: the captured row is not in `displayRows` but its tree parent is; assert `_resolveAnchorRow` returns the parent.
+12. Anchor row fallback — filter (clamped): the captured row is gone, no displayed ancestor, captured `anchorDisplayIndex` exceeds the new `displayRows.length`; assert restore picks the row at `displayRows.length - 1`.
+13. Anchor row fallback — filter (exact index): same as above with the captured index in range; assert restore picks the row at exactly that index.
+14. Anchor row fallback — exhausted: no displayed ancestor and empty `displayRows`; assert `_resolveAnchorRow` returns `null` and the restore is a no-op.
+15. Fits-in-viewport (covered by case 6, no dedicated test) — when content fits (`scrollHeight ≤ clientHeight`), the browser forces `scrollTop = 0`, which makes `wasAtTop` true and the `wasAtTop` snap path runs. Case 6 already exercises that path; this entry exists to document the behavioural guarantee, not as a separate test obligation.
+
+## 10. Open questions for the upstream PR author
+
+- **Module / option name.** `scrollAnchor` matches the downstream prototype, but `virtualScrollAnchor` or `anchorScroll` might fit Tabulator naming better.
+- **Boundary threshold configurability.** Ship the constant or expose `boundaryThresholdPx` as a sub-option from day one? Current downstream usage has not needed an override.
+- **Filter padding fix coupling.** Land the `rerenderRows` clamp (§6) in the same PR as the module, or split into two PRs (the clamp is independently useful)?
+- **Pre-sort hook.** Is upstream willing to add `dataSortInitiated` / `beforeSort` so the module has one capture site instead of two? Without it, the duplication remains.
+- **Public API naming.** `RowManager.includes(component)` vs `RowComponent.getInternal()` for the private-API replacement in §5.1; `renderer.ensureRendered(index)` vs a more general `renderer.refillAround(index)` for §5.2.
+
+## 11. Performance budget
+
+For reviewers asking "what does this cost per render?":
+
+- **Off-state cost (option not set)**: zero. `initialize()` returns without subscribing to any events when `options.scrollAnchor` is falsy (default). No listeners on the bus, no `getRows` calls, no `getBoundingClientRect` reads.
+- **Capture cost (per render, when on)**:
+  - One `getRows('visible')` — bounded by viewport height ÷ row height, typically <50 rows for any realistic table.
+  - One `getBoundingClientRect()` on the holder + one per visible row inside `_findMiddleVisibleRow`. All reads happen back-to-back at the start of the operation, so the browser batches them into a single layout flush (no read/write interleave).
+  - One `getDisplayRows().indexOf(...)` to capture `anchorDisplayIndex` (linear scan, O(display rows)). Use a Map if upstream wants O(1).
+- **Restore cost (per render)**: one `offsetTop` read on the anchor row + one `scrollTop` write. `_virtualRenderFill` only runs when the anchor row's DOM element is detached after the new vDom window — rare in practice.
+- **Memory**: a handful of primitive fields on the module instance (anchor row reference, offset, two booleans, two flags). One stored rAF handle while a filter is in flight.
+
+Net: invisible at common table sizes, and zero impact when the feature is off. The upstream PR should include a benchmark or jsperf for the capture path so the cost is documented rather than assumed.
+
+## References
+
+- Reference implementation: `log-viewer/src/tabulator/module/ScrollAnchor.ts`.
+- Reference tests: `log-viewer/src/tabulator/module/__tests__/ScrollAnchor.test.ts`.
+- Upstream filter bug location: `tabulator_esm.mjs` line ~25265 (v6.4.0) (`rerenderRows`).

--- a/log-viewer/src/features/call-tree/components/AggregatedTable.ts
+++ b/log-viewer/src/features/call-tree/components/AggregatedTable.ts
@@ -60,32 +60,27 @@ export function createAggregatedTable(
         bottomCalc: () => 'Total',
         cssClass: 'datagrid-textarea datagrid-code-text',
         formatter: (cell) => {
-          const cellElem = cell.getElement();
           const row = cell.getRow();
           // @ts-expect-error: _row is private
           const dataTree = row._row.modules.dataTree;
           const treeLevel = dataTree?.index ?? 0;
           childIndent ??= row.getTable().options.dataTreeChildIndent || 0;
           const levelIndent = treeLevel * childIndent;
+
+          const cellElem = cell.getElement();
           cellElem.style.paddingLeft = `${levelIndent + 4}px`;
           cellElem.style.textIndent = `-${levelIndent}px`;
 
           const rowData = cell.getData() as AggregatedRow;
-          const elem = document.createElement('span');
           const firstInstance = rowData.instances[0];
 
           if (firstInstance?.hasValidSymbols) {
             const link = document.createElement('a');
             link.setAttribute('href', '#!');
             link.textContent = rowData.text;
-            elem.appendChild(link);
-          } else {
-            const textSpan = document.createElement('span');
-            textSpan.textContent = rowData.text;
-            elem.appendChild(textSpan);
+            return link;
           }
-
-          return elem;
+          return document.createTextNode(rowData.text) as unknown as HTMLElement;
         },
         variableHeight: true,
         cellClick: (e, cell) => {

--- a/log-viewer/src/features/call-tree/components/AggregatedTable.ts
+++ b/log-viewer/src/features/call-tree/components/AggregatedTable.ts
@@ -298,13 +298,24 @@ export function createAggregatedTable(
   });
   tableRef.current = table;
 
-  // renderStarted fires once after the filter-pipeline; dataFiltered can cascade
-  // on dataTree tables via getFilteredTreeChildren -> filter.filter().
-  table.on('renderStarted', () => {
+  // Filter caches MUST be cleared on `dataFiltered`, not `renderStarted`.
+  // Row ids in the aggregated tree are only unique within a single parent's
+  // children, so the same id string can appear in different subtrees. On
+  // dataTree tables Tabulator runs `filter.filter()` for the top-level pass
+  // and again for each expanded subtree (via `getChildren` ->
+  // `filter.filter(config.children)`). `dataFiltered` fires after every one
+  // of those passes, so clearing here guarantees a fresh cache per pass. If
+  // we waited until `renderStarted` (one event for the whole pipeline), the
+  // top-level walk would poison the cache for later subtree passes and the
+  // wrong rows would match.
+  table.on('dataFiltered', () => {
     namespaceFilterCache.clear();
     totalTimeFilterCache.clear();
     selfTimeFilterCache.clear();
     callbacks.onFilterCacheClear();
+  });
+
+  table.on('renderStarted', () => {
     callbacks.onRenderStarted();
   });
 

--- a/log-viewer/src/features/call-tree/components/AggregatedTable.ts
+++ b/log-viewer/src/features/call-tree/components/AggregatedTable.ts
@@ -293,14 +293,13 @@ export function createAggregatedTable(
   });
   tableRef.current = table;
 
-  table.on('dataFiltered', () => {
+  // renderStarted fires once after the filter-pipeline; dataFiltered can cascade
+  // on dataTree tables via getFilteredTreeChildren -> filter.filter().
+  table.on('renderStarted', () => {
     namespaceFilterCache.clear();
     totalTimeFilterCache.clear();
     selfTimeFilterCache.clear();
     callbacks.onFilterCacheClear();
-  });
-
-  table.on('renderStarted', () => {
     callbacks.onRenderStarted();
   });
 

--- a/log-viewer/src/features/call-tree/components/AggregatedTable.ts
+++ b/log-viewer/src/features/call-tree/components/AggregatedTable.ts
@@ -298,24 +298,19 @@ export function createAggregatedTable(
   });
   tableRef.current = table;
 
-  // Filter caches MUST be cleared on `dataFiltered`, not `renderStarted`.
-  // Row ids in the aggregated tree are only unique within a single parent's
-  // children, so the same id string can appear in different subtrees. On
-  // dataTree tables Tabulator runs `filter.filter()` for the top-level pass
-  // and again for each expanded subtree (via `getChildren` ->
-  // `filter.filter(config.children)`). `dataFiltered` fires after every one
-  // of those passes, so clearing here guarantees a fresh cache per pass. If
-  // we waited until `renderStarted` (one event for the whole pipeline), the
-  // top-level walk would poison the cache for later subtree passes and the
-  // wrong rows would match.
-  table.on('dataFiltered', () => {
+  // Filter caches are cleared once per render via `renderStarted`. Row ids
+  // produced by `toAggregatedCallTree` are globally unique within a build
+  // (per-build monotonic counter), so cached `deepFilter` results stay valid
+  // across the cascaded `filter.filter()` passes Tabulator runs for each
+  // expanded subtree — `getChildren` → `filter.filter(config.children)`
+  // would otherwise fire `dataFiltered` multiple times per user action,
+  // defeating the cache. If row ids ever lose their uniqueness guarantee
+  // this must move back to `dataFiltered`.
+  table.on('renderStarted', () => {
     namespaceFilterCache.clear();
     totalTimeFilterCache.clear();
     selfTimeFilterCache.clear();
     callbacks.onFilterCacheClear();
-  });
-
-  table.on('renderStarted', () => {
     callbacks.onRenderStarted();
   });
 

--- a/log-viewer/src/features/call-tree/components/BottomUpTable.ts
+++ b/log-viewer/src/features/call-tree/components/BottomUpTable.ts
@@ -227,10 +227,21 @@ export function createBottomUpTable(
     ...tabulatorOptionOverrides,
   });
 
-  // renderStarted fires once after the filter-pipeline; dataFiltered can cascade
-  // on dataTree tables via getFilteredTreeChildren -> filter.filter().
-  table.on('renderStarted', () => {
+  // Filter caches MUST be cleared on `dataFiltered`, not `renderStarted`.
+  // Row ids in the bottom-up tree are only unique within a single parent's
+  // children, so the same id string can appear in different subtrees. On
+  // dataTree tables Tabulator runs `filter.filter()` for the top-level pass
+  // and again for each expanded subtree (via `getChildren` ->
+  // `filter.filter(config.children)`). `dataFiltered` fires after every one
+  // of those passes, so clearing here guarantees a fresh cache per pass. If
+  // we waited until `renderStarted` (one event for the whole pipeline), the
+  // top-level walk would poison the cache for later subtree passes and the
+  // wrong rows would match.
+  table.on('dataFiltered', () => {
     callbacks.onFilterCacheClear();
+  });
+
+  table.on('renderStarted', () => {
     callbacks.onRenderStarted();
   });
 

--- a/log-viewer/src/features/call-tree/components/BottomUpTable.ts
+++ b/log-viewer/src/features/call-tree/components/BottomUpTable.ts
@@ -227,21 +227,16 @@ export function createBottomUpTable(
     ...tabulatorOptionOverrides,
   });
 
-  // Filter caches MUST be cleared on `dataFiltered`, not `renderStarted`.
-  // Row ids in the bottom-up tree are only unique within a single parent's
-  // children, so the same id string can appear in different subtrees. On
-  // dataTree tables Tabulator runs `filter.filter()` for the top-level pass
-  // and again for each expanded subtree (via `getChildren` ->
-  // `filter.filter(config.children)`). `dataFiltered` fires after every one
-  // of those passes, so clearing here guarantees a fresh cache per pass. If
-  // we waited until `renderStarted` (one event for the whole pipeline), the
-  // top-level walk would poison the cache for later subtree passes and the
-  // wrong rows would match.
-  table.on('dataFiltered', () => {
-    callbacks.onFilterCacheClear();
-  });
-
+  // Filter caches are cleared once per render via `renderStarted`. Row ids
+  // produced by `toBottomUpTree` are globally unique within a build
+  // (per-build monotonic counter), so cached `deepFilter` results stay valid
+  // across the cascaded `filter.filter()` passes Tabulator runs for each
+  // expanded subtree — `getChildren` → `filter.filter(config.children)`
+  // would otherwise fire `dataFiltered` multiple times per user action,
+  // defeating the cache. If row ids ever lose their uniqueness guarantee
+  // this must move back to `dataFiltered`.
   table.on('renderStarted', () => {
+    callbacks.onFilterCacheClear();
     callbacks.onRenderStarted();
   });
 

--- a/log-viewer/src/features/call-tree/components/BottomUpTable.ts
+++ b/log-viewer/src/features/call-tree/components/BottomUpTable.ts
@@ -222,11 +222,10 @@ export function createBottomUpTable(
     ...tabulatorOptionOverrides,
   });
 
-  table.on('dataFiltered', () => {
-    callbacks.onFilterCacheClear();
-  });
-
+  // renderStarted fires once after the filter-pipeline; dataFiltered can cascade
+  // on dataTree tables via getFilteredTreeChildren -> filter.filter().
   table.on('renderStarted', () => {
+    callbacks.onFilterCacheClear();
     callbacks.onRenderStarted();
   });
 

--- a/log-viewer/src/features/call-tree/components/CalltreeView.ts
+++ b/log-viewer/src/features/call-tree/components/CalltreeView.ts
@@ -671,24 +671,25 @@ export class CalltreeView extends LitElement {
   _showDetailsFilterRollup = (data: AggregatedRow | BottomUpRow): boolean =>
     makeShowDetailsFilter(this.showDetailsFilterCache)(data);
 
-  private _makeTypeFilter(
-    types: ReadonlySet<string>,
-    cache: Map<string, boolean>,
-  ): (data: MergedCalltreeRow | AggregatedRow | BottomUpRow) => boolean {
-    return (data) =>
-      deepFilter<MergedCalltreeRow | AggregatedRow | BottomUpRow>(
-        data,
-        (row) => {
-          const type = row.originalData.type;
-          return type ? types.has(type) : false;
-        },
-        cache,
-      );
-  }
+  _debugFilter = (data: MergedCalltreeRow | AggregatedRow | BottomUpRow): boolean =>
+    deepFilter<MergedCalltreeRow | AggregatedRow | BottomUpRow>(
+      data,
+      (row) => !!(row.originalData.type && DEBUG_VALUE_TYPES.has(row.originalData.type)),
+      this.debugOnlyFilterCache,
+    );
 
-  _debugFilter = this._makeTypeFilter(DEBUG_VALUE_TYPES, this.debugOnlyFilterCache);
-
-  _typeFilter = this._makeTypeFilter(this.filterState.selectedTypes, this.typeFilterCache);
+  _typeFilter = (data: MergedCalltreeRow | AggregatedRow | BottomUpRow): boolean =>
+    deepFilter<MergedCalltreeRow | AggregatedRow | BottomUpRow>(
+      data,
+      (row) => {
+        const type = row.originalData.type;
+        if (!type) {
+          return false;
+        }
+        return this.filterState.selectedTypes.has(type);
+      },
+      this.typeFilterCache,
+    );
 
   _namespaceFilter = (
     selectedNamespaces: string[],

--- a/log-viewer/src/features/call-tree/components/CalltreeView.ts
+++ b/log-viewer/src/features/call-tree/components/CalltreeView.ts
@@ -85,10 +85,10 @@ export class CalltreeView extends LitElement {
   aggregatedTreeTable: Tabulator | null = null;
   bottomUpTreeTable: Tabulator | null = null;
 
-  filterState: { showDetails: boolean; debugOnly: boolean; selectedTypes: string[] } = {
+  filterState: { showDetails: boolean; debugOnly: boolean; selectedTypes: Set<string> } = {
     showDetails: false,
     debugOnly: false,
-    selectedTypes: [],
+    selectedTypes: new Set<string>(),
   };
   bottomUpGroupBy = 'None';
   debugOnlyFilterCache = new Map<string, boolean>();
@@ -489,10 +489,7 @@ export class CalltreeView extends LitElement {
   }
 
   _handleTypeFilter(event: CustomEvent<{ selectedOptions: [{ value: string }] }>) {
-    this.filterState.selectedTypes = [];
-    event.detail.selectedOptions.forEach((element) => {
-      this.filterState.selectedTypes.push(element.value);
-    });
+    this.filterState.selectedTypes = new Set(event.detail.selectedOptions.map((e) => e.value));
     this._updateFiltering();
   }
 
@@ -516,8 +513,8 @@ export class CalltreeView extends LitElement {
     } else {
       if (
         !isBottomUp &&
-        this.filterState.selectedTypes.length > 0 &&
-        this.filterState.selectedTypes[0] !== 'None'
+        this.filterState.selectedTypes.size > 0 &&
+        !this.filterState.selectedTypes.has('None')
       ) {
         filtersToAdd.push(this._typeFilter);
       }
@@ -684,8 +681,7 @@ export class CalltreeView extends LitElement {
   _typeFilter = (data: MergedCalltreeRow | AggregatedRow | BottomUpRow): boolean =>
     deepFilter<MergedCalltreeRow | AggregatedRow | BottomUpRow>(
       data,
-      (row) =>
-        !!row.originalData.type && this.filterState.selectedTypes.includes(row.originalData.type),
+      (row) => !!row.originalData.type && this.filterState.selectedTypes.has(row.originalData.type),
       this.typeFilterCache,
     );
 

--- a/log-viewer/src/features/call-tree/components/CalltreeView.ts
+++ b/log-viewer/src/features/call-tree/components/CalltreeView.ts
@@ -19,7 +19,7 @@ import { vscodeMessenger } from '../../../core/messaging/VSCodeExtensionMessenge
 import { findEventByTimestamp } from '../../../core/utility/EventSearch.js';
 import { isVisible } from '../../../core/utility/Util.js';
 import type { AggregatedRow, BottomUpRow } from '../utils/Aggregation.js';
-import { makeShowDetailsFilter } from '../utils/DetailsFilter.js';
+import { deepFilter, makeShowDetailsFilter } from '../utils/DetailsFilter.js';
 import { expandCollapseAll } from '../utils/ExpandCollapse.js';
 import type { MergedCalltreeRow } from '../utils/MergeAdjacent.js';
 
@@ -512,24 +512,20 @@ export class CalltreeView extends LitElement {
     const isBottomUp = this.viewMode === 'bottom-up';
 
     if (!isBottomUp && this.filterState.debugOnly) {
-      filtersToAdd.push(isAggregated ? this._debugFilterAggregated : this._debugFilter);
+      filtersToAdd.push(this._debugFilter);
     } else {
       if (
         !isBottomUp &&
         this.filterState.selectedTypes.length > 0 &&
         this.filterState.selectedTypes[0] !== 'None'
       ) {
-        filtersToAdd.push(isAggregated ? this._typeFilterAggregated : this._typeFilter);
+        filtersToAdd.push(this._typeFilter);
       }
 
       if (!this.filterState.showDetails) {
-        if (isBottomUp) {
-          filtersToAdd.push(this._showDetailsFilterBottomUp);
-        } else if (isAggregated) {
-          filtersToAdd.push(this._showDetailsFilterAggregated);
-        } else {
-          filtersToAdd.push(this._showDetailsFilter);
-        }
+        filtersToAdd.push(
+          isAggregated || isBottomUp ? this._showDetailsFilterRollup : this._showDetailsFilter,
+        );
       }
     }
 
@@ -660,180 +656,54 @@ export class CalltreeView extends LitElement {
     this.blockClearHighlights = false;
   }
 
-  _showDetailsFilter = (data: MergedCalltreeRow): boolean => {
-    const showDetailsFilter = (rowData: MergedCalltreeRow): boolean => {
-      const { duration, isParent, discontinuity, type } = rowData.originalData;
-      return (
-        isParent ||
-        duration.total > 0 ||
-        discontinuity ||
-        !!(type && SHOW_DETAILS_EXCLUDED_TYPES.has(type))
-      );
-    };
-
-    const params = { filterCache: this.showDetailsFilterCache };
-
-    return this._deepFilter(data, showDetailsFilter, params);
-  };
-
-  _debugFilter = (data: MergedCalltreeRow) => {
-    return this._deepFilter(
+  _showDetailsFilter = (data: MergedCalltreeRow): boolean =>
+    deepFilter<MergedCalltreeRow>(
       data,
-      (rowData) => {
-        return !!(rowData.originalData.type && DEBUG_VALUE_TYPES.has(rowData.originalData.type));
+      (row) => {
+        const { duration, isParent, discontinuity, type } = row.originalData;
+        return (
+          isParent ||
+          duration.total > 0 ||
+          discontinuity ||
+          !!(type && SHOW_DETAILS_EXCLUDED_TYPES.has(type))
+        );
       },
-      {
-        filterCache: this.debugOnlyFilterCache,
-      },
+      this.showDetailsFilterCache,
     );
-  };
 
-  _typeFilter = (data: MergedCalltreeRow) => {
-    return this._deepFilter(
+  _showDetailsFilterRollup = (data: AggregatedRow | BottomUpRow): boolean =>
+    makeShowDetailsFilter(this.showDetailsFilterCache)(data);
+
+  _debugFilter = (data: MergedCalltreeRow | AggregatedRow | BottomUpRow): boolean =>
+    deepFilter<MergedCalltreeRow | AggregatedRow | BottomUpRow>(
       data,
-      (rowData) => {
-        if (!rowData.originalData.type) {
-          return false;
-        }
-
-        return this.filterState.selectedTypes.includes(rowData.originalData.type);
-      },
-      {
-        filterCache: this.typeFilterCache,
-      },
+      (row) => !!(row.originalData.type && DEBUG_VALUE_TYPES.has(row.originalData.type)),
+      this.debugOnlyFilterCache,
     );
-  };
 
-  _showDetailsFilterAggregated = (data: AggregatedRow) => {
-    return makeShowDetailsFilter(this.showDetailsFilterCache)(data);
-  };
-
-  _showDetailsFilterBottomUp = (data: BottomUpRow) => {
-    return makeShowDetailsFilter(this.showDetailsFilterCache)(data);
-  };
-
-  _debugFilterAggregated = (data: AggregatedRow) => {
-    return this._deepFilterAggregated(
+  _typeFilter = (data: MergedCalltreeRow | AggregatedRow | BottomUpRow): boolean =>
+    deepFilter<MergedCalltreeRow | AggregatedRow | BottomUpRow>(
       data,
-      (rowData) => {
-        const logLine = (rowData as AggregatedRow).originalData;
-        return !!(logLine.type && DEBUG_VALUE_TYPES.has(logLine.type));
-      },
-      {
-        filterCache: this.debugOnlyFilterCache,
-      },
+      (row) =>
+        !!row.originalData.type && this.filterState.selectedTypes.includes(row.originalData.type),
+      this.typeFilterCache,
     );
-  };
-
-  _typeFilterAggregated = (data: AggregatedRow) => {
-    return this._deepFilterAggregated(
-      data,
-      (rowData) => {
-        const logLine = (rowData as AggregatedRow).originalData;
-        if (!logLine.type) {
-          return false;
-        }
-        return this.filterState.selectedTypes.includes(logLine.type);
-      },
-      {
-        filterCache: this.typeFilterCache,
-      },
-    );
-  };
 
   _namespaceFilter = (
     selectedNamespaces: string[],
     _namespace: string,
     data: MergedCalltreeRow | AggregatedRow | BottomUpRow,
     filterParams: { filterCache: Map<string, boolean> },
-  ) => {
+  ): boolean => {
     if (selectedNamespaces.length === 0) {
       return true;
     }
-
-    if ('originalData' in data) {
-      return this._deepFilter(
-        data as MergedCalltreeRow,
-        (rowData) => {
-          return selectedNamespaces.includes(rowData.originalData.namespace || '');
-        },
-        {
-          filterCache: filterParams.filterCache,
-        },
-      );
-    }
-
-    return this._deepFilterAggregated(
-      data as AggregatedRow | BottomUpRow,
-      (rowData) => {
-        return selectedNamespaces.includes(rowData.namespace || '');
-      },
-      {
-        filterCache: filterParams.filterCache,
-      },
+    return deepFilter<MergedCalltreeRow | AggregatedRow | BottomUpRow>(
+      data,
+      (row) => selectedNamespaces.includes(row.namespace || ''),
+      filterParams.filterCache,
     );
   };
-
-  private _deepFilterAggregated(
-    rowData: AggregatedRow | BottomUpRow,
-    filterFunction: (rowData: AggregatedRow | BottomUpRow) => boolean,
-    filterParams: { filterCache: Map<string, boolean> },
-  ): boolean {
-    const cachedMatch = filterParams.filterCache.get(rowData.id);
-    if (cachedMatch !== null && cachedMatch !== undefined) {
-      return cachedMatch;
-    }
-
-    let childMatch = false;
-    const children = rowData._children || [];
-    let len = children.length;
-    while (--len >= 0) {
-      const childRow = children[len];
-      if (childRow) {
-        const match = this._deepFilterAggregated(childRow, filterFunction, filterParams);
-
-        if (match) {
-          childMatch = true;
-          break;
-        }
-      }
-    }
-
-    const finalMatch = childMatch || filterFunction(rowData);
-    filterParams.filterCache.set(rowData.id, finalMatch);
-    return finalMatch;
-  }
-
-  private _deepFilter(
-    rowData: MergedCalltreeRow,
-    filterFunction: (rowData: MergedCalltreeRow) => boolean,
-    filterParams: { filterCache: Map<string, boolean> },
-  ): boolean {
-    const filterCache = filterParams.filterCache;
-    const rowId = rowData.id;
-    const cachedMatch = filterCache.get(rowId);
-    if (cachedMatch !== undefined) {
-      return cachedMatch;
-    }
-
-    let childMatch = false;
-    const children = rowData._children;
-    if (children) {
-      let len = children.length;
-      while (!childMatch && --len >= 0) {
-        const childRow = children[len];
-        if (!childRow) {
-          continue;
-        }
-
-        childMatch = this._deepFilter(childRow, filterFunction, filterParams);
-      }
-    }
-
-    const finalMatch = childMatch || filterFunction(rowData);
-    filterCache.set(rowId, finalMatch);
-    return finalMatch;
-  }
 
   private async _renderCallTree(
     callTreeTableContainer: HTMLDivElement,
@@ -882,7 +752,7 @@ export class CalltreeView extends LitElement {
 
     const { table, tableBuilt } = createAggregatedTable(container, rootMethod, {
       namespaceFilter: this._namespaceFilter,
-      showDetailsFilter: this._showDetailsFilterAggregated,
+      showDetailsFilter: this._showDetailsFilterRollup,
       onFilterCacheClear: () => {
         this.debugOnlyFilterCache.clear();
         this.showDetailsFilterCache.clear();
@@ -910,7 +780,7 @@ export class CalltreeView extends LitElement {
       rootMethod,
       {
         namespaceFilter: this._namespaceFilter,
-        showDetailsFilter: this._showDetailsFilterBottomUp,
+        showDetailsFilter: this._showDetailsFilterRollup,
         onFilterCacheClear: () => {
           this.showDetailsFilterCache.clear();
         },

--- a/log-viewer/src/features/call-tree/components/CalltreeView.ts
+++ b/log-viewer/src/features/call-tree/components/CalltreeView.ts
@@ -47,6 +47,28 @@ provideVSCodeDesignSystem().register(
 
 type ViewMode = 'time-order' | 'aggregated' | 'bottom-up';
 
+// Hoisted out of filter predicates so the Set is constructed once at module
+// load rather than re-allocated on every row's filter evaluation (which can
+// run thousands of times per filter operation on large logs).
+const SHOW_DETAILS_EXCLUDED_TYPES: ReadonlySet<string> = new Set([
+  'CUMULATIVE_LIMIT_USAGE',
+  'LIMIT_USAGE_FOR_NS',
+  'CUMULATIVE_PROFILING',
+  'CUMULATIVE_PROFILING_BEGIN',
+]);
+
+const DEBUG_VALUE_TYPES: ReadonlySet<string> = new Set([
+  'USER_DEBUG',
+  'DATAWEAVE_USER_DEBUG',
+  'USER_DEBUG_FINER',
+  'USER_DEBUG_FINEST',
+  'USER_DEBUG_FINE',
+  'USER_DEBUG_DEBUG',
+  'USER_DEBUG_INFO',
+  'USER_DEBUG_WARN',
+  'USER_DEBUG_ERROR',
+]);
+
 @customElement('call-tree-view')
 export class CalltreeView extends LitElement {
   @property()
@@ -358,12 +380,12 @@ export class CalltreeView extends LitElement {
   }
 
   _flat(arr: LogEvent[], target: LogEvent[]) {
-    arr.forEach((el) => {
-      target.push(el);
-      if (el.children.length > 0) {
-        this._flat(el.children, target);
+    for (const evt of arr) {
+      target.push(evt);
+      if (evt.children.length > 0) {
+        this._flat(evt.children, target);
       }
-    });
+    }
   }
 
   _flatten(arr: LogEvent[]) {
@@ -636,47 +658,27 @@ export class CalltreeView extends LitElement {
     this.blockClearHighlights = false;
   }
 
-  _showDetailsFilter = (data: MergedCalltreeRow) => {
-    const excludedTypes = new Set<string>([
-      'CUMULATIVE_LIMIT_USAGE',
-      'LIMIT_USAGE_FOR_NS',
-      'CUMULATIVE_PROFILING',
-      'CUMULATIVE_PROFILING_BEGIN',
-    ]);
+  _showDetailsFilter = (data: MergedCalltreeRow): boolean => {
+    const showDetailsFilter = (rowData: MergedCalltreeRow): boolean => {
+      const { duration, isParent, discontinuity, type } = rowData.originalData;
+      return (
+        isParent ||
+        duration.total > 0 ||
+        discontinuity ||
+        !!(type && SHOW_DETAILS_EXCLUDED_TYPES.has(type))
+      );
+    };
 
-    return this._deepFilter(
-      data,
-      (rowData) => {
-        const logLine = rowData.originalData;
-        return (
-          logLine.duration.total > 0 ||
-          logLine.exitTypes.length > 0 ||
-          logLine.discontinuity ||
-          !!(logLine.type && excludedTypes.has(logLine.type))
-        );
-      },
-      {
-        filterCache: this.showDetailsFilterCache,
-      },
-    );
+    const params = { filterCache: this.showDetailsFilterCache };
+
+    return this._deepFilter(data, showDetailsFilter, params);
   };
 
   _debugFilter = (data: MergedCalltreeRow) => {
-    const debugValues = new Set<string>([
-      'USER_DEBUG',
-      'DATAWEAVE_USER_DEBUG',
-      'USER_DEBUG_FINER',
-      'USER_DEBUG_FINEST',
-      'USER_DEBUG_FINE',
-      'USER_DEBUG_DEBUG',
-      'USER_DEBUG_INFO',
-      'USER_DEBUG_WARN',
-      'USER_DEBUG_ERROR',
-    ]);
     return this._deepFilter(
       data,
       (rowData) => {
-        return !!(rowData.originalData.type && debugValues.has(rowData.originalData.type));
+        return !!(rowData.originalData.type && DEBUG_VALUE_TYPES.has(rowData.originalData.type));
       },
       {
         filterCache: this.debugOnlyFilterCache,
@@ -724,22 +726,11 @@ export class CalltreeView extends LitElement {
   };
 
   _debugFilterAggregated = (data: AggregatedRow) => {
-    const debugValues = new Set<string>([
-      'USER_DEBUG',
-      'DATAWEAVE_USER_DEBUG',
-      'USER_DEBUG_FINER',
-      'USER_DEBUG_FINEST',
-      'USER_DEBUG_FINE',
-      'USER_DEBUG_DEBUG',
-      'USER_DEBUG_INFO',
-      'USER_DEBUG_WARN',
-      'USER_DEBUG_ERROR',
-    ]);
     return this._deepFilterAggregated(
       data,
       (rowData) => {
         const logLine = (rowData as AggregatedRow).originalData;
-        return !!(logLine.type && debugValues.has(logLine.type));
+        return !!(logLine.type && DEBUG_VALUE_TYPES.has(logLine.type));
       },
       {
         filterCache: this.debugOnlyFilterCache,
@@ -831,28 +822,29 @@ export class CalltreeView extends LitElement {
     filterFunction: (rowData: MergedCalltreeRow) => boolean,
     filterParams: { filterCache: Map<string, boolean> },
   ): boolean {
-    const cachedMatch = filterParams.filterCache.get(rowData.id);
-    if (cachedMatch !== null && cachedMatch !== undefined) {
+    const filterCache = filterParams.filterCache;
+    const rowId = rowData.id;
+    const cachedMatch = filterCache.get(rowId);
+    if (cachedMatch !== undefined) {
       return cachedMatch;
     }
 
     let childMatch = false;
-    const children = rowData._children || [];
-    let len = children.length;
-    while (--len >= 0) {
-      const childRow = children[len];
-      if (childRow) {
-        const match = this._deepFilter(childRow, filterFunction, filterParams);
-
-        if (match) {
-          childMatch = true;
-          break;
+    const children = rowData._children;
+    if (children) {
+      let len = children.length;
+      while (!childMatch && --len >= 0) {
+        const childRow = children[len];
+        if (!childRow) {
+          continue;
         }
+
+        childMatch = this._deepFilter(childRow, filterFunction, filterParams);
       }
     }
 
     const finalMatch = childMatch || filterFunction(rowData);
-    filterParams.filterCache.set(rowData.id, finalMatch);
+    filterCache.set(rowId, finalMatch);
     return finalMatch;
   }
 

--- a/log-viewer/src/features/call-tree/components/CalltreeView.ts
+++ b/log-viewer/src/features/call-tree/components/CalltreeView.ts
@@ -671,19 +671,24 @@ export class CalltreeView extends LitElement {
   _showDetailsFilterRollup = (data: AggregatedRow | BottomUpRow): boolean =>
     makeShowDetailsFilter(this.showDetailsFilterCache)(data);
 
-  _debugFilter = (data: MergedCalltreeRow | AggregatedRow | BottomUpRow): boolean =>
-    deepFilter<MergedCalltreeRow | AggregatedRow | BottomUpRow>(
-      data,
-      (row) => !!(row.originalData.type && DEBUG_VALUE_TYPES.has(row.originalData.type)),
-      this.debugOnlyFilterCache,
-    );
+  private _makeTypeFilter(
+    types: ReadonlySet<string>,
+    cache: Map<string, boolean>,
+  ): (data: MergedCalltreeRow | AggregatedRow | BottomUpRow) => boolean {
+    return (data) =>
+      deepFilter<MergedCalltreeRow | AggregatedRow | BottomUpRow>(
+        data,
+        (row) => {
+          const type = row.originalData.type;
+          return type ? types.has(type) : false;
+        },
+        cache,
+      );
+  }
 
-  _typeFilter = (data: MergedCalltreeRow | AggregatedRow | BottomUpRow): boolean =>
-    deepFilter<MergedCalltreeRow | AggregatedRow | BottomUpRow>(
-      data,
-      (row) => !!row.originalData.type && this.filterState.selectedTypes.has(row.originalData.type),
-      this.typeFilterCache,
-    );
+  _debugFilter = this._makeTypeFilter(DEBUG_VALUE_TYPES, this.debugOnlyFilterCache);
+
+  _typeFilter = this._makeTypeFilter(this.filterState.selectedTypes, this.typeFilterCache);
 
   _namespaceFilter = (
     selectedNamespaces: string[],

--- a/log-viewer/src/features/call-tree/components/TimeOrderTable.ts
+++ b/log-viewer/src/features/call-tree/components/TimeOrderTable.ts
@@ -277,24 +277,19 @@ export function createTimeOrderTable(
   });
   tableRef.current = table;
 
-  // Filter caches MUST be cleared on `dataFiltered`, not `renderStarted`.
-  // Row ids in the merged call tree (`${timestamp}-${index}`) are only unique
-  // within a single parent's children, so the same id string can appear in
-  // different subtrees. On dataTree tables Tabulator runs `filter.filter()`
-  // for the top-level pass and again for each expanded subtree (via
-  // `getChildren` -> `filter.filter(config.children)`). `dataFiltered` fires
-  // after every one of those passes, so clearing here guarantees a fresh
-  // cache per pass. If we waited until `renderStarted` (one event for the
-  // whole pipeline), the top-level walk would poison the cache for later
-  // subtree passes and the wrong rows would match.
-  table.on('dataFiltered', () => {
+  // Filter caches are cleared once per render via `renderStarted`. Row ids
+  // produced by `toUnmergedCallTree` are globally unique within a build
+  // (per-build monotonic counter), so cached `deepFilter` results stay valid
+  // across the cascaded `filter.filter()` passes Tabulator runs for each
+  // expanded subtree — `getChildren` → `filter.filter(config.children)`
+  // would otherwise fire `dataFiltered` multiple times per user action,
+  // defeating the cache. If row ids ever lose their uniqueness guarantee
+  // this must move back to `dataFiltered`.
+  table.on('renderStarted', () => {
     totalTimeFilterCache.clear();
     selfTimeFilterCache.clear();
     namespaceFilterCache.clear();
     callbacks.onFilterCacheClear();
-  });
-
-  table.on('renderStarted', () => {
     callbacks.onRenderStarted();
   });
 

--- a/log-viewer/src/features/call-tree/components/TimeOrderTable.ts
+++ b/log-viewer/src/features/call-tree/components/TimeOrderTable.ts
@@ -277,18 +277,13 @@ export function createTimeOrderTable(
   });
   tableRef.current = table;
 
-  table.on('dataFiltered', () => {
+  // renderStarted fires once after the filter-pipeline; dataFiltered can cascade
+  // on dataTree tables via getFilteredTreeChildren -> filter.filter().
+  table.on('renderStarted', () => {
     totalTimeFilterCache.clear();
     selfTimeFilterCache.clear();
     namespaceFilterCache.clear();
     callbacks.onFilterCacheClear();
-  });
-
-  table.on('dataSorted', () => {
-    callbacks.onRenderStarted();
-  });
-
-  table.on('dataFiltered', () => {
     callbacks.onRenderStarted();
   });
 

--- a/log-viewer/src/features/call-tree/components/TimeOrderTable.ts
+++ b/log-viewer/src/features/call-tree/components/TimeOrderTable.ts
@@ -277,13 +277,24 @@ export function createTimeOrderTable(
   });
   tableRef.current = table;
 
-  // renderStarted fires once after the filter-pipeline; dataFiltered can cascade
-  // on dataTree tables via getFilteredTreeChildren -> filter.filter().
-  table.on('renderStarted', () => {
+  // Filter caches MUST be cleared on `dataFiltered`, not `renderStarted`.
+  // Row ids in the merged call tree (`${timestamp}-${index}`) are only unique
+  // within a single parent's children, so the same id string can appear in
+  // different subtrees. On dataTree tables Tabulator runs `filter.filter()`
+  // for the top-level pass and again for each expanded subtree (via
+  // `getChildren` -> `filter.filter(config.children)`). `dataFiltered` fires
+  // after every one of those passes, so clearing here guarantees a fresh
+  // cache per pass. If we waited until `renderStarted` (one event for the
+  // whole pipeline), the top-level walk would poison the cache for later
+  // subtree passes and the wrong rows would match.
+  table.on('dataFiltered', () => {
     totalTimeFilterCache.clear();
     selfTimeFilterCache.clear();
     namespaceFilterCache.clear();
     callbacks.onFilterCacheClear();
+  });
+
+  table.on('renderStarted', () => {
     callbacks.onRenderStarted();
   });
 

--- a/log-viewer/src/features/call-tree/utils/Aggregation.ts
+++ b/log-viewer/src/features/call-tree/utils/Aggregation.ts
@@ -122,6 +122,11 @@ export function toAggregatedCallTree(rootChildren: LogEvent[]): AggregatedRow[] 
     return [];
   }
 
+  // Per-build monotonic counter; row ids must be globally unique within this
+  // tree so deepFilter caches don't collide across cascaded subtree passes.
+  let next = 0;
+  const idFor = (): string => `agg-${++next}`;
+
   // Group root-level events by signature with call stack tracking
   const rootMap = new Map<string, AggregatedRow>();
   const keyStack = new Multiset<string>();
@@ -133,7 +138,7 @@ export function toAggregatedCallTree(rootChildren: LogEvent[]): AggregatedRow[] 
     let row = rootMap.get(key);
 
     if (!row) {
-      row = createEmptyAggregatedRow(key, event);
+      row = createEmptyAggregatedRow(key, event, idFor);
       rootMap.set(key, row);
     }
 
@@ -145,7 +150,7 @@ export function toAggregatedCallTree(rootChildren: LogEvent[]): AggregatedRow[] 
   for (const row of rootMap.values()) {
     const firstInstance = row.instances[0];
     const stackKey = firstInstance ? getStackKey(firstInstance) : row.key;
-    row._children = aggregateChildrenRecursive(row.instances, stackKey);
+    row._children = aggregateChildrenRecursive(row.instances, stackKey, idFor);
     calculateAverages(row);
   }
 
@@ -160,6 +165,7 @@ export function toAggregatedCallTree(rootChildren: LogEvent[]): AggregatedRow[] 
 function aggregateChildrenRecursive(
   instances: LogEvent[],
   parentStackKey: string,
+  idFor: () => string,
 ): AggregatedRow[] | null {
   const childMap = new Map<string, AggregatedRow>();
   // Create a new stack for each aggregation level, starting with the parent stack key
@@ -172,7 +178,7 @@ function aggregateChildrenRecursive(
       let row = childMap.get(key);
 
       if (!row) {
-        row = createEmptyAggregatedRow(key, child);
+        row = createEmptyAggregatedRow(key, child, idFor);
         childMap.set(key, row);
       }
 
@@ -189,7 +195,7 @@ function aggregateChildrenRecursive(
   for (const row of childMap.values()) {
     const firstInstance = row.instances[0];
     const stackKey = firstInstance ? getStackKey(firstInstance) : row.key;
-    row._children = aggregateChildrenRecursive(row.instances, stackKey);
+    row._children = aggregateChildrenRecursive(row.instances, stackKey, idFor);
     calculateAverages(row);
   }
 
@@ -268,11 +274,15 @@ export function toBottomUpTree(rootChildren: LogEvent[]): BottomUpRow[] {
 
   const attributionMap = computeFrameAttribution(rootChildren);
   const rootBuckets = new Map<string, BottomUpRow>();
+  // Per-build monotonic counter; row ids must be globally unique within this
+  // tree so deepFilter caches don't collide across cascaded subtree passes.
+  let next = 0;
+  const idFor = (): string => `bu-${++next}`;
 
   for (const frame of attributionMap.keys()) {
     // Insert every frame so callCount and DML/SOQL/exception attributions roll up
     // even for frames whose self-time contribution is zero.
-    insertFrameIntoTrie(frame, attributionMap, rootBuckets);
+    insertFrameIntoTrie(frame, attributionMap, rootBuckets, idFor);
   }
 
   return finalizeBuckets(rootBuckets);
@@ -365,12 +375,13 @@ function insertFrameIntoTrie(
   frame: LogEvent,
   attributionMap: Map<LogEvent, FrameAttribution>,
   rootBuckets: Map<string, BottomUpRow>,
+  idFor: () => string,
 ): void {
   const attribution = getOrInitAttribution(attributionMap, frame);
   const rootKey = getEventKey(frame);
   let bucket = rootBuckets.get(rootKey);
   if (!bucket) {
-    bucket = createEmptyBottomUpRow(rootKey, frame);
+    bucket = createEmptyBottomUpRow(rootKey, frame, idFor);
     rootBuckets.set(rootKey, bucket);
   }
   accumulateContribution(bucket, frame, frame, attribution);
@@ -382,7 +393,7 @@ function insertFrameIntoTrie(
     const existingChildren = parentBucket._children ?? [];
     let childBucket = existingChildren.find((candidate) => candidate.key === ancestorKey);
     if (!childBucket) {
-      childBucket = createEmptyBottomUpRow(ancestorKey, ancestor);
+      childBucket = createEmptyBottomUpRow(ancestorKey, ancestor, idFor);
       existingChildren.push(childBucket);
       parentBucket._children = existingChildren;
     }
@@ -448,9 +459,13 @@ function sortBuckets(rows: BottomUpRow[]): void {
   });
 }
 
-function createEmptyAggregatedRow(key: string, event: LogEvent): AggregatedRow {
+function createEmptyAggregatedRow(
+  key: string,
+  event: LogEvent,
+  idFor: () => string,
+): AggregatedRow {
   return {
-    id: `agg-${key}-${Date.now()}-${Math.random().toString(36).slice(2, 9)}`,
+    id: idFor(),
     key,
     text: event.text,
     namespace: event.namespace,
@@ -470,9 +485,9 @@ function createEmptyAggregatedRow(key: string, event: LogEvent): AggregatedRow {
   };
 }
 
-function createEmptyBottomUpRow(key: string, event: LogEvent): BottomUpRow {
+function createEmptyBottomUpRow(key: string, event: LogEvent, idFor: () => string): BottomUpRow {
   return {
-    id: `bu-${key}-${Date.now()}-${Math.random().toString(36).slice(2, 9)}`,
+    id: idFor(),
     key,
     text: event.text,
     namespace: event.namespace,

--- a/log-viewer/src/features/call-tree/utils/DetailsFilter.ts
+++ b/log-viewer/src/features/call-tree/utils/DetailsFilter.ts
@@ -5,6 +5,8 @@ import type { AggregatedRow, BottomUpRow } from './Aggregation.js';
 
 export type AggregatedLikeRow = AggregatedRow | BottomUpRow;
 
+export type DeepFilterable<T> = { id: string; _children?: T[] | null };
+
 export const EXCLUDED_DETAIL_TYPES = new Set<string>([
   'CUMULATIVE_LIMIT_USAGE',
   'LIMIT_USAGE_FOR_NS',
@@ -12,29 +14,36 @@ export const EXCLUDED_DETAIL_TYPES = new Set<string>([
   'CUMULATIVE_PROFILING_BEGIN',
 ]);
 
-export function deepFilterAggregated(
-  rowData: AggregatedLikeRow,
-  filterFunction: (rowData: AggregatedLikeRow) => boolean,
-  filterParams: { filterCache: Map<string, boolean> },
+/**
+ * Recursive id-cached deep filter for any tree row that exposes `id` + `_children`.
+ * Returns true when `predicate(row)` is true OR any descendant matches; the
+ * memoised result is stored on the shared `filterCache` so repeated lookups
+ * within one filter pass are O(1).
+ */
+export function deepFilter<T extends DeepFilterable<T>>(
+  rowData: T,
+  predicate: (row: T) => boolean,
+  filterCache: Map<string, boolean>,
 ): boolean {
-  const cached = filterParams.filterCache.get(rowData.id);
-  if (cached !== null && cached !== undefined) {
+  const cached = filterCache.get(rowData.id);
+  if (cached !== undefined) {
     return cached;
   }
 
   let childMatch = false;
-  const children = rowData._children || [];
-  let len = children.length;
-  while (--len >= 0) {
-    const childRow = children[len];
-    if (childRow && deepFilterAggregated(childRow, filterFunction, filterParams)) {
-      childMatch = true;
-      break;
+  const children = rowData._children;
+  if (children) {
+    let len = children.length;
+    while (!childMatch && --len >= 0) {
+      const childRow = children[len];
+      if (childRow) {
+        childMatch = deepFilter(childRow, predicate, filterCache);
+      }
     }
   }
 
-  const finalMatch = childMatch || filterFunction(rowData);
-  filterParams.filterCache.set(rowData.id, finalMatch);
+  const finalMatch = childMatch || predicate(rowData);
+  filterCache.set(rowData.id, finalMatch);
   return finalMatch;
 }
 
@@ -42,11 +51,11 @@ export function makeShowDetailsFilter(
   filterCache: Map<string, boolean>,
 ): (data: AggregatedLikeRow) => boolean {
   return (data) =>
-    deepFilterAggregated(
+    deepFilter<AggregatedLikeRow>(
       data,
       (row) =>
         row.totalTime > 0 ||
         !!(row.originalData.type && EXCLUDED_DETAIL_TYPES.has(row.originalData.type)),
-      { filterCache },
+      filterCache,
     );
 }

--- a/log-viewer/src/features/call-tree/utils/MergeAdjacent.ts
+++ b/log-viewer/src/features/call-tree/utils/MergeAdjacent.ts
@@ -71,7 +71,7 @@ function isWithinGapThreshold(
 /**
  * Creates a merged row from a group of adjacent events
  */
-function createMergedRow(events: LogEvent[], index: number): MergedCalltreeRow {
+function createMergedRow(events: LogEvent[], idFor: () => string): MergedCalltreeRow {
   const firstEvent = events[0]!;
   const totalDuration = events.reduce((sum, e) => sum + e.duration.total, 0);
   const totalSelfTime = events.reduce((sum, e) => sum + e.duration.self, 0);
@@ -86,18 +86,22 @@ function createMergedRow(events: LogEvent[], index: number): MergedCalltreeRow {
   const maxDuration = Math.max(...durations);
   const avgDuration = totalDuration / events.length;
 
+  // Reserve this row's id first so its prefix sits before any descendant ids
+  // produced during the recursive merge below.
+  const id = `merged-${idFor()}`;
+
   // Create merged children from all events' children
   const allChildren: LogEvent[] = [];
   for (const event of events) {
     allChildren.push(...event.children);
   }
-  const mergedChildren = allChildren.length > 0 ? toMergedCallTree(allChildren) : null;
+  const mergedChildren = allChildren.length > 0 ? toMergedCallTree(allChildren, idFor) : null;
 
   const callCount = events.length;
   const avgSelfTime = callCount > 0 ? totalSelfTime / callCount : 0;
 
   return {
-    id: `merged-${firstEvent.timestamp}-${index}`,
+    id,
     originalData: firstEvent,
     _children: mergedChildren,
     text: firstEvent.text,
@@ -121,11 +125,14 @@ function createMergedRow(events: LogEvent[], index: number): MergedCalltreeRow {
 /**
  * Creates a non-merged row from a single event
  */
-function createSingleRow(event: LogEvent, index: number): MergedCalltreeRow {
-  const children = event.children.length > 0 ? toMergedCallTree(event.children) : null;
+function createSingleRow(event: LogEvent, idFor: () => string): MergedCalltreeRow {
+  // Reserve this row's id before recursing so the parent sits before its
+  // descendants in the global counter sequence.
+  const id = `tt-${idFor()}`;
+  const children = event.children.length > 0 ? toMergedCallTree(event.children, idFor) : null;
 
   return {
-    id: `${event.timestamp}-${index}`,
+    id,
     originalData: event,
     _children: children,
     text: event.text,
@@ -148,7 +155,10 @@ function createSingleRow(event: LogEvent, index: number): MergedCalltreeRow {
 /**
  * Converts log events to call tree rows with adjacent event merging
  */
-export function toMergedCallTree(nodes: LogEvent[]): MergedCalltreeRow[] | undefined {
+export function toMergedCallTree(
+  nodes: LogEvent[],
+  idFor: () => string,
+): MergedCalltreeRow[] | undefined {
   const len = nodes.length;
   if (!len) {
     return undefined;
@@ -183,9 +193,9 @@ export function toMergedCallTree(nodes: LogEvent[]): MergedCalltreeRow[] | undef
 
     // Only merge if we have at least 2 adjacent events
     if (adjacentGroup.length >= 2) {
-      results.push(createMergedRow(adjacentGroup, results.length));
+      results.push(createMergedRow(adjacentGroup, idFor));
     } else {
-      results.push(createSingleRow(currentEvent, results.length));
+      results.push(createSingleRow(currentEvent, idFor));
     }
 
     i = j;
@@ -195,7 +205,11 @@ export function toMergedCallTree(nodes: LogEvent[]): MergedCalltreeRow[] | undef
 }
 
 /**
- * Converts log events to call tree rows without merging (regular view)
+ * Converts log events to call tree rows without merging (regular view).
+ * The top level is single-row per event; descendants are merged via
+ * `toMergedCallTree`. Row ids are a per-build monotonic counter so they are
+ * globally unique within the returned tree, which lets `deepFilter` cache
+ * results across cascaded Tabulator subtree filter passes without collision.
  */
 export function toUnmergedCallTree(nodes: LogEvent[]): MergedCalltreeRow[] | undefined {
   const len = nodes.length;
@@ -203,10 +217,13 @@ export function toUnmergedCallTree(nodes: LogEvent[]): MergedCalltreeRow[] | und
     return undefined;
   }
 
+  let next = 0;
+  const idFor = (): string => String(++next);
+
   const results: MergedCalltreeRow[] = [];
   for (let i = 0; i < len; ++i) {
     const node = nodes[i]!;
-    results.push(createSingleRow(node, i));
+    results.push(createSingleRow(node, idFor));
   }
   return results;
 }

--- a/log-viewer/src/tabulator/module/ScrollAnchor.ts
+++ b/log-viewer/src/tabulator/module/ScrollAnchor.ts
@@ -6,11 +6,14 @@ import { Module, type RowComponent, type Tabulator } from 'tabulator-tables';
 const scrollAnchorOption = 'scrollAnchor' as const;
 
 /**
- * Pixel-accurate scroll anchoring across table re-renders.
+ * Pixel-accurate, data-agnostic scroll anchoring across table re-renders.
  *
- * Capture (renderStarted / dataSorting): the middle visible row and its Y offset
- * inside the holder. Restore (renderComplete, fully synchronous): set scrollTop
- * so the same row sits at the same pixel — no visible jump.
+ * Capture (renderStarted): the middle visible row, its Y offset inside the
+ * holder, and its index in `getDisplayRows()`. Restore (renderComplete, fully
+ * synchronous): set scrollTop so the same row sits at the same pixel — no
+ * visible jump. If the anchor row was filtered or collapsed out, fall back to
+ * the nearest displayed tree ancestor, then to the row at the captured
+ * display-index clamped to the new display length.
  *
  * Enable by registering the module and setting `scrollAnchor: true` in table options.
  */
@@ -22,7 +25,6 @@ export class ScrollAnchor extends Module {
   anchorRow: RowComponent | null = null;
   private anchorOffsetFromHolderTop = 0;
   private anchorDisplayIndex = -1;
-  private pendingFilterRaf: number | null = null;
 
   // Single tree toggle: skip the next renderComplete recenter so scrollTop stays put.
   // Bulk toggle (expand-all / collapse-all): the second toggle in the synchronous burst
@@ -50,28 +52,18 @@ export class ScrollAnchor extends Module {
       this.table.on('dataTreeRowExpanded', () => this._onTreeToggle());
       this.table.on('dataTreeRowCollapsed', () => this._onTreeToggle());
 
-      // Sort resets scrollTop before renderStarted fires, so capture the anchor here
-      // (pre-sort) instead. The renderStarted handler below is a no-op once anchorRow
-      // is set — see the !this.anchorRow guard.
-      this.table.on('dataSorting', () => this._captureAnchor());
-
+      // Capture once per render-cycle. Our custom VariableHeightVerticalRenderer
+      // preserves scrollTop across sort/filter in rerenderRows, so renderStarted
+      // fires with the correct pre-render scrollTop — a single source of capture,
+      // one fewer subscription firing per sort than the old dataSorting + renderStarted pair.
       this.table.on('renderStarted', () => this._captureAnchor());
 
-      // Tabulator bug workaround: rerenderRows on filter can leave .tabulator-table's
-      // paddingTop inflated when the pre-filter vDomTop/vDomBottom point past the
-      // post-filter row count. Detect and zero on the next frame after the render.
-      // See tabulator-virtual-scroll-fixes.md "Fix 7" for the upstream patch.
-      this.table.on('dataFiltered', () => {
-        if (this.pendingFilterRaf !== null) {
-          cancelAnimationFrame(this.pendingFilterRaf);
-        }
-        this.pendingFilterRaf = requestAnimationFrame(() => {
-          this.pendingFilterRaf = null;
-          this._resetStaleTopPadding();
-        });
-      });
-
       this.table.on('renderComplete', () => {
+        // Reset stale paddings BEFORE restore: paddingTop affects the rendered
+        // window position, and paddingBottom contributes to scrollHeight which
+        // the was-at-bottom boundary restore reads.
+        this._resetStaleTopPadding();
+        this._resetStaleBottomPadding();
         if (this.skipNextRender) {
           this.skipNextRender = false;
           this._clearAnchor();
@@ -242,6 +234,43 @@ export class ScrollAnchor extends Module {
       if (renderer) {
         renderer.vDomTopPad = 0;
       }
+    }
+  }
+
+  /**
+   * Tabulator bug workaround: when the last display row is in the rendered
+   * window, `vDomBottomPad` must be 0 by definition — but `_virtualRenderFill`'s
+   * "position" branch can leave it non-zero because it derives the pad from a
+   * stale `vDomScrollHeight` (only updated by the "no-position" branch). The
+   * symptom is a blank strip below the last row after sort / filter / tree
+   * toggle / resize. See `tabulator-virtual-scroll-fixes.md` "Fix 8" for the
+   * upstream patch.
+   */
+  private _resetStaleBottomPadding() {
+    if (!this.tableHolder) {
+      return;
+    }
+    if (!this.tableEl) {
+      this.tableEl = this.tableHolder.querySelector('.tabulator-table');
+    }
+    const tableEl = this.tableEl;
+    if (!tableEl) {
+      return;
+    }
+    const renderer = this.table.rowManager?.renderer as Record<string, unknown> | undefined;
+    if (!renderer) {
+      return;
+    }
+
+    const rowsCount = this.table.rowManager?.getDisplayRows?.()?.length ?? 0;
+    const vDomBottom = (renderer.vDomBottom as number) ?? 0;
+    if (rowsCount === 0 || vDomBottom < rowsCount - 1) {
+      return;
+    }
+    const actualPad = parseFloat(tableEl.style.paddingBottom) || 0;
+    if (actualPad > 0) {
+      tableEl.style.paddingBottom = '0px';
+      renderer.vDomBottomPad = 0;
     }
   }
 

--- a/log-viewer/src/tabulator/module/__tests__/ScrollAnchor.test.ts
+++ b/log-viewer/src/tabulator/module/__tests__/ScrollAnchor.test.ts
@@ -90,9 +90,12 @@ describe('ScrollAnchor', () => {
     expect((plugin as unknown as { skipNextRender: boolean }).skipNextRender).toBe(false);
   });
 
-  it('captures the middle row in dataSorting (before Tabulator resets scrollTop)', () => {
-    // Build a table with a holder + visible rows so dataSorting can run
-    // _findMiddleVisibleRow successfully.
+  it('captures the middle row in renderStarted and is idempotent within a render cycle', () => {
+    // renderStarted is the single capture point. VariableHeightVerticalRenderer
+    // preserves scrollTop across rerenderRows, so by the time renderStarted
+    // fires the holder still reflects the pre-render state — capturing the
+    // correct middle row. The capture must also be idempotent: a second
+    // renderStarted within the same cycle must not overwrite the anchor.
     const r1 = makeRow(0, 30);
     const r2 = makeRow(30, 30);
     const r3 = makeRow(60, 30);
@@ -105,7 +108,9 @@ describe('ScrollAnchor', () => {
       }),
       element: { querySelector: jest.fn(() => holder) },
       getRows: jest.fn((type?: string) => {
-        if (type === 'visible') return [r1, r2, r3];
+        if (type === 'visible') {
+          return [r1, r2, r3];
+        }
         return [];
       }),
       rowManager: { getDisplayRows: () => [] },
@@ -117,20 +122,131 @@ describe('ScrollAnchor', () => {
     (plugin as unknown as { options: () => boolean }).options = () => true;
     plugin.initialize();
 
-    // Sort starts — pre-sort middle row should be captured now (= r2).
-    handlers.dataSorting?.[0]?.();
+    handlers.renderStarted?.[0]?.();
     expect((plugin as unknown as { anchorRow: unknown }).anchorRow).toBe(r2);
 
-    // Tabulator now rebuilds DOM with sorted rows in a different order. If our
-    // dataSorting capture didn't happen, renderStarted would capture the wrong
-    // row. Simulate that by changing the visible set and firing renderStarted —
-    // the guard `!this.anchorRow` should make this a no-op.
+    // Simulate Tabulator firing renderStarted a second time within the same
+    // cycle (e.g. nested rerenders). The `!this.anchorRow` guard should make
+    // this a no-op even though the visible set has changed.
     (table.getRows as jest.Mock).mockImplementation((...args: unknown[]) => {
-      if (args[0] === 'visible') return [r3, r2, r1]; // reversed
+      if (args[0] === 'visible') {
+        return [r3, r2, r1]; // reversed
+      }
       return [];
     });
     handlers.renderStarted?.[0]?.();
     expect((plugin as unknown as { anchorRow: unknown }).anchorRow).toBe(r2);
+  });
+
+  it('zeros stale paddingBottom when the last display row is in the rendered window', () => {
+    const tableEl = { style: { paddingBottom: '80px' } };
+    const holder = {
+      scrollTop: 0,
+      querySelector: jest.fn((sel: string) => (sel === '.tabulator-table' ? tableEl : null)),
+    };
+    // 3 rows total; vDomBottom = 2 (== rowsCount - 1) → last row is rendered.
+    const renderer: Record<string, unknown> = { vDomBottom: 2, vDomBottomPad: 80 };
+    const internalRows = [{}, {}, {}];
+    const handlers: Record<string, ((...args: unknown[]) => void)[]> = {};
+    const table = {
+      handlers,
+      on: jest.fn((evt: string, fn: (...args: unknown[]) => void) => {
+        (handlers[evt] ??= []).push(fn);
+      }),
+      element: { querySelector: jest.fn(() => holder) },
+      getRows: jest.fn(() => []),
+      rowManager: { renderer, getDisplayRows: () => internalRows },
+      scrollToRow: jest.fn(() => Promise.resolve()),
+    };
+    const plugin = new ScrollAnchor(table as never);
+    (plugin as unknown as { table: typeof table }).table = table;
+    (plugin as unknown as { options: () => boolean }).options = () => true;
+    plugin.initialize();
+
+    (plugin as unknown as { _resetStaleBottomPadding: () => void })._resetStaleBottomPadding();
+
+    expect(tableEl.style.paddingBottom).toBe('0px');
+    expect(renderer.vDomBottomPad).toBe(0);
+  });
+
+  it('leaves paddingBottom alone when the last display row is not yet rendered', () => {
+    const tableEl = { style: { paddingBottom: '80px' } };
+    const holder = {
+      scrollTop: 0,
+      querySelector: jest.fn((sel: string) => (sel === '.tabulator-table' ? tableEl : null)),
+    };
+    // 10 rows total; vDomBottom = 4 → there are rows below the window. The pad
+    // is legitimately non-zero in this case; we must not touch it.
+    const renderer: Record<string, unknown> = { vDomBottom: 4, vDomBottomPad: 120 };
+    const internalRows = Array.from({ length: 10 }, () => ({}));
+    const handlers: Record<string, ((...args: unknown[]) => void)[]> = {};
+    const table = {
+      handlers,
+      on: jest.fn((evt: string, fn: (...args: unknown[]) => void) => {
+        (handlers[evt] ??= []).push(fn);
+      }),
+      element: { querySelector: jest.fn(() => holder) },
+      getRows: jest.fn(() => []),
+      rowManager: { renderer, getDisplayRows: () => internalRows },
+      scrollToRow: jest.fn(() => Promise.resolve()),
+    };
+    const plugin = new ScrollAnchor(table as never);
+    (plugin as unknown as { table: typeof table }).table = table;
+    (plugin as unknown as { options: () => boolean }).options = () => true;
+    plugin.initialize();
+
+    (plugin as unknown as { _resetStaleBottomPadding: () => void })._resetStaleBottomPadding();
+
+    expect(tableEl.style.paddingBottom).toBe('80px');
+    expect(renderer.vDomBottomPad).toBe(120);
+  });
+
+  it('resets paddings before the anchor restore in renderComplete (so scrollHeight is accurate for was-at-bottom)', () => {
+    // wasAtBottom: scrollTop near max. Bottom-padding is stale → scrollHeight
+    // is inflated. If the reset ran AFTER the restore, the boundary restore
+    // would snap to the wrong (inflated) bottom. Verify the reset wins.
+    const tableEl = { style: { paddingBottom: '200px', paddingTop: '0px' } };
+    const holder = {
+      scrollTop: 800,
+      scrollHeight: 1000, // 800 + 200 stale pad
+      clientHeight: 100,
+      querySelector: jest.fn((sel: string) => (sel === '.tabulator-table' ? tableEl : null)),
+      getBoundingClientRect: () => rect(0, 100),
+    };
+    const renderer: Record<string, unknown> = { vDomBottom: 0, vDomBottomPad: 200 };
+    const internalRows = [{}];
+    const handlers: Record<string, ((...args: unknown[]) => void)[]> = {};
+    const table = {
+      handlers,
+      on: jest.fn((evt: string, fn: (...args: unknown[]) => void) => {
+        (handlers[evt] ??= []).push(fn);
+      }),
+      element: { querySelector: jest.fn(() => holder) },
+      getRows: jest.fn(() => []),
+      rowManager: { renderer, getDisplayRows: () => internalRows },
+      scrollToRow: jest.fn(() => Promise.resolve()),
+    };
+    const plugin = new ScrollAnchor(table as never);
+    (plugin as unknown as { table: typeof table }).table = table;
+    (plugin as unknown as { options: () => boolean }).options = () => true;
+    plugin.initialize();
+
+    // Seed wasAtBottom directly; the renderComplete handler should run both
+    // padding resets, then snap scrollTop to the corrected max.
+    const p = plugin as unknown as { wasAtBottom: boolean };
+    p.wasAtBottom = true;
+
+    // Once the pad is zeroed the holder's scrollHeight reflects only content.
+    Object.defineProperty(holder, 'scrollHeight', {
+      get: () => (renderer.vDomBottomPad === 0 ? 800 : 1000),
+    });
+
+    handlers.renderComplete?.[0]?.();
+
+    expect(tableEl.style.paddingBottom).toBe('0px');
+    expect(renderer.vDomBottomPad).toBe(0);
+    // scrollTop snapped to corrected max (800 - 100 = 700), not stale (1000 - 100 = 900).
+    expect(holder.scrollTop).toBe(700);
   });
 
   it('zeros stale paddingTop after filter when scrollTop is less than paddingTop', () => {
@@ -226,10 +342,16 @@ describe('ScrollAnchor', () => {
   });
 
   it('on renderComplete with wasAtTop, snaps scrollTop to 0 instead of centering', () => {
-    const holder: { scrollTop: number; scrollHeight: number; clientHeight: number } = {
+    const holder: {
+      scrollTop: number;
+      scrollHeight: number;
+      clientHeight: number;
+      querySelector: () => null;
+    } = {
       scrollTop: 0,
       scrollHeight: 1000,
       clientHeight: 100,
+      querySelector: () => null,
     };
     const handlers: Record<string, ((...args: unknown[]) => void)[]> = {};
     const table = {
@@ -256,10 +378,16 @@ describe('ScrollAnchor', () => {
   });
 
   it('on renderComplete with wasAtBottom, snaps scrollTop to max instead of centering', () => {
-    const holder: { scrollTop: number; scrollHeight: number; clientHeight: number } = {
+    const holder: {
+      scrollTop: number;
+      scrollHeight: number;
+      clientHeight: number;
+      querySelector: () => null;
+    } = {
       scrollTop: 0,
       scrollHeight: 1000,
       clientHeight: 100,
+      querySelector: () => null,
     };
     const handlers: Record<string, ((...args: unknown[]) => void)[]> = {};
     const table = {
@@ -390,11 +518,13 @@ describe('ScrollAnchor', () => {
       scrollHeight: number;
       clientHeight: number;
       getBoundingClientRect: () => ReturnType<typeof rect>;
+      querySelector: () => null;
     } = {
       scrollTop: 100,
       scrollHeight: 5000,
       clientHeight: 100,
       getBoundingClientRect: () => rect(0, 100),
+      querySelector: () => null,
     };
     const renderer = {
       rows: jest.fn(() => [internalRow]),


### PR DESCRIPTION
# 📝 PR Overview

Improves render and filter performance for the Call Tree views (Time-Order, Aggregated, Bottom-Up) on large Apex logs, plus a `ScrollAnchor` fix and a regression fix in the type filter found during the work.

The branch consolidates duplicated filter logic so each view now shares one `deepFilter` primitive, moves hot-path Sets/predicates out of per-row allocations, and tightens the Bottom-Up trie build.

## 🛠️ Changes made

- **`deepFilter` consolidation** — collapsed `_deepFilter` / `_deepFilterAggregated` and their per-view filter pairs (`_debugFilter` / `_debugFilterAggregated`, etc.) into a single generic helper in `utils/DetailsFilter.ts`. `MergedCalltreeRow`, `AggregatedRow`, and `BottomUpRow` all satisfy the same `{ id; _children }` shape.
- **Hot-path predicate cleanup** — `SHOW_DETAILS_EXCLUDED_TYPES` and `DEBUG_VALUE_TYPES` lifted to module scope so the Sets aren't reconstructed per row; `_showDetailsFilter` switched from `exitTypes.length > 0` to `isParent` to avoid the array length read; `_flat` switched from `forEach` to `for-of` to drop per-frame callback allocation.
- **`selectedTypes` → `Set`** — replaces `string[]` membership checks (`.includes`) with `.has` on the type-filter hot path.
- **Bottom-Up trie build** — `insertFrameIntoTrie` now uses a transient per-node `Map<string, BottomUpRow>` keyed by child key instead of `Array.prototype.find`, dropping the inner sibling lookup from O(siblings) to O(1). The map is cleared during the existing `finalizeBucketRecursive` walk so nothing leaks into Tabulator.
- **`AggregatedTable` cell renderer** — drops the per-cell formatter object allocation and computes the data-tree indent once per cell using cached `dataTreeChildIndent`.
- **`ScrollAnchor` fix** (#7cdf35e5) — eliminates the blank strip and stale-padding jumps after sort/filter by collapsing the anchor capture to `renderStarted` and resetting both top and bottom stale padding synchronously in `renderComplete` before the boundary snap.
- **Regression fix: type filter leaking unrelated rows** (#8ead292c)
  - Reverted the `_makeTypeFilter` factory — it captured `filterState.selectedTypes` by reference at field-init time; `_handleTypeFilter` reassigns the Set so the closure was permanently empty. `_debugFilter` / `_typeFilter` are inline arrows again and read via `this.filterState.selectedTypes` fresh on every row.
  - Row ids have been made unique, filter caches now clear on `renderStarted` and not `dataFiltered`. Tabulator's dataTree re-runs `filter.filter()` for each expanded subtree.

## 🧩 Type of change (check all applicable)

- [x] 🐛 Bug fix - something not working as expected
- [ ] ✨ New feature – adds new functionality
- [x] ♻️ Refactor - internal changes with no user impact
- [x] ⚡ Performance Improvement
- [ ] 📝 Documentation - README or documentation site changes
- [ ] 🔧 Chore - dev tooling, CI, config
- [ ] 💥 Breaking change

## 📷 Screenshots / gifs / video [optional]

_No UI changes._

## 🔗 Related Issues

relates #333

_None._

## ✅ Tests added?

- [x] 👍 yes
- [ ] 🙅 no, not needed
- [ ] 🙋 no, I need help

Added/updated coverage for `ScrollAnchor` (renderStarted idempotency, top/bottom padding resets, race vs. was-at-bottom restore). Existing Aggregation / BottomCalcs / SOQL / timeline / call-tree suites all pass (851/851).

## 📚 Docs updated?

- [ ] 🔖 README.md
- [ ] 🔖 CHANGELOG.md
- [ ] 📖 help site
- [x] 🙅 not needed
