### PR TITLE
docs: link GitHub Discussions from issue templates and community

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -15,7 +15,7 @@ NOTE:
 
 - This is a community project. We will triage your bug as soon as we can.
 - Before raising a new bug, please check our [issue list](https://github.com/certinia/debug-log-analyzer/issues) to see if it has already been reported.
-- For general help, use [discussions](https://github.com/certinia/debug-log-analyzer/discussions) or [Salesforce Stack Exchange](https://salesforce.stackexchange.com/search?q=apex+log+analyzer).
+- For general help or if you are not sure this is a bug, use [Q&A discussions](https://github.com/certinia/debug-log-analyzer/discussions/categories/q-a) or [all discussions](https://github.com/certinia/debug-log-analyzer/discussions).
 
 ### 💡 Description
 

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,11 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Discussions
+    url: https://github.com/certinia/debug-log-analyzer/discussions
+    about: Browse all discussions or start a new one if nothing else fits.
+  - name: Ask a question
+    url: https://github.com/certinia/debug-log-analyzer/discussions/categories/q-a
+    about: Not sure if it's a bug? Ask in Q&A first.
+  - name: Discuss an idea
+    url: https://github.com/certinia/debug-log-analyzer/discussions/categories/ideas
+    about: Suggest or validate a feature idea before opening a feature request.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -11,6 +11,8 @@ assignees: ''
 
 Search [existing issues](https://github.com/certinia/debug-log-analyzer/issues) to check if this feature has already been suggested.
 
+If this is an early idea, open question, or you want feedback before filing, please start an [Ideas discussion](https://github.com/certinia/debug-log-analyzer/discussions/categories/ideas) first.
+
 > If your idea is new — awesome! Continue below 👇
 
 ## ✨ Feature Request

--- a/README.md
+++ b/README.md
@@ -225,6 +225,13 @@ Or go to: `Preferences > Extensions > Apex Log Analyzer`.
 - [Contribute](https://github.com/certinia/debug-log-analyzer/blob/main/CONTRIBUTING.md)
 - [Develop](https://github.com/certinia/debug-log-analyzer/blob/main/DEVELOPING.md)
 
+## 💬 Community
+
+- [All Discussions](https://github.com/certinia/debug-log-analyzer/discussions) – Browse or start a discussion if nothing below fits.
+- [Announcements](https://github.com/certinia/debug-log-analyzer/discussions/categories/announcement) – Release notes and project updates
+- [Q&A](https://github.com/certinia/debug-log-analyzer/discussions/categories/q-a) – Ask usage questions
+- [Ideas](https://github.com/certinia/debug-log-analyzer/discussions/categories/ideas) – Suggest or discuss features
+
 ## ❤️ Contributors
 
 Thanks to our amazing contributors!

--- a/lana-docs/docs/community/support.md
+++ b/lana-docs/docs/community/support.md
@@ -25,4 +25,7 @@ If you see an idea you like then join the conversation to get your ideas into th
 
 ## 💬 Discussion
 
-For discussion about best practices or if you have any questions or need help, please start a [discussion on github](https://github.com/certinia/debug-log-analyzer/discussions)
+- **[All Discussions](https://github.com/certinia/debug-log-analyzer/discussions)** – Browse or start a discussion if nothing below fits.
+- **[Q&A](https://github.com/certinia/debug-log-analyzer/discussions/categories/q-a)** – Ask usage questions or get help troubleshooting.
+- **[Ideas](https://github.com/certinia/debug-log-analyzer/discussions/categories/ideas)** – Suggest or validate a feature before opening a feature request issue.
+- **[Announcements](https://github.com/certinia/debug-log-analyzer/discussions/categories/announcement)** – Stay up to date with releases and project news.


### PR DESCRIPTION
# 📝 PR Overview

Adds GitHub Discussions links across issue templates and community-facing docs so users are routed to the right place (questions, ideas, general discussion) instead of opening issues for non-bug topics.

## 🛠️ Changes made

- Add `.github/ISSUE_TEMPLATE/config.yml` with contact links routing to the Q&A, Ideas, and general Discussions categories
- Update `bug_report` and `feature_request` templates to link the relevant Discussion categories
- Add a Community section to root `README.md` and `lana/README.md` pointing to Discussions
- Expand the support page (`lana-docs/docs/community/support.md`) with per-category Discussion links

## 🧩 Type of change (check all applicable)

- [ ] 🐛 Bug fix - something not working as expected
- [ ] ✨ New feature – adds new functionality
- [ ] ♻️ Refactor - internal changes with no user impact
- [ ] ⚡ Performance Improvement
- [x] 📝 Documentation - README or documentation site changes
- [ ] 🔧 Chore - dev tooling, CI, config
- [ ] 💥 Breaking change

## ✅ Tests added?

- [ ] 👍 yes
- [x] 🙅 no, not needed
- [ ] 🙋 no, I need help

## 📚 Docs updated?

- [x] 🔖 README.md
- [ ] 🔖 CHANGELOG.md
- [x] 📖 help site
- [ ] 🙅 not needed