### PR TITLE
docs: restructure agent instructions around AGENTS.md

### DIFF
--- a/.claude/rules/lana.md
+++ b/.claude/rules/lana.md
@@ -1,0 +1,18 @@
+---
+paths:
+  - 'lana/**'
+---
+
+# lana rules
+
+VS Code extension. Applies when working under `lana/`.
+
+## UX
+
+- Major features reachable via Command Palette, context menus, and code lenses.
+- Error messages are actionable with clear next steps.
+- Full keyboard navigation for accessibility.
+
+## Key paths
+
+- Commands: `lana/src/commands/`

--- a/.claude/rules/log-viewer.md
+++ b/.claude/rules/log-viewer.md
@@ -1,0 +1,30 @@
+---
+paths:
+  - 'log-viewer/**'
+---
+
+# log-viewer rules
+
+Webview UI. Applies when working under `log-viewer/`.
+
+## Boundary
+
+- MUST NOT import `vscode` or anything from `lana/`.
+- Communicate with the extension via message passing only.
+
+## Performance budgets
+
+- Parse + render: `<5MB` → `<1s`, `10MB` → `<3s`, `20MB+` → `<5s`.
+- No synchronous operations >50ms blocking the extension host.
+- Operations >100ms show a progress indicator.
+- Benchmark against large logs from `sample-app/`.
+
+## Key paths
+
+- Timeline: `log-viewer/src/features/timeline/`
+- Parser: `log-viewer/src/core/log-parser/`
+
+## Testing
+
+- Features and bug fixes include tests.
+- Breaking changes to log parsing cover both old and new formats.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,38 +1,52 @@
-# Context
+# Apex Log Analyzer
 
-**Apex Log Analyzer** - VS Code extension for analyzing Salesforce debug logs with interactive visualizations (flame charts, call trees, SOQL/DML breakdowns).
+VS Code extension for analyzing Salesforce debug logs with interactive visualizations
+(flame charts, call trees, SOQL/DML breakdowns).
 
-## Monorepo Structure
+> Canonical agent instructions for all tools. Claude Code loads this via `CLAUDE.md`.
+> Area-specific rules live in `.claude/rules/` — see the Rules manifest below.
 
-- lana/: VS Code extension (TypeScript)
-- log-viewer/: Webview UI (TypeScript)
-- lana-docs/: Docusaurus documentation
-- sample-app/: Sample Salesforce app with test logs
+## Monorepo structure
 
-## Technology + Tooling
+- `lana/` — VS Code extension (TypeScript)
+- `log-viewer/` — webview UI (TypeScript; lit / html / css)
+- `lana-docs/` — Docusaurus documentation
+- `sample-app/` — sample Salesforce app with test logs
 
-- TypeScript
-- lit, html, css, js
+## Commands
 
-Always use pnpm
+Always use pnpm.
 
-## Key Commands
+- `pnpm watch` — dev build with hot reload
+- `pnpm build` — production build
+- `pnpm test` — run tests (before committing)
+- `pnpm lint` — type + lint check
+- `pnpm prettier-format` — auto-format
 
-- pnpm watch: Dev build with hot reload
-- pnpm build: Production build
-- pnpm test: Run tests before commiting
-- pnpm lint: Type + lint check
-- pnpm prettier-format: Auto-format all files
+## Core principles
 
-## Development Guidelines
+- **Type safety** — strict TypeScript, no `any` (use `unknown` + justification if unavoidable).
+- **Modularity** — keep `lana/` and `log-viewer/` independent; cross-package contracts only.
+- **Performance** — handle large logs (50MB+, 500k+ lines) without blocking the UI.
+- **UX** — discoverable, accessible, actionable errors.
+- **Testing** — features and bug fixes ship with tests; CI blocks failures.
 
-- Strict TypeScript enabled
-- `log-viewer/` + `lana/` must remain independent + `log-viewer/` can not import VSCode APIs
-- Write tests first (TDD)
-- Fast performance + Handle 50MB+ logs (500k+ lines)
+## Critical boundary
 
-## Important notes
+`log-viewer/` MUST NOT import `vscode` or anything from `lana/`. The two packages
+communicate via message passing only.
 
-- See `.claude/rules/` for core principles, development standards, release process
-- Conventional commit messages
-- Don't auto commit
+## Workflow
+
+- Conventional commits (`feat:`, `fix:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`,
+  `refactor:`, `perf:`, `test:`). Don't auto-commit.
+- Branches: `feat-*` for features, `bug-*` for defects.
+- Releases follow SemVer; update CHANGELOG; breaking changes need a migration guide.
+- Never reference Anthropic or Claude in commit messages, PRs, etc.
+
+## Rules manifest
+
+Area-specific rules load on demand (Claude Code, scoped by path):
+
+- `.claude/rules/log-viewer.md` — webview/UI: boundary, performance budgets, key paths.
+- `.claude/rules/lana.md` — VS Code extension: UX, command paths.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,21 +1,8 @@
-# Apex Log Analyzer
+<!-- Canonical instructions live in AGENTS.md and .claude/rules/. Edit those, NOT this
+     import stub. This file only wires AGENTS.md into Claude Code. -->
 
-VS Code extension for Salesforce debug log analysis.
+@AGENTS.md
 
-## Structure
+## Claude Code
 
-- `lana/` - VS Code extension
-- `log-viewer/` - Webview UI (NO vscode imports allowed)
-
-## Commands
-
-pnpm watch | build | test | lint | prettier-format
-
-## Standards
-
-See `.claude/rules/` for full guidelines.
-
-- Strict TypeScript, no `any`
-- Performance: <3s for 10MB logs
-- Tests required for features
-- Conventional commits, no auto-commit
+- Area rules in `.claude/rules/` load by path; see the Rules manifest in AGENTS.md.


### PR DESCRIPTION
# 📝 PR Overview

Makes AGENTS.md the canonical, single source of agent instructions and reduces CLAUDE.md to a thin import stub, so guidance lives in one place. Adds path-scoped rule files under `.claude/rules/` that Claude Code loads on demand per area.

## 🛠️ Changes made

- Rewrite AGENTS.md as the canonical instructions: monorepo structure, commands, core principles, critical boundary, workflow, and a rules manifest
- Reduce CLAUDE.md to an `@AGENTS.md` import stub with a pointer to the path-scoped rules
- Add `.claude/rules/log-viewer.md` (`log-viewer/**`) covering the vscode-import boundary, performance budgets, key paths, and testing
- Add `.claude/rules/lana.md` (`lana/**`) covering extension UX and command paths

## 🧩 Type of change (check all applicable)

- [ ] 🐛 Bug fix - something not working as expected
- [ ] ✨ New feature – adds new functionality
- [ ] ♻️ Refactor - internal changes with no user impact
- [ ] ⚡ Performance Improvement
- [x] 📝 Documentation - README or documentation site changes
- [ ] 🔧 Chore - dev tooling, CI, config
- [ ] 💥 Breaking change

## ✅ Tests added?

- [ ] 👍 yes
- [x] 🙅 no, not needed
- [ ] 🙋 no, I need help

## 📚 Docs updated?

- [ ] 🔖 README.md
- [ ] 🔖 CHANGELOG.md
- [ ] 📖 help site
- [x] 🙅 not needed