### PR TITLE
docs: add MCP server install snippets and feature page

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,42 @@ Seamlessly navigate between the visual analysis and your raw `.log` files:
 - **Hover Details** – Hover near the ghost text to see SOQL/DML counts, row counts, and exception info.
 - **Total Duration** – First line displays total log execution time.
 
+## 🤖 AI Assistant (MCP Server)
+
+A companion Model Context Protocol server, [`@certinia/apex-log-mcp`](https://www.npmjs.com/package/@certinia/apex-log-mcp) ([source on GitHub](https://github.com/certinia/debug-log-analyzer-mcp)), exposes Apex log analysis tools to AI assistants. Use it with GitHub Copilot Chat, Claude Code, Cursor, or any MCP client.
+
+**Available tools:** `get_apex_log_summary`, `analyze_apex_log_performance`, `find_performance_bottlenecks`, `execute_anonymous`.
+
+### VS Code
+
+Run `**MCP: Add Server**` from the Command Palette and add an `npx` server with the command `npx -y @certinia/apex-log-mcp`, or add it to `.vscode/mcp.json`:
+
+```json
+{
+  "servers": {
+    "apex-log-mcp": {
+      "command": "npx",
+      "args": ["-y", "@certinia/apex-log-mcp"]
+    }
+  }
+}
+```
+
+<details>
+<summary><strong>Claude Code</strong></summary>
+
+Add the server with the Claude CLI:
+
+```bash
+claude mcp add apex-log-mcp -- npx -y @certinia/apex-log-mcp
+```
+
+</details>
+
+### Other MCP clients
+
+The same npm package works in Cursor and other MCP clients. See the [`@certinia/apex-log-mcp` README](https://github.com/certinia/debug-log-analyzer-mcp#readme) for client-specific configuration snippets.
+
 ## 🎨 Customization
 
 Adjust event colors in `settings.json`:

--- a/lana-docs/docs/docs/features/mcp.md
+++ b/lana-docs/docs/docs/features/mcp.md
@@ -1,0 +1,48 @@
+---
+id: mcp
+title: AI Assistant (MCP Server)
+description: Use the companion @certinia/apex-log-mcp Model Context Protocol server to expose Apex log analysis tools to AI assistants like GitHub Copilot Chat, Claude Code, and Cursor.
+keywords:
+  [
+    salesforce apex mcp,
+    apex log mcp server,
+    model context protocol salesforce,
+    claude code apex logs,
+    copilot chat apex logs,
+    ai assistant salesforce debug log,
+  ]
+hide_title: true
+---
+
+## 🤖 AI Assistant (MCP Server)
+
+A companion Model Context Protocol server, [`@certinia/apex-log-mcp`](https://www.npmjs.com/package/@certinia/apex-log-mcp) ([source on GitHub](https://github.com/certinia/debug-log-analyzer-mcp)), exposes Apex log analysis tools to AI assistants. Use it with GitHub Copilot Chat, Claude Code, Cursor, or any MCP client.
+
+**Available tools:** `get_apex_log_summary`, `analyze_apex_log_performance`, `find_performance_bottlenecks`, `execute_anonymous`.
+
+### VS Code (GitHub Copilot Chat)
+
+Run **MCP: Add Server** from the Command Palette and add an `npx` server with the command `npx -y @certinia/apex-log-mcp`, or add it to `.vscode/mcp.json`:
+
+```json
+{
+  "servers": {
+    "apex-log-analyzer": {
+      "command": "npx",
+      "args": ["-y", "@certinia/apex-log-mcp"]
+    }
+  }
+}
+```
+
+### Claude Code
+
+Add the server with the Claude CLI:
+
+```bash
+claude mcp add apex-log-analyzer -- npx -y @certinia/apex-log-mcp
+```
+
+### Other MCP clients
+
+The same npm package works in Cursor, and other MCP hosts. See the [`@certinia/apex-log-mcp` README](https://github.com/certinia/debug-log-analyzer-mcp#readme) for client-specific configuration snippets.

--- a/lana-docs/sidebars.ts
+++ b/lana-docs/sidebars.ts
@@ -27,6 +27,7 @@ const sidebars: SidebarsConfig = {
         'docs/features/database',
         'docs/features/find',
         'docs/features/raw-log',
+        'docs/features/mcp',
       ],
     },
     'docs/settings',


### PR DESCRIPTION
# 📝 PR Overview

Adds documentation for the companion `@certinia/apex-log-mcp` Model Context Protocol server so users can discover and install it from the repo README and the Docusaurus docs site. Surfaces both the existing VS Code (Copilot Chat) setup and a new Claude Code `claude mcp add` install snippet.

## 🛠️ Changes made

- Add an "🤖 AI Assistant (MCP Server)" section to the root `README.md` covering available tools, VS Code (`.vscode/mcp.json`) configuration, and a collapsible Claude Code accordion with the `claude mcp add` command.
- Add a new Docusaurus feature page at `lana-docs/docs/docs/features/mcp.md` mirroring the README content, with `VS Code`, `Claude Code`, and `Other MCP clients` subsections.
- Register the new page in `lana-docs/sidebars.ts` under the Features category, after Raw Log Navigation.

## 🧩 Type of change (check all applicable)

- [ ] 🐛 Bug fix - something not working as expected
- [ ] ✨ New feature – adds new functionality
- [ ] ♻️ Refactor - internal changes with no user impact
- [ ] ⚡ Performance Improvement
- [x] 📝 Documentation - README or documentation site changes
- [ ] 🔧 Chore - dev tooling, CI, config
- [ ] 💥 Breaking change

## 🔗 Related Issues

resolves #654

## ✅ Tests added?

- [ ] 👍 yes
- [x] 🙅 no, not needed
- [ ] 🙋 no, I need help

## 📚 Docs updated?

- [x] 🔖 README.md
- [ ] 🔖 CHANGELOG.md
- [x] 📖 help site
- [ ] 🙅 not needed