### PR TITLE
perf(call-tree): avoid DataTree row init in self-time bottom calc

### DIFF
--- a/log-viewer/src/features/call-tree/utils/BottomCalcs.ts
+++ b/log-viewer/src/features/call-tree/utils/BottomCalcs.ts
@@ -2,28 +2,20 @@
  * Copyright (c) 2026 Certinia Inc. All rights reserved.
  */
 
-import type { RowComponent, Tabulator } from 'tabulator-tables';
+import type { Tabulator } from 'tabulator-tables';
 
 import type { AggregatedRow, BottomUpRow } from './Aggregation.js';
+import { getFilteredDataTreeRows, type DataTreeFilterTable } from './DataTreeFilter.js';
 import { type TimeOrderRow } from './TimeOrderTree.js';
 
 type CalltreeRowUnion = TimeOrderRow | AggregatedRow | BottomUpRow;
 
-interface InternalRow {
-  getComponent(): RowComponent;
-  getData(): CalltreeRowUnion;
+interface FilterModule {
+  filterRow(row: { getData(): CalltreeRowUnion }, filters?: unknown): boolean;
 }
 
-interface DataTreeModule {
-  getFilteredTreeChildren(row: InternalRow): InternalRow[];
-}
-
-interface RowComponentInternal extends RowComponent {
-  _getSelf(): InternalRow;
-}
-
-type TabulatorInternals = Tabulator & {
-  modules: { dataTree?: DataTreeModule };
+type BottomCalcTable = DataTreeFilterTable<CalltreeRowUnion> & {
+  modules: { filter?: FilterModule };
 };
 
 function getRowSelfTime(row: CalltreeRowUnion): number {
@@ -40,28 +32,24 @@ function getRowSelfTime(row: CalltreeRowUnion): number {
  *
  * Tabulator's public `RowComponent.getTreeChildren()` ignores filters, and
  * `getRows('active')` only walks expanded branches. To get an accurate sum we
- * reach into `table.modules.dataTree.getFilteredTreeChildren(internalRow)`,
- * which applies the active filters to a row's tree children. The internal Row
- * is obtained via `RowComponent._getSelf()`.
+ * collect rows through a data-only table-centric helper that applies the
+ * active filter rules without DataTree child-row initialization side effects.
  */
 export function makeSumSelfTimeAllVisible(getTable: () => Tabulator | undefined) {
   return (_values: number[], _data: CalltreeRowUnion[], _calcParams: unknown): number => {
-    const table = getTable() as TabulatorInternals | undefined;
-    const dataTree = table?.modules.dataTree;
-    if (!table || !dataTree) {
+    const table = getTable() as BottomCalcTable | undefined;
+    if (!table) {
       return 0;
     }
 
     let total = 0;
-    const walk = (rows: InternalRow[]): void => {
-      for (const row of rows) {
-        total += getRowSelfTime(row.getData());
-        walk(dataTree.getFilteredTreeChildren(row));
-      }
-    };
 
-    const topLevel = table.getRows('active') as RowComponentInternal[];
-    walk(topLevel.map((rc) => rc._getSelf()));
+    const allVisibleRows = getFilteredDataTreeRows(table);
+
+    for (const row of allVisibleRows) {
+      total += getRowSelfTime(row);
+    }
+
     return total;
   };
 }

--- a/log-viewer/src/features/call-tree/utils/DataTreeFilter.ts
+++ b/log-viewer/src/features/call-tree/utils/DataTreeFilter.ts
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) 2026 Certinia Inc. All rights reserved.
+ */
+
+import type { RowComponent } from 'tabulator-tables';
+
+type TabulatorFilterRow<T> = (row: { getData(): T }, filters?: unknown) => boolean;
+
+type InternalRow<T> = { getData(): T };
+
+type TableRow<T> = RowComponent | InternalRow<T> | T;
+
+export interface DataTreeFilterTable<T extends object> {
+  getRows(rowRange?: string): TableRow<T>[];
+  modules?: {
+    filter?: {
+      filterRow: TabulatorFilterRow<T>;
+    };
+  };
+  options?: {
+    dataTreeChildField?: string;
+    dataTreeFilter?: boolean;
+  };
+}
+
+function getChildren<T extends object>(row: T, childField: string): T[] {
+  const childRows = (row as Record<string, unknown>)[childField];
+  return Array.isArray(childRows) ? (childRows as T[]) : [];
+}
+
+function toDataRow<T extends object>(row: TableRow<T>): T {
+  if (typeof row !== 'object' || row === null) {
+    return row as T;
+  }
+
+  if ('getData' in row && typeof row.getData === 'function') {
+    return row.getData() as T;
+  }
+
+  if ('_getSelf' in row) {
+    return (row as { _getSelf(): InternalRow<T> })._getSelf().getData();
+  }
+
+  return row as T;
+}
+
+export function getFilteredDataTreeRows<T extends object>(table: DataTreeFilterTable<T>): T[] {
+  const anchors = (table.getRows('active') as readonly TableRow<T>[]).map((row) => toDataRow(row));
+  const childField = table.options?.dataTreeChildField ?? '_children';
+  const filterModule = table.modules?.filter;
+  const shouldApplyFilter = table.options?.dataTreeFilter !== false && !!filterModule;
+
+  const rowShim: { _data: T | null; getData(): T } = {
+    _data: null,
+    getData() {
+      return this._data as T;
+    },
+  };
+  const passesFilter = shouldApplyFilter
+    ? (row: T): boolean => {
+        rowShim._data = row;
+        return filterModule!.filterRow(rowShim);
+      }
+    : (_row: T): boolean => true;
+
+  const output: T[] = [];
+
+  const walk = (row: T): void => {
+    if (!passesFilter(row)) {
+      return;
+    }
+    output.push(row);
+    for (const child of getChildren(row, childField)) {
+      walk(child);
+    }
+  };
+
+  for (const anchor of anchors) {
+    walk(anchor);
+  }
+
+  return output;
+}

--- a/log-viewer/src/features/call-tree/utils/__tests__/BottomCalcs.test.ts
+++ b/log-viewer/src/features/call-tree/utils/__tests__/BottomCalcs.test.ts
@@ -9,13 +9,18 @@ interface FakeRow<TData = unknown> {
 
 interface InternalRowLike {
   getData(): unknown;
-  __children: FakeRow[];
+}
+
+function attachDataChildren(row: FakeRow): unknown {
+  const data = row.data as { _children?: unknown[] };
+  data._children = row.children.map((child) => attachDataChildren(child));
+  return data;
 }
 
 function toInternalRow(row: FakeRow): InternalRowLike {
+  attachDataChildren(row);
   return {
     getData: () => row.data,
-    __children: row.children,
   };
 }
 
@@ -26,11 +31,7 @@ function fakeTable(rootRows: FakeRow[]): Tabulator {
       internalRows.map((ir) => ({
         _getSelf: () => ir,
       })),
-    modules: {
-      dataTree: {
-        getFilteredTreeChildren: (row: InternalRowLike) => row.__children.map(toInternalRow),
-      },
-    },
+    modules: {},
   } as unknown as Tabulator;
 }
 

--- a/log-viewer/src/features/call-tree/utils/__tests__/DataTreeFilter.test.ts
+++ b/log-viewer/src/features/call-tree/utils/__tests__/DataTreeFilter.test.ts
@@ -1,0 +1,97 @@
+import { getFilteredDataTreeRows } from '../DataTreeFilter.js';
+
+type Node = {
+  id: string;
+  value: number;
+  _children?: Node[];
+};
+
+describe('getFilteredDataTreeRows', () => {
+  it('returns all rows from active anchors when no filter is configured', () => {
+    const root: Node = {
+      id: 'root',
+      value: 0,
+      _children: [
+        { id: 'a', value: 1, _children: [{ id: 'a1', value: 11 }] },
+        { id: 'b', value: 2 },
+      ],
+    };
+
+    const table = {
+      getRows: () => [{ getData: () => root }],
+      modules: {},
+      options: {},
+    };
+
+    const result = getFilteredDataTreeRows<Node>(table);
+    expect(result.map((row) => row.id)).toEqual(['root', 'a', 'a1', 'b']);
+  });
+
+  it('applies the table filter to anchors and descendants', () => {
+    const root: Node = {
+      id: 'root',
+      value: 1,
+      _children: [
+        { id: 'drop', value: 0, _children: [{ id: 'drop-child', value: 1 }] },
+        { id: 'keep', value: 2, _children: [{ id: 'keep-child', value: 3 }] },
+      ],
+    };
+
+    const table = {
+      getRows: () => [{ getData: () => root }],
+      modules: {
+        filter: {
+          filterRow: (row: { getData(): Node }) => row.getData().value > 0,
+        },
+      },
+      options: {
+        dataTreeFilter: true,
+      },
+    };
+
+    const result = getFilteredDataTreeRows<Node>(table);
+    expect(result.map((row) => row.id)).toEqual(['root', 'keep', 'keep-child']);
+  });
+
+  it('skips filtering when dataTreeFilter is disabled', () => {
+    const root: Node = {
+      id: 'root',
+      value: 0,
+      _children: [{ id: 'child', value: 0 }],
+    };
+
+    const table = {
+      getRows: () => [{ getData: () => root }],
+      modules: {
+        filter: {
+          filterRow: () => false,
+        },
+      },
+      options: {
+        dataTreeFilter: false,
+      },
+    };
+
+    const result = getFilteredDataTreeRows<Node>(table);
+    expect(result.map((row) => row.id)).toEqual(['root', 'child']);
+  });
+
+  it('honors a custom dataTreeChildField', () => {
+    const root = {
+      id: 'root',
+      value: 1,
+      kids: [{ id: 'child', value: 1 }],
+    } as unknown as Node;
+
+    const table = {
+      getRows: () => [{ getData: () => root }],
+      modules: {},
+      options: {
+        dataTreeChildField: 'kids',
+      },
+    };
+
+    const result = getFilteredDataTreeRows<Node>(table);
+    expect(result.map((row) => row.id)).toEqual(['root', 'child']);
+  });
+});


### PR DESCRIPTION
# 📝 PR Overview

Speeds up and decouples the "sum self-time across all visible rows" bottom calc by walking the data tree directly instead of materializing Tabulator `RowComponent`s for every descendant via the internal `dataTree.getFilteredTreeChildren` API. The calc now passes through a small, table-centric helper that applies the active filter to row data without DataTree child-row initialization side effects.

## 🛠️ Changes made

- Add `DataTreeFilter.ts` with `getFilteredDataTreeRows(table)`: walks `getRows('active')` anchors plus all descendants via the configured `dataTreeChildField`, applying the table's `filter.filterRow` through a reusable row shim so no internal `Row` instances are constructed.
- Rework `BottomCalcs.makeSumSelfTimeAllVisible` to call the new helper and drop the `RowComponent._getSelf()` / `dataTree.getFilteredTreeChildren` dependency, removing the per-descendant DataTree initialization cost on every bottom-calc recompute.
- Update the BottomCalcs test fake to expose children via `_children` data instead of a `__children` shim on the internal-row mock, matching the new data-driven traversal path.
- Cover the new helper with `DataTreeFilter.test.ts` (no filter, table filter applied to anchors + descendants, `dataTreeFilter: false` bypass, custom `dataTreeChildField`).

## 🧩 Type of change (check all applicable)

- [ ] 🐛 Bug fix - something not working as expected
- [ ] ✨ New feature – adds new functionality
- [x] ♻️ Refactor - internal changes with no user impact
- [x] ⚡ Performance Improvement
- [ ] 📝 Documentation - README or documentation site changes
- [ ] 🔧 Chore - dev tooling, CI, config
- [ ] 💥 Breaking change

## 🔗 Related Issues

related #333

## ✅ Tests added?

- [x] 👍 yes

## 📚 Docs updated?

- [x] 🙅 not needed