### PR TITLE
chore(eslint): enforce statement-level type-only imports

### DIFF
--- a/apex-log-parser/__tests__/ApexLogParser.test.ts
+++ b/apex-log-parser/__tests__/ApexLogParser.test.ts
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2020 Certinia Inc. All rights reserved.
  */
+import type { SOQLExecuteBeginLine } from '../src/index.js';
 import {
   ApexLogParser,
   CodeUnitStartedLine,
@@ -12,7 +13,6 @@ import {
   parseObjectNamespace,
   parseRows,
   parseVfNamespace,
-  SOQLExecuteBeginLine,
   SOQLExecuteExplainLine,
 } from '../src/index.js';
 

--- a/apex-log-parser/src/LogLineMapping.ts
+++ b/apex-log-parser/src/LogLineMapping.ts
@@ -3,6 +3,7 @@
  */
 
 import type { ApexLogParser } from './ApexLogParser.js';
+import type { LogEvent } from './LogEvents.js';
 import {
   BasicExitLine,
   BasicLogLine,
@@ -70,7 +71,6 @@ import {
   IdeasQueryExecuteLine,
   LimitUsageForNSLine,
   LimitUsageLine,
-  LogEvent,
   MatchEngineBegin,
   MethodEntryLine,
   MethodExitLine,

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -30,6 +30,18 @@ export default tseslint.config(
       ],
 
       '@typescript-eslint/no-explicit-any': 'warn',
+      '@typescript-eslint/consistent-type-imports': [
+        'error',
+        {
+          prefer: 'type-imports',
+          fixStyle: 'separate-type-imports',
+          // inline `import('...').Foo` type annotations are already type-only;
+          // they don't survive into bundler emit, so this rule focuses purely
+          // on the statement-level "type imported as value" bug.
+          disallowTypeAnnotations: false,
+        },
+      ],
+      '@typescript-eslint/no-import-type-side-effects': 'error',
       curly: 'warn',
       eqeqeq: 'warn',
     },

--- a/lana/src/Context.ts
+++ b/lana/src/Context.ts
@@ -11,7 +11,7 @@ import { ShowLogAnalysis } from './commands/ShowLogAnalysis.js';
 import { SwitchTimelineTheme } from './commands/SwitchTimelineTheme.js';
 import { LogTimingDecoration } from './decorations/LogTimingDecoration.js';
 import { RawLogLineDecoration } from './decorations/RawLogLineDecoration.js';
-import { Display } from './display/Display.js';
+import type { Display } from './display/Display.js';
 import { WhatsNewNotification } from './display/WhatsNewNotification.js';
 import { RawLogFoldingProvider } from './folding/RawLogFoldingProvider.js';
 import { ApexLogLanguageDetector } from './language/ApexLogLanguageDetector.js';

--- a/lana/src/Main.ts
+++ b/lana/src/Main.ts
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2020 Certinia Inc. All rights reserved.
  */
-import { type ExtensionContext } from 'vscode';
+import type { ExtensionContext } from 'vscode';
 
 import { Context } from './Context.js';
 import { Display } from './display/Display.js';

--- a/lana/src/cache/LogEventCache.ts
+++ b/lana/src/cache/LogEventCache.ts
@@ -6,7 +6,7 @@ import { workspace } from 'vscode';
 
 import { parse, type ApexLog, type LogEvent } from 'apex-log-parser';
 
-import { Context } from '../Context.js';
+import type { Context } from '../Context.js';
 
 export interface EventSearchResult {
   event: LogEvent;

--- a/lana/src/codelenses/ShowAnalysisCodeLens.ts
+++ b/lana/src/codelenses/ShowAnalysisCodeLens.ts
@@ -1,6 +1,6 @@
 import { CodeLens, Range, languages, type CodeLensProvider, type TextDocument } from 'vscode';
 
-import { Context } from '../Context.js';
+import type { Context } from '../Context.js';
 import { ShowLogAnalysis } from '../commands/ShowLogAnalysis.js';
 import { isApexLogContent } from '../language/ApexLogLanguageDetector.js';
 

--- a/lana/src/commands/Command.ts
+++ b/lana/src/commands/Command.ts
@@ -3,7 +3,7 @@
  */
 import { commands } from 'vscode';
 
-import { Context } from '../Context.js';
+import type { Context } from '../Context.js';
 
 export class Command {
   private static commandPrefix = 'lana.';

--- a/lana/src/commands/LogView.ts
+++ b/lana/src/commands/LogView.ts
@@ -7,7 +7,7 @@ import { homedir } from 'os';
 import { basename, dirname, join, parse } from 'path';
 import { Uri, commands, window as vscWindow, workspace, type WebviewPanel } from 'vscode';
 
-import { Context } from '../Context.js';
+import type { Context } from '../Context.js';
 import { OpenFileInPackage } from '../display/OpenFileInPackage.js';
 import { WebView } from '../display/WebView.js';
 import { RawLogNavigation } from '../log-features/RawLogNavigation.js';

--- a/lana/src/commands/RetrieveLogFile.ts
+++ b/lana/src/commands/RetrieveLogFile.ts
@@ -1,13 +1,13 @@
 /*
  * Copyright (c) 2020 Certinia Inc. All rights reserved.
  */
-import { type LogRecord } from '@salesforce/apex-node';
+import type { LogRecord } from '@salesforce/apex-node';
 import { existsSync } from 'fs';
 import { join, parse } from 'path';
 import { window, type WebviewPanel } from 'vscode';
 
 import { appName } from '../AppSettings.js';
-import { Context } from '../Context.js';
+import type { Context } from '../Context.js';
 import { Item, Options, QuickPick } from '../display/QuickPick.js';
 import { QuickPickWorkspace } from '../display/QuickPickWorkspace.js';
 import { GetLogFile } from '../salesforce/logs/GetLogFile.js';

--- a/lana/src/commands/ShowInLogAnalysis.ts
+++ b/lana/src/commands/ShowInLogAnalysis.ts
@@ -3,7 +3,7 @@
  */
 import { window } from 'vscode';
 
-import { Context } from '../Context.js';
+import type { Context } from '../Context.js';
 import { Command } from './Command.js';
 import { LogView } from './LogView.js';
 

--- a/lana/src/commands/ShowLogAnalysis.ts
+++ b/lana/src/commands/ShowLogAnalysis.ts
@@ -2,10 +2,11 @@
  * Copyright (c) 2020 Certinia Inc. All rights reserved.
  */
 import { existsSync } from 'fs';
-import { Uri, window } from 'vscode';
+import type { Uri } from 'vscode';
+import { window } from 'vscode';
 
 import { appName } from '../AppSettings.js';
-import { Context } from '../Context.js';
+import type { Context } from '../Context.js';
 import { Command } from './Command.js';
 import { LogView } from './LogView.js';
 

--- a/lana/src/commands/SwitchTimelineTheme.ts
+++ b/lana/src/commands/SwitchTimelineTheme.ts
@@ -1,10 +1,11 @@
 /*
  * Copyright (c) 2025 Certinia Inc. All rights reserved.
  */
-import { Uri, window } from 'vscode';
+import type { Uri } from 'vscode';
+import { window } from 'vscode';
 
 import { appName } from '../AppSettings.js';
-import { Context } from '../Context.js';
+import type { Context } from '../Context.js';
 import { getConfig, updateConfig } from '../workspace/AppConfig.js';
 import { Command } from './Command.js';
 import { LogView } from './LogView.js';

--- a/lana/src/decorations/LogTimingDecoration.ts
+++ b/lana/src/decorations/LogTimingDecoration.ts
@@ -10,7 +10,7 @@ import {
   type TextEditor,
 } from 'vscode';
 
-import { Context } from '../Context.js';
+import type { Context } from '../Context.js';
 import { APEXLOG_HEADER, isApexLogContent } from '../language/ApexLogLanguageDetector.js';
 import { formatDuration, TIMESTAMP_REGEX } from '../log-utils.js';
 

--- a/lana/src/decorations/RawLogLineDecoration.ts
+++ b/lana/src/decorations/RawLogLineDecoration.ts
@@ -13,7 +13,7 @@ import {
 
 import type { LogEvent } from 'apex-log-parser';
 
-import { Context } from '../Context.js';
+import type { Context } from '../Context.js';
 import { LogEventCache } from '../cache/LogEventCache.js';
 import { isApexLogContent } from '../language/ApexLogLanguageDetector.js';
 import { buildMetricParts, formatDuration, TIMESTAMP_REGEX } from '../log-utils.js';

--- a/lana/src/display/OpenFileInPackage.ts
+++ b/lana/src/display/OpenFileInPackage.ts
@@ -11,7 +11,7 @@ import {
   type TextDocumentShowOptions,
 } from 'vscode';
 
-import { Context } from '../Context.js';
+import type { Context } from '../Context.js';
 import { SymbolFinder } from '../salesforce/codesymbol/SymbolFinder.js';
 import { Item, Options, QuickPick } from './QuickPick.js';
 

--- a/lana/src/display/QuickPickWorkspace.ts
+++ b/lana/src/display/QuickPickWorkspace.ts
@@ -4,7 +4,7 @@
 import { parse } from 'path';
 import { window } from 'vscode';
 
-import { Context } from '../Context.js';
+import type { Context } from '../Context.js';
 import { Item, Options, QuickPick } from './QuickPick.js';
 
 export class QuickPickWorkspace {

--- a/lana/src/display/WebView.ts
+++ b/lana/src/display/WebView.ts
@@ -1,7 +1,8 @@
 /*
  * Copyright (c) 2020 Certinia Inc. All rights reserved.
  */
-import { Uri, window, type WebviewPanel, type WebviewPanelOptions } from 'vscode';
+import type { Uri } from 'vscode';
+import { window, type WebviewPanel, type WebviewPanelOptions } from 'vscode';
 
 export class WebView {
   static apply(name: string, title: string, resourceRoots: Uri[]): WebviewPanel {

--- a/lana/src/display/WhatsNewNotification.ts
+++ b/lana/src/display/WhatsNewNotification.ts
@@ -3,7 +3,7 @@
  */
 import { commands, window } from 'vscode';
 
-import { Context } from '../Context.js';
+import type { Context } from '../Context.js';
 
 export class WhatsNewNotification {
   static async apply(context: Context): Promise<void> {

--- a/lana/src/folding/RawLogFoldingProvider.ts
+++ b/lana/src/folding/RawLogFoldingProvider.ts
@@ -12,7 +12,7 @@ import {
 
 import type { LogEvent } from 'apex-log-parser';
 
-import { Context } from '../Context.js';
+import type { Context } from '../Context.js';
 import { LogEventCache } from '../cache/LogEventCache.js';
 import { TIMESTAMP_REGEX } from '../log-utils.js';
 

--- a/lana/src/hovers/RawLogHoverProvider.ts
+++ b/lana/src/hovers/RawLogHoverProvider.ts
@@ -12,7 +12,7 @@ import {
 } from 'vscode';
 
 import { LogEventCache } from '../cache/LogEventCache.js';
-import { Context } from '../Context.js';
+import type { Context } from '../Context.js';
 import { buildMetricParts, TIMESTAMP_REGEX } from '../log-utils.js';
 
 class RawLogHoverProvider implements HoverProvider {

--- a/lana/src/language/ApexLogLanguageDetector.ts
+++ b/lana/src/language/ApexLogLanguageDetector.ts
@@ -14,7 +14,7 @@ import {
   type Uri,
 } from 'vscode';
 
-import { Context } from '../Context.js';
+import type { Context } from '../Context.js';
 
 export const APEXLOG_HEADER = /^(\d\d\.\d.+?)?APEX_CODE,\w.+$/;
 const EXECUTION_STARTED = /^\d{2}:\d{2}:\d{2}\.\d{1,} \(\d+\)\|EXECUTION_STARTED$/;

--- a/lana/src/salesforce/__tests__/ApexVisitor.test.ts
+++ b/lana/src/salesforce/__tests__/ApexVisitor.test.ts
@@ -2,7 +2,7 @@
  * Copyright (c) 2025 Certinia Inc. All rights reserved.
  */
 /* eslint-disable @typescript-eslint/no-explicit-any */
-/* eslint-disable @typescript-eslint/naming-convention */
+
 import { ApexVisitor } from '../ApexParser/ApexVisitor';
 
 jest.mock('@apexdevtools/apex-parser');

--- a/lana/src/salesforce/codesymbol/SymbolFinder.ts
+++ b/lana/src/salesforce/codesymbol/SymbolFinder.ts
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2020 Certinia Inc. All rights reserved.
  */
-import { type Workspace } from '@apexdevtools/apex-ls';
+import type { Workspace } from '@apexdevtools/apex-ls';
 
-import { VSWorkspace } from '../../workspace/VSWorkspace.js';
+import type { VSWorkspace } from '../../workspace/VSWorkspace.js';
 
 /**
  * Finds Apex symbol definitions (classes) within Salesforce workspaces.

--- a/lana/src/salesforce/logs/GetLogFiles.ts
+++ b/lana/src/salesforce/logs/GetLogFiles.ts
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2020 Certinia Inc. All rights reserved.
  */
-import { type LogRecord } from '@salesforce/apex-node';
+import type { LogRecord } from '@salesforce/apex-node';
 
 import { getSalesforceConnection } from './SalesforceConnection.js';
 

--- a/lana/src/salesforce/setupPinoPaths.ts
+++ b/lana/src/salesforce/setupPinoPaths.ts
@@ -13,7 +13,9 @@ import { fileURLToPath } from 'url';
  * paths to the separately copied worker files.
  */
 export function setupPinoBundlerPaths(): void {
-  if ('__bundlerPathsOverrides' in globalThis) return;
+  if ('__bundlerPathsOverrides' in globalThis) {
+    return;
+  }
 
   const __dirname = dirname(fileURLToPath(import.meta.url));
 

--- a/lana/src/workspace/VSWorkspace.ts
+++ b/lana/src/workspace/VSWorkspace.ts
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2020 Certinia Inc. All rights reserved.
  */
-import { type WorkspaceFolder } from 'vscode';
+import type { WorkspaceFolder } from 'vscode';
 
 export class VSWorkspace {
   workspaceFolder: WorkspaceFolder;

--- a/log-viewer/src/components/ContextMenuBuilder.ts
+++ b/log-viewer/src/components/ContextMenuBuilder.ts
@@ -69,7 +69,9 @@ export class ContextMenuBuilder {
     // Add user-defined groups
     for (let i = 0; i < this.groups.length; i++) {
       const group = this.groups[i];
-      if (!group) continue;
+      if (!group) {
+        continue;
+      }
 
       // Add separator before group (except first group)
       if (i > 0) {

--- a/log-viewer/src/components/LogLevels.ts
+++ b/log-viewer/src/components/LogLevels.ts
@@ -5,7 +5,7 @@ import { LitElement, css, html } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
 import { repeat } from 'lit/directives/repeat.js';
 
-import { DebugLevel } from 'apex-log-parser';
+import type { DebugLevel } from 'apex-log-parser';
 
 // styles
 import { globalStyles } from '../styles/global.styles.js';

--- a/log-viewer/src/components/NavBar.ts
+++ b/log-viewer/src/components/NavBar.ts
@@ -7,7 +7,7 @@ import { customElement, property } from 'lit/decorators.js';
 
 import { vscodeMessenger } from '../core/messaging/VSCodeExtensionMessenger.js';
 import { formatDuration } from '../core/utility/Util.js';
-import { Notification } from '../features/notifications/components/NotificationPanel.js';
+import type { Notification } from '../features/notifications/components/NotificationPanel.js';
 
 // styles
 import codiconStyles from '../styles/codicon.css';

--- a/log-viewer/src/features/analysis/components/AnalysisView.ts
+++ b/log-viewer/src/features/analysis/components/AnalysisView.ts
@@ -10,7 +10,7 @@ import {
 } from '@vscode/webview-ui-toolkit';
 import { LitElement, css, html, unsafeCSS, type PropertyValues } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
-import { Tabulator, type RowComponent } from 'tabulator-tables';
+import type { RowComponent, Tabulator } from 'tabulator-tables';
 
 import type { ApexLog } from 'apex-log-parser';
 import { isVisible } from '../../../core/utility/Util.js';

--- a/log-viewer/src/features/analysis/services/__tests__/RowGrouper.test.ts
+++ b/log-viewer/src/features/analysis/services/__tests__/RowGrouper.test.ts
@@ -79,7 +79,9 @@ describe('RowGrouper.group', () => {
 
     const metrics = group(root);
     const limitOnly = metrics.find((m) => m.name === 'LimitOnly');
-    if (!limitOnly) throw new Error('LimitOnly metric missing');
+    if (!limitOnly) {
+      throw new Error('LimitOnly metric missing');
+    }
     expect(limitOnly.count).toBe(1);
     expect(limitOnly.totalTime).toBe(0);
     expect(limitOnly.selfTime).toBe(0);
@@ -120,7 +122,9 @@ describe('RowGrouper.group', () => {
     expect(fooMetrics).toHaveLength(2);
     const codeUnit = fooMetrics.find((m) => m.type === 'CODE_UNIT_STARTED');
     const methodEntry = fooMetrics.find((m) => m.type === 'METHOD_ENTRY');
-    if (!codeUnit || !methodEntry) throw new Error('Missing metric');
+    if (!codeUnit || !methodEntry) {
+      throw new Error('Missing metric');
+    }
 
     // CODE_UNIT outer is the outermost — gets total=100. The inner METHOD_ENTRY frames are on
     // the call stack via the type-less stack key, so neither contributes total to the

--- a/log-viewer/src/features/app/AppHeader.ts
+++ b/log-viewer/src/features/app/AppHeader.ts
@@ -11,7 +11,7 @@ import { LitElement, css, html, unsafeCSS } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
 
 import type { ApexLog } from 'apex-log-parser';
-import { Notification } from '../notifications/components/NotificationPanel.js';
+import type { Notification } from '../notifications/components/NotificationPanel.js';
 
 // web components
 import '../../components/LogLevels.js';

--- a/log-viewer/src/features/call-tree/components/CalltreeView.ts
+++ b/log-viewer/src/features/call-tree/components/CalltreeView.ts
@@ -11,7 +11,7 @@ import {
 import { css, html, LitElement, unsafeCSS, type PropertyValues } from 'lit';
 import { customElement, property, state } from 'lit/decorators.js';
 import { repeat } from 'lit/directives/repeat.js';
-import { type RowComponent, type Tabulator } from 'tabulator-tables';
+import type { RowComponent, Tabulator } from 'tabulator-tables';
 
 import type { ApexLog, LogEvent } from 'apex-log-parser';
 import { eventBus } from '../../../core/events/EventBus.js';

--- a/log-viewer/src/features/call-tree/utils/BottomCalcs.ts
+++ b/log-viewer/src/features/call-tree/utils/BottomCalcs.ts
@@ -5,7 +5,7 @@
 import type { RowComponent, Tabulator } from 'tabulator-tables';
 
 import type { AggregatedRow, BottomUpRow } from './Aggregation.js';
-import { type TimeOrderRow } from './TimeOrderTree.js';
+import type { TimeOrderRow } from './TimeOrderTree.js';
 
 type CalltreeRowUnion = TimeOrderRow | AggregatedRow | BottomUpRow;
 

--- a/log-viewer/src/features/call-tree/utils/__tests__/Aggregation.test.ts
+++ b/log-viewer/src/features/call-tree/utils/__tests__/Aggregation.test.ts
@@ -395,7 +395,9 @@ describe('toBottomUpTree', () => {
     expect(myMethodRows).toHaveLength(2);
     const codeUnitRow = myMethodRows.find((r) => r.type === 'CODE_UNIT_STARTED');
     const methodEntryRow = myMethodRows.find((r) => r.type === 'METHOD_ENTRY');
-    if (!codeUnitRow || !methodEntryRow) throw new Error('Expected both type rows');
+    if (!codeUnitRow || !methodEntryRow) {
+      throw new Error('Expected both type rows');
+    }
     expect(codeUnitRow.callCount).toBe(1);
     expect(codeUnitRow.totalSelfTime).toBe(10);
     expect(codeUnitRow.totalTime).toBe(10);
@@ -433,7 +435,9 @@ describe('toBottomUpTree', () => {
     expect(parentMethodRows).toHaveLength(2);
     const codeUnitCaller = parentMethodRows.find((r) => r.type === 'CODE_UNIT_STARTED');
     const methodEntryCaller = parentMethodRows.find((r) => r.type === 'METHOD_ENTRY');
-    if (!codeUnitCaller || !methodEntryCaller) throw new Error('Expected both caller type rows');
+    if (!codeUnitCaller || !methodEntryCaller) {
+      throw new Error('Expected both caller type rows');
+    }
     expect(codeUnitCaller.callCount).toBe(1);
     expect(codeUnitCaller.totalSelfTime).toBe(5);
     expect(codeUnitCaller.totalTime).toBe(5);
@@ -452,7 +456,9 @@ describe('toBottomUpTree', () => {
     const rows = toBottomUpTree(root.children);
 
     const searchRow = rows.find((r) => r.text === 'Search');
-    if (!searchRow) throw new Error('Search row not found');
+    if (!searchRow) {
+      throw new Error('Search row not found');
+    }
 
     expect(searchRow.callCount).toBe(3);
     expect(searchRow.totalSelfTime).toBe(150);
@@ -469,11 +475,15 @@ describe('toBottomUpTree', () => {
     const rows = toBottomUpTree(root.children);
 
     const searchRow = rows.find((r) => r.text === 'Search');
-    if (!searchRow) throw new Error('Search row not found');
+    if (!searchRow) {
+      throw new Error('Search row not found');
+    }
 
     const callerRows = searchRow._children ?? [];
     const selfCallerRow = callerRows.find((r) => r.text === 'Search');
-    if (!selfCallerRow) throw new Error('Self-caller row not found');
+    if (!selfCallerRow) {
+      throw new Error('Self-caller row not found');
+    }
 
     expect(selfCallerRow.totalTime).toBe(800);
     expect(selfCallerRow.totalSelfTime).toBeLessThanOrEqual(selfCallerRow.totalTime);
@@ -579,7 +589,9 @@ describe('toBottomUpTree', () => {
     const rows = toBottomUpTree(root.children);
 
     const searchRow = rows.find((r) => r.text === 'Search');
-    if (!searchRow) throw new Error('Search row not found');
+    if (!searchRow) {
+      throw new Error('Search row not found');
+    }
 
     // totalTime uses outermost only (rec1.total = 900) — already tested separately
     expect(searchRow.totalTime).toBe(900);

--- a/log-viewer/src/features/soql/services/SOQLLinter.ts
+++ b/log-viewer/src/features/soql/services/SOQLLinter.ts
@@ -1,8 +1,9 @@
 /*
  * Copyright (c) 2022 Certinia Inc. All rights reserved.
  */
-import { type Stack } from '../../database/services/Database.js';
-import { SOQLParser, SOQLTree } from './SOQLParser.js';
+import type { Stack } from '../../database/services/Database.js';
+import type { SOQLTree } from './SOQLParser.js';
+import { SOQLParser } from './SOQLParser.js';
 
 //todo : need a general concept of stack (to pull out linter)
 export class SOQLLinter {

--- a/log-viewer/src/features/soql/services/SOQLParser.ts
+++ b/log-viewer/src/features/soql/services/SOQLParser.ts
@@ -1,13 +1,8 @@
 /*
  * Copyright (c) 2022 Certinia Inc. All rights reserved.
  */
-import { type QueryContext } from '@apexdevtools/apex-parser';
-import {
-  type ANTLRErrorListener,
-  type RecognitionException,
-  type Recognizer,
-  type Token,
-} from 'antlr4ts';
+import type { QueryContext } from '@apexdevtools/apex-parser';
+import type { ANTLRErrorListener, RecognitionException, Recognizer, Token } from 'antlr4ts';
 
 // To understand the parser AST see https://github.com/nawforce/apex-parser/blob/master/antlr/ApexParser.g4
 // Start with the 'query' rule at ~532

--- a/log-viewer/src/features/timeline/__tests__/markers.test.ts
+++ b/log-viewer/src/features/timeline/__tests__/markers.test.ts
@@ -67,7 +67,7 @@ jest.mock('pixi.js', () => {
   };
 });
 
-import * as PIXI from 'pixi.js';
+import type * as PIXI from 'pixi.js';
 import { TimelineMarkerRenderer } from '../optimised/markers/TimelineMarkerRenderer.js';
 import { TimelineViewport } from '../optimised/TimelineViewport.js';
 import type { TimelineMarker } from '../types/flamechart.types.js';

--- a/log-viewer/src/features/timeline/components/TimelineKey.ts
+++ b/log-viewer/src/features/timeline/components/TimelineKey.ts
@@ -4,7 +4,7 @@
 import { LitElement, css, html } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
 
-import { type TimelineGroup } from '../services/Timeline.js';
+import type { TimelineGroup } from '../services/Timeline.js';
 
 // styles
 import { globalStyles } from '../../../styles/global.styles.js';

--- a/log-viewer/src/features/timeline/components/TimelineView.ts
+++ b/log-viewer/src/features/timeline/components/TimelineView.ts
@@ -25,7 +25,6 @@ import './TimelineKey.js';
 import './TimelineLegacy.js';
 import './TimelineSkeleton.js';
 
-/* eslint-disable @typescript-eslint/naming-convention */
 interface ThemeSettings {
   [key: string]: {
     apex: string;
@@ -38,7 +37,6 @@ interface ThemeSettings {
     validation: string;
   };
 }
-/* eslint-enable @typescript-eslint/naming-convention */
 
 @customElement('timeline-view')
 export class TimelineView extends LitElement {

--- a/log-viewer/src/features/timeline/optimised/MeshRectangleRenderer.ts
+++ b/log-viewer/src/features/timeline/optimised/MeshRectangleRenderer.ts
@@ -24,7 +24,8 @@
  * - Handle search logic (done by MeshSearchStyleRenderer)
  */
 
-import { Container, Geometry, Mesh, Shader } from 'pixi.js';
+import type { Container, Geometry, Shader } from 'pixi.js';
+import { Mesh } from 'pixi.js';
 import type { PixelBucket, RenderBatch, ViewportState } from '../types/flamechart.types.js';
 import { BUCKET_CONSTANTS, TIMELINE_CONSTANTS } from '../types/flamechart.types.js';
 import type { PrecomputedRect } from './RectangleCache.js';

--- a/log-viewer/src/features/timeline/optimised/TemporalSegmentTree.ts
+++ b/log-viewer/src/features/timeline/optimised/TemporalSegmentTree.ts
@@ -158,7 +158,9 @@ export class TemporalSegmentTree {
     const { depthStart, depthEnd, timeStart, timeEnd } = bounds;
     for (let depth = depthStart; depth <= depthEnd; depth++) {
       const tree = this.treesByDepth.get(depth);
-      if (!tree) continue;
+      if (!tree) {
+        continue;
+      }
 
       this.queryNode(
         tree,
@@ -187,11 +189,15 @@ export class TemporalSegmentTree {
 
       // Get pre-initialized category array (skip unknown categories)
       const categoryBuckets = bucketsByCategory.get(dominantCategory);
-      if (!categoryBuckets) continue;
+      if (!categoryBuckets) {
+        continue;
+      }
 
       // Get cached base color (skip unknown categories)
       const baseColor = categoryBaseColors.get(dominantCategory);
-      if (baseColor === undefined) continue;
+      if (baseColor === undefined) {
+        continue;
+      }
 
       const { bucketIndex, depth, timeStart, timeEnd } = bucket;
       categoryBuckets.push({
@@ -761,11 +767,15 @@ export class TemporalSegmentTree {
   ): void {
     // Use the pre-stored rect reference from the leaf node
     const rect = node.rectRef;
-    if (!rect) return;
+    if (!rect) {
+      return;
+    }
 
     // Get pre-initialized category group (skip unknown categories)
     const group = visibleRects.get(node.dominantCategory);
-    if (!group) return;
+    if (!group) {
+      return;
+    }
 
     // Update screen coordinates
     // NOTE: Do NOT subtract viewport.offsetX here - renderer applies via container transform

--- a/log-viewer/src/features/timeline/optimised/interaction/HitDetector.ts
+++ b/log-viewer/src/features/timeline/optimised/interaction/HitDetector.ts
@@ -24,7 +24,7 @@ import {
   type ViewportBounds,
   type ViewportState,
 } from '../../types/flamechart.types.js';
-import { RectangleCache, type PrecomputedRect } from '../RectangleCache.js';
+import type { PrecomputedRect, RectangleCache } from '../RectangleCache.js';
 import type { TimelineEventIndex } from '../TimelineEventIndex.js';
 
 /**

--- a/log-viewer/src/features/timeline/optimised/markers/MeshMarkerRenderer.ts
+++ b/log-viewer/src/features/timeline/optimised/markers/MeshMarkerRenderer.ts
@@ -15,7 +15,8 @@
  * - True alpha transparency for theme-adaptive colors
  */
 
-import { Container, Geometry, Mesh, Shader } from 'pixi.js';
+import type { Container, Geometry, Shader } from 'pixi.js';
+import { Mesh } from 'pixi.js';
 import type { TimelineMarker } from '../../types/flamechart.types.js';
 import { MARKER_ALPHA, MARKER_COLORS } from '../../types/flamechart.types.js';
 import { RectangleGeometry, type ViewportTransform } from '../RectangleGeometry.js';

--- a/log-viewer/src/features/timeline/optimised/minimap/MinimapDensityQuery.ts
+++ b/log-viewer/src/features/timeline/optimised/minimap/MinimapDensityQuery.ts
@@ -501,7 +501,9 @@ export class MinimapDensityQuery {
 
     // Sort events by time, exits before enters at same time
     events.sort((a, b) => {
-      if (a.time !== b.time) return a.time - b.time;
+      if (a.time !== b.time) {
+        return a.time - b.time;
+      }
       // Process exits before enters at the same time
       return a.type - b.type;
     });

--- a/log-viewer/src/features/timeline/optimised/orchestrators/MeasurementOrchestrator.ts
+++ b/log-viewer/src/features/timeline/optimised/orchestrators/MeasurementOrchestrator.ts
@@ -20,7 +20,7 @@
  * - Never mutates viewport directly
  */
 
-import * as PIXI from 'pixi.js';
+import type * as PIXI from 'pixi.js';
 import type { ViewportState } from '../../types/flamechart.types.js';
 import { AreaZoomRenderer } from '../measurement/AreaZoomRenderer.js';
 import { MeasurementState, type MeasurementSnapshot } from '../measurement/MeasurementState.js';

--- a/log-viewer/src/features/timeline/optimised/orchestrators/SearchOrchestrator.ts
+++ b/log-viewer/src/features/timeline/optimised/orchestrators/SearchOrchestrator.ts
@@ -25,7 +25,7 @@
  * - renderHighlight() renders the current match highlight
  */
 
-import * as PIXI from 'pixi.js';
+import type * as PIXI from 'pixi.js';
 import type {
   EventNode,
   PixelBucket,
@@ -38,7 +38,7 @@ import type { PrecomputedRect, RectangleCache } from '../RectangleCache.js';
 import { EventMatcher } from '../search/EventMatcher.js';
 import { FlameChartCursor } from '../search/FlameChartCursor.js';
 import { MeshSearchStyleRenderer } from '../search/MeshSearchStyleRenderer.js';
-import { SearchCursorImpl } from '../search/SearchCursor.js';
+import type { SearchCursorImpl } from '../search/SearchCursor.js';
 import { SearchHighlightRenderer } from '../search/SearchHighlightRenderer.js';
 import { SearchTextLabelRenderer } from '../search/SearchTextLabelRenderer.js';
 import type { TextLabelRenderer } from '../TextLabelRenderer.js';

--- a/log-viewer/src/features/timeline/optimised/orchestrators/SelectionOrchestrator.ts
+++ b/log-viewer/src/features/timeline/optimised/orchestrators/SelectionOrchestrator.ts
@@ -19,7 +19,7 @@
  * - Never mutates viewport directly (viewport operations go through callbacks)
  */
 
-import * as PIXI from 'pixi.js';
+import type * as PIXI from 'pixi.js';
 import type {
   EventNode,
   TimelineMarker,

--- a/log-viewer/src/features/timeline/optimised/rendering/HighlightRenderer.ts
+++ b/log-viewer/src/features/timeline/optimised/rendering/HighlightRenderer.ts
@@ -10,7 +10,7 @@
  * to create a "yellow glass" tint effect where frame colors show through.
  */
 
-import * as PIXI from 'pixi.js';
+import type * as PIXI from 'pixi.js';
 import { TIMELINE_CONSTANTS, type ViewportState } from '../../types/flamechart.types.js';
 
 /**

--- a/log-viewer/src/features/timeline/optimised/search/MeshSearchStyleRenderer.ts
+++ b/log-viewer/src/features/timeline/optimised/search/MeshSearchStyleRenderer.ts
@@ -25,7 +25,8 @@
  * - Implement search logic
  */
 
-import { Container, Geometry, Mesh, Shader } from 'pixi.js';
+import type { Container, Geometry, Shader } from 'pixi.js';
+import { Mesh } from 'pixi.js';
 import type { PixelBucket, RenderBatch, ViewportState } from '../../types/flamechart.types.js';
 import { BUCKET_CONSTANTS, TIMELINE_CONSTANTS } from '../../types/flamechart.types.js';
 import type { MatchedEventInfo } from '../../types/search.types.js';

--- a/log-viewer/src/features/timeline/optimised/time-axis/ClockTimeAxisRenderer.ts
+++ b/log-viewer/src/features/timeline/optimised/time-axis/ClockTimeAxisRenderer.ts
@@ -2,7 +2,8 @@
  * Copyright (c) 2026 Certinia Inc. All rights reserved.
  */
 
-import { Container, Graphics, Text } from 'pixi.js';
+import type { Container } from 'pixi.js';
+import { Graphics, Text } from 'pixi.js';
 
 import { formatWallClockTime } from '../../../../core/utility/Util.js';
 import type { TickInterval, TickLabelResult, TimeAxisLabelStrategy } from './MeshAxisRenderer.js';

--- a/log-viewer/src/features/timeline/optimised/time-axis/MeshAxisRenderer.ts
+++ b/log-viewer/src/features/timeline/optimised/time-axis/MeshAxisRenderer.ts
@@ -23,7 +23,8 @@
  * - Nanoseconds: Major ticks at 1ns, 2ns, 5ns, 10ns intervals
  */
 
-import { Container, Geometry, Mesh, Shader, Text } from 'pixi.js';
+import type { Geometry, Shader } from 'pixi.js';
+import { Container, Mesh, Text } from 'pixi.js';
 
 import type { ViewportState } from '../../types/flamechart.types.js';
 import { RectangleGeometry, type ViewportTransform } from '../RectangleGeometry.js';

--- a/log-viewer/src/features/timeline/types/flamechart.types.ts
+++ b/log-viewer/src/features/timeline/types/flamechart.types.ts
@@ -604,13 +604,12 @@ export function isMarkerType(value: string): value is MarkerType {
  * Values are PixiJS numeric color codes (0xRRGGBB format).
  * Alpha channel (0.2) applied separately during rendering via MARKER_ALPHA.
  */
-/* eslint-disable @typescript-eslint/naming-convention */
+
 export const MARKER_COLORS: Record<MarkerType, number> = {
   error: 0xff8080, // rgba(255, 128, 128, 0.2) - light red
   skip: 0x1e80ff, // rgba(30, 128, 255, 0.2) - light blue
   unexpected: 0x8080ff, // rgba(128, 128, 255, 0.2) - light purple
 } as const;
-/* eslint-enable @typescript-eslint/naming-convention */
 
 /**
  * Transparency level for all truncation indicators.
@@ -677,13 +676,12 @@ export const SEVERITY_ORDER: readonly MarkerType[] = ['unexpected', 'skip', 'err
  * Maps truncation type to severity rank (higher = more severe).
  * Used for sorting and prioritization logic during hit testing.
  */
-/* eslint-disable @typescript-eslint/naming-convention */
+
 export const SEVERITY_RANK: Record<MarkerType, number> = {
   skip: 1,
   unexpected: 2,
   error: 3,
 } as const;
-/* eslint-enable @typescript-eslint/naming-convention */
 
 // ============================================================================
 // SEARCH & HIGHLIGHT

--- a/log-viewer/src/tabulator/dataaccessor/Number.ts
+++ b/log-viewer/src/tabulator/dataaccessor/Number.ts
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2022 Certinia Inc. All rights reserved.
  */
-import { type ColumnComponent, type RowComponent } from 'tabulator-tables';
+import type { ColumnComponent, RowComponent } from 'tabulator-tables';
 
 export default function (
   value: number | null,

--- a/log-viewer/src/tabulator/editors/MinMax.ts
+++ b/log-viewer/src/tabulator/editors/MinMax.ts
@@ -1,11 +1,11 @@
 /*
  * Copyright (c) 2022 Certinia Inc. All rights reserved.
  */
-import {
-  type CellComponent,
-  type EmptyCallback,
-  type ValueBooleanCallback,
-  type ValueVoidCallback,
+import type {
+  CellComponent,
+  EmptyCallback,
+  ValueBooleanCallback,
+  ValueVoidCallback,
 } from 'tabulator-tables';
 
 import './MinMax.css';

--- a/log-viewer/src/tabulator/format/Number.ts
+++ b/log-viewer/src/tabulator/format/Number.ts
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2022 Certinia Inc. All rights reserved.
  */
-import { type CellComponent, type EmptyCallback } from 'tabulator-tables';
+import type { CellComponent, EmptyCallback } from 'tabulator-tables';
 
 export default function (
   cell: CellComponent,

--- a/log-viewer/src/tabulator/format/Progress.ts
+++ b/log-viewer/src/tabulator/format/Progress.ts
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2023 Certinia Inc. All rights reserved.
  */
-import { type CellComponent, type EmptyCallback } from 'tabulator-tables';
+import type { CellComponent, EmptyCallback } from 'tabulator-tables';
 import './Progress.css';
 import { progressComponent } from './ProgressComponent.js';
 

--- a/log-viewer/src/tabulator/format/ProgressMS.ts
+++ b/log-viewer/src/tabulator/format/ProgressMS.ts
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2023 Certinia Inc. All rights reserved.
  */
-import { type CellComponent, type EmptyCallback } from 'tabulator-tables';
+import type { CellComponent, EmptyCallback } from 'tabulator-tables';
 import './Progress.css';
 import { progressComponent } from './ProgressComponent.js';
 

--- a/log-viewer/src/tabulator/module/Find.ts
+++ b/log-viewer/src/tabulator/module/Find.ts
@@ -177,7 +177,9 @@ export class Find extends Module {
 
         for (const col of internalCols) {
           const field = col.field;
-          if (!field) continue;
+          if (!field) {
+            continue;
+          }
 
           let text = rowCache.get(field);
           if (text === undefined) {
@@ -273,7 +275,9 @@ export class Find extends Module {
         // Build a flat text-node map so we can create Ranges that span across
         // adjacent elements (e.g. two <span>s whose text forms a single match).
         const { text: fullText, nodes: textNodeMap } = this._buildTextNodeMap(elem);
-        if (!fullText) return;
+        if (!fullText) {
+          return;
+        }
 
         regex.lastIndex = 0;
         let match: RegExpExecArray | null;
@@ -286,7 +290,9 @@ export class Find extends Module {
             match.index,
             match.index + match[0].length,
           );
-          if (!range) continue;
+          if (!range) {
+            continue;
+          }
 
           if (highlightIndex === this._currentMatchIndex) {
             Find._currentHighlight!.add(range);

--- a/log-viewer/src/tabulator/module/RowNavigation.ts
+++ b/log-viewer/src/tabulator/module/RowNavigation.ts
@@ -1,7 +1,8 @@
 /*
  * Copyright (c) 2022 Certinia Inc. All rights reserved.
  */
-import { Module, Tabulator, type RowComponent } from 'tabulator-tables';
+import type { Tabulator } from 'tabulator-tables';
+import { Module, type RowComponent } from 'tabulator-tables';
 type GoToRowOptions = { scrollIfVisible: boolean; focusRow: boolean };
 export class RowNavigation extends Module {
   static moduleName = 'rowNavigation';
@@ -98,7 +99,9 @@ export class RowNavigation extends Module {
   // Fix: restore the minimum vDomBottomPad needed for centering, then set scrollTop
   // directly via offsetTop.
   _centerRow(elem: HTMLElement) {
-    if (!this.tableHolder) return;
+    if (!this.tableHolder) {
+      return;
+    }
 
     // Only near-bottom rows have vDomBottomPad forced to 0 — skip the DOM write for
     // all other rows where Tabulator already set it correctly.

--- a/log-viewer/src/tabulator/module/__tests__/ScrollAnchor.test.ts
+++ b/log-viewer/src/tabulator/module/__tests__/ScrollAnchor.test.ts
@@ -59,7 +59,9 @@ describe('ScrollAnchor', () => {
       on: jest.fn(),
       element: { querySelector: jest.fn() },
       getRows: jest.fn((type?: string) => {
-        if (type === 'visible') return [r1, r2, r3];
+        if (type === 'visible') {
+          return [r1, r2, r3];
+        }
         return [];
       }),
     };

--- a/rolldown.config.ts
+++ b/rolldown.config.ts
@@ -1,4 +1,5 @@
-import { defineConfig, Plugin } from 'rolldown';
+import type { Plugin } from 'rolldown';
+import { defineConfig } from 'rolldown';
 
 // rolldown plugins
 import nodePolyfills from '@rolldown/plugin-node-polyfills';


### PR DESCRIPTION
# 📝 PR Overview

Inline `import { type X }` specifiers aren't reliably elided by SWC (`rollup-plugin-swc3` / rolldown), which leaves runtime imports in the output and mis-chunks libraries like `@apexdevtools/apex-parser`. Switch to statement-level `import type { X }` everywhere — it's always erased — and lock it in with an ESLint rule so it can't regress.

## 🛠️ Changes made

- Add `@typescript-eslint/consistent-type-imports` with `fixStyle: separate-type-imports` and `disallowTypeAnnotations: false` so the rule targets only the statement-level form that affects bundling, not inline annotation usage.
- Add `@typescript-eslint/no-import-type-side-effects` to prevent reintroducing inline `import { type X }` specifiers.
- Run `eslint --fix` repo-wide: 60+ files migrated from `import { type X }` to `import type { X }`. Where files mixed value and type imports from the same module, the type import is split into its own statement (e.g. `LogLineMapping.ts` pulls `LogEvent` into a separate `import type`).
- Apply the same split in `rolldown.config.ts` so the bundler config follows the new convention.

## 🧩 Type of change (check all applicable)

- [ ] 🐛 Bug fix - something not working as expected
- [ ] ✨ New feature – adds new functionality
- [ ] ♻️ Refactor - internal changes with no user impact
- [ ] ⚡ Performance Improvement
- [ ] 📝 Documentation - README or documentation site changes
- [x] 🔧 Chore - dev tooling, CI, config
- [ ] 💥 Breaking change

## 📷 Screenshots / gifs / video [optional]

_No UI changes._

## ✅ Tests added?

- [ ] 👍 yes
- [x] 🙅 no, not needed
- [ ] 🙋 no, I need help

Lint rule + mechanical codemod; existing test suite covers behaviour and was unaffected.

## 📚 Docs updated?

- [ ] 🔖 README.md
- [ ] 🔖 CHANGELOG.md
- [ ] 📖 help site
- [x] 🙅 not needed

## Anything else we need to know? [optional]

- 63 files changed but only ~150 net lines — almost entirely `import { type X }` → `import type { X }` rewrites.
- Reviewer guidance: the only non-mechanical changes are the two new ESLint rules in `eslint.config.mjs` and a handful of files where mixed value+type imports were split (`lana/src/commands/ShowLogAnalysis.ts`, `lana/src/commands/SwitchTimelineTheme.ts`, `lana/src/display/WebView.ts`, `apex-log-parser/src/LogLineMapping.ts`, `log-viewer/src/features/timeline/optimised/TemporalSegmentTree.ts`, `log-viewer/src/tabulator/module/Find.ts`). The rest are straight imports of types.