### PR TITLE
feat(soql): syntax-highlight and pretty-print queries everywhere

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -3,5 +3,6 @@
   "tabWidth": 2,
   "printWidth": 100,
   "semi": true,
-  "singleQuote": true
+  "singleQuote": true,
+  "htmlWhitespaceSensitivity": "strict"
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,6 +83,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - **Total Duration**: First line shows total log execution time.
   - **Syntax Highlighting**: Apex debug log files are automatically recognized and syntax highlighted for improved readability.
 - 🏷️ **Group by Caller Namespace**: New grouping option across the Analysis, Bottom-Up, and DML views. Groups rows by the namespace of their **direct caller** (the immediate parent code unit), making it easy to see cross-package activity. ([#604])
+- 🎨 **SOQL Syntax Highlighting & Pretty-Printing**: SOQL queries are now syntax-highlighted and pretty-printed wherever they appear — Database view, Call Tree, Timeline tooltips, and call-stack rows. Keywords, functions, strings, numbers, and bind variables are themed. ([#605])
 
 ### Changed
 
@@ -484,6 +485,7 @@ Skipped due to adopting odd numbering for pre releases and even number for relea
 
 <!-- Unreleased -->
 
+[#605]: https://github.com/certinia/debug-log-analyzer/issues/605
 [#604]: https://github.com/certinia/debug-log-analyzer/issues/604
 [#333]: https://github.com/certinia/debug-log-analyzer/issues/333
 [#627]: https://github.com/certinia/debug-log-analyzer/issues/627

--- a/log-viewer/src/components/CallStack.ts
+++ b/log-viewer/src/components/CallStack.ts
@@ -1,14 +1,13 @@
 /*
  * Copyright (c) 2021 Certinia Inc. All rights reserved.
  */
-import { LitElement, css, html, unsafeCSS } from 'lit';
-import { customElement, property } from 'lit/decorators.js';
-import { unsafeHTML } from 'lit/directives/unsafe-html.js';
+import { LitElement, css, html, unsafeCSS, type PropertyValues, type TemplateResult } from 'lit';
+import { customElement, property, state } from 'lit/decorators.js';
 
 import type { LogEvent } from 'apex-log-parser';
 import { goToRow } from '../features/call-tree/components/CalltreeView.js';
 import { DatabaseAccess } from '../features/database/services/Database.js';
-import { formatSOQL } from '../features/soql/format/formatter.js';
+import { formatSOQLToTemplate } from '../features/soql/format/formatter.js';
 import { soqlSyntaxStyles } from '../features/soql/styles/soql-syntax.css.js';
 
 // styles
@@ -23,6 +22,10 @@ export class CallStack extends LitElement {
   @property({ type: Number })
   endDepth = -1;
 
+  // Internal state to hold the pre-formatted Lit templates
+  @state()
+  private _formattedDetails: TemplateResult[] = [];
+
   static styles = [
     globalStyles,
     unsafeCSS(soqlSyntaxStyles),
@@ -32,7 +35,6 @@ export class CallStack extends LitElement {
         min-width: 0%;
         min-height: 1ch;
         max-height: 30vh;
-        padding: 0px 5px 0px 5px;
         white-space: normal;
       }
 
@@ -66,24 +68,43 @@ export class CallStack extends LitElement {
         font-weight: var(--vscode-font-weight, normal);
         font-size: var(--vscode-editor-font-size, 0.9em);
       }
+
+      pre {
+        display: inline;
+      }
     `,
   ];
 
+  // 1. THE PERFORMANCE ENGINE: Process data BEFORE rendering
+  protected willUpdate(changedProperties: PropertyValues) {
+    if (
+      changedProperties.has('timestamp') ||
+      changedProperties.has('startDepth') ||
+      changedProperties.has('endDepth')
+    ) {
+      const stack = DatabaseAccess.instance()?.getStack(this.timestamp).reverse() ?? [];
+
+      if (stack.length > 0) {
+        // Run the heavy loop and formatting logic here, only when inputs change
+        this._formattedDetails = stack
+          .slice(this.startDepth, this.endDepth)
+          .map((entry) => this.lineLink(entry));
+      } else {
+        this._formattedDetails = [];
+      }
+    }
+  }
+
   render() {
-    const stack = DatabaseAccess.instance()?.getStack(this.timestamp).reverse() ?? [];
-    if (!stack.length) {
+    if (!this._formattedDetails.length) {
       return html`<div class="callstack__item">No call stack available</div>`;
     }
 
-    const details = stack.slice(this.startDepth, this.endDepth).map((entry) => {
-      return this.lineLink(entry);
-    });
-
-    if (details.length === 1) {
-      return details;
+    if (this._formattedDetails.length === 1) {
+      return this._formattedDetails;
     }
 
-    const [first, ...rest] = details;
+    const [first, ...rest] = this._formattedDetails;
     return html`<details>
       <summary>${first}</summary>
       <div class="callstack">${rest}</div>
@@ -93,12 +114,13 @@ export class CallStack extends LitElement {
   private lineLink(line: LogEvent) {
     const isSoql = line?.type === 'SOQL_EXECUTE_BEGIN';
     const isSosl = line?.type === 'SOSL_EXECUTE_BEGIN';
-    const soqlBlock =
+    const formatted =
       (isSoql || isSosl) && line?.text
-        ? html`<pre class="soql-block callstack__soql">
-  ${unsafeHTML(formatSOQL(line.text, { mode: 'pretty', dialect: isSosl ? 'sosl' : 'soql' }))}</pre
-          >`
-        : `${line.text}`;
+        ? this.formatSOQL(line.text, isSosl ? 'sosl' : 'soql')
+        : null;
+    const soqlBlock = formatted
+      ? html`<div class="soql-block callstack__soql">${formatted}</div>`
+      : `${line.text}`;
 
     return html`<a
       @click=${this.onCallerClick}
@@ -106,6 +128,10 @@ export class CallStack extends LitElement {
       data-timestamp="${line.timestamp}"
       >${soqlBlock}</a
     >`;
+  }
+
+  private formatSOQL(soql: string, type: 'soql' | 'sosl') {
+    return formatSOQLToTemplate(soql, { mode: 'pretty', dialect: type });
   }
 
   private onCallerClick(evt: Event) {

--- a/log-viewer/src/components/CallStack.ts
+++ b/log-viewer/src/components/CallStack.ts
@@ -1,7 +1,8 @@
 /*
  * Copyright (c) 2021 Certinia Inc. All rights reserved.
  */
-import { LitElement, css, html, unsafeCSS, type PropertyValues, type TemplateResult } from 'lit';
+import type { PropertyValues, TemplateResult } from 'lit';
+import { LitElement, css, html, unsafeCSS } from 'lit';
 import { customElement, property, state } from 'lit/decorators.js';
 
 import type { LogEvent } from 'apex-log-parser';

--- a/log-viewer/src/components/CallStack.ts
+++ b/log-viewer/src/components/CallStack.ts
@@ -1,12 +1,15 @@
 /*
  * Copyright (c) 2021 Certinia Inc. All rights reserved.
  */
-import { LitElement, css, html } from 'lit';
+import { LitElement, css, html, unsafeCSS } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
+import { unsafeHTML } from 'lit/directives/unsafe-html.js';
 
 import type { LogEvent } from 'apex-log-parser';
 import { goToRow } from '../features/call-tree/components/CalltreeView.js';
 import { DatabaseAccess } from '../features/database/services/Database.js';
+import { formatSOQL } from '../features/soql/format/formatter.js';
+import { soqlSyntaxStyles } from '../features/soql/styles/soql-syntax.css.js';
 
 // styles
 import { globalStyles } from '../styles/global.styles.js';
@@ -22,6 +25,7 @@ export class CallStack extends LitElement {
 
   static styles = [
     globalStyles,
+    unsafeCSS(soqlSyntaxStyles),
     css`
       :host {
         overflow: hidden;
@@ -30,6 +34,10 @@ export class CallStack extends LitElement {
         max-height: 30vh;
         padding: 0px 5px 0px 5px;
         white-space: normal;
+      }
+
+      .callstack__soql {
+        margin: 4px 0;
       }
 
       :host(:hover) {
@@ -83,11 +91,20 @@ export class CallStack extends LitElement {
   }
 
   private lineLink(line: LogEvent) {
+    const isSoql = line?.type === 'SOQL_EXECUTE_BEGIN';
+    const isSosl = line?.type === 'SOSL_EXECUTE_BEGIN';
+    const soqlBlock =
+      (isSoql || isSosl) && line?.text
+        ? html`<pre class="soql-block callstack__soql">
+  ${unsafeHTML(formatSOQL(line.text, { mode: 'pretty', dialect: isSosl ? 'sosl' : 'soql' }))}</pre
+          >`
+        : `${line.text}`;
+
     return html`<a
       @click=${this.onCallerClick}
       class="callstack__item code_text"
       data-timestamp="${line.timestamp}"
-      >${line.text}</a
+      >${soqlBlock}</a
     >`;
   }
 

--- a/log-viewer/src/features/analysis/components/AnalysisView.ts
+++ b/log-viewer/src/features/analysis/components/AnalysisView.ts
@@ -24,6 +24,7 @@ import dataGridStyles from '../../../tabulator/style/DataGrid.scss';
 // styles
 import codiconStyles from '../../../styles/codicon.css';
 import { globalStyles } from '../../../styles/global.styles.js';
+import { soqlSyntaxStyles } from '../../soql/styles/soql-syntax.css.js';
 
 // Components
 import '../../../components/GridSkeleton.js';
@@ -41,6 +42,7 @@ export class AnalysisView extends LitElement {
   static styles = [
     unsafeCSS(dataGridStyles),
     unsafeCSS(codiconStyles),
+    unsafeCSS(soqlSyntaxStyles),
     globalStyles,
     css`
       :host {

--- a/log-viewer/src/features/call-tree/components/BottomUpTable.ts
+++ b/log-viewer/src/features/call-tree/components/BottomUpTable.ts
@@ -12,6 +12,7 @@ import { progressFormatterMS } from '../../../tabulator/format/ProgressMS.js';
 import { GroupCalcs } from '../../../tabulator/groups/GroupCalcs.js';
 import { GroupSort } from '../../../tabulator/groups/GroupSort.js';
 import { sumDurationTotalForRootEvents } from '../../analysis/services/CallStackSum.js';
+import { soqlGroupHeader } from '../../soql/format/groupHeader.js';
 import { toBottomUpTree, type BottomUpRow } from '../utils/Aggregation.js';
 import {
   commonColumnDefaults,
@@ -110,6 +111,7 @@ export function createBottomUpTable(
     headerSortElement,
     columnCalcs: 'table',
     groupCalcs: true,
+    groupHeader: soqlGroupHeader,
     groupSort: true,
     groupClosedShowCalcs: true,
     groupStartOpen: false,

--- a/log-viewer/src/features/call-tree/components/CalltreeNameFormatter.ts
+++ b/log-viewer/src/features/call-tree/components/CalltreeNameFormatter.ts
@@ -3,6 +3,7 @@
  */
 import type { LogEvent, LogEventType } from 'apex-log-parser';
 import type { CellComponent, EmptyCallback } from 'tabulator-tables';
+import { formatSOQL } from '../../soql/format/formatter.js';
 
 export function createCalltreeNameFormatter(excludedTypes: Set<LogEventType>) {
   let childIndent: number;
@@ -27,6 +28,18 @@ export function createCalltreeNameFormatter(excludedTypes: Set<LogEventType>) {
     const { originalData: node } = cell.getData() as { originalData: LogEvent };
     if (!node) {
       return document.createTextNode(cell.getValue()) as unknown as HTMLElement;
+    }
+
+    const isSoql = node.type === 'SOQL_EXECUTE_BEGIN';
+    const isSosl = node.type === 'SOSL_EXECUTE_BEGIN';
+    if (isSoql || isSosl) {
+      const span = document.createElement('span');
+      span.className = 'soql-block';
+      span.innerHTML = formatSOQL(node.text, {
+        mode: 'pretty',
+        dialect: isSosl ? 'sosl' : 'soql',
+      });
+      return span;
     }
 
     if (node.hasValidSymbols) {

--- a/log-viewer/src/features/call-tree/components/CalltreeView.ts
+++ b/log-viewer/src/features/call-tree/components/CalltreeView.ts
@@ -27,6 +27,7 @@ import dataGridStyles from '../../../tabulator/style/DataGrid.scss';
 
 // styles
 import { globalStyles } from '../../../styles/global.styles.js';
+import { soqlSyntaxStyles } from '../../soql/styles/soql-syntax.css.js';
 
 // web components
 import '../../../components/ContextMenu.js';
@@ -157,6 +158,7 @@ export class CalltreeView extends LitElement {
   static styles = [
     unsafeCSS(dataGridStyles),
     unsafeCSS(codiconStyles),
+    unsafeCSS(soqlSyntaxStyles),
     globalStyles,
     css`
       :host {

--- a/log-viewer/src/features/database/components/DatabaseView.scss
+++ b/log-viewer/src/features/database/components/DatabaseView.scss
@@ -2,7 +2,7 @@
 
 .row__details-container {
   height: 100%;
-  padding: 4px 4px 4px 4px;
+  padding: 4px 4px 6px 4px;
   background-color: var(--vscode-editorHoverWidget-background);
 }
 .db-group-row {

--- a/log-viewer/src/features/database/components/SOQLView.ts
+++ b/log-viewer/src/features/database/components/SOQLView.ts
@@ -19,6 +19,8 @@ import {
 import type { ApexLog, SOQLExecuteBeginLine } from 'apex-log-parser';
 import { vscodeMessenger } from '../../../core/messaging/VSCodeExtensionMessenger.js';
 import { isVisible } from '../../../core/utility/Util.js';
+import { soqlGroupHeader } from '../../soql/format/groupHeader.js';
+import { soqlSyntaxStyles } from '../../soql/styles/soql-syntax.css.js';
 import { DatabaseAccess } from '../services/Database.js';
 
 // Tabulator custom modules, imports + styles
@@ -106,6 +108,7 @@ export class SOQLView extends LitElement {
     unsafeCSS(dataGridStyles),
     unsafeCSS(databaseViewStyles),
     unsafeCSS(codiconStyles),
+    unsafeCSS(soqlSyntaxStyles),
     globalStyles,
     css`
       :host {
@@ -343,6 +346,7 @@ export class SOQLView extends LitElement {
       keybindings: { copyToClipboard: ['ctrl + 67', 'meta + 67'] },
       clipboardCopyRowRange: 'all',
       groupCalcs: true,
+      groupHeader: soqlGroupHeader,
       groupSort: true,
       groupClosedShowCalcs: true,
       groupStartOpen: false,

--- a/log-viewer/src/features/soql/components/SOQLLinterIssues.ts
+++ b/log-viewer/src/features/soql/components/SOQLLinterIssues.ts
@@ -52,7 +52,7 @@ export class SOQLLinterIssues extends LitElement {
       const stack = DatabaseAccess.instance()?.getStack(this.timestamp).reverse() || [];
       const soqlLine = stack[0] as SOQLExecuteBeginLine;
       this.issues = this.getIssuesFromSOQLLine(soqlLine);
-      this.issues = this.issues.concat(await new SOQLLinter().lint(this.soql, stack));
+      this.issues = this.issues.concat(await new SOQLLinter().lint(soqlLine.text, stack));
       this.issues.sort((a, b) => {
         return SEVERITY_TYPES.indexOf(a.severity) - SEVERITY_TYPES.indexOf(b.severity);
       });

--- a/log-viewer/src/features/soql/format/__tests__/format.test.ts
+++ b/log-viewer/src/features/soql/format/__tests__/format.test.ts
@@ -1,0 +1,135 @@
+/*
+ * Copyright (c) 2026 Certinia Inc. All rights reserved.
+ */
+import { formatSOQL } from '../formatter.js';
+import { detectDialect, tokenize } from '../tokenize.js';
+
+describe('SOQL/SOSL formatter', () => {
+  describe('tokenize', () => {
+    it('classifies SELECT/FROM/WHERE as keywords', () => {
+      const tokens = tokenize('SELECT Id FROM Account WHERE x = 1').filter((t) => t.kind !== 'ws');
+      expect(tokens.map((t) => t.kind)).toEqual([
+        'keyword', // SELECT
+        'ident', // Id
+        'keyword', // FROM
+        'ident', // Account
+        'keyword', // WHERE
+        'ident', // x
+        'punct', // =
+        'number', // 1
+      ]);
+    });
+
+    it('classifies aggregate functions as function', () => {
+      const tokens = tokenize('SELECT COUNT(Id) FROM Account').filter((t) => t.kind !== 'ws');
+      const count = tokens.find((t) => t.text === 'COUNT');
+      expect(count?.kind).toBe('function');
+    });
+
+    it('recognises bind variables', () => {
+      const tokens = tokenize('SELECT Id FROM Account WHERE Name = :name').filter(
+        (t) => t.kind !== 'ws',
+      );
+      expect(tokens[tokens.length - 1]).toEqual({ kind: 'bind', text: ':name' });
+    });
+
+    it('keeps single-quoted strings intact including escapes', () => {
+      const tokens = tokenize("Name = 'O\\'Brien'").filter((t) => t.kind !== 'ws');
+      const str = tokens.find((t) => t.kind === 'string');
+      expect(str?.text).toBe("'O\\'Brien'");
+    });
+
+    it('handles SOSL { } search terms as strings', () => {
+      const tokens = tokenize('FIND {acme} RETURNING Account', 'sosl').filter(
+        (t) => t.kind !== 'ws',
+      );
+      expect(tokens[1]).toEqual({ kind: 'string', text: '{acme}' });
+    });
+  });
+
+  describe('detectDialect', () => {
+    it('flags FIND as sosl', () => {
+      expect(detectDialect('  FIND {x} RETURNING Account')).toBe('sosl');
+    });
+    it('defaults to soql', () => {
+      expect(detectDialect('SELECT Id FROM Account')).toBe('soql');
+    });
+  });
+
+  describe('formatSOQL inline', () => {
+    it('returns empty string for empty input', () => {
+      expect(formatSOQL('', { mode: 'inline' })).toBe('');
+    });
+
+    it('wraps SELECT in keyword span', () => {
+      const html = formatSOQL('SELECT Id FROM Account', { mode: 'inline' });
+      expect(html).toContain('<span class="soql-tok-keyword">SELECT</span>');
+      expect(html).toContain('<span class="soql-tok-keyword">FROM</span>');
+    });
+
+    it('escapes HTML in identifiers', () => {
+      const html = formatSOQL('SELECT a<b> FROM x', { mode: 'inline' });
+      expect(html).not.toContain('<b>');
+      expect(html).toContain('&lt;');
+      expect(html).toContain('&gt;');
+    });
+
+    it('auto-detects SOSL', () => {
+      const html = formatSOQL('FIND {acme} RETURNING Account', { mode: 'inline', dialect: 'auto' });
+      expect(html).toContain('<span class="soql-tok-keyword">FIND</span>');
+      expect(html).toContain('<span class="soql-tok-keyword">RETURNING</span>');
+      expect(html).toContain('<span class="soql-tok-string">{acme}</span>');
+    });
+  });
+
+  describe('formatSOQL pretty', () => {
+    it('breaks before major clauses', () => {
+      const html = formatSOQL('SELECT Id FROM Account WHERE x = 1 LIMIT 10', { mode: 'pretty' });
+      const lines = html.split('\n');
+      expect(lines[0]).toContain('>SELECT<');
+      expect(lines[1]).toMatch(/^<span class="soql-tok-keyword">FROM<\/span>/);
+      expect(lines[2]).toMatch(/^<span class="soql-tok-keyword">WHERE<\/span>/);
+      expect(lines[3]).toMatch(/^<span class="soql-tok-keyword">LIMIT<\/span>/);
+    });
+
+    it('breaks AND/OR onto new lines inside WHERE', () => {
+      const html = formatSOQL('SELECT Id FROM A WHERE x=1 AND y=2 OR z=3', { mode: 'pretty' });
+      const lines = html.split('\n');
+      const andLine = lines.find((l) => l.includes('>AND<'));
+      const orLine = lines.find((l) => l.includes('>OR<'));
+      expect(andLine).toBeDefined();
+      expect(orLine).toBeDefined();
+      expect(andLine!.startsWith('  ')).toBe(true);
+      expect(orLine!.startsWith('  ')).toBe(true);
+    });
+
+    it('indents subqueries', () => {
+      const html = formatSOQL('SELECT Id, (SELECT Id FROM Contacts) FROM Account', {
+        mode: 'pretty',
+      });
+      expect(html).toContain('\n  <span class="soql-tok-keyword">SELECT</span>');
+      expect(html).toContain('\n  <span class="soql-tok-keyword">FROM</span>');
+    });
+
+    it('does not break before function-call parens', () => {
+      const html = formatSOQL('SELECT COUNT(Id) FROM Account', { mode: 'pretty' });
+      expect(html).toMatch(/COUNT<\/span>\s*<span class="soql-tok-punct">\(/);
+      expect(html).not.toMatch(/COUNT<\/span>\s+<span class="soql-tok-punct">\(/);
+    });
+
+    it('does not emit a blank line between ( and inner SELECT', () => {
+      const html = formatSOQL('SELECT Id, (SELECT Id FROM Contacts) FROM Account', {
+        mode: 'pretty',
+      });
+      expect(html).not.toMatch(/\n\s*\n/);
+    });
+
+    it('never throws on malformed input', () => {
+      expect(() => formatSOQL("SELECT 'unterminated FROM x", { mode: 'pretty' })).not.toThrow();
+      expect(() => formatSOQL('((((((', { mode: 'pretty' })).not.toThrow();
+      expect(() => formatSOQL('<script>', { mode: 'inline' })).not.toThrow();
+      const safe = formatSOQL('<script>alert(1)</script>', { mode: 'inline' });
+      expect(safe).not.toContain('<script>');
+    });
+  });
+});

--- a/log-viewer/src/features/soql/format/__tests__/groupHeader.test.ts
+++ b/log-viewer/src/features/soql/format/__tests__/groupHeader.test.ts
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2026 Certinia Inc. All rights reserved.
+ */
+import { soqlGroupHeader } from '../groupHeader.js';
+
+describe('soqlGroupHeader', () => {
+  it('returns null when value is missing or empty', () => {
+    expect(soqlGroupHeader('', 3, [])).toBe('');
+    expect(soqlGroupHeader(undefined, 3, [])).toBe('');
+  });
+
+  it('returns null for non-SOQL rows', () => {
+    const data = [{ originalData: { type: 'METHOD_ENTRY' } }];
+    expect(soqlGroupHeader('SomeMethod', 5, data)).toBe('');
+  });
+
+  it('formats SOQL when first row is SOQL_EXECUTE_BEGIN', () => {
+    const data = [{ originalData: { type: 'SOQL_EXECUTE_BEGIN' } }];
+    const html = soqlGroupHeader('SELECT Id FROM Account', 2, data);
+    expect(html).toContain('soql-block soql-inline');
+    expect(html).toContain('<span class="soql-tok-keyword">SELECT</span>');
+    expect(html).toContain('(2)');
+  });
+
+  it('formats SOSL when first row is SOSL_EXECUTE_BEGIN', () => {
+    const data = [{ originalData: { type: 'SOSL_EXECUTE_BEGIN' } }];
+    const html = soqlGroupHeader('FIND {acme} RETURNING Account', 1, data);
+    expect(html).toContain('<span class="soql-tok-keyword">FIND</span>');
+    expect(html).toContain('<span class="soql-tok-keyword">RETURNING</span>');
+  });
+
+  it('formats when first row has matching soql field (SOQLView path)', () => {
+    const key = 'SELECT Id FROM Account';
+    const data = [{ soql: key }];
+    const html = soqlGroupHeader(key, 4, data);
+    expect(html).toContain('soql-tok-keyword');
+    expect(html).toContain('(4)');
+  });
+
+  it('escapes html in identifiers', () => {
+    const data = [{ originalData: { type: 'SOQL_EXECUTE_BEGIN' } }];
+    const html = soqlGroupHeader('SELECT a<b> FROM x', 1, data);
+    expect(html).not.toContain('<b>');
+    expect(html).toContain('&lt;');
+  });
+});

--- a/log-viewer/src/features/soql/format/__tests__/groupHeader.test.ts
+++ b/log-viewer/src/features/soql/format/__tests__/groupHeader.test.ts
@@ -17,7 +17,7 @@ describe('soqlGroupHeader', () => {
   it('formats SOQL when first row is SOQL_EXECUTE_BEGIN', () => {
     const data = [{ originalData: { type: 'SOQL_EXECUTE_BEGIN' } }];
     const html = soqlGroupHeader('SELECT Id FROM Account', 2, data);
-    expect(html).toContain('soql-block soql-inline');
+    expect(html).toContain('soql-block');
     expect(html).toContain('<span class="soql-tok-keyword">SELECT</span>');
     expect(html).toContain('(2)');
   });

--- a/log-viewer/src/features/soql/format/formatter.ts
+++ b/log-viewer/src/features/soql/format/formatter.ts
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2026 Certinia Inc. All rights reserved.
+ */
+import { escapeHtml, renderInline } from './renderInline.js';
+import { renderPretty } from './renderPretty.js';
+import { detectDialect, tokenize, type Dialect } from './tokenize.js';
+
+export interface FormatOptions {
+  mode: 'inline' | 'pretty';
+  dialect?: Dialect | 'auto';
+}
+
+export function formatSOQL(text: string, opts: FormatOptions): string {
+  if (!text) {
+    return '';
+  }
+  try {
+    const dialect: Dialect =
+      !opts.dialect || opts.dialect === 'auto' ? detectDialect(text) : opts.dialect;
+    const tokens = tokenize(text, dialect);
+    return opts.mode === 'pretty' ? renderPretty(tokens) : renderInline(tokens);
+  } catch {
+    return escapeHtml(text);
+  }
+}
+
+export type { Dialect } from './tokenize.js';

--- a/log-viewer/src/features/soql/format/formatter.ts
+++ b/log-viewer/src/features/soql/format/formatter.ts
@@ -1,9 +1,10 @@
 /*
  * Copyright (c) 2026 Certinia Inc. All rights reserved.
  */
-import { escapeHtml, renderInline } from './renderInline.js';
-import { renderPretty } from './renderPretty.js';
-import { detectDialect, tokenize, type Dialect } from './tokenize.js';
+import { html, nothing, type TemplateResult } from 'lit';
+import { CLASS_BY_KIND, escapeHtml, renderInline } from './renderInline.js';
+import { prettyChunks, renderPretty } from './renderPretty.js';
+import { detectDialect, tokenize, type Dialect, type Token } from './tokenize.js';
 
 export interface FormatOptions {
   mode: 'inline' | 'pretty';
@@ -22,6 +23,36 @@ export function formatSOQL(text: string, opts: FormatOptions): string {
   } catch {
     return escapeHtml(text);
   }
+}
+
+/**
+ * Lit-template variant of {@link formatSOQL}. Returns a `TemplateResult` whose
+ * spans are real Lit-managed nodes, so callers don't need `unsafeHTML` (which
+ * re-parses an HTML string on every render). Lit caches the per-token
+ * `<span class=${cls}>${text}</span>` template and diffs only the dynamic
+ * class/text values.
+ */
+export function formatSOQLToTemplate(text: string, opts: FormatOptions): TemplateResult {
+  if (!text) {
+    return html`${nothing}`;
+  }
+  try {
+    const dialect: Dialect =
+      !opts.dialect || opts.dialect === 'auto' ? detectDialect(text) : opts.dialect;
+    const tokens = tokenize(text, dialect);
+    const chunks: (Token | string)[] = opts.mode === 'pretty' ? prettyChunks(tokens) : tokens;
+    return html`${chunks.map(chunkToTemplate)}`;
+  } catch {
+    return html`${text}`;
+  }
+}
+
+function chunkToTemplate(c: Token | string): TemplateResult | string {
+  if (typeof c === 'string') {
+    return c;
+  }
+  const cls = CLASS_BY_KIND[c.kind];
+  return cls ? html`<span class=${cls}>${c.text}</span>` : c.text;
 }
 
 export type { Dialect } from './tokenize.js';

--- a/log-viewer/src/features/soql/format/groupHeader.ts
+++ b/log-viewer/src/features/soql/format/groupHeader.ts
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2026 Certinia Inc. All rights reserved.
+ */
+import { formatSOQL } from './formatter.js';
+
+type SoqlishRow = {
+  originalData?: { type?: string };
+  soql?: string;
+};
+
+/**
+ * Tabulator `groupHeader` renderer that formats SOQL/SOSL group keys.
+ *
+ * Returns the HTML to use as the first-cell content of a group header row,
+ * or an empty string when the group does not look like SOQL/SOSL (so the host's
+ * default header rendering is used instead — `GroupCalcs` treats empty as a
+ * no-op).
+ *
+ * Detection precedence:
+ *  - `data[0].originalData.type === 'SOQL_EXECUTE_BEGIN'` → soql
+ *  - `data[0].originalData.type === 'SOSL_EXECUTE_BEGIN'` → sosl
+ *  - `data[0].soql === value`                            → soql (SOQLView rows)
+ */
+export function soqlGroupHeader(value: unknown, count: number, data: unknown): string {
+  if (typeof value !== 'string' || !value) {
+    return '';
+  }
+  const first = Array.isArray(data) ? (data[0] as SoqlishRow | undefined) : undefined;
+  const type = first?.originalData?.type;
+  let dialect: 'soql' | 'sosl' | null = null;
+  if (type === 'SOQL_EXECUTE_BEGIN') {
+    dialect = 'soql';
+  } else if (type === 'SOSL_EXECUTE_BEGIN') {
+    dialect = 'sosl';
+  } else if (typeof first?.soql === 'string' && first.soql === value) {
+    dialect = 'soql';
+  }
+  if (!dialect) {
+    return '';
+  }
+  const inner = formatSOQL(value, { mode: 'inline', dialect });
+  return `<span class="soql-block">${inner}</span> (${count})`;
+}

--- a/log-viewer/src/features/soql/format/renderInline.ts
+++ b/log-viewer/src/features/soql/format/renderInline.ts
@@ -3,7 +3,7 @@
  */
 import type { Token, TokenKind } from './tokenize.js';
 
-const CLASS_BY_KIND: Record<TokenKind, string | null> = {
+export const CLASS_BY_KIND: Record<TokenKind, string | null> = {
   keyword: 'soql-tok-keyword',
   function: 'soql-tok-function',
   string: 'soql-tok-string',

--- a/log-viewer/src/features/soql/format/renderInline.ts
+++ b/log-viewer/src/features/soql/format/renderInline.ts
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2026 Certinia Inc. All rights reserved.
+ */
+import type { Token, TokenKind } from './tokenize.js';
+
+const CLASS_BY_KIND: Record<TokenKind, string | null> = {
+  keyword: 'soql-tok-keyword',
+  function: 'soql-tok-function',
+  string: 'soql-tok-string',
+  number: 'soql-tok-number',
+  bind: 'soql-tok-bind',
+  punct: 'soql-tok-punct',
+  ident: null,
+  ws: null,
+};
+
+export function escapeHtml(text: string): string {
+  return text.replace(/[&<>"']/g, (c) => {
+    switch (c) {
+      case '&':
+        return '&amp;';
+      case '<':
+        return '&lt;';
+      case '>':
+        return '&gt;';
+      case '"':
+        return '&quot;';
+      case "'":
+        return '&#39;';
+      default:
+        return c;
+    }
+  });
+}
+
+export function renderInline(tokens: Token[]): string {
+  let out = '';
+  for (const t of tokens) {
+    const cls = CLASS_BY_KIND[t.kind];
+    const escaped = escapeHtml(t.text);
+    out += cls ? `<span class="${cls}">${escaped}</span>` : escaped;
+  }
+  return out;
+}

--- a/log-viewer/src/features/soql/format/renderPretty.ts
+++ b/log-viewer/src/features/soql/format/renderPretty.ts
@@ -1,19 +1,8 @@
 /*
  * Copyright (c) 2026 Certinia Inc. All rights reserved.
  */
-import { escapeHtml } from './renderInline.js';
-import type { Token, TokenKind } from './tokenize.js';
-
-const CLASS_BY_KIND: Record<TokenKind, string | null> = {
-  keyword: 'soql-tok-keyword',
-  function: 'soql-tok-function',
-  string: 'soql-tok-string',
-  number: 'soql-tok-number',
-  bind: 'soql-tok-bind',
-  punct: 'soql-tok-punct',
-  ident: null,
-  ws: null,
-};
+import { CLASS_BY_KIND, escapeHtml } from './renderInline.js';
+import type { Token } from './tokenize.js';
 
 const MAJOR_CLAUSE = new Set<string>([
   'SELECT',
@@ -36,12 +25,6 @@ const COND_JOIN = new Set<string>(['AND', 'OR']);
 
 const INDENT = '  ';
 
-function renderToken(t: Token): string {
-  const cls = CLASS_BY_KIND[t.kind];
-  const escaped = escapeHtml(t.text);
-  return cls ? `<span class="${cls}">${escaped}</span>` : escaped;
-}
-
 function isKeyword(t: Token | undefined, name: string): boolean {
   return !!t && (t.kind === 'keyword' || t.kind === 'function') && t.text.toUpperCase() === name;
 }
@@ -50,9 +33,18 @@ function isPunct(t: Token | undefined, ch: string): boolean {
   return !!t && t.kind === 'punct' && t.text === ch;
 }
 
-export function renderPretty(tokens: Token[]): string {
+/**
+ * Walk the token stream and emit a flat sequence of chunks for pretty-print
+ * layout. Each chunk is either a `Token` (to render as a classed span) or a
+ * plain `string` (literal text — spaces, newlines, indentation).
+ *
+ * Splitting the walker from the rendering target keeps the layout state
+ * machine in one place; downstream renderers (HTML string, Lit template)
+ * just map chunks to their output form.
+ */
+export function prettyChunks(tokens: Token[]): (Token | string)[] {
   const nonWs = tokens.filter((t) => t.kind !== 'ws');
-  let out = '';
+  const out: (Token | string)[] = [];
   let depth = 0;
   // depths at which '(' opened a subquery (so ')' needs a leading newline)
   const subqueryDepths = new Set<number>();
@@ -61,15 +53,21 @@ export function renderPretty(tokens: Token[]): string {
   // whether the most recent major clause at each depth is WHERE/HAVING (for AND/OR breaks)
   const condClauseStack: boolean[] = [];
 
-  const write = (s: string) => {
-    out += s;
-    if (s.length > 0) {
-      atLineStart = s.endsWith('\n');
+  const pushText = (s: string) => {
+    if (!s) {
+      return;
     }
+    out.push(s);
+    atLineStart = s.endsWith('\n');
+  };
+
+  const pushToken = (t: Token) => {
+    out.push(t);
+    atLineStart = false;
   };
 
   const newline = (level: number) => {
-    out += '\n' + INDENT.repeat(level);
+    out.push('\n' + INDENT.repeat(level));
     atLineStart = true;
   };
 
@@ -85,7 +83,7 @@ export function renderPretty(tokens: Token[]): string {
       }
       depth = Math.max(0, depth - 1);
       condClauseStack.length = Math.min(condClauseStack.length, depth + 1);
-      write(renderToken(t));
+      pushToken(t);
       prev = t;
       continue;
     }
@@ -97,7 +95,7 @@ export function renderPretty(tokens: Token[]): string {
       if (!atLineStart && out.length > 0) {
         newline(depth);
       }
-      write(renderToken(t));
+      pushToken(t);
       condClauseStack[depth] = upper === 'WHERE' || upper === 'HAVING';
       prev = t;
       continue;
@@ -110,7 +108,7 @@ export function renderPretty(tokens: Token[]): string {
       condClauseStack[depth]
     ) {
       newline(depth + 1);
-      write(renderToken(t));
+      pushToken(t);
       prev = t;
       continue;
     }
@@ -119,9 +117,9 @@ export function renderPretty(tokens: Token[]): string {
     if (t.kind === 'punct' && t.text === '(') {
       // separator before '('
       if (needsSpaceBefore(prev, t)) {
-        write(' ');
+        pushText(' ');
       }
-      write(renderToken(t));
+      pushToken(t);
       depth++;
       // detect subquery: next non-ws is SELECT / FIND
       if (isKeyword(next, 'SELECT') || isKeyword(next, 'FIND')) {
@@ -134,12 +132,26 @@ export function renderPretty(tokens: Token[]): string {
 
     // default token
     if (!atLineStart && needsSpaceBefore(prev, t)) {
-      write(' ');
+      pushText(' ');
     }
-    write(renderToken(t));
+    pushToken(t);
     prev = t;
   }
 
+  return out;
+}
+
+export function renderPretty(tokens: Token[]): string {
+  let out = '';
+  for (const c of prettyChunks(tokens)) {
+    if (typeof c === 'string') {
+      out += c;
+      continue;
+    }
+    const cls = CLASS_BY_KIND[c.kind];
+    const escaped = escapeHtml(c.text);
+    out += cls ? `<span class="${cls}">${escaped}</span>` : escaped;
+  }
   return out;
 }
 

--- a/log-viewer/src/features/soql/format/renderPretty.ts
+++ b/log-viewer/src/features/soql/format/renderPretty.ts
@@ -1,0 +1,173 @@
+/*
+ * Copyright (c) 2026 Certinia Inc. All rights reserved.
+ */
+import { escapeHtml } from './renderInline.js';
+import type { Token, TokenKind } from './tokenize.js';
+
+const CLASS_BY_KIND: Record<TokenKind, string | null> = {
+  keyword: 'soql-tok-keyword',
+  function: 'soql-tok-function',
+  string: 'soql-tok-string',
+  number: 'soql-tok-number',
+  bind: 'soql-tok-bind',
+  punct: 'soql-tok-punct',
+  ident: null,
+  ws: null,
+};
+
+const MAJOR_CLAUSE = new Set<string>([
+  'SELECT',
+  'FROM',
+  'WHERE',
+  'WITH',
+  'GROUP',
+  'HAVING',
+  'ORDER',
+  'LIMIT',
+  'OFFSET',
+  'FOR',
+  'FIND',
+  'RETURNING',
+  'USING',
+  'TYPEOF',
+]);
+
+const COND_JOIN = new Set<string>(['AND', 'OR']);
+
+const INDENT = '  ';
+
+function renderToken(t: Token): string {
+  const cls = CLASS_BY_KIND[t.kind];
+  const escaped = escapeHtml(t.text);
+  return cls ? `<span class="${cls}">${escaped}</span>` : escaped;
+}
+
+function isKeyword(t: Token | undefined, name: string): boolean {
+  return !!t && (t.kind === 'keyword' || t.kind === 'function') && t.text.toUpperCase() === name;
+}
+
+function isPunct(t: Token | undefined, ch: string): boolean {
+  return !!t && t.kind === 'punct' && t.text === ch;
+}
+
+export function renderPretty(tokens: Token[]): string {
+  const nonWs = tokens.filter((t) => t.kind !== 'ws');
+  let out = '';
+  let depth = 0;
+  // depths at which '(' opened a subquery (so ')' needs a leading newline)
+  const subqueryDepths = new Set<number>();
+  let prev: Token | undefined;
+  let atLineStart = true;
+  // whether the most recent major clause at each depth is WHERE/HAVING (for AND/OR breaks)
+  const condClauseStack: boolean[] = [];
+
+  const write = (s: string) => {
+    out += s;
+    if (s.length > 0) {
+      atLineStart = s.endsWith('\n');
+    }
+  };
+
+  const newline = (level: number) => {
+    out += '\n' + INDENT.repeat(level);
+    atLineStart = true;
+  };
+
+  for (let i = 0; i < nonWs.length; i++) {
+    const t = nonWs[i]!;
+    const next = nonWs[i + 1];
+
+    // closing paren - if subquery, break before
+    if (t.kind === 'punct' && t.text === ')') {
+      if (subqueryDepths.has(depth)) {
+        subqueryDepths.delete(depth);
+        newline(depth - 1);
+      }
+      depth = Math.max(0, depth - 1);
+      condClauseStack.length = Math.min(condClauseStack.length, depth + 1);
+      write(renderToken(t));
+      prev = t;
+      continue;
+    }
+
+    // major clause start
+    const upper = t.text.toUpperCase();
+    const isMajor = (t.kind === 'keyword' || t.kind === 'function') && MAJOR_CLAUSE.has(upper);
+    if (isMajor) {
+      if (!atLineStart && out.length > 0) {
+        newline(depth);
+      }
+      write(renderToken(t));
+      condClauseStack[depth] = upper === 'WHERE' || upper === 'HAVING';
+      prev = t;
+      continue;
+    }
+
+    // AND/OR inside WHERE/HAVING at current depth
+    if (
+      (t.kind === 'keyword' || t.kind === 'ident') &&
+      COND_JOIN.has(upper) &&
+      condClauseStack[depth]
+    ) {
+      newline(depth + 1);
+      write(renderToken(t));
+      prev = t;
+      continue;
+    }
+
+    // opening paren
+    if (t.kind === 'punct' && t.text === '(') {
+      // separator before '('
+      if (needsSpaceBefore(prev, t)) {
+        write(' ');
+      }
+      write(renderToken(t));
+      depth++;
+      // detect subquery: next non-ws is SELECT / FIND
+      if (isKeyword(next, 'SELECT') || isKeyword(next, 'FIND')) {
+        subqueryDepths.add(depth);
+        newline(depth);
+      }
+      prev = t;
+      continue;
+    }
+
+    // default token
+    if (!atLineStart && needsSpaceBefore(prev, t)) {
+      write(' ');
+    }
+    write(renderToken(t));
+    prev = t;
+  }
+
+  return out;
+}
+
+function needsSpaceBefore(prev: Token | undefined, cur: Token): boolean {
+  if (!prev) {
+    return false;
+  }
+  if (isPunct(prev, '(')) {
+    return false;
+  }
+  if (isPunct(prev, '.')) {
+    return false;
+  }
+  if (isPunct(cur, ')')) {
+    return false;
+  }
+  if (isPunct(cur, ',')) {
+    return false;
+  }
+  if (isPunct(cur, '.')) {
+    return false;
+  }
+  // function-call open paren attaches to identifier/function
+  if (isPunct(cur, '(') && prev.kind === 'function') {
+    return false;
+  }
+  if (isPunct(cur, '(') && prev.kind === 'ident') {
+    return false;
+  }
+  return true;
+}

--- a/log-viewer/src/features/soql/format/tokenize.ts
+++ b/log-viewer/src/features/soql/format/tokenize.ts
@@ -1,0 +1,345 @@
+/*
+ * Copyright (c) 2026 Certinia Inc. All rights reserved.
+ */
+
+export type TokenKind =
+  | 'keyword'
+  | 'function'
+  | 'string'
+  | 'number'
+  | 'bind'
+  | 'punct'
+  | 'ident'
+  | 'ws';
+
+export interface Token {
+  kind: TokenKind;
+  text: string;
+}
+
+const SOQL_KEYWORDS = new Set<string>([
+  'SELECT',
+  'FROM',
+  'WHERE',
+  'WITH',
+  'GROUP',
+  'BY',
+  'HAVING',
+  'ORDER',
+  'ASC',
+  'DESC',
+  'NULLS',
+  'FIRST',
+  'LAST',
+  'LIMIT',
+  'OFFSET',
+  'FOR',
+  'VIEW',
+  'REFERENCE',
+  'UPDATE',
+  'TRACKING',
+  'TYPEOF',
+  'WHEN',
+  'THEN',
+  'ELSE',
+  'END',
+  'USING',
+  'SCOPE',
+  'FIELDS',
+  'STANDARD',
+  'CUSTOM',
+  'ALL',
+  'AND',
+  'OR',
+  'NOT',
+  'IN',
+  'LIKE',
+  'INCLUDES',
+  'EXCLUDES',
+  'NULL',
+  'TRUE',
+  'FALSE',
+  'DATA',
+  'CATEGORY',
+  'AT',
+  'ABOVE',
+  'BELOW',
+  'ABOVE_OR_BELOW',
+  'SECURITY_ENFORCED',
+  'USER_MODE',
+  'SYSTEM_MODE',
+  // date literal labels - treat as keywords for highlighting
+  'YESTERDAY',
+  'TODAY',
+  'TOMORROW',
+  'LAST_WEEK',
+  'THIS_WEEK',
+  'NEXT_WEEK',
+  'LAST_MONTH',
+  'THIS_MONTH',
+  'NEXT_MONTH',
+  'LAST_90_DAYS',
+  'NEXT_90_DAYS',
+  'LAST_N_DAYS',
+  'NEXT_N_DAYS',
+  'THIS_QUARTER',
+  'LAST_QUARTER',
+  'NEXT_QUARTER',
+  'THIS_YEAR',
+  'LAST_YEAR',
+  'NEXT_YEAR',
+  'THIS_FISCAL_QUARTER',
+  'LAST_FISCAL_QUARTER',
+  'NEXT_FISCAL_QUARTER',
+  'THIS_FISCAL_YEAR',
+  'LAST_FISCAL_YEAR',
+  'NEXT_FISCAL_YEAR',
+  'LAST_N_WEEKS',
+  'NEXT_N_WEEKS',
+  'LAST_N_MONTHS',
+  'NEXT_N_MONTHS',
+  'LAST_N_QUARTERS',
+  'NEXT_N_QUARTERS',
+  'LAST_N_YEARS',
+  'NEXT_N_YEARS',
+  'LAST_N_FISCAL_QUARTERS',
+  'NEXT_N_FISCAL_QUARTERS',
+  'LAST_N_FISCAL_YEARS',
+  'NEXT_N_FISCAL_YEARS',
+  'N_DAYS_AGO',
+  'N_WEEKS_AGO',
+  'N_MONTHS_AGO',
+  'N_QUARTERS_AGO',
+  'N_YEARS_AGO',
+  'N_FISCAL_QUARTERS_AGO',
+  'N_FISCAL_YEARS_AGO',
+]);
+
+const SOSL_KEYWORDS = new Set<string>([
+  'FIND',
+  'IN',
+  'RETURNING',
+  'USING',
+  'LISTVIEW',
+  'SNIPPET',
+  'HIGHLIGHT',
+  'CONVERSATION',
+  'PHONE',
+  'EMAIL',
+  'NAME',
+  'SIDEBAR',
+  'DIVISION',
+  'NETWORK',
+  'METADATA',
+  'WHERE',
+  'WITH',
+  'ORDER',
+  'BY',
+  'LIMIT',
+  'OFFSET',
+  'AND',
+  'OR',
+  'NOT',
+  'DATA',
+  'CATEGORY',
+  'FIELDS',
+  'ALL',
+  'TRUE',
+  'FALSE',
+  'NULL',
+]);
+
+const FUNCTIONS = new Set<string>([
+  'COUNT',
+  'COUNT_DISTINCT',
+  'SUM',
+  'AVG',
+  'MIN',
+  'MAX',
+  'GROUPING',
+  'FORMAT',
+  'TOLABEL',
+  'CONVERTCURRENCY',
+  'DISTANCE',
+  'GEOLOCATION',
+  'CALENDAR_YEAR',
+  'CALENDAR_MONTH',
+  'CALENDAR_QUARTER',
+  'DAY_IN_MONTH',
+  'DAY_IN_WEEK',
+  'DAY_IN_YEAR',
+  'DAY_ONLY',
+  'FISCAL_YEAR',
+  'FISCAL_MONTH',
+  'FISCAL_QUARTER',
+  'HOUR_IN_DAY',
+  'WEEK_IN_MONTH',
+  'WEEK_IN_YEAR',
+  'CUBE',
+  'ROLLUP',
+]);
+
+export type Dialect = 'soql' | 'sosl';
+
+const PUNCT_CHARS = new Set<string>([
+  '(',
+  ')',
+  ',',
+  '.',
+  ';',
+  '=',
+  '<',
+  '>',
+  '!',
+  '+',
+  '-',
+  '*',
+  '/',
+  '|',
+  '&',
+  '%',
+]);
+
+function isIdentStart(ch: string): boolean {
+  return (ch >= 'A' && ch <= 'Z') || (ch >= 'a' && ch <= 'z') || ch === '_';
+}
+
+function isIdentCont(ch: string): boolean {
+  return isIdentStart(ch) || (ch >= '0' && ch <= '9');
+}
+
+function isDigit(ch: string): boolean {
+  return ch >= '0' && ch <= '9';
+}
+
+export function tokenize(input: string, dialect: Dialect = 'soql'): Token[] {
+  const tokens: Token[] = [];
+  const keywords = dialect === 'sosl' ? SOSL_KEYWORDS : SOQL_KEYWORDS;
+  const len = input.length;
+  let i = 0;
+
+  while (i < len) {
+    const ch = input[i]!;
+
+    // whitespace run
+    if (ch === ' ' || ch === '\t' || ch === '\n' || ch === '\r') {
+      const start = i;
+      while (i < len) {
+        const c = input[i]!;
+        if (c !== ' ' && c !== '\t' && c !== '\n' && c !== '\r') {
+          break;
+        }
+        i++;
+      }
+      tokens.push({ kind: 'ws', text: input.slice(start, i) });
+      continue;
+    }
+
+    // quoted string '...' with \' and \\ escapes
+    if (ch === "'") {
+      const start = i;
+      i++;
+      while (i < len) {
+        const c = input[i]!;
+        if (c === '\\' && i + 1 < len) {
+          i += 2;
+          continue;
+        }
+        if (c === "'") {
+          i++;
+          break;
+        }
+        i++;
+      }
+      tokens.push({ kind: 'string', text: input.slice(start, i) });
+      continue;
+    }
+
+    // SOSL search term {...} - treat as string
+    if (ch === '{') {
+      const start = i;
+      i++;
+      while (i < len && input[i] !== '}') {
+        i++;
+      }
+      if (i < len) {
+        i++;
+      }
+      tokens.push({ kind: 'string', text: input.slice(start, i) });
+      continue;
+    }
+
+    // bind variable :foo or :foo.bar
+    if (ch === ':') {
+      const start = i;
+      i++;
+      while (i < len && (isIdentCont(input[i]!) || input[i] === '.')) {
+        i++;
+      }
+      tokens.push({ kind: 'bind', text: input.slice(start, i) });
+      continue;
+    }
+
+    // number
+    if (isDigit(ch) || (ch === '-' && i + 1 < len && isDigit(input[i + 1]!))) {
+      const start = i;
+      if (ch === '-') {
+        i++;
+      }
+      while (i < len && (isDigit(input[i]!) || input[i] === '.')) {
+        i++;
+      }
+      tokens.push({ kind: 'number', text: input.slice(start, i) });
+      continue;
+    }
+
+    // identifier / keyword
+    if (isIdentStart(ch)) {
+      const start = i;
+      i++;
+      while (i < len && isIdentCont(input[i]!)) {
+        i++;
+      }
+      const text = input.slice(start, i);
+      const upper = text.toUpperCase();
+      let kind: TokenKind = 'ident';
+      if (FUNCTIONS.has(upper)) {
+        kind = 'function';
+      } else if (keywords.has(upper)) {
+        kind = 'keyword';
+      }
+      tokens.push({ kind, text });
+      continue;
+    }
+
+    // multi-char punct: != <= >= <>
+    if (i + 1 < len) {
+      const two = input.slice(i, i + 2);
+      if (two === '!=' || two === '<=' || two === '>=' || two === '<>') {
+        tokens.push({ kind: 'punct', text: two });
+        i += 2;
+        continue;
+      }
+    }
+
+    if (PUNCT_CHARS.has(ch)) {
+      tokens.push({ kind: 'punct', text: ch });
+      i++;
+      continue;
+    }
+
+    // fallback - emit as ident so we still escape it
+    tokens.push({ kind: 'ident', text: ch });
+    i++;
+  }
+
+  return tokens;
+}
+
+export function detectDialect(input: string): Dialect {
+  const m = input.match(/^\s*([A-Za-z_]+)/);
+  if (m && m[1] && m[1].toUpperCase() === 'FIND') {
+    return 'sosl';
+  }
+  return 'soql';
+}

--- a/log-viewer/src/features/soql/styles/soql-syntax.css.ts
+++ b/log-viewer/src/features/soql/styles/soql-syntax.css.ts
@@ -4,6 +4,7 @@
 
 export const soqlSyntaxStyles = `
 .soql-block {
+  display: inline;
   font-family: var(--vscode-editor-font-family, monospace);
   font-size: var(--vscode-editor-font-size, 0.9em);
   white-space: pre-wrap;

--- a/log-viewer/src/features/soql/styles/soql-syntax.css.ts
+++ b/log-viewer/src/features/soql/styles/soql-syntax.css.ts
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2026 Certinia Inc. All rights reserved.
+ */
+
+export const soqlSyntaxStyles = `
+.soql-block {
+  font-family: var(--vscode-editor-font-family, monospace);
+  font-size: var(--vscode-editor-font-size, 0.9em);
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+.soql-block.soql-inline {
+  white-space: nowrap;
+}
+
+.soql-tok-keyword {
+  color: var(--vscode-debugTokenExpression-name, inherit);
+  font-weight: 700;
+}
+
+.soql-tok-function {
+  color: var(--vscode-symbolIcon-functionForeground, var(--vscode-debugTokenExpression-name, inherit));
+  font-weight: 700;
+}
+
+.soql-tok-string {
+  color: var(--vscode-debugTokenExpression-string, #ce9178);
+}
+
+.soql-tok-number {
+  color: var(--vscode-debugTokenExpression-number, #b5cea8);
+}
+
+.soql-tok-bind {
+  color: var(--vscode-symbolIcon-variableForeground, var(--vscode-debugTokenExpression-name, inherit));
+  font-style: italic;
+}
+
+.soql-tok-punct {
+  opacity: 0.65;
+}
+`;

--- a/log-viewer/src/features/timeline/optimised/FrameTooltipRenderer.ts
+++ b/log-viewer/src/features/timeline/optimised/FrameTooltipRenderer.ts
@@ -15,6 +15,7 @@ import {
   formatDuration,
   formatWallClockTime,
 } from '../../../core/utility/Util.js';
+import { formatSOQL } from '../../soql/format/formatter.js';
 import type { TimelineMarker } from '../types/flamechart.types.js';
 
 /**
@@ -368,11 +369,19 @@ export class FrameTooltipRenderer {
         }
       }
 
+      const descriptionText = event.text + (event.suffix ?? '');
+      const isSoql = event.type === 'SOQL_EXECUTE_BEGIN';
+      const isSosl = event.type === 'SOSL_EXECUTE_BEGIN';
+      const descriptionHtml =
+        isSoql || isSosl
+          ? formatSOQL(descriptionText, { mode: 'pretty', dialect: isSosl ? 'sosl' : 'soql' })
+          : undefined;
       return this.createTooltip(
         '',
-        event.text + (event.suffix ?? ''),
+        descriptionText,
         rows,
         this.options.categoryColors[event.category] || '',
+        descriptionHtml,
       );
     }
 
@@ -389,6 +398,7 @@ export class FrameTooltipRenderer {
     description = '',
     rows: { label: string; value: string }[],
     color: string,
+    descriptionHtml?: string,
   ) {
     const tooltipBody = document.createElement('div');
     tooltipBody.className = 'timeline-tooltip';
@@ -405,8 +415,13 @@ export class FrameTooltipRenderer {
     }
 
     const descriptionDiv = document.createElement('div');
-    descriptionDiv.className = 'tooltip-header';
-    descriptionDiv.textContent = description;
+    if (descriptionHtml !== undefined) {
+      descriptionDiv.className = 'tooltip-header soql-block';
+      descriptionDiv.innerHTML = descriptionHtml;
+    } else {
+      descriptionDiv.className = 'tooltip-header';
+      descriptionDiv.textContent = description;
+    }
     tooltipBody.appendChild(descriptionDiv);
 
     rows.forEach(({ label, value }) => {

--- a/log-viewer/src/features/timeline/styles/timeline.css.ts
+++ b/log-viewer/src/features/timeline/styles/timeline.css.ts
@@ -1,8 +1,9 @@
 /*
  * Copyright (c) 2025 Certinia Inc. All rights reserved.
  */
+import { soqlSyntaxStyles } from '../../soql/styles/soql-syntax.css.js';
 
-export const tooltipStyles = `
+export const tooltipStyles = `${soqlSyntaxStyles}
    #timeline-tooltip {
         display: none;
         position: absolute;

--- a/log-viewer/src/tabulator/groups/GroupCalcs.ts
+++ b/log-viewer/src/tabulator/groups/GroupCalcs.ts
@@ -1,7 +1,16 @@
 import { Module, type GroupComponent, type Tabulator } from 'tabulator-tables';
 
+type GroupHeaderFn = (
+  value: unknown,
+  count: number,
+  data: unknown,
+  group: GroupComponent,
+) => string | HTMLElement | null | undefined;
+
 export class GroupCalcs extends Module {
   static moduleName = 'groupCalcs';
+
+  private userGroupHeader?: GroupHeaderFn;
 
   constructor(table: Tabulator) {
     super(table);
@@ -9,10 +18,15 @@ export class GroupCalcs extends Module {
   }
 
   initialize() {
-    // @ts-expect-error groupCalcs
-    if (this.table.options.groupCalcs && !this.table.options.groupHeader) {
-      this.table.options.groupHeader = this.groupHeader;
+    // @ts-expect-error groupCalcs is a custom option registered above
+    if (!this.table.options.groupCalcs) {
+      return;
     }
+    const existing = this.table.options.groupHeader;
+    if (typeof existing === 'function') {
+      this.userGroupHeader = existing as GroupHeaderFn;
+    }
+    this.table.options.groupHeader = this.groupHeader.bind(this);
   }
 
   groupHeader(value: unknown, count: number, data: unknown, group: GroupComponent) {
@@ -21,13 +35,22 @@ export class GroupCalcs extends Module {
     const columnCalcs = group.getTable().modules.columnCalcs;
 
     const row = columnCalcs.generateBottomRow(rawGroup.rows);
-    row.data[columnCalcs.botCalcs[0].field] = group.getKey() + ` (${count})`;
+    const firstField = columnCalcs.botCalcs[0].field;
+    row.data[firstField] = group.getKey() + ` (${count})`;
     row.generateCells();
 
     const arrowClone = rawGroup.arrowElement.cloneNode(true);
     rawGroup.arrowElement = document.createElement('span');
 
     const firstCell = row.cells[0].getElement();
+    if (this.userGroupHeader) {
+      const provided = this.userGroupHeader(value, count, data, group);
+      if (typeof provided === 'string' && provided.length > 0) {
+        firstCell.innerHTML = provided;
+      } else if (provided instanceof HTMLElement) {
+        firstCell.replaceChildren(provided);
+      }
+    }
     firstCell.insertBefore(arrowClone, firstCell.firstChild);
 
     const rowFrag = document.createDocumentFragment();
@@ -36,9 +59,6 @@ export class GroupCalcs extends Module {
     });
     row.element.appendChild(rowFrag);
 
-    // row.cells.forEach((cell) => {
-    //   cell.cellRendered();
-    // });
     return row.element;
   }
 }

--- a/log-viewer/src/tabulator/style/DataGrid.scss
+++ b/log-viewer/src/tabulator/style/DataGrid.scss
@@ -39,138 +39,149 @@ $footerBorderColor: transparent; //footer border color
 $footerSeparatorColor: transparent; //footer bottom separator color
 $footerActiveColor: #d00 !default; //footer bottom active text color
 
-@import '~tabulator-tables/src/scss/tabulator.scss';
-@import '../editors/MinMax';
-@import '../format/Progress';
+// Demote upstream tabulator styles (and our scss-mixin partials that build
+// on them) into a cascade layer so any unlayered rule — at any specificity —
+// wins. The neutralising overrides for upstream's hard-coded colours go
+// inside the SAME layer so they beat upstream within the layer, but lose to
+// any unlayered child-span colour (e.g. classed token spans) automatically.
+@layer tabulator {
+  @import '~tabulator-tables/src/scss/tabulator.scss';
+  @import '../editors/MinMax';
+  @import '../format/Progress';
 
-.tabulator {
-  .tabulator-tableholder {
-    overflow-x: hidden;
-    overflow-anchor: none;
-    .tabulator-table {
-      display: block;
+  .tabulator {
+    .tabulator-tableholder {
+      overflow-x: hidden;
+      overflow-anchor: none;
+      .tabulator-table {
+        display: block;
+        background-color: default;
+      }
+    }
+
+    .tabulator-header-filter {
+      input[type='search'] {
+        color: var(--vscode-editor-foreground);
+        background-color: var(--vscode-dropdown-background, default);
+        border: 1px solid var(--vscode-dropdown-border, transparent);
+        width: 50%;
+        box-sizing: border-box;
+        position: relative;
+        padding: 2px 4px;
+        box-sizing: border-box;
+        border-radius: 2px;
+        appearance: textfield !important;
+      }
+      input[type='search']:focus {
+        outline: var(--vscode-focusBorder, default) solid 1px;
+      }
+    }
+
+    .tabulator-row {
       background-color: default;
-    }
-  }
+      .tabulator-row-even {
+        background-color: default;
+      }
 
-  .tabulator-header-filter {
-    input[type='search'] {
-      color: var(--vscode-editor-foreground);
-      background-color: var(--vscode-dropdown-background, default);
-      border: 1px solid var(--vscode-dropdown-border, transparent);
-      width: 50%;
-      box-sizing: border-box;
-      position: relative;
-      padding: 2px 4px;
-      box-sizing: border-box;
-      border-radius: 2px;
-      appearance: textfield !important;
-    }
-    input[type='search']:focus {
-      outline: var(--vscode-focusBorder, default) solid 1px;
-    }
-  }
+      &.tabulator-group {
+        font-family: monospace;
+        background: unset;
+        border-bottom: unset;
+        border-right: unset;
+        border-top: unset;
+        max-width: 100%;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        padding: unset;
+        &:hover {
+          background-color: $rowHoverBackground;
+        }
 
-  .tabulator-row {
-    background-color: default;
-    .tabulator-row-even {
-      background-color: default;
+        // Neutralise upstream `.tabulator-row.tabulator-group span { color: #d00 }`
+        // so plain text in group headers inherits the theme foreground. Lives in
+        // the same layer as the rule it's overriding — that keeps it out of the
+        // way of any descendant span with its own colour.
+        span {
+          margin-left: unset;
+          color: inherit;
+        }
+      }
     }
 
-    &.tabulator-group {
+    .datagrid-code-text {
       font-family: monospace;
-      background: unset;
-      border-bottom: unset;
-      border-right: unset;
-      border-top: unset;
-      max-width: 100%;
-      overflow: hidden;
-      text-overflow: ellipsis;
-      padding: unset;
-      &:hover {
-        background-color: $rowHoverBackground;
-      }
+      font-weight: var(--vscode-font-weight, normal);
+      font-size: var(--vscode-editor-font-size, 0.9em);
+    }
 
-      span {
-        margin-left: unset;
-        color: unset;
-      }
+    .tabulator-row.tabulator-selected {
+      color: var(--vscode-list-activeSelectionForeground);
+    }
+
+    .tabulator-cell.datagrid-textarea {
+      white-space: pre-wrap;
+      overflow-wrap: break-word;
+      min-height: 0;
+      height: 100%;
+    }
+
+    input[type='checkbox'] {
+      vertical-align: middle;
+    }
+
+    .sort-by {
+      display: flex;
+      flex-direction: column;
+      gap: 2px;
+    }
+
+    .sort-by--bottom {
+      color: rgb(102, 102, 102);
+      border-bottom: none;
+      border-top: 6px solid rgb(102, 102, 102);
+      border-left: 6px solid transparent;
+      border-right: 6px solid transparent;
+    }
+    .sort-by--top {
+      color: rgb(102, 102, 102);
+      border-bottom: 6px solid rgb(102, 102, 102);
+      border-top: none;
+      border-left: 6px solid transparent;
+      border-right: 6px solid transparent;
+    }
+
+    .number-cell {
+      font-variant-numeric: tabular-nums;
     }
   }
 
-  .datagrid-code-text {
+  .tabulator-tooltip {
+    // Match timeline tooltip styling for consistency
+    background: var(--vscode-editorHoverWidget-background, var(--vscode-editorWidget-background));
+    color: var(--vscode-editorHoverWidget-foreground, var(--vscode-editor-foreground));
+    overflow-wrap: anywhere;
     font-family: monospace;
-    font-weight: var(--vscode-font-weight, normal);
-    font-size: var(--vscode-editor-font-size, 0.9em);
-  }
-
-  .tabulator-row.tabulator-selected {
-    color: var(--vscode-list-activeSelectionForeground);
-  }
-
-  .tabulator-cell.datagrid-textarea {
-    white-space: pre-wrap;
-    overflow-wrap: break-word;
-    min-height: 0;
-    height: 100%;
-  }
-
-  input[type='checkbox'] {
-    vertical-align: middle;
-  }
-
-  .sort-by {
-    display: flex;
-    flex-direction: column;
-    gap: 2px;
-  }
-
-  .sort-by--bottom {
-    color: rgb(102, 102, 102);
-    border-bottom: none;
-    border-top: 6px solid rgb(102, 102, 102);
-    border-left: 6px solid transparent;
-    border-right: 6px solid transparent;
-  }
-  .sort-by--top {
-    color: rgb(102, 102, 102);
-    border-bottom: 6px solid rgb(102, 102, 102);
-    border-top: none;
-    border-left: 6px solid transparent;
-    border-right: 6px solid transparent;
-  }
-
-  .number-cell {
+    font-size: 0.92rem;
     font-variant-numeric: tabular-nums;
+    padding: 5px;
+    border-radius: 4px;
+    box-shadow: 0 8px 24px rgba(0, 0, 0, 0.5);
   }
-}
 
-.tabulator-tooltip {
-  // Match timeline tooltip styling for consistency
-  background: var(--vscode-editorHoverWidget-background, var(--vscode-editorWidget-background));
-  color: var(--vscode-editorHoverWidget-foreground, var(--vscode-editor-foreground));
-  overflow-wrap: anywhere;
-  font-family: monospace;
-  font-size: 0.92rem;
-  font-variant-numeric: tabular-nums;
-  padding: 5px;
-  border-radius: 4px;
-  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.5);
-}
+  .tabulator-edit-list {
+    border-color: var(--vscode-focusBorder, default);
 
-.tabulator-edit-list {
-  border-color: var(--vscode-focusBorder, default);
-
-  .tabulator-edit-list-item {
-    color: var(--vscode-editor-foreground, 'white');
-    &.active {
-      background-color: var(--vscode-list-activeSelectionBackground);
+    .tabulator-edit-list-item {
       color: var(--vscode-editor-foreground, 'white');
-    }
+      &.active {
+        background-color: var(--vscode-list-activeSelectionBackground);
+        color: var(--vscode-editor-foreground, 'white');
+      }
 
-    &:hover {
-      background-color: var(--vscode-list-activeSelectionBackground);
-      color: var(--vscode-editor-foreground, 'white');
+      &:hover {
+        background-color: var(--vscode-list-activeSelectionBackground);
+        color: var(--vscode-editor-foreground, 'white');
+      }
     }
   }
 }


### PR DESCRIPTION
# 📝 PR Overview

Adds inline syntax highlighting and pretty-printing for SOQL and SOSL queries across every surface that renders them — timeline tooltips, call-tree name cells, the call-stack widget (which feeds the Database SOQL view and its detail panel), the analysis view, and grouped-row headers in the SOQL and bottom-up tables. Queries are often very long single-line strings; this makes them scannable without leaving the current view.

## 🛠️ Changes made

- New `features/soql/format` module: a small tokenizer + inline and pretty-print renderers, dialect auto-detect, and HTML-escape fallback for malformed input. Covered by unit tests.
- New `features/soql/styles/soql-syntax.css.ts` exposing token classes that resolve through VS Code theme tokens (works in light, dark, and high-contrast).
- Wired the formatter into the timeline tooltip (`SOQL/SOSL_EXECUTE_BEGIN` events), the call-tree name cell formatter, the analysis view stylesheet, and the `<call-stack>` web component — so the Database SOQL cell and detail panel get formatted queries automatically.
- Group headers: new `soqlGroupHeader` renderer wired into `SOQLView` and `BottomUpTable`. `GroupCalcs` is left domain-agnostic and gains a generic extension point — it now captures any user-supplied `groupHeader` and uses it as the source of the first-cell content of the calc row.
- `DataGrid.scss`: wraps the upstream tabulator imports (and our scss customisations) in `@layer tabulator` so unlayered token-colour rules win without specificity wars, and neutralises the upstream hard-coded `#d00` group-span colour from within the same layer.

## 🧩 Type of change (check all applicable)

- [ ] 🐛 Bug fix - something not working as expected
- [x] ✨ New feature – adds new functionality
- [ ] ♻️ Refactor - internal changes with no user impact
- [ ] ⚡ Performance Improvement
- [ ] 📝 Documentation - README or documentation site changes
- [ ] 🔧 Chore - dev tooling, CI, config
- [ ] 💥 Breaking change

## 📷 Screenshots / gifs / video [optional]

<img width="1025" height="336" alt="image" src="https://github.com/user-attachments/assets/c78d674a-784a-41d3-88be-10ffac4ec7c8" />

<img width="1463" height="606" alt="image" src="https://github.com/user-attachments/assets/d66953e7-1bf2-43a8-b0f8-098f405113aa" />

<img width="1163" height="368" alt="image" src="https://github.com/user-attachments/assets/a6324899-1a42-4380-bca6-e52dc6801f08" />



## 🔗 Related Issues

resolves #605

## ✅ Tests added?

- [x] 👍 yes
- [ ] 🙅 no, not needed
- [ ] 🙋 no, I need help

## 📚 Docs updated?

- [ ] 🔖 README.md
- [ ] 🔖 CHANGELOG.md
- [ ] 📖 help site
- [x] 🙅 not needed

## Anything else we need to know? [optional]

Reviewer guidance:

- The interesting algorithmic bits are in \`renderPretty.ts\` (single-pass token-stream walker with paren-depth tracking for subqueries and per-depth WHERE/HAVING context for AND/OR line breaks) and the tokenizer's keyword/function/date-literal sets.
- The \`GroupCalcs\` change is intentionally generic: the SOQL detection lives in \`features/soql/format/groupHeader.ts\`, and tables opt in by setting \`groupHeader: soqlGroupHeader\` next to their existing \`groupCalcs: true\`.
- The \`@layer tabulator\` wrap in \`DataGrid.scss\` is the cleanest way I found to defeat upstream's hard-coded \`.tabulator-row.tabulator-group span { color: #d00 }\` without leaking SOQL class names into the shared stylesheet. Worth a focused look during review.

Test plan:

- [x] \`pnpm lint\` (eslint + prettier + tsc on all three projects)
- [x] \`pnpm jest\` (874 tests, including 17 formatter + 6 group-header)
- [ ] Manual smoke: hover SOQL/SOSL frames on the timeline; inspect call-tree name cells; open Database SOQL view (cells + detail panel); group by SOQL in the SOQL view; group BottomUp by a SOQL-event field; verify Light, Dark, and High-Contrast VS Code themes.