### PR TITLE
chore(docs-site): align homepage types and tsconfig with docusaurus 3.10

### DIFF
--- a/lana-docs/src/components/HomepageFeatures/index.tsx
+++ b/lana-docs/src/components/HomepageFeatures/index.tsx
@@ -1,3 +1,4 @@
+import type {ReactNode} from 'react';
 import clsx from 'clsx';
 import Heading from '@theme/Heading';
 import styles from './styles.module.css';
@@ -5,7 +6,7 @@ import styles from './styles.module.css';
 type FeatureItem = {
   title: string;
   Svg: React.ComponentType<React.ComponentProps<'svg'>>;
-  description: JSX.Element;
+  description: ReactNode;
 };
 
 const FeatureList: FeatureItem[] = [
@@ -55,7 +56,7 @@ function Feature({title, Svg, description}: FeatureItem) {
   );
 }
 
-export default function HomepageFeatures(): JSX.Element {
+export default function HomepageFeatures(): ReactNode {
   return (
     <section className={styles.features}>
       <div className="container">

--- a/lana-docs/tsconfig.json
+++ b/lana-docs/tsconfig.json
@@ -1,7 +1,12 @@
+// This file is not used by "docusaurus start/build" commands.
+// It is here to improve your IDE experience (type-checking, autocompletion...),
+// and can also run the package.json "typecheck" script manually.
 {
-  // This file is not used in compilation. It is here just for a nice editor experience.
   "extends": "@docusaurus/tsconfig",
   "compilerOptions": {
-    "baseUrl": "."
-  }
+    "baseUrl": ".",
+    "ignoreDeprecations": "6.0",
+    "strict": true
+  },
+  "exclude": [".docusaurus", "build"]
 }


### PR DESCRIPTION
## Summary

Updates the docs-site TypeScript setup to match the current Docusaurus 3.10 template: switches the homepage feature component off the deprecated global `JSX.Element` and tightens `tsconfig.json` for editor type-checking.

## Changes

- Import `ReactNode` from `react` and use it in place of `JSX.Element` for `FeatureItem.description` and the `HomepageFeatures` return type (the global `JSX` namespace is gone in React 19 / TS 6).
- Enable `strict: true` and `ignoreDeprecations: "6.0"` in `lana-docs/tsconfig.json` so IDE type-checking matches what the upstream template ships.
- Exclude `.docusaurus` and `build` from the IDE TS project to avoid noise from generated output.
- Refresh the leading comment to reflect that the config is IDE-only (not used by `docusaurus start/build`).

## Test plan

- [ ] `pnpm --filter lana-docs typecheck`
- [ ] `pnpm --filter lana-docs build`
- [ ] manual smoke of the homepage in `pnpm --filter lana-docs start`