### PR TITLE
feat(analysis): show category color strip in analysis view

### DIFF
--- a/lana/package.json
+++ b/lana/package.json
@@ -129,6 +129,13 @@
       "type": "object",
       "title": "Apex Log Analyzer",
       "properties": {
+        "lana.callTree.categoryColorize": {
+          "title": "Colorize Call Tree category names",
+          "type": "boolean",
+          "default": false,
+          "markdownDescription": "When enabled, applies a background tint and text color to the Name column in the Call Tree based on the event category, matching the Timeline flame graph colors. When disabled (default), a small color chip is shown instead.",
+          "order": 2
+        },
         "lana.timeline.activeTheme": {
           "type": "string",
           "default": "50 shades of green",
@@ -252,13 +259,6 @@
           "type": "boolean",
           "default": false,
           "markdownDescription": "Enable/ disable the legacy timeline. Default is `false`.",
-          "order": 2
-        },
-        "lana.callTree.categoryColorize": {
-          "title": "Colorize Call Tree category names",
-          "type": "boolean",
-          "default": false,
-          "markdownDescription": "When enabled, applies a background tint and text color to the Name column in the Call Tree based on the event category, matching the Timeline flame graph colors. When disabled (default), a small color chip is shown instead.",
           "order": 2
         },
         "lana.timeline.colors": {

--- a/log-viewer/src/features/analysis/components/AnalysisView.ts
+++ b/log-viewer/src/features/analysis/components/AnalysisView.ts
@@ -16,6 +16,11 @@ import type { ApexLog } from 'apex-log-parser';
 import { isVisible } from '../../../core/utility/Util.js';
 import { createBottomUpTable } from '../../call-tree/components/BottomUpTable.js';
 import type { BottomUpRow } from '../../call-tree/utils/Aggregation.js';
+import {
+  categoryColoringStyles,
+  categoryRowFormatter,
+  wireCategoryColoring,
+} from '../../call-tree/utils/CategoryColoring.js';
 import { expandCollapseAll } from '../../call-tree/utils/ExpandCollapse.js';
 
 import dataGridStyles from '../../../tabulator/style/DataGrid.scss';
@@ -111,6 +116,7 @@ export class AnalysisView extends LitElement {
         width: auto;
       }
     `,
+    categoryColoringStyles,
   ];
 
   @property()
@@ -139,6 +145,11 @@ export class AnalysisView extends LitElement {
     document.addEventListener('lv-find', this._findEvt);
     document.addEventListener('lv-find-match', this._findEvt);
     document.addEventListener('lv-find-close', this._findEvt);
+  }
+
+  override connectedCallback(): void {
+    super.connectedCallback();
+    wireCategoryColoring(this);
   }
 
   disconnectedCallback(): void {
@@ -371,6 +382,7 @@ export class AnalysisView extends LitElement {
             this._clearSearchHighlights();
           }
         },
+        rowFormatter: categoryRowFormatter,
       },
       {
         placeholder: 'No Analysis Available',

--- a/log-viewer/src/features/call-tree/components/CalltreeView.ts
+++ b/log-viewer/src/features/call-tree/components/CalltreeView.ts
@@ -15,16 +15,15 @@ import type { RowComponent, Tabulator } from 'tabulator-tables';
 
 import type { ApexLog, LogEvent } from 'apex-log-parser';
 import { eventBus } from '../../../core/events/EventBus.js';
-import {
-  VSCodeExtensionMessenger,
-  vscodeMessenger,
-} from '../../../core/messaging/VSCodeExtensionMessenger.js';
+import { vscodeMessenger } from '../../../core/messaging/VSCodeExtensionMessenger.js';
 import { findEventByEventIndex } from '../../../core/utility/EventSearch.js';
 import { isVisible } from '../../../core/utility/Util.js';
-import { getSettings } from '../../settings/Settings.js';
-import { DEFAULT_THEME_NAME } from '../../timeline/themes/Themes.js';
-import { addCustomThemes, getTheme } from '../../timeline/themes/ThemeSelector.js';
 import type { AggregatedRow, BottomUpRow } from '../utils/Aggregation.js';
+import {
+  categoryColoringStyles,
+  categoryRowFormatter,
+  wireCategoryColoring,
+} from '../utils/CategoryColoring.js';
 import { deepFilter } from '../utils/DetailsFilter.js';
 import { expandCollapseAll } from '../utils/ExpandCollapse.js';
 import type { TimeOrderRow } from '../utils/TimeOrderTree.js';
@@ -129,46 +128,8 @@ export class CalltreeView extends LitElement {
 
   override connectedCallback(): void {
     super.connectedCallback();
-    this._applyTheme(DEFAULT_THEME_NAME);
-
-    VSCodeExtensionMessenger.listen<{ activeTheme: string }>((event) => {
-      const { cmd, payload } = event.data;
-      if (cmd === 'switchTimelineTheme') {
-        this._applyTheme(payload.activeTheme ?? DEFAULT_THEME_NAME);
-      }
-    });
-
-    getSettings().then((settings) => {
-      const { timeline, callTree } = settings;
-      addCustomThemes(timeline.customThemes);
-      this._applyTheme(timeline.activeTheme ?? DEFAULT_THEME_NAME);
-      this._setCategoryColorize(callTree?.categoryColorize ?? false);
-    });
+    wireCategoryColoring(this);
   }
-
-  private _applyTheme(themeName: string): void {
-    const theme = getTheme(themeName);
-    this.style.setProperty('--ct-color-apex', theme.apex);
-    this.style.setProperty('--ct-color-code-unit', theme.codeUnit);
-    this.style.setProperty('--ct-color-system', theme.system);
-    this.style.setProperty('--ct-color-automation', theme.automation);
-    this.style.setProperty('--ct-color-dml', theme.dml);
-    this.style.setProperty('--ct-color-soql', theme.soql);
-    this.style.setProperty('--ct-color-callout', theme.callout);
-    this.style.setProperty('--ct-color-validation', theme.validation);
-  }
-
-  private _setCategoryColorize(enabled: boolean): void {
-    this.classList.toggle('category-colorize', enabled);
-  }
-
-  private _rowFormatter = (row: RowComponent): void => {
-    const data = row.getData() as { originalData?: { category?: string } };
-    const category = data.originalData?.category;
-    if (category) {
-      row.getElement().classList.add(`row-cat-${category.toLowerCase().replace(' ', '-')}`);
-    }
-  };
 
   disconnectedCallback(): void {
     super.disconnectedCallback();
@@ -308,65 +269,8 @@ export class CalltreeView extends LitElement {
         opacity: 0;
         pointer-events: none;
       }
-
-      .tabulator-row.row-cat-apex .datagrid-code-text {
-        border-left: 6px solid var(--ct-color-apex);
-      }
-      .tabulator-row.row-cat-code-unit .datagrid-code-text {
-        border-left: 6px solid var(--ct-color-code-unit);
-      }
-      .tabulator-row.row-cat-system .datagrid-code-text {
-        border-left: 6px solid var(--ct-color-system);
-      }
-      .tabulator-row.row-cat-automation .datagrid-code-text {
-        border-left: 6px solid var(--ct-color-automation);
-      }
-      .tabulator-row.row-cat-dml .datagrid-code-text {
-        border-left: 6px solid var(--ct-color-dml);
-      }
-      .tabulator-row.row-cat-soql .datagrid-code-text {
-        border-left: 6px solid var(--ct-color-soql);
-      }
-      .tabulator-row.row-cat-callout .datagrid-code-text {
-        border-left: 6px solid var(--ct-color-callout);
-      }
-      .tabulator-row.row-cat-validation .datagrid-code-text {
-        border-left: 6px solid var(--ct-color-validation);
-      }
-
-      :host(.category-colorize) .tabulator-row.row-cat-apex .datagrid-code-text {
-        background-color: color-mix(in srgb, var(--ct-color-apex) 10%, transparent);
-        color: var(--ct-color-apex);
-      }
-      :host(.category-colorize) .tabulator-row.row-cat-code-unit .datagrid-code-text {
-        background-color: color-mix(in srgb, var(--ct-color-code-unit) 10%, transparent);
-        color: var(--ct-color-code-unit);
-      }
-      :host(.category-colorize) .tabulator-row.row-cat-system .datagrid-code-text {
-        background-color: color-mix(in srgb, var(--ct-color-system) 10%, transparent);
-        color: var(--ct-color-system);
-      }
-      :host(.category-colorize) .tabulator-row.row-cat-automation .datagrid-code-text {
-        background-color: color-mix(in srgb, var(--ct-color-automation) 10%, transparent);
-        color: var(--ct-color-automation);
-      }
-      :host(.category-colorize) .tabulator-row.row-cat-dml .datagrid-code-text {
-        background-color: color-mix(in srgb, var(--ct-color-dml) 10%, transparent);
-        color: var(--ct-color-dml);
-      }
-      :host(.category-colorize) .tabulator-row.row-cat-soql .datagrid-code-text {
-        background-color: color-mix(in srgb, var(--ct-color-soql) 10%, transparent);
-        color: var(--ct-color-soql);
-      }
-      :host(.category-colorize) .tabulator-row.row-cat-callout .datagrid-code-text {
-        background-color: color-mix(in srgb, var(--ct-color-callout) 10%, transparent);
-        color: var(--ct-color-callout);
-      }
-      :host(.category-colorize) .tabulator-row.row-cat-validation .datagrid-code-text {
-        background-color: color-mix(in srgb, var(--ct-color-validation) 10%, transparent);
-        color: var(--ct-color-validation);
-      }
     `,
+    categoryColoringStyles,
   ];
 
   render() {
@@ -822,7 +726,7 @@ export class CalltreeView extends LitElement {
         const mouseEvent = e as MouseEvent;
         this._showRowContextMenu(row, mouseEvent.clientX, mouseEvent.clientY);
       },
-      rowFormatter: this._rowFormatter,
+      rowFormatter: categoryRowFormatter,
     });
     this.calltreeTable = table;
     await tableBuilt;
