### PR TITLE
fix(soql-parser): silence rolldown INEFFECTIVE_DYNAMIC_IMPORT warning

### DIFF
--- a/log-viewer/src/features/soql/services/SOQLParser.ts
+++ b/log-viewer/src/features/soql/services/SOQLParser.ts
@@ -3,8 +3,6 @@
  */
 import type { QueryContext } from '@apexdevtools/apex-parser';
 
-import { ApexErrorListener } from '@apexdevtools/apex-parser';
-
 // To understand the parser AST see https://github.com/nawforce/apex-parser/blob/master/antlr/ApexParser.g4
 // Start with the 'query' rule at ~532
 // Salesforce SOQL Reference: https://developer.salesforce.com/docs/atlas.en-us.soql_sosl.meta/soql_sosl/sforce_api_calls_soql.htm
@@ -69,7 +67,14 @@ export class SOQLParser {
   async parse(query: string): Promise<SOQLTree> {
     // Dynamic import for code splitting. Improves performance by reducing the amount of JS that is loaded and parsed at the start.
     // eslint-disable-next-line @typescript-eslint/naming-convention
-    const { ApexParserFactory } = await import('@apexdevtools/apex-parser');
+    const { ApexParserFactory, ApexErrorListener } = await import('@apexdevtools/apex-parser');
+
+    class ThrowingErrorListener extends ApexErrorListener {
+      apexSyntaxError(line: number, column: number, message: string): void {
+        throw new SyntaxException(line, column, message);
+      }
+    }
+
     const parser = ApexParserFactory.createParser(query);
     parser.removeErrorListeners();
     parser.addErrorListener(new ThrowingErrorListener());
@@ -86,11 +91,5 @@ export class SyntaxException {
     this.line = line;
     this.column = column;
     this.message = message;
-  }
-}
-
-class ThrowingErrorListener extends ApexErrorListener {
-  apexSyntaxError(line: number, column: number, message: string): void {
-    throw new SyntaxException(line, column, message);
   }
 }


### PR DESCRIPTION
# 📝 PR Overview

\`pnpm build:fast\` / \`build:dev:fast\` (rolldown) warned that \`@apexdevtools/apex-parser\` was both statically and dynamically imported by \`SOQLParser.ts\`, so the dynamic import couldn't move the parser into its own chunk. The static side was just \`ApexErrorListener\` (used as the base of \`ThrowingErrorListener\`). Move it into the same dynamic import so the only top-level reference left is the erased \`import type { QueryContext }\`, and the parser chunk-splits as intended.

## 🛠️ Changes made

- Pull `ApexErrorListener` into the existing `await import('@apexdevtools/apex-parser')` call in `SOQLParser.parse()` and drop the standalone top-level value import.
- Move the `ThrowingErrorListener` class definition inside `parse()` so it can extend the dynamically imported base class.

## 🧩 Type of change (check all applicable)

- [x] 🐛 Bug fix - something not working as expected
- [ ] ✨ New feature – adds new functionality
- [ ] ♻️ Refactor - internal changes with no user impact
- [ ] ⚡ Performance Improvement
- [ ] 📝 Documentation - README or documentation site changes
- [ ] 🔧 Chore - dev tooling, CI, config
- [ ] 💥 Breaking change

## 📷 Screenshots / gifs / video [optional]

_No UI changes._

## ✅ Tests added?

- [ ] 👍 yes
- [x] 🙅 no, not needed
- [ ] 🙋 no, I need help

Existing SOQL parser tests exercise the runtime path end-to-end and pass unchanged (861/861).

## 📚 Docs updated?

- [ ] 🔖 README.md
- [ ] 🔖 CHANGELOG.md
- [ ] 📖 help site
- [x] 🙅 not needed

## Anything else we need to know? [optional]

After this change, rolldown emits a separate `log-viewer-apex-parser.js` chunk (~5 kB stub + lazy parser) instead of inlining the parser into the main bundle, so the webview's initial JS gets smaller.