### PR TITLE
docs: add 🧪 pre-release tagging convention and badges

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -41,6 +41,7 @@ related #
 - [ ] 🔖 README.md
 - [ ] 🔖 CHANGELOG.md
 - [ ] 📖 help site
+- [ ] 🧪 Marked any pre-release-only features (README `🧪` badge — see [RELEASING.md](../RELEASING.md#-marking-pre-release-only-features))
 - [ ] 🙅 not needed
 
 ## Anything else we need to know? [optional]

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ dist/
 build/
 out/
 coverage/
+
+tsconfig.tsbuildinfo

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,6 +37,10 @@ We can't wait to see your contributions! Whether it’s fixing a bug, adding a n
 - We follow a simple format for commit messages: [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
 - Use the imperative mood in the subject line (e.g., "fix: date parsing in log parser" rather than "fixed date parsing in log parser").
 
+## 🧪 New Features
+
+> 🧪 Adding a user-facing feature that isn't in the stable release yet? Add a `🧪` badge in `README.md` in the same PR so stable users aren't misled. See [Marking Pre-Release-Only Features](https://github.com/certinia/debug-log-analyzer/blob/main/RELEASING.md#-marking-pre-release-only-features).
+
 ## 💬 Need Help?
 
 If you get stuck at any point, feel free to open an issue or reach out to us in the discussions tab. We’re here to help and we want to make your contribution experience as smooth as possible. 🤗

--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ Apex Log Analyzer is a blazing-fast VS Code extension for Salesforce developers.
 
 > ✨ Works with any `.log` Salesforce debug log file.
 
+> 🧪 **Pre-Release only** — available in the [Pre-Release Version](#-try-the-pre-release-version); not yet in the stable release.
+
 ## 🛠️ Installation
 
 ### 📦 Install Apex Log Analyzer in VS Code
@@ -41,7 +43,7 @@ You can install Apex Log Analyzer directly from Visual Studio Code, the command 
 
 [➡️ Install Apex Log Analyzer on Visual Studio Code Marketplace](https://marketplace.visualstudio.com/items?itemName=financialforce.lana)
 
-#### 🧪 Option 3: Install via Command Line
+#### >\_ Option 3: Install via Command Line
 
 ```bash
 code install financialforce.lana
@@ -81,13 +83,13 @@ Use `Log: Retrieve Apex Log And Show Analysis` from the Command Palette.
 
 The Timeline view shows a live visualization of your Salesforce Apex log execution — including methods, SOQL queries, DML operations, workflows, flows, and more.
 
-- **⚡ Fast** – Blazing-fast zoom, pan, and rendering even on massive logs (500k+ lines).
-- **🗺️ Minimap** – Bird's-eye view with skyline density overview, viewport lens, and instant teleport.
-- **📊 Governor Limits Strip** – At-a-glance limit usage with traffic light coloring. Expand for detailed step chart.
-- **📏 Measure & Zoom** – `Shift+Drag` to measure durations, `Alt/Option+Drag` to area-zoom, precision keyboard controls.
-- **🕐 Wall-Clock Time** – Toggle between elapsed and real-time (HH:MM:SS.mmm) on the time axis via the toolbar clock button.
+- **⚡ Fast** – Blazing-fast zoom, pan, and rendering even on massive logs (500k+ lines). 🧪
+- **🗺️ Minimap** – Bird's-eye view with skyline density overview, viewport lens, and instant teleport. 🧪
+- **📊 Governor Limits Strip** – At-a-glance limit usage with traffic light coloring. Expand for detailed step chart. 🧪
+- **📏 Measure & Zoom** – `Shift+Drag` to measure durations, `Alt/Option+Drag` to area-zoom, precision keyboard controls. 🧪
+- **🕐 Wall-Clock Time** – Toggle between elapsed and real-time (HH:MM:SS.mmm) on the time axis via the toolbar clock button. 🧪
 
-Also: Frame Selection & Navigation, Dynamic Frame Labels, Adaptive Frame Detail, Tooltips, Context Menu, Search & Highlight, 19 Curated Themes.
+Also: Frame Selection & Navigation, Dynamic Frame Labels, Adaptive Frame Detail, Tooltips, Context Menu, Search & Highlight, 19 Curated Themes. 🧪
 
 ![Flame Chart](https://raw.githubusercontent.com/certinia/debug-log-analyzer/main/lana/assets/v1.18/lana-timeline.png)
 
@@ -98,7 +100,7 @@ Also: Frame Selection & Navigation, Dynamic Frame Labels, Adaptive Frame Detail,
 Explore nested method calls with performance metrics:
 
 - **Metrics**: Self Time, Total Time, SOQL/DML/Thrown Counts, SOQL/DML/Rows
-- **Views**: Use Time Order for sequence, Aggregated for repeated hot paths, Bottom-Up for caller attribution
+- **Views**: Use Time Order for sequence, Aggregated for repeated hot paths, Bottom-Up for caller attribution 🧪
 - **Filter by Namespace, Type or Duration**
 - **Toggle Debug-Only + Detail Events**
 - **Keyboard Navigation**
@@ -110,7 +112,7 @@ Explore nested method calls with performance metrics:
 
 See which methods are the slowest, most frequent. or expensive.
 
-- **Group by Type, Namespace, or Caller Namespace**
+- **Group by Type, Namespace, or Caller Namespace 🧪**
 - **Sort by Duration, Count, Name, Type or Namespace**
 - **Filter to specific event types**
 - **Copy or Export to CSV**
@@ -122,7 +124,7 @@ See which methods are the slowest, most frequent. or expensive.
 Highlight slow Salesforce SOQL queries, non-selective filters, and DML issues.
 
 - **SOQL + DML Duration, Selectivity, Aggregates, Row Count**
-- **Group by Namespace, Caller Namespace, or Query**
+- **Group by Namespace, Caller Namespace 🧪, or Query**
 - **View the Call Stack**
 - **SOQL Optimization Tips**
 - **Sort by SOQL or DML, Duration, Selectivity, Aggregates, Row Count**
@@ -141,7 +143,7 @@ Search across all visualizations:
 
 Quickly step through matches, auto-expand parents, and automatically show timeline tooltips.
 
-## 📄 Raw Log Navigation
+## 📄 Raw Log Navigation 🧪
 
 Seamlessly navigate between the visual analysis and your raw `.log` files:
 
@@ -190,7 +192,7 @@ The same npm package works in Cursor and other MCP clients. See the [`@certinia/
 
 ## 🎨 Customization
 
-Adjust event colors in `settings.json`:
+Adjust event colors with custom timeline themes in `settings.json`: 🧪
 
 ```json
 "lana.timeline.customThemes": {

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -11,7 +11,7 @@ This guide explains how maintainers release stable and pre-release versions.
 2. [Pre-Release Flow (Automated)](#-pre-release-flow-automated)
 3. [Stable Release Flow (Manual)](#-stable-release-flow-manual)
 4. [Marketplace README Limitation](#-marketplace-readme-limitation)
-5. [Marking Pre-Release-Only Features in the README](#-marking-pre-release-only-features-in-the-readme)
+5. [Marking Pre-Release-Only Features](#-marking-pre-release-only-features)
 
 ## 🔢 Versioning Convention
 
@@ -44,8 +44,7 @@ A stable release is cut by hand. Do these steps in order:
 1. **Update the changelog + readme.**
    - Rename `[Unreleased]` in the root [`CHANGELOG.md`](./CHANGELOG.md) to `## [X.Y.Z] YYYY-MM-DD` .
    - Only edit the **root** `CHANGELOG.md`
-   - Remove any `🧪 Pre-Release` markers in the root `README.md` for features that ship in this
-     release (see [Marking Pre-Release-Only Features](#-marking-pre-release-only-features-in-the-readme)).
+   - For features that ship in this release, remove their `🧪` badges in the root `README.md` (see [Marking Pre-Release-Only Features](#-marking-pre-release-only-features)).
 
 1. **Bump the version.** Set `version` in [`lana/package.json`](./lana/package.json) to the new stable version. Use the **next even minor** (`1.18.x` → `1.20.0`) for a feature release, or a patch bump (`1.18.1` → `1.18.2`) for a fix-only release. Commit these changes to the selected release branch.
 1. **Create a GitHub Release.** Tag the release with a name that **exactly equals** the
@@ -68,14 +67,27 @@ Practical consequences:
 - Keep the README channel-neutral.
 - Treat root `README.md`, `CHANGELOG.md`, and `LICENSE.txt` as the source of truth. Do not hand-edit the generated `lana/` copies.
 
-## 🧪 Marking Pre-Release-Only Features in the README
+## 🧪 Marking Pre-Release-Only Features
 
-Because the public README can show pre-release content to stable users (see above), make pre-release-only features clearly marked so stable users aren't misled about what they can use today.
+Because the public README can show pre-release content to stable users (see above), mark
+pre-release-only features clearly so stable users aren't misled about what they can use today.
+**Add the marker in the same PR that introduces the feature** (the PR template has a checklist
+reminder).
 
-Add a blockquote callout directly under the relevant feature in the root `README.md`:
+### README — inline `🧪` badge
+
+The README uses a compact inline badge so deeply nested feature lists stay readable. The legend is
+defined once near the top:
 
 ```md
-> 🧪 **Pre-Release** — available in the Pre-Release Version; not yet in the stable release.
+> 🧪 **Pre-Release only** — available in the [Pre-Release Version](#-try-the-pre-release-version); not yet in the stable release.
 ```
 
-When a feature graduates to stable, **removing its `🧪 Pre-Release` marker is part of the stable release checklist** (step 1 above).
+Then append `🧪` at the smallest accurate scope:
+
+- **Whole feature/section** is pre-release → on the section heading (e.g. `## 📄 Raw Log Navigation 🧪`).
+- **A single bullet** is pre-release → at the end of that bullet.
+- **Only part of a bullet** → right after the specific phrase (e.g. `… or Caller Namespace 🧪, or Query`).
+
+When a feature graduates to stable, **removing its `🧪` badge is part of the stable release
+checklist** (step 1 above).

--- a/lana/.gitignore
+++ b/lana/.gitignore
@@ -9,7 +9,6 @@
 .idea/
 
 *.vsix
-tsconfig.tsbuildinfo
 
 out/
 node_modules/*

--- a/log-viewer/.gitignore
+++ b/log-viewer/.gitignore
@@ -2,5 +2,3 @@
 
 node_modules/*
 out/
-
-tsconfig.tsbuildinfo


### PR DESCRIPTION
# 📝 PR Overview

Establishes a lightweight convention for marking pre-release-only features so stable Marketplace users aren't misled about what they can use today. Replaces the verbose per-feature blockquote callout with a compact, scoped inline `🧪` badge, and wires reminders into the PR template and contributor docs.

## 🛠️ Changes made

- **RELEASING.md** — document the inline `🧪` badge convention (README-only, applied at the smallest accurate scope), replacing the old blockquote callout; add the "mark in the same PR" guidance.
- **README.md** — add the `🧪` legend near the top and tag current pre-release-only features; free up the misused `🧪` on the CLI install option.
- **PR template** — add a Docs checklist item reminding authors to badge pre-release-only features.
- **CONTRIBUTING.md** — add a short "New Features" note pointing to the convention.
- **.gitignore** — consolidate `tsconfig.tsbuildinfo` into the root ignore (removed from `lana/` and `log-viewer/`).

## 🧩 Type of change (check all applicable)

- [ ] 🐛 Bug fix - something not working as expected
- [ ] ✨ New feature – adds new functionality
- [ ] ♻️ Refactor - internal changes with no user impact
- [ ] ⚡ Performance Improvement
- [x] 📝 Documentation - README or documentation site changes
- [x] 🔧 Chore - dev tooling, CI, config
- [ ] 💥 Breaking change

## ✅ Tests added?

- [ ] 👍 yes
- [x] 🙅 no, not needed
- [ ] 🙋 no, I need help

## 📚 Docs updated?

- [x] 🔖 README.md
- [ ] 🔖 CHANGELOG.md
- [ ] 📖 help site
- [x] 🧪 Marked any pre-release-only features (README `🧪` badge — see [RELEASING.md](../RELEASING.md#-marking-pre-release-only-features))
- [ ] 🙅 not needed