@@ -850,7 +754,7 @@ export class CalltreeView extends LitElement {
           this._clearSearchHighlights();
         }
       },
-      rowFormatter: this._rowFormatter,
+      rowFormatter: categoryRowFormatter,
     });
     this.aggregatedTreeTable = table;
     await tableBuilt;
@@ -874,7 +778,7 @@ export class CalltreeView extends LitElement {
             this._clearSearchHighlights();
           }
         },
-        rowFormatter: this._rowFormatter,
+        rowFormatter: categoryRowFormatter,
       },
       {
         selectableRows: 'highlight',

--- a/log-viewer/src/features/call-tree/utils/CategoryColoring.ts
+++ b/log-viewer/src/features/call-tree/utils/CategoryColoring.ts
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) 2025 Certinia Inc. All rights reserved.
+ */
+import { css } from 'lit';
+import type { RowComponent } from 'tabulator-tables';
+
+import { VSCodeExtensionMessenger } from '../../../core/messaging/VSCodeExtensionMessenger.js';
+import { getSettings } from '../../settings/Settings.js';
+import { DEFAULT_THEME_NAME, type TimelineColors } from '../../timeline/themes/Themes.js';
+import { addCustomThemes, getTheme } from '../../timeline/themes/ThemeSelector.js';
+
+/**
+ * Single source of truth for the call-tree category colour strip, shared by every
+ * view that renders the bottom-up/aggregated tables (Call Tree tabs + Analysis view).
+ *
+ * Each row points at one host theme var via the inherited `--row-cat-color` custom
+ * property, so a theme switch only updates the host vars and rows re-resolve in place —
+ * no Tabulator reformat, no scroll shift.
+ */
+
+// Maps a LogEvent.category string to its TimelineColors key, so a row can point at the
+// matching `--ct-color-<key>` host variable. Single source of truth for the set.
+/* eslint-disable @typescript-eslint/naming-convention */
+const CATEGORY_THEME_VAR: Readonly<Record<string, keyof TimelineColors>> = {
+  Apex: 'apex',
+  System: 'system',
+  'Code Unit': 'codeUnit',
+  Automation: 'automation',
+  DML: 'dml',
+  SOQL: 'soql',
+  Validation: 'validation',
+  Callout: 'callout',
+};
+/* eslint-enable @typescript-eslint/naming-convention */
+
+export const categoryColoringStyles = css`
+  .tabulator-row .datagrid-code-text {
+    border-left: 6px solid var(--row-cat-color, transparent);
+  }
+  :host(.category-colorize) .tabulator-row .datagrid-code-text {
+    background-color: color-mix(in srgb, var(--row-cat-color, transparent) 10%, transparent);
+    color: var(--row-cat-color, inherit);
+  }
+`;
+
+/**
+ * Tabulator `rowFormatter`: points a row at its category's host theme var. A row element
+ * is bound to one data row for its lifetime, so the category never changes once set.
+ */
+export const categoryRowFormatter = (row: RowComponent): void => {
+  const data = row.getData() as { originalData?: { category?: string } };
+  const category = data.originalData?.category;
+  const themeKey = category ? CATEGORY_THEME_VAR[category] : undefined;
+  if (themeKey) {
+    row.getElement().style.setProperty('--row-cat-color', `var(--ct-color-${themeKey})`);
+  }
+};
+
+function applyCategoryTheme(host: HTMLElement, themeName: string): void {
+  const theme = getTheme(themeName);
+  for (const [key, value] of Object.entries(theme)) {
+    host.style.setProperty(`--ct-color-${key}`, value);
+  }
+}
+
+/**
+ * Wire category colouring onto a host element: seed the theme vars, follow live theme
+ * switches, and toggle the colorize tint from settings. Call from `connectedCallback`.
+ */
+export function wireCategoryColoring(host: HTMLElement): void {
+  applyCategoryTheme(host, DEFAULT_THEME_NAME);
+
+  VSCodeExtensionMessenger.listen<{ activeTheme: string }>((event) => {
+    const { cmd, payload } = event.data;
+    if (cmd === 'switchTimelineTheme') {
+      applyCategoryTheme(host, payload.activeTheme ?? DEFAULT_THEME_NAME);
+    }
+  });
+
+  getSettings().then((settings) => {
+    const { timeline, callTree } = settings;
+    addCustomThemes(timeline.customThemes);
+    applyCategoryTheme(host, timeline.activeTheme ?? DEFAULT_THEME_NAME);
+    host.classList.toggle('category-colorize', callTree?.categoryColorize ?? false);
+  });
+}


