### PR TITLE
build(deps): upgrade @apexdevtools/apex-parser to 5.1.0-beta.1

### DIFF
--- a/lana/package.json
+++ b/lana/package.json
@@ -315,9 +315,10 @@
   },
   "dependencies": {
     "@apexdevtools/apex-ls": "^6.0.2",
-    "@apexdevtools/apex-parser": "^4.4.0",
+    "@apexdevtools/apex-parser": "5.1.0-beta.1",
     "@salesforce/apex-node": "^8.4.11",
-    "@salesforce/core": "^8.26.3"
+    "@salesforce/core": "^8.26.3",
+    "antlr4": "4.13.2"
   },
   "devDependencies": {
     "@types/node": "~22.16.5",

--- a/lana/src/salesforce/ApexParser/ApexSymbolLocator.ts
+++ b/lana/src/salesforce/ApexParser/ApexSymbolLocator.ts
@@ -1,13 +1,7 @@
 /*
  * Copyright (c) 2025 Certinia Inc. All rights reserved.
  */
-import {
-  ApexLexer,
-  ApexParser,
-  CaseInsensitiveInputStream,
-  CommonTokenStream,
-} from '@apexdevtools/apex-parser';
-import { CharStreams } from 'antlr4ts';
+import { ApexParserFactory } from '@apexdevtools/apex-parser';
 import {
   ApexVisitor,
   type ApexConstructorNode,
@@ -23,11 +17,7 @@ export type SymbolLocation = {
 };
 
 export function parseApex(apexCode: string): ApexNode {
-  const parser = new ApexParser(
-    new CommonTokenStream(
-      new ApexLexer(new CaseInsensitiveInputStream(CharStreams.fromString(apexCode))),
-    ),
-  );
+  const parser = ApexParserFactory.createParser(apexCode);
   return new ApexVisitor().visit(parser.compilationUnit());
 }
 

--- a/lana/src/salesforce/ApexParser/ApexVisitor.ts
+++ b/lana/src/salesforce/ApexParser/ApexVisitor.ts
@@ -1,14 +1,18 @@
 /*
  * Copyright (c) 2025 Certinia Inc. All rights reserved.
  */
-import type {
-  ApexParserVisitor,
-  ClassDeclarationContext,
-  ConstructorDeclarationContext,
-  FormalParametersContext,
-  MethodDeclarationContext,
+import {
+  ApexParserBaseVisitor,
+  type ApexErrorNode,
+  type ApexParserRuleContext,
+  type ApexParseTree,
+  type ApexRuleNode,
+  type ApexTerminalNode,
+  type ClassDeclarationContext,
+  type ConstructorDeclarationContext,
+  type FormalParametersContext,
+  type MethodDeclarationContext,
 } from '@apexdevtools/apex-parser';
-import type { ErrorNode, ParseTree, RuleNode, TerminalNode } from 'antlr4ts/tree';
 
 type ApexNature = 'Constructor' | 'Class' | 'Method';
 
@@ -67,21 +71,23 @@ export interface ApexConstructorNode extends ApexParamNode {
   nature: 'Constructor';
 }
 
-type VisitableApex = ParseTree & {
-  accept<Result>(visitor: ApexParserVisitor<Result>): Result;
+type VisitableApex = ApexParseTree & {
+  accept(visitor: ApexVisitor): ApexNode;
 };
 
-export class ApexVisitor implements ApexParserVisitor<ApexNode> {
-  visit(ctx: ParseTree): ApexNode {
+export class ApexVisitor extends ApexParserBaseVisitor<ApexNode> {
+  override visit(ctx: ApexParseTree): ApexNode {
     return ctx ? (ctx as VisitableApex).accept(this) : {};
   }
 
-  visitChildren(ctx: RuleNode): ApexNode {
+  override visitChildren(ctx: ApexRuleNode): ApexNode {
     const children: ApexNode[] = [];
+    const rule = ctx as ApexParserRuleContext;
+    const childCount = rule.getChildCount();
 
-    for (let index = 0; index < ctx.childCount; index++) {
-      const child = ctx.getChild(index);
-      const node = this.visit(child);
+    for (let index = 0; index < childCount; index++) {
+      const child = rule.getChild(index);
+      const node = child ? this.visit(child) : undefined;
       if (!node) {
         continue;
       }
@@ -92,59 +98,59 @@ export class ApexVisitor implements ApexParserVisitor<ApexNode> {
     return { children };
   }
 
-  visitClassDeclaration(ctx: ClassDeclarationContext): ApexClassNode {
+  visitClassDeclaration = (ctx: ClassDeclarationContext): ApexClassNode => {
     const { start } = ctx;
     const ident = ctx.id();
 
     return {
       nature: 'Class',
-      name: ident.text ?? '',
+      name: ident.getText() ?? '',
       children: ctx.children?.length ? this.visitChildren(ctx).children : [],
       line: start.line,
-      idCharacter: ident.start.charPositionInLine ?? 0,
+      idCharacter: ident.start.column ?? 0,
     };
-  }
+  };
 
-  visitConstructorDeclaration(ctx: ConstructorDeclarationContext): ApexConstructorNode {
+  visitConstructorDeclaration = (ctx: ConstructorDeclarationContext): ApexConstructorNode => {
     const { start } = ctx;
-    const idContexts = ctx.qualifiedName().id();
+    const idContexts = ctx.qualifiedName().id_list();
     const constructorName = idContexts[idContexts.length - 1];
 
     return {
       nature: 'Constructor',
-      name: constructorName?.text ?? '',
+      name: constructorName?.getText() ?? '',
       children: ctx.children?.length ? this.visitChildren(ctx).children : [],
       params: this.getParameters(ctx.formalParameters()),
       line: start.line,
-      idCharacter: start.charPositionInLine ?? 0,
+      idCharacter: start.column ?? 0,
     };
-  }
+  };
 
-  visitMethodDeclaration(ctx: MethodDeclarationContext): ApexMethodNode {
+  visitMethodDeclaration = (ctx: MethodDeclarationContext): ApexMethodNode => {
     const { start } = ctx;
     const ident = ctx.id();
 
     return {
       nature: 'Method',
-      name: ident.text ?? '',
+      name: ident.getText() ?? '',
       children: ctx.children?.length ? this.visitChildren(ctx).children : [],
       params: this.getParameters(ctx.formalParameters()),
       line: start.line,
-      idCharacter: ident.start.charPositionInLine ?? 0,
+      idCharacter: ident.start.column ?? 0,
     };
-  }
+  };
 
-  visitTerminal(_ctx: TerminalNode): ApexNode {
+  override visitTerminal(_ctx: ApexTerminalNode): ApexNode {
     return {};
   }
 
-  visitErrorNode(_ctx: ErrorNode): ApexNode {
+  override visitErrorNode(_ctx: ApexErrorNode): ApexNode {
     return {};
   }
 
   private getParameters(ctx: FormalParametersContext): string {
-    const paramsList = ctx.formalParameterList()?.formalParameter();
-    return paramsList?.map((param) => param.typeRef().text).join(',') ?? '';
+    const paramsList = ctx.formalParameterList()?.formalParameter_list();
+    return paramsList?.map((param) => param.typeRef().getText()).join(',') ?? '';
   }
 
   private forNode(node: ApexNode, anonHandler: (n: ApexNode) => void) {

--- a/lana/src/salesforce/__tests__/ApexSymbolLocator.test.ts
+++ b/lana/src/salesforce/__tests__/ApexSymbolLocator.test.ts
@@ -5,7 +5,12 @@ import { getMethodLine, parseApex } from '../ApexParser/ApexSymbolLocator';
 import { ApexVisitor, type ApexNode } from '../ApexParser/ApexVisitor';
 
 jest.mock('../ApexParser/ApexVisitor');
-jest.mock('@apexdevtools/apex-parser');
+jest.mock('@apexdevtools/apex-parser', () => ({
+  ApexParserFactory: {
+    createParser: jest.fn(() => ({ compilationUnit: jest.fn() })),
+  },
+  ApexParserBaseVisitor: class {},
+}));
 
 describe('ApexSymbolLocator', () => {
   const mockAST = {

--- a/lana/src/salesforce/__tests__/ApexVisitor.test.ts
+++ b/lana/src/salesforce/__tests__/ApexVisitor.test.ts
@@ -6,7 +6,6 @@
 import { ApexVisitor } from '../ApexParser/ApexVisitor';
 
 jest.mock('@apexdevtools/apex-parser');
-jest.mock('antlr4ts/tree');
 
 describe('ApexVisitor', () => {
   let visitor: ApexVisitor;
@@ -16,11 +15,11 @@ describe('ApexVisitor', () => {
   });
 
   describe('visitClassDeclaration', () => {
-    it('should use empty string when ident.text is null', () => {
+    it('should use empty string when ident.getText() is null', () => {
       const ctx = {
         id: () => ({
-          text: null,
-          start: { charPositionInLine: 5 },
+          getText: () => null,
+          start: { column: 5 },
         }),
         children: [],
         start: { line: 1 },
@@ -32,11 +31,11 @@ describe('ApexVisitor', () => {
       expect(node.name).toBe('');
     });
 
-    it('should use 0 when charPositionInLine is null', () => {
+    it('should use 0 when column is null', () => {
       const ctx = {
         id: () => ({
-          text: 'MyClass',
-          start: { charPositionInLine: null },
+          getText: () => 'MyClass',
+          start: { column: null },
         }),
         children: [],
         start: { line: 1 },
@@ -51,13 +50,11 @@ describe('ApexVisitor', () => {
     it('should return class node with name and children', () => {
       const ctx = {
         id: () => ({
-          text: 'MyClass',
-          start: { charPositionInLine: 0 },
+          getText: () => 'MyClass',
+          start: { column: 0 },
         }),
         children: [{}],
-        get childCount() {
-          return 1;
-        },
+        getChildCount: () => 1,
         getChild: jest.fn().mockReturnValue({
           accept: jest.fn().mockReturnValue({ nature: 'Method', name: 'foo' }),
         }),
@@ -78,8 +75,8 @@ describe('ApexVisitor', () => {
     it('should handle missing Identifier', () => {
       const ctx = {
         id: () => ({
-          text: '',
-          start: { charPositionInLine: 0 },
+          getText: () => '',
+          start: { column: 0 },
         }),
         children: [],
         start: { line: 10 },
@@ -95,8 +92,8 @@ describe('ApexVisitor', () => {
     it('should handle missing children', () => {
       const ctx = {
         id: () => ({
-          text: 'NoChildren',
-          start: { charPositionInLine: 0 },
+          getText: () => 'NoChildren',
+          start: { column: 0 },
         }),
         children: undefined,
         start: { line: 15 },
@@ -110,11 +107,11 @@ describe('ApexVisitor', () => {
   });
 
   describe('visitMethodDeclaration', () => {
-    it('should use empty string when ident.text is null', () => {
+    it('should use empty string when ident.getText() is null', () => {
       const ctx = {
         id: () => ({
-          text: null,
-          start: { charPositionInLine: 5 },
+          getText: () => null,
+          start: { column: 5 },
         }),
         children: [],
         formalParameters: () => ({
@@ -129,11 +126,11 @@ describe('ApexVisitor', () => {
       expect(node.name).toBe('');
     });
 
-    it('should use 0 when charPositionInLine is null', () => {
+    it('should use 0 when column is null', () => {
       const ctx = {
         id: () => ({
-          text: 'myMethod',
-          start: { charPositionInLine: null },
+          getText: () => 'myMethod',
+          start: { column: null },
         }),
         children: [],
         formalParameters: () => ({
@@ -151,15 +148,15 @@ describe('ApexVisitor', () => {
     it('should return method node with name, params, and line', () => {
       const ctx = {
         id: () => ({
-          text: 'myMethod',
-          start: { charPositionInLine: 2 },
+          getText: () => 'myMethod',
+          start: { column: 2 },
         }),
         children: [{}],
         formalParameters: () => ({
           formalParameterList: () => ({
-            formalParameter: () => [
-              { typeRef: () => ({ text: 'Integer' }) },
-              { typeRef: () => ({ text: 'String' }) },
+            formalParameter_list: () => [
+              { typeRef: () => ({ getText: () => 'Integer' }) },
+              { typeRef: () => ({ getText: () => 'String' }) },
             ],
           }),
         }),
@@ -178,8 +175,8 @@ describe('ApexVisitor', () => {
     it('should handle missing Identifier and params', () => {
       const ctx = {
         id: () => ({
-          text: '',
-          start: { charPositionInLine: 0 },
+          getText: () => '',
+          start: { column: 0 },
         }),
         children: [],
         formalParameters: () => ({
@@ -197,16 +194,16 @@ describe('ApexVisitor', () => {
   });
 
   describe('visitConstructorDeclaration', () => {
-    it('should use empty string when constructorName.text is null', () => {
+    it('should use empty string when constructorName.getText() is null', () => {
       const ctx = {
         qualifiedName: () => ({
-          id: () => [{ text: null }],
+          id_list: () => [{ getText: () => null }],
         }),
         children: [],
         formalParameters: () => ({
           formalParameterList: () => undefined,
         }),
-        start: { line: 1, charPositionInLine: 5 },
+        start: { line: 1, column: 5 },
       };
       visitor.visitChildren = jest.fn().mockReturnValue({ children: [] });
 
@@ -215,16 +212,16 @@ describe('ApexVisitor', () => {
       expect(node.name).toBe('');
     });
 
-    it('should use 0 when start.charPositionInLine is null', () => {
+    it('should use 0 when start.column is null', () => {
       const ctx = {
         qualifiedName: () => ({
-          id: () => [{ text: 'MyConstructor' }],
+          id_list: () => [{ getText: () => 'MyConstructor' }],
         }),
         children: [],
         formalParameters: () => ({
           formalParameterList: () => undefined,
         }),
-        start: { line: 1, charPositionInLine: null },
+        start: { line: 1, column: null },
       };
       visitor.visitChildren = jest.fn().mockReturnValue({ children: [] });
 
@@ -236,18 +233,18 @@ describe('ApexVisitor', () => {
     it('should return constructor node with name, params, and line', () => {
       const ctx = {
         qualifiedName: () => ({
-          id: () => [{ text: 'OuterClass' }, { text: 'MyConstructor' }],
+          id_list: () => [{ getText: () => 'OuterClass' }, { getText: () => 'MyConstructor' }],
         }),
         children: [{}],
         formalParameters: () => ({
           formalParameterList: () => ({
-            formalParameter: () => [
-              { typeRef: () => ({ text: 'String' }) },
-              { typeRef: () => ({ text: 'Integer' }) },
+            formalParameter_list: () => [
+              { typeRef: () => ({ getText: () => 'String' }) },
+              { typeRef: () => ({ getText: () => 'Integer' }) },
             ],
           }),
         }),
-        start: { line: 20, charPositionInLine: 5 },
+        start: { line: 20, column: 5 },
       };
       visitor.visitChildren = jest.fn().mockReturnValue({ children: [] });
 
@@ -263,13 +260,13 @@ describe('ApexVisitor', () => {
     it('should handle constructor with no params', () => {
       const ctx = {
         qualifiedName: () => ({
-          id: () => [{ text: 'MyClass' }],
+          id_list: () => [{ getText: () => 'MyClass' }],
         }),
         children: [],
         formalParameters: () => ({
           formalParameterList: () => undefined,
         }),
-        start: { line: 10, charPositionInLine: 2 },
+        start: { line: 10, column: 2 },
       };
       visitor.visitChildren = jest.fn().mockReturnValue({ children: [] });
 
@@ -284,15 +281,19 @@ describe('ApexVisitor', () => {
     it('should handle nested class constructor', () => {
       const ctx = {
         qualifiedName: () => ({
-          id: () => [{ text: 'OuterClass' }, { text: 'InnerClass' }, { text: 'InnerClass' }],
+          id_list: () => [
+            { getText: () => 'OuterClass' },
+            { getText: () => 'InnerClass' },
+            { getText: () => 'InnerClass' },
+          ],
         }),
         children: [{}],
         formalParameters: () => ({
           formalParameterList: () => ({
-            formalParameter: () => [{ typeRef: () => ({ text: 'Boolean' }) }],
+            formalParameter_list: () => [{ typeRef: () => ({ getText: () => 'Boolean' }) }],
           }),
         }),
-        start: { line: 35, charPositionInLine: 10 },
+        start: { line: 35, column: 10 },
       };
       visitor.visitChildren = jest.fn().mockReturnValue({ children: [] });
 
@@ -340,7 +341,7 @@ describe('ApexVisitor', () => {
   describe('visitChildren', () => {
     it('should skip null nodes returned from visit', () => {
       const ctx = {
-        childCount: 2,
+        getChildCount: () => 2,
         getChild: jest.fn().mockImplementation((index: number) => ({
           accept: jest.fn().mockReturnValue(index === 0 ? null : { nature: 'Method', name: 'foo' }),
         })),
@@ -354,7 +355,7 @@ describe('ApexVisitor', () => {
 
     it('should skip undefined nodes returned from visit', () => {
       const ctx = {
-        childCount: 2,
+        getChildCount: () => 2,
         getChild: jest.fn().mockImplementation((index: number) => ({
           accept: jest
             .fn()
@@ -370,7 +371,7 @@ describe('ApexVisitor', () => {
 
     it('should process multiple valid nodes', () => {
       const ctx = {
-        childCount: 3,
+        getChildCount: () => 3,
         getChild: jest.fn().mockImplementation((index: number) => ({
           accept: jest.fn().mockReturnValue({ nature: 'Method', name: `method${index}` }),
         })),
@@ -384,7 +385,7 @@ describe('ApexVisitor', () => {
     it('should flatten children from non-anon nodes (nodes without nature)', () => {
       // A node without 'nature' should have its children extracted
       const ctx = {
-        childCount: 1,
+        getChildCount: () => 1,
         getChild: jest.fn().mockReturnValue({
           accept: jest.fn().mockReturnValue({
             // No nature property - this is a "non-anon" wrapper node
@@ -406,7 +407,7 @@ describe('ApexVisitor', () => {
 
     it('should handle non-anon nodes with empty children array', () => {
       const ctx = {
-        childCount: 1,
+        getChildCount: () => 1,
         getChild: jest.fn().mockReturnValue({
           accept: jest.fn().mockReturnValue({
             // No nature, empty children
@@ -422,7 +423,7 @@ describe('ApexVisitor', () => {
 
     it('should handle non-anon nodes with no children property', () => {
       const ctx = {
-        childCount: 1,
+        getChildCount: () => 1,
         getChild: jest.fn().mockReturnValue({
           accept: jest.fn().mockReturnValue({
             // No nature, no children property
@@ -439,7 +440,7 @@ describe('ApexVisitor', () => {
 
     it('should handle mix of anon and non-anon nodes', () => {
       const ctx = {
-        childCount: 2,
+        getChildCount: () => 2,
         getChild: jest.fn().mockImplementation((index: number) => ({
           accept: jest.fn().mockReturnValue(
             index === 0

--- a/log-viewer/package.json
+++ b/log-viewer/package.json
@@ -5,9 +5,10 @@
   "scripts": {},
   "version": "0.1.0",
   "dependencies": {
-    "@apexdevtools/apex-parser": "^4.4.0",
+    "@apexdevtools/apex-parser": "5.1.0-beta.1",
     "@vscode/codicons": "^0.0.44",
     "@vscode/webview-ui-toolkit": "^1.4.0",
+    "antlr4": "4.13.2",
     "lit": "^3.3.2",
     "pixi.js": "^8.16.0",
     "tabulator-tables": "^6.4.0"

--- a/log-viewer/src/features/soql/services/SOQLLinter.ts
+++ b/log-viewer/src/features/soql/services/SOQLLinter.ts
@@ -66,12 +66,12 @@ class LeadingPercentWildcardRule implements SOQLLinterRule {
     if (whereClause) {
       const hasLeadingWildcard = whereClause
         .logicalExpression()
-        .conditionalExpression()
+        .conditionalExpression_list()
         .find((exp) => {
           const fieldExp = exp.fieldExpression();
           if (
             fieldExp?.comparisonOperator().LIKE() &&
-            fieldExp.value().StringLiteral()?.text.startsWith("'%")
+            fieldExp.value().StringLiteral()?.getText().startsWith("'%")
           ) {
             return exp;
           }
@@ -99,7 +99,7 @@ class NegativeFilterOperatorRule implements SOQLLinterRule {
 
       const hasNegativeOp =
         exp.NOT() ||
-        exp.conditionalExpression().find((exp) => {
+        exp.conditionalExpression_list().find((exp) => {
           const operator = exp.fieldExpression()?.comparisonOperator();
 
           if (
@@ -148,11 +148,11 @@ class LastModifiedDateSystemModStampIndexRule implements SOQLLinterRule {
     if (whereClause) {
       const result = whereClause
         .logicalExpression()
-        .conditionalExpression()
+        .conditionalExpression_list()
         .find((exp) => {
           const fieldExp = exp.fieldExpression();
           if (
-            fieldExp?.fieldName()?.text.toLowerCase().endsWith('lastmodifieddate') &&
+            fieldExp?.fieldName()?.getText().toLowerCase().endsWith('lastmodifieddate') &&
             fieldExp.comparisonOperator().LT()
           ) {
             return exp;

--- a/log-viewer/src/features/soql/services/SOQLParser.ts
+++ b/log-viewer/src/features/soql/services/SOQLParser.ts
@@ -1,13 +1,7 @@
 /*
  * Copyright (c) 2022 Certinia Inc. All rights reserved.
  */
-import { type QueryContext } from '@apexdevtools/apex-parser';
-import {
-  type ANTLRErrorListener,
-  type RecognitionException,
-  type Recognizer,
-  type Token,
-} from 'antlr4ts';
+import { ApexErrorListener, type QueryContext } from '@apexdevtools/apex-parser';
 
 // To understand the parser AST see https://github.com/nawforce/apex-parser/blob/master/antlr/ApexParser.g4
 // Start with the 'query' rule at ~532
@@ -23,46 +17,46 @@ export class SOQLTree {
   /* Return true if SELECT list only contains field names, no functions, sub-queries or typeof */
   isSimpleSelect(): boolean {
     const selectList = this._queryContext.selectList();
-    const selectEntries = selectList.selectEntry();
-    return selectEntries.every((selectEntry) => selectEntry.fieldName() !== undefined);
+    const selectEntries = selectList.selectEntry_list();
+    return selectEntries.every((selectEntry) => selectEntry.fieldName() != null);
   }
 
   /* Return true for queries only containing WHERE, ORDER BY & LIMIT clauses */
   isTrivialQuery(): boolean {
     return (
-      this._queryContext.usingScope() === undefined &&
-      this._queryContext.withClause() === undefined &&
-      this._queryContext.groupByClause() === undefined &&
-      this._queryContext.offsetClause() === undefined &&
-      this._queryContext.allRowsClause() === undefined &&
-      this._queryContext.forClauses().childCount === 0 &&
-      this._queryContext.updateList() === undefined
+      this._queryContext.usingScope() == null &&
+      this._queryContext.withClause() == null &&
+      this._queryContext.groupByClause() == null &&
+      this._queryContext.offsetClause() == null &&
+      this._queryContext.allRowsClause() == null &&
+      this._queryContext.forClauses().getChildCount() === 0 &&
+      this._queryContext.updateList() == null
     );
   }
 
   /* Return true if query has ORDER BY */
   isOrdered(): boolean {
-    return this._queryContext.orderByClause() !== undefined;
+    return this._queryContext.orderByClause() != null;
   }
 
   /* Return limit value if defined, maybe a number or a bound expression */
   limitValue(): number | string | undefined {
     const limitClause = this._queryContext.limitClause();
-    if (limitClause === undefined) {
+    if (limitClause == null) {
       return undefined;
-    } else if (limitClause?.IntegerLiteral() !== undefined) {
-      return parseInt(limitClause?.IntegerLiteral()?.text as string);
+    } else if (limitClause.IntegerLiteral() != null) {
+      return parseInt(limitClause.IntegerLiteral()?.getText() as string);
     } else {
-      return limitClause?.boundExpression()?.text as string;
+      return limitClause.boundExpression()?.getText() as string;
     }
   }
 
   /* Return FROM clase SObject name, if there is a single SObject */
   fromObject(): undefined | string {
     const fromContext = this._queryContext.fromNameList();
-    const fieldNames = fromContext.fieldName();
+    const fieldNames = fromContext.fieldName_list();
     if (fieldNames.length === 1) {
-      return fieldNames[0]?.text;
+      return fieldNames[0]?.getText();
     } else {
       return undefined;
     }
@@ -73,14 +67,8 @@ export class SOQLParser {
   async parse(query: string): Promise<SOQLTree> {
     // Dynamic import for code splitting. Improves performance by reducing the amount of JS that is loaded and parsed at the start.
     // eslint-disable-next-line @typescript-eslint/naming-convention
-    const { ApexLexer, ApexParser, CaseInsensitiveInputStream } =
-      await import('@apexdevtools/apex-parser');
-    // Dynamic import for code splitting. Improves performance by reducing the amount of JS that is loaded and parsed at the start.
-    // eslint-disable-next-line @typescript-eslint/naming-convention
-    const { CharStreams, CommonTokenStream } = await import('antlr4ts');
-    const lexer = new ApexLexer(new CaseInsensitiveInputStream(CharStreams.fromString(query)));
-    const tokens = new CommonTokenStream(lexer);
-    const parser = new ApexParser(tokens);
+    const { ApexParserFactory } = await import('@apexdevtools/apex-parser');
+    const parser = ApexParserFactory.createParser(query);
     parser.removeErrorListeners();
     parser.addErrorListener(new ThrowingErrorListener());
     return new SOQLTree(parser.query());
@@ -99,16 +87,8 @@ export class SyntaxException {
   }
 }
 
-class ThrowingErrorListener implements ANTLRErrorListener<Token> {
-  syntaxError<Token>(
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    recognizer: Recognizer<Token, any>,
-    offendingSymbol: Token,
-    line: number,
-    charPositionInLine: number,
-    msg: string,
-    _e: RecognitionException | undefined,
-  ): void {
-    throw new SyntaxException(line, charPositionInLine, msg);
+class ThrowingErrorListener extends ApexErrorListener {
+  apexSyntaxError(line: number, column: number, message: string): void {
+    throw new SyntaxException(line, column, message);
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -99,14 +99,17 @@ importers:
         specifier: ^6.0.2
         version: 6.0.2
       '@apexdevtools/apex-parser':
-        specifier: ^4.4.0
-        version: 4.4.1
+        specifier: 5.1.0-beta.1
+        version: 5.1.0-beta.1
       '@salesforce/apex-node':
         specifier: ^8.4.11
         version: 8.4.11(tslib@2.8.1)
       '@salesforce/core':
         specifier: ^8.26.3
         version: 8.26.3(tslib@2.8.1)
+      antlr4:
+        specifier: 4.13.2
+        version: 4.13.2
     devDependencies:
       '@types/node':
         specifier: ~22.16.5
@@ -164,14 +167,17 @@ importers:
   log-viewer:
     dependencies:
       '@apexdevtools/apex-parser':
-        specifier: ^4.4.0
-        version: 4.4.1
+        specifier: 5.1.0-beta.1
+        version: 5.1.0-beta.1
       '@vscode/codicons':
         specifier: ^0.0.44
         version: 0.0.44
       '@vscode/webview-ui-toolkit':
         specifier: ^1.4.0
         version: 1.4.0(react@19.2.4)
+      antlr4:
+        specifier: 4.13.2
+        version: 4.13.2
       lit:
         specifier: ^3.3.2
         version: 3.3.2
@@ -278,9 +284,11 @@ packages:
     resolution: {integrity: sha512-RlaWpAFudE0GvUcim/xLBNw5ipNgT0Yd1eM7jeZJS0R9qn5DxeUGY3636zfgKgWkK04075y1fgNbPsIi/EjKiw==}
     engines: {node: '>=8.0.0'}
 
-  '@apexdevtools/apex-parser@4.4.1':
-    resolution: {integrity: sha512-tLHQ8DkI7/aoL9nOax+Xb3OEXk8IK1mTIpcCBaBJ3kk0Mhy4ik9jfQVAoSxjbWo8aLrjz2E4jnjmSU1iZlEt+Q==}
-    engines: {node: '>=8.0.0'}
+  '@apexdevtools/apex-parser@5.1.0-beta.1':
+    resolution: {integrity: sha512-IBuDgIMNypFJ9KXQDPZ44tbroj7Qi+to+l7fTqz+PiiXSw1MRFJfIPznO0oZcY68rohyEaMfeLWG2fYAPNc7hQ==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+    bundledDependencies:
+      - antlr4
 
   '@apexdevtools/vf-parser@1.1.0':
     resolution: {integrity: sha512-dP45Y3b4F0b8HosvGEMo6ugRx8yKhaz7h6eJh1cD/YvFxajk6x9Hfrtw63U2EKAstug6waBsT6QC7h+4USjBnA==}
@@ -3232,6 +3240,10 @@ packages:
   ansi-styles@6.2.3:
     resolution: {integrity: sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==}
     engines: {node: '>=12'}
+
+  antlr4@4.13.2:
+    resolution: {integrity: sha512-QiVbZhyy4xAZ17UPEuG3YTOt8ZaoeOR1CvEAqrEsDBsOqINslaB147i9xqljZqoyf5S+EUlGStaj+t22LT9MOg==}
+    engines: {node: '>=16'}
 
   antlr4ts@0.5.0-alpha.4:
     resolution: {integrity: sha512-WPQDt1B74OfPv/IMS2ekXAKkTZIHl88uMetg6q3OTqgFxZ/dxDXI0EWLyZid/1Pe6hTftyg5N7gel5wNAGxXyQ==}
@@ -8213,10 +8225,7 @@ snapshots:
       antlr4ts: 0.5.0-alpha.4
       node-dir: 0.1.17
 
-  '@apexdevtools/apex-parser@4.4.1':
-    dependencies:
-      antlr4ts: 0.5.0-alpha.4
-      node-dir: 0.1.17
+  '@apexdevtools/apex-parser@5.1.0-beta.1': {}
 
   '@apexdevtools/vf-parser@1.1.0':
     dependencies:
@@ -12086,6 +12095,8 @@ snapshots:
   ansi-styles@5.2.0: {}
 
   ansi-styles@6.2.3: {}
+
+  antlr4@4.13.2: {}
 
   antlr4ts@0.5.0-alpha.4: {}
 

--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -34,6 +34,10 @@ export default [
             find: 'apex-log-parser',
             replacement: path.resolve(__dirname, 'apex-log-parser/src/index.ts'),
           },
+          {
+            find: 'antlr4',
+            replacement: path.resolve(__dirname, 'node_modules/antlr4/dist/antlr4.node.mjs'),
+          },
         ],
       }),
       nodeResolve({ preferBuiltins: true }),
@@ -47,7 +51,7 @@ export default [
           jsc: {
             minify: {
               compress: production ? { keep_classnames: true, keep_fnames: true } : false,
-              mangle: production? { keep_classnames: true,  } : false,
+              mangle: production ? { keep_classnames: true } : false,
             },
           },
         }),
@@ -97,6 +101,10 @@ export default [
           {
             find: 'eventemitter3',
             replacement: path.resolve(__dirname, 'node_modules/eventemitter3/index.js'),
+          },
+          {
+            find: 'antlr4',
+            replacement: path.resolve(__dirname, 'node_modules/antlr4/dist/antlr4.web.mjs'),
           },
         ],
       }),


### PR DESCRIPTION
# 📝 PR Overview

Upgrade `@apexdevtools/apex-parser` from `^4.4.0` to `5.1.0-beta.1`. v5 swapped the underlying ANTLR runtime from `antlr4ts` to the official `antlr4` package and reshaped the public API, so this PR migrates the three call sites (`ApexSymbolLocator`, `ApexVisitor`, `SOQLParser`/`SOQLLinter`), their tests, and the bundling setup.

## 🛠️ Changes made

- Migrate parser construction to `ApexParserFactory.createParser(source)` — replaces the manual `ApexLexer` / `CaseInsensitiveInputStream` / `CommonTokenStream` / `ApexParser` chain and removes the direct `antlr4ts` import.
- Rebase `ApexVisitor` on the new `ApexParserBaseVisitor<T>` abstract class (the old `ApexParserVisitor<T>` interface is gone) and update antlr4 JS API call sites: `ctx.text` → `ctx.getText()`, `Token.charPositionInLine` → `Token.column`, `ctx.childCount` → `ctx.getChildCount()`, multi-rule accessors like `id()` / `formalParameter()` / `selectEntry()` / `conditionalExpression()` / `fieldName()` → `*_list()`.
- Update SOQL optional-context checks to null-aware comparisons (`== null` / `!= null`) — antlr4 returns `null` for missing optional rules where antlr4ts returned `undefined`, which was silently breaking `isOrdered`, `isSimpleSelect`, and `limitValue`.
- Replace the antlr4ts `ANTLRErrorListener<Token>` implementation with a subclass of the new `ApexErrorListener` abstract base (single `apexSyntaxError(line, column, message)` hook).
- Add `antlr4@4.13.2` as a direct dependency in `lana` and `log-viewer` (matching apex-parser's bundled version) and alias it in both Rollup passes so the bundler resolves cleanly under pnpm's nested layout instead of leaving `antlr4` external with "Could not resolve" warnings.
- Refresh `jest.mock` shapes in the visitor / locator tests to match the new API (`getText()` methods, `column` instead of `charPositionInLine`, `id_list`/`formalParameter_list`, factory mock for `ApexParserFactory.createParser`).

## 🧩 Type of change (check all applicable)

- [ ] 🐛 Bug fix - something not working as expected
- [ ] ✨ New feature – adds new functionality
- [ ] ♻️ Refactor - internal changes with no user impact
- [ ] ⚡ Performance Improvement
- [ ] 📝 Documentation - README or documentation site changes
- [x] 🔧 Chore - dev tooling, CI, config
- [ ] 💥 Breaking change

## 📷 Screenshots / gifs / video [optional]

_No UI changes._

## 🔗 Related Issues

fixes #
resolves #
closes #
related #

## ✅ Tests added?

- [ ] 👍 yes
- [x] 🙅 no, not needed
- [ ] 🙋 no, I need help

Existing tests for \`ApexVisitor\` and \`ApexSymbolLocator\` were updated to the v5 API; the SOQL parser is covered by integration tests that exercise the real parser end-to-end. All 851 tests pass.

## 📚 Docs updated?

- [ ] 🔖 README.md
- [ ] 🔖 CHANGELOG.md
- [ ] 📖 help site
- [x] 🙅 not needed

## Anything else we need to know? [optional]

- Min Node bumped to 20.19+ (apex-parser v5 is ESM-only). VS Code 1.100 ships Node 22, so the extension host is fine.
- Rollup still warns about circular deps inside `@salesforce/core`, `@jsforce/jsforce-node`, and `semver` — those are upstream and not actionable here.
- Verified locally: \`pnpm build\`, \`pnpm build:dev\`, \`pnpm lint\`, \`pnpm test\` all clean.