### PR TITLE
perf(call-tree): precompute show-details filter as O(1) row flag

### DIFF
--- a/log-viewer/src/features/analysis/components/AnalysisView.ts
+++ b/log-viewer/src/features/analysis/components/AnalysisView.ts
@@ -16,7 +16,6 @@ import type { ApexLog } from 'apex-log-parser';
 import { isVisible } from '../../../core/utility/Util.js';
 import { createBottomUpTable } from '../../call-tree/components/BottomUpTable.js';
 import type { BottomUpRow } from '../../call-tree/utils/Aggregation.js';
-import { makeShowDetailsFilter } from '../../call-tree/utils/DetailsFilter.js';
 import { expandCollapseAll } from '../../call-tree/utils/ExpandCollapse.js';
 
 import dataGridStyles from '../../../tabulator/style/DataGrid.scss';
@@ -127,11 +126,10 @@ export class AnalysisView extends LitElement {
   blockClearHighlights = true;
 
   filterState = { showDetails: false };
-  showDetailsFilterCache = new Map<string, boolean>();
 
-  _showDetailsFilter = (data: BottomUpRow) => {
-    return makeShowDetailsFilter(this.showDetailsFilterCache)(data);
-  };
+  // Precomputed at tree-build time on each BottomUpRow; the filter is a
+  // single boolean read with no walk and no cache.
+  _showDetailsFilter = (data: BottomUpRow): boolean => data._hasDetailsDeep;
 
   constructor() {
     super();
@@ -265,7 +263,6 @@ export class AnalysisView extends LitElement {
     if (!table) {
       return;
     }
-    this.showDetailsFilterCache.clear();
     table.blockRedraw();
     table.clearFilter(false);
     if (!this.filterState.showDetails) {
@@ -362,7 +359,6 @@ export class AnalysisView extends LitElement {
         namespaceFilter: () => true,
         showDetailsFilter: this._showDetailsFilter,
         onFilterCacheClear: () => {
-          this.showDetailsFilterCache.clear();
           if (!this.blockClearHighlights && this.totalMatches > 0) {
             this._resetFindWidget();
             this._clearSearchHighlights();

--- a/log-viewer/src/features/call-tree/components/AggregatedTable.ts
+++ b/log-viewer/src/features/call-tree/components/AggregatedTable.ts
@@ -310,7 +310,7 @@ export function createAggregatedTable(
     namespaceFilterCache.clear();
     totalTimeFilterCache.clear();
     selfTimeFilterCache.clear();
-    callbacks.onFilterCacheClear();
+    callbacks.onFilterCacheClear?.();
     callbacks.onRenderStarted();
   });
 

--- a/log-viewer/src/features/call-tree/components/BottomUpTable.ts
+++ b/log-viewer/src/features/call-tree/components/BottomUpTable.ts
@@ -237,7 +237,7 @@ export function createBottomUpTable(
   // defeating the cache. If row ids ever lose their uniqueness guarantee
   // this must move back to `dataFiltered`.
   table.on('renderStarted', () => {
-    callbacks.onFilterCacheClear();
+    callbacks.onFilterCacheClear?.();
     callbacks.onRenderStarted();
   });
 

--- a/log-viewer/src/features/call-tree/components/CalltreeView.ts
+++ b/log-viewer/src/features/call-tree/components/CalltreeView.ts
@@ -19,7 +19,7 @@ import { vscodeMessenger } from '../../../core/messaging/VSCodeExtensionMessenge
 import { findEventByTimestamp } from '../../../core/utility/EventSearch.js';
 import { isVisible } from '../../../core/utility/Util.js';
 import type { AggregatedRow, BottomUpRow } from '../utils/Aggregation.js';
-import { deepFilter, makeShowDetailsFilter } from '../utils/DetailsFilter.js';
+import { deepFilter } from '../utils/DetailsFilter.js';
 import { expandCollapseAll } from '../utils/ExpandCollapse.js';
 import type { TimeOrderRow } from '../utils/TimeOrderTree.js';
 
@@ -48,16 +48,6 @@ provideVSCodeDesignSystem().register(
 );
 
 type ViewMode = 'time-order' | 'aggregated' | 'bottom-up';
-
-// Hoisted out of filter predicates so the Set is constructed once at module
-// load rather than re-allocated on every row's filter evaluation (which can
-// run thousands of times per filter operation on large logs).
-const SHOW_DETAILS_EXCLUDED_TYPES: ReadonlySet<string> = new Set([
-  'CUMULATIVE_LIMIT_USAGE',
-  'LIMIT_USAGE_FOR_NS',
-  'CUMULATIVE_PROFILING',
-  'CUMULATIVE_PROFILING_BEGIN',
-]);
 
 const DEBUG_VALUE_TYPES: ReadonlySet<string> = new Set([
   'USER_DEBUG',
@@ -92,7 +82,6 @@ export class CalltreeView extends LitElement {
   };
   bottomUpGroupBy = 'None';
   debugOnlyFilterCache = new Map<string, boolean>();
-  showDetailsFilterCache = new Map<string, boolean>();
   typeFilterCache = new Map<string, boolean>();
 
   findMap: { [key: number]: RowComponent } = {};
@@ -500,12 +489,10 @@ export class CalltreeView extends LitElement {
     }
 
     this.debugOnlyFilterCache.clear();
-    this.showDetailsFilterCache.clear();
     this.typeFilterCache.clear();
 
     const filtersToAdd = [];
 
-    const isAggregated = this.viewMode === 'aggregated';
     const isBottomUp = this.viewMode === 'bottom-up';
 
     if (!isBottomUp && this.filterState.debugOnly) {
@@ -520,9 +507,7 @@ export class CalltreeView extends LitElement {
       }
 
       if (!this.filterState.showDetails) {
-        filtersToAdd.push(
-          isAggregated || isBottomUp ? this._showDetailsFilterRollup : this._showDetailsFilter,
-        );
+        filtersToAdd.push(this._showDetailsFilter);
       }
     }
 
@@ -653,23 +638,11 @@ export class CalltreeView extends LitElement {
     this.blockClearHighlights = false;
   }
 
-  _showDetailsFilter = (data: TimeOrderRow): boolean =>
-    deepFilter<TimeOrderRow>(
-      data,
-      (row) => {
-        const { duration, isParent, discontinuity, type } = row.originalData;
-        return (
-          isParent ||
-          duration.total > 0 ||
-          discontinuity ||
-          !!(type && SHOW_DETAILS_EXCLUDED_TYPES.has(type))
-        );
-      },
-      this.showDetailsFilterCache,
-    );
-
-  _showDetailsFilterRollup = (data: AggregatedRow | BottomUpRow): boolean =>
-    makeShowDetailsFilter(this.showDetailsFilterCache)(data);
+  // Show-Details predicate is precomputed at tree-build time (see
+  // `_hasDetailsDeep` in TimeOrderTree/Aggregation), so the Tabulator filter
+  // is a single boolean read — no per-toggle tree walk, no cache.
+  _showDetailsFilter = (data: TimeOrderRow | AggregatedRow | BottomUpRow): boolean =>
+    data._hasDetailsDeep;
 
   _debugFilter = (data: TimeOrderRow | AggregatedRow | BottomUpRow): boolean =>
     deepFilter<TimeOrderRow | AggregatedRow | BottomUpRow>(
@@ -721,7 +694,6 @@ export class CalltreeView extends LitElement {
       namespaceFilter: this._namespaceFilter,
       onFilterCacheClear: () => {
         this.debugOnlyFilterCache.clear();
-        this.showDetailsFilterCache.clear();
         this.typeFilterCache.clear();
       },
       onRenderStarted: () => {
@@ -754,10 +726,9 @@ export class CalltreeView extends LitElement {
 
     const { table, tableBuilt } = createAggregatedTable(container, rootMethod, {
       namespaceFilter: this._namespaceFilter,
-      showDetailsFilter: this._showDetailsFilterRollup,
+      showDetailsFilter: this._showDetailsFilter,
       onFilterCacheClear: () => {
         this.debugOnlyFilterCache.clear();
-        this.showDetailsFilterCache.clear();
         this.typeFilterCache.clear();
       },
       onRenderStarted: () => {
@@ -782,10 +753,7 @@ export class CalltreeView extends LitElement {
       rootMethod,
       {
         namespaceFilter: this._namespaceFilter,
-        showDetailsFilter: this._showDetailsFilterRollup,
-        onFilterCacheClear: () => {
-          this.showDetailsFilterCache.clear();
-        },
+        showDetailsFilter: this._showDetailsFilter,
         onRenderStarted: () => {
           if (!this.blockClearHighlights && this.totalMatches > 0) {
             this._resetFindWidget();

--- a/log-viewer/src/features/call-tree/components/TableShared.ts
+++ b/log-viewer/src/features/call-tree/components/TableShared.ts
@@ -18,7 +18,7 @@ export interface TableCallbacks {
     data: TimeOrderRow | AggregatedRow | BottomUpRow,
     filterParams: { filterCache: Map<string, boolean> },
   ) => boolean;
-  onFilterCacheClear: () => void;
+  onFilterCacheClear?: () => void;
   onRenderStarted: () => void;
 }
 

--- a/log-viewer/src/features/call-tree/components/TimeOrderTable.ts
+++ b/log-viewer/src/features/call-tree/components/TimeOrderTable.ts
@@ -289,7 +289,7 @@ export function createTimeOrderTable(
     totalTimeFilterCache.clear();
     selfTimeFilterCache.clear();
     namespaceFilterCache.clear();
-    callbacks.onFilterCacheClear();
+    callbacks.onFilterCacheClear?.();
     callbacks.onRenderStarted();
   });
 

--- a/log-viewer/src/features/call-tree/utils/Aggregation.ts
+++ b/log-viewer/src/features/call-tree/utils/Aggregation.ts
@@ -5,6 +5,7 @@
 import type { LogEvent, SelfTotal } from 'apex-log-parser';
 import { getCallerNamespace } from '../../../core/utility/CallerNamespace.js';
 import { Multiset } from '../../../core/utility/Multiset.js';
+import { EXCLUDED_DETAIL_TYPES } from './DetailsFilter.js';
 
 /**
  * Represents a row in the aggregated call tree view.
@@ -45,6 +46,8 @@ export interface AggregatedRow {
   instances: LogEvent[];
   /** Representative event for this row (used by formatters) */
   originalData: LogEvent;
+  /** See {@link TimeOrderRow._hasDetailsDeep}. Precomputed during tree build. */
+  _hasDetailsDeep: boolean;
 }
 
 /**
@@ -95,6 +98,8 @@ export interface BottomUpRow {
   instances: LogEvent[];
   /** Representative event for this row (used by formatters) */
   originalData: LogEvent;
+  /** See {@link TimeOrderRow._hasDetailsDeep}. Precomputed during tree build. */
+  _hasDetailsDeep: boolean;
 }
 
 /**
@@ -157,6 +162,7 @@ export function toAggregatedCallTree(rootChildren: LogEvent[]): AggregatedRow[] 
     const stackKey = firstInstance ? getStackKey(firstInstance) : row.key;
     row._children = aggregateChildrenRecursive(row.instances, stackKey, idFor);
     calculateAverages(row);
+    row._hasDetailsDeep = computeHasDetailsDeep(row, row.totalTime, row.originalData.type);
   }
 
   // Sort by total time descending
@@ -202,6 +208,7 @@ function aggregateChildrenRecursive(
     const stackKey = firstInstance ? getStackKey(firstInstance) : row.key;
     row._children = aggregateChildrenRecursive(row.instances, stackKey, idFor);
     calculateAverages(row);
+    row._hasDetailsDeep = computeHasDetailsDeep(row, row.totalTime, row.originalData.type);
   }
 
   // Sort by total time descending
@@ -493,6 +500,7 @@ function finalizeBucketRecursive(row: BottomUpRow): void {
     }
     sortBuckets(row._children);
   }
+  row._hasDetailsDeep = computeHasDetailsDeep(row, row.totalTime, row.type);
 }
 
 function sortBuckets(rows: BottomUpRow[]): void {
@@ -528,6 +536,7 @@ function createEmptyAggregatedRow(
     _children: null,
     instances: [],
     originalData: event,
+    _hasDetailsDeep: false,
   };
 }
 
@@ -557,6 +566,7 @@ function createEmptyBottomUpRow(
     _children: null,
     instances: [],
     originalData: event,
+    _hasDetailsDeep: false,
   };
 }
 
@@ -570,4 +580,32 @@ function calculateBottomUpAverages(row: BottomUpRow): void {
   if (row.callCount > 0) {
     row.avgSelfTime = row.totalSelfTime / row.callCount;
   }
+}
+
+/**
+ * Show-Details predicate, rolled up across children. Called post-order after
+ * `_children` is set and each child's own `_hasDetailsDeep` is populated.
+ * Generic over `AggregatedRow` (type lives on `originalData`) and `BottomUpRow`
+ * (type lives on the row directly) — caller passes whichever applies.
+ */
+function computeHasDetailsDeep<T extends { _children?: T[] | null; _hasDetailsDeep: boolean }>(
+  row: T,
+  totalTime: number,
+  type: string | null | undefined,
+): boolean {
+  if (totalTime > 0) {
+    return true;
+  }
+  if (type && EXCLUDED_DETAIL_TYPES.has(type)) {
+    return true;
+  }
+  const children = row._children;
+  if (children) {
+    for (let i = 0, len = children.length; i < len; i++) {
+      if (children[i]!._hasDetailsDeep) {
+        return true;
+      }
+    }
+  }
+  return false;
 }

--- a/log-viewer/src/features/call-tree/utils/DetailsFilter.ts
+++ b/log-viewer/src/features/call-tree/utils/DetailsFilter.ts
@@ -1,13 +1,16 @@
 /*
  * Copyright (c) 2026 Certinia Inc. All rights reserved.
  */
-import type { AggregatedRow, BottomUpRow } from './Aggregation.js';
-
-export type AggregatedLikeRow = AggregatedRow | BottomUpRow;
 
 export type DeepFilterable<T> = { id: string; _children?: T[] | null };
 
-export const EXCLUDED_DETAIL_TYPES = new Set<string>([
+/**
+ * Event types that count as "significant" for the Show Details filter even
+ * though they may have zero duration. Shared by the call-tree row builders
+ * (which pre-compute `_hasDetailsDeep`) and by any runtime predicate that
+ * needs to mirror the same rule.
+ */
+export const EXCLUDED_DETAIL_TYPES: ReadonlySet<string> = new Set<string>([
   'CUMULATIVE_LIMIT_USAGE',
   'LIMIT_USAGE_FOR_NS',
   'CUMULATIVE_PROFILING',
@@ -45,17 +48,4 @@ export function deepFilter<T extends DeepFilterable<T>>(
   const finalMatch = childMatch || predicate(rowData);
   filterCache.set(rowData.id, finalMatch);
   return finalMatch;
-}
-
-export function makeShowDetailsFilter(
-  filterCache: Map<string, boolean>,
-): (data: AggregatedLikeRow) => boolean {
-  return (data) =>
-    deepFilter<AggregatedLikeRow>(
-      data,
-      (row) =>
-        row.totalTime > 0 ||
-        !!(row.originalData.type && EXCLUDED_DETAIL_TYPES.has(row.originalData.type)),
-      filterCache,
-    );
 }

--- a/log-viewer/src/features/call-tree/utils/TimeOrderTree.ts
+++ b/log-viewer/src/features/call-tree/utils/TimeOrderTree.ts
@@ -4,6 +4,7 @@
 import type { LogEvent, SelfTotal } from 'apex-log-parser';
 
 import { getCallerNamespace } from '../../../core/utility/CallerNamespace.js';
+import { EXCLUDED_DETAIL_TYPES } from './DetailsFilter.js';
 
 /**
  * One row per LogEvent for the time-order view; no merging at any level.
@@ -21,6 +22,14 @@ export interface TimeOrderRow {
   dmlRowCount: SelfTotal;
   soqlRowCount: SelfTotal;
   totalThrownCount: number;
+  /**
+   * True when this row is itself a "detail" (the per-row predicate matches —
+   * non-zero `duration.total`, `isParent`, `discontinuity`, or a type in
+   * `EXCLUDED_DETAIL_TYPES`) OR any descendant has `_hasDetailsDeep === true`.
+   * Precomputed bottom-up at tree-build time so the Show-Details filter is
+   * an O(1) property read instead of a recursive walk.
+   */
+  _hasDetailsDeep: boolean;
 }
 
 /**
@@ -42,12 +51,23 @@ export function toTimeOrderTree(nodes: LogEvent[]): TimeOrderRow[] | undefined {
     const children = event.children;
     const childCount = children.length;
     let mappedChildren: TimeOrderRow[] | null = null;
+    let childHasDetailsDeep = false;
     if (childCount > 0) {
       mappedChildren = new Array<TimeOrderRow>(childCount);
       for (let i = 0; i < childCount; i++) {
-        mappedChildren[i] = buildRow(children[i]!);
+        const childRow = buildRow(children[i]!);
+        mappedChildren[i] = childRow;
+        if (childRow._hasDetailsDeep) {
+          childHasDetailsDeep = true;
+        }
       }
     }
+    const { duration, isParent, discontinuity, type } = event;
+    const selfIsDetail =
+      isParent ||
+      duration.total > 0 ||
+      discontinuity ||
+      !!(type && EXCLUDED_DETAIL_TYPES.has(type));
     return {
       id,
       originalData: event,
@@ -61,6 +81,7 @@ export function toTimeOrderTree(nodes: LogEvent[]): TimeOrderRow[] | undefined {
       dmlRowCount: event.dmlRowCount,
       soqlRowCount: event.soqlRowCount,
       totalThrownCount: event.totalThrownCount,
+      _hasDetailsDeep: selfIsDetail || childHasDetailsDeep,
     };
   }
 

--- a/log-viewer/src/features/call-tree/utils/__tests__/Aggregation.test.ts
+++ b/log-viewer/src/features/call-tree/utils/__tests__/Aggregation.test.ts
@@ -1011,3 +1011,82 @@ describe('toAggregatedCallTree', () => {
     expect(limitOnly.soqlCount.self).toBe(2);
   });
 });
+
+describe('_hasDetailsDeep precomputation', () => {
+  beforeEach(() => {
+    nextTimestamp = 1;
+  });
+
+  it('aggregated: marks zero-time leaf with no excluded type as not significant', () => {
+    const root = createEvent({ text: 'LOG_ROOT', self: 0, total: 0, type: 'EXECUTION_STARTED' });
+    createEvent({ text: 'NoTime', self: 0, total: 0, parent: root });
+
+    const rows = toAggregatedCallTree(root.children);
+    const noTime = findRowByText(rows, 'NoTime');
+    expect(noTime._hasDetailsDeep).toBe(false);
+  });
+
+  it('aggregated: marks zero-time leaf with excluded type as significant', () => {
+    const root = createEvent({ text: 'LOG_ROOT', self: 0, total: 0, type: 'EXECUTION_STARTED' });
+    createEvent({
+      text: 'LimitUsage',
+      self: 0,
+      total: 0,
+      parent: root,
+      type: 'CUMULATIVE_LIMIT_USAGE',
+    });
+
+    const rows = toAggregatedCallTree(root.children);
+    const limit = findRowByText(rows, 'LimitUsage');
+    expect(limit._hasDetailsDeep).toBe(true);
+  });
+
+  it('aggregated: marks zero-time parent as significant when any descendant is', () => {
+    const root = createEvent({ text: 'LOG_ROOT', self: 0, total: 0, type: 'EXECUTION_STARTED' });
+    const parent = createEvent({ text: 'ZeroParent', self: 0, total: 0, parent: root });
+    createEvent({ text: 'BusyChild', self: 5, total: 5, parent });
+
+    const rows = toAggregatedCallTree(root.children);
+    const zeroParent = findRowByText(rows, 'ZeroParent');
+    expect(zeroParent.totalTime).toBe(0);
+    expect(zeroParent._hasDetailsDeep).toBe(true);
+  });
+
+  it('aggregated: marks zero-time parent as not significant when no descendant is', () => {
+    const root = createEvent({ text: 'LOG_ROOT', self: 0, total: 0, type: 'EXECUTION_STARTED' });
+    const parent = createEvent({ text: 'ZeroParent', self: 0, total: 0, parent: root });
+    createEvent({ text: 'ZeroChild', self: 0, total: 0, parent });
+
+    const rows = toAggregatedCallTree(root.children);
+    const zeroParent = findRowByText(rows, 'ZeroParent');
+    expect(zeroParent._hasDetailsDeep).toBe(false);
+  });
+
+  it('bottom-up: rolls up significance from callers (children)', () => {
+    const root = createEvent({ text: 'LOG_ROOT', self: 0, total: 0, type: 'EXECUTION_STARTED' });
+    const caller = createEvent({ text: 'Caller', self: 0, total: 5, parent: root });
+    createEvent({ text: 'Callee', self: 5, total: 5, parent: caller });
+
+    const rows = toBottomUpTree(root.children);
+    const callee = findRowByText(rows, 'Callee');
+    expect(callee._hasDetailsDeep).toBe(true);
+    // Caller appears as a child of Callee in bottom-up
+    const callerChild = findRowByText(callee._children ?? [], 'Caller');
+    expect(callerChild._hasDetailsDeep).toBe(true);
+  });
+
+  it('bottom-up: zero-time with excluded type is significant', () => {
+    const root = createEvent({ text: 'LOG_ROOT', self: 0, total: 0, type: 'EXECUTION_STARTED' });
+    createEvent({
+      text: 'LimitUsage',
+      self: 0,
+      total: 0,
+      parent: root,
+      type: 'LIMIT_USAGE_FOR_NS',
+    });
+
+    const rows = toBottomUpTree(root.children);
+    const limit = findRowByText(rows, 'LimitUsage');
+    expect(limit._hasDetailsDeep).toBe(true);
+  });
+});


### PR DESCRIPTION
# 📝 PR Overview

Replaces the cached recursive `deepFilter` walk that the "Show Details" checkbox triggered on every toggle with a precomputed `_hasDetailsDeep` boolean on each call-tree row. The flag is rolled up bottom-up during tree construction, so the Tabulator filter becomes a single property read — noticeably faster on large logs where toggling the checkbox previously walked the full tree.

## 🛠️ Changes made

- Add `_hasDetailsDeep` to `TimeOrderRow` / `AggregatedRow` / `BottomUpRow`, computed post-order in `toTimeOrderTree`, `toAggregatedCallTree`, and `finalizeBucketRecursive` so each row knows whether it (or any descendant) is a detail
- Collapse the per-view Show-Details filter callbacks into one shared `_showDetailsFilter = data => data._hasDetailsDeep` in `CalltreeView` and `AnalysisView`; remove `showDetailsFilterCache` and the now-unused `makeShowDetailsFilter` from `DetailsFilter.ts`
- Unify the aggregated and bottom-up rollup into one generic `computeHasDetailsDeep` helper (the only difference was `row.originalData.type` vs `row.type`)
- Make `onFilterCacheClear` optional on `TableShared` callbacks and drop the empty `() => {}` from the bottom-up render path

## 🧩 Type of change (check all applicable)

- [ ] 🐛 Bug fix - something not working as expected
- [ ] ✨ New feature – adds new functionality
- [x] ♻️ Refactor - internal changes with no user impact
- [x] ⚡ Performance Improvement
- [ ] 📝 Documentation - README or documentation site changes
- [ ] 🔧 Chore - dev tooling, CI, config
- [ ] 💥 Breaking change

## 📷 Screenshots / gifs / video [optional]

_No UI change to show — filter behaviour is unchanged, only its cost._

## 🔗 Related Issues

related #333

## ✅ Tests added?

- [x] 👍 yes
- [ ] 🙅 no, not needed
- [ ] 🙋 no, I need help

Added six `_hasDetailsDeep` precomputation cases to `Aggregation.test.ts` covering zero-time leaves with/without excluded types, parent rollup, and bottom-up child rollup.

## 📚 Docs updated?

- [ ] 🔖 README.md
- [ ] 🔖 CHANGELOG.md
- [ ] 📖 help site
- [x] 🙅 not needed

## Anything else we need to know? [optional]

Toggle the Details checkbox in Call Tree (time-order, aggregated, bottom-up) and Analysis views against a large log — the visible row set should match the previous behaviour exactly, just without the per-toggle walk.