### PR DESCRIPTION
# 📝 PR Overview

The category color strip (the colored left border on the Name column) was missing from the Analysis view even though it shares the bottom-up table with the Call Tree's Bottom Up tab. The coloring lived entirely inside `CalltreeView`, so any other host of that table got no strip. This extracts the coloring into one shared source and wires it into the Analysis view so both render identically.

## 🛠️ Changes made

- Add `call-tree/utils/CategoryColoring.ts` as the single source of truth: shared styles, the Tabulator row formatter, and theme/colorize wiring.
- Wire it into `AnalysisView` (styles, `connectedCallback`, and `rowFormatter`), which previously rendered no strip despite using the same `createBottomUpTable`.
- Replace `CalltreeView`'s inline theme vars, formatter, and 16 hand-written CSS rules with the shared module, collapsing onto one inherited `--row-cat-color` custom property.
- Relocate the `lana.callTree.categoryColorize` setting in `lana/package.json` (no behavior change).

## 🧩 Type of change (check all applicable)

- [ ] 🐛 Bug fix - something not working as expected
- [x] ✨ New feature – adds new functionality
- [x] ♻️ Refactor - internal changes with no user impact
- [ ] ⚡ Performance Improvement
- [ ] 📝 Documentation - README or documentation site changes
- [ ] 🔧 Chore - dev tooling, CI, config
- [ ] 💥 Breaking change

## 📷 Screenshots / gifs / video [optional]

<img width="1920" height="990" alt="lana-analysis" src="https://github.com/user-attachments/assets/d58e3666-c656-46ca-b2a5-0188c0cc35e2" />


_To be added after opening._

## ✅ Tests added?

- [ ] 👍 yes
- [x] 🙅 no, not needed
- [ ] 🙋 no, I need help

## 📚 Docs updated?

- [ ] 🔖 README.md
- [ ] 🔖 CHANGELOG.md
- [ ] 📖 help site
- [ ] 🧪 Marked any pre-release-only features (README `🧪` badge — see [RELEASING.md](../RELEASING.md#-marking-pre-release-only-features))
- [x] 🙅 not needed

## Anything else we need to know? [optional]

Verified via tsc, eslint, and prettier. Not yet smoke-tested visually in the running webview.