### PR TITLE
feat(raw-log): add outline, breadcrumbs, sticky scroll; fix folding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - **Show in Raw Log**: Right-click timeline or call tree frames → "Show in Log File" to jump to the corresponding line.
   - **Show in Log Analysis**: Click the hover link on raw log lines to navigate back to the log analysis.
   - **Code Folding**: Collapse/expand matching start/end events (METHOD_ENTRY/EXIT, CODE_UNIT, DML, SOQL, etc.).
+  - **Outline, Breadcrumbs & Sticky Scroll**: Outline view, breadcrumbs, and sticky scroll in the editor.
   - **Line Decorations**: Duration appears as ghost text at the end of the cursor line (e.g., `1.23s (self: 45ms)`).
   - **Hover Details**: Hover near the ghost text to see SOQL/DML counts, row counts, and exception info.
   - **Total Duration**: First line shows total log execution time.

--- a/lana/src/Context.ts
+++ b/lana/src/Context.ts
@@ -15,6 +15,7 @@ import type { Display } from './display/Display.js';
 import { WhatsNewNotification } from './display/WhatsNewNotification.js';
 import { RawLogFoldingProvider } from './folding/RawLogFoldingProvider.js';
 import { ApexLogLanguageDetector } from './language/ApexLogLanguageDetector.js';
+import { RawLogSymbolProvider } from './symbols/RawLogSymbolProvider.js';
 import { VSWorkspace } from './workspace/VSWorkspace.js';
 
 export class Context {
@@ -42,6 +43,7 @@ export class Context {
     LogTimingDecoration.apply(this);
     RawLogLineDecoration.apply(this);
     RawLogFoldingProvider.apply(this);
+    RawLogSymbolProvider.apply(this);
     WhatsNewNotification.apply(this);
   }
 }

--- a/lana/src/__tests__/mocks/vscode.ts
+++ b/lana/src/__tests__/mocks/vscode.ts
@@ -140,6 +140,43 @@ export const FoldingRangeKind = {
 } as const;
 export type FoldingRangeKind = (typeof FoldingRangeKind)[keyof typeof FoldingRangeKind];
 
+// Mock EventEmitter
+export class EventEmitter<T> {
+  private listeners: ((e: T) => void)[] = [];
+  readonly event = (listener: (e: T) => void): { dispose: () => void } => {
+    this.listeners.push(listener);
+    return { dispose: jest.fn() };
+  };
+  fire(data: T): void {
+    this.listeners.forEach((listener) => listener(data));
+  }
+  dispose = jest.fn();
+}
+
+// Mock SymbolKind enum (only the members used by the extension)
+export const SymbolKind = {
+  Method: 5,
+} as const;
+export type SymbolKind = (typeof SymbolKind)[keyof typeof SymbolKind];
+
+// Mock DocumentSymbol
+export class DocumentSymbol {
+  name: string;
+  detail: string;
+  kind: SymbolKind;
+  range: Range;
+  selectionRange: Range;
+  children: DocumentSymbol[] = [];
+
+  constructor(name: string, detail: string, kind: SymbolKind, range: Range, selectionRange: Range) {
+    this.name = name;
+    this.detail = detail;
+    this.kind = kind;
+    this.range = range;
+    this.selectionRange = selectionRange;
+  }
+}
+
 // Mock TextLine
 export interface MockTextLine {
   lineNumber: number;
@@ -206,6 +243,7 @@ export const createMockTextDocument = (options: {
 // Mock workspace
 export const workspace = {
   workspaceFolders: [] as { uri: ReturnType<typeof Uri.file>; name: string; index: number }[],
+  textDocuments: [] as TextDocument[],
   getConfiguration: jest.fn(() => ({
     get: jest.fn(),
     has: jest.fn(() => false),
@@ -313,6 +351,11 @@ export const languages = {
     return disposable;
   }),
   registerCodeLensProvider: jest.fn(() => {
+    const disposable = { dispose: jest.fn() };
+    subscriptions.push(disposable);
+    return disposable;
+  }),
+  registerDocumentSymbolProvider: jest.fn(() => {
     const disposable = { dispose: jest.fn() };
     subscriptions.push(disposable);
     return disposable;

--- a/lana/src/folding/RawLogFoldingProvider.ts
+++ b/lana/src/folding/RawLogFoldingProvider.ts
@@ -2,9 +2,12 @@
  * Copyright (c) 2026 Certinia Inc. All rights reserved.
  */
 import {
+  EventEmitter,
   FoldingRange,
   FoldingRangeKind,
   languages,
+  window,
+  workspace,
   type FoldingContext,
   type FoldingRangeProvider,
   type TextDocument,
@@ -14,9 +17,13 @@ import type { LogEvent } from 'apex-log-parser';
 
 import type { Context } from '../Context.js';
 import { LogEventCache } from '../cache/LogEventCache.js';
+import { isApexLogContent } from '../language/ApexLogLanguageDetector.js';
 import { TIMESTAMP_REGEX } from '../log-utils.js';
 
 class RawLogFoldingProvider implements FoldingRangeProvider {
+  private readonly changeEmitter = new EventEmitter<void>();
+  readonly onDidChangeFoldingRanges = this.changeEmitter.event;
+
   async provideFoldingRanges(
     document: TextDocument,
     _context: FoldingContext,
@@ -73,15 +80,47 @@ class RawLogFoldingProvider implements FoldingRangeProvider {
     }
   }
 
+  /**
+   * Warm the parse cache for an Apex log document and signal VS Code to re-request
+   * folding ranges once the data is ready. Without this, a slow first parse loses the
+   * race against VS Code's initial folding request and folding never appears until an
+   * unrelated action forces a re-evaluation.
+   */
+  private warmAndSignal(document: TextDocument): void {
+    if (document.uri.scheme !== 'file' || !isApexLogContent(document)) {
+      return;
+    }
+
+    void LogEventCache.getApexLog(document.uri.fsPath).then((apexLog) => {
+      if (apexLog) {
+        this.changeEmitter.fire();
+      }
+    });
+  }
+
   static apply(context: Context): void {
     const docSelector = [{ scheme: 'file', language: 'apexlog' }];
+    const provider = new RawLogFoldingProvider();
 
-    const disposable = languages.registerFoldingRangeProvider(
-      docSelector,
-      new RawLogFoldingProvider(),
+    context.context.subscriptions.push(
+      provider.changeEmitter,
+      languages.registerFoldingRangeProvider(docSelector, provider),
+      workspace.onDidOpenTextDocument((doc) => {
+        provider.warmAndSignal(doc);
+      }),
+      // Reopening a closed editor often re-attaches the retained document model
+      // without re-firing onDidOpenTextDocument, so also signal on editor activation.
+      window.onDidChangeActiveTextEditor((editor) => {
+        if (editor) {
+          provider.warmAndSignal(editor.document);
+        }
+      }),
     );
 
-    context.context.subscriptions.push(disposable);
+    // Cover logs already open when the extension activates.
+    for (const doc of workspace.textDocuments) {
+      provider.warmAndSignal(doc);
+    }
   }
 }
 

--- a/lana/src/folding/__tests__/RawLogFoldingProvider.test.ts
+++ b/lana/src/folding/__tests__/RawLogFoldingProvider.test.ts
@@ -3,7 +3,7 @@
  */
 import { beforeEach, describe, expect, it } from '@jest/globals';
 
-import { FoldingRangeKind, languages } from 'vscode';
+import { FoldingRangeKind, languages, window, workspace } from 'vscode';
 
 import {
   createMockApexLog,
@@ -317,12 +317,98 @@ describe('RawLogFoldingProvider', () => {
       );
     });
 
-    it('should add disposable to context subscriptions', () => {
+    it('should register an onDidOpenTextDocument listener', () => {
       const mockContext = createMockContext();
 
       RawLogFoldingProvider.apply(mockContext as unknown as import('../../Context.js').Context);
 
-      expect(mockContext.context.subscriptions.length).toBe(1);
+      expect(workspace.onDidOpenTextDocument).toHaveBeenCalledTimes(1);
+    });
+
+    it('should add disposables to context subscriptions', () => {
+      const mockContext = createMockContext();
+
+      RawLogFoldingProvider.apply(mockContext as unknown as import('../../Context.js').Context);
+
+      // emitter + folding provider registration + open listener + active-editor listener
+      expect(mockContext.context.subscriptions.length).toBe(4);
+    });
+  });
+
+  describe('signals VS Code when a log is parsed', () => {
+    // An EXECUTION_STARTED line makes isApexLogContent() return true.
+    const apexLogLines = ['16:35:06.2 (2706460)|EXECUTION_STARTED'];
+
+    function applyAndCapture() {
+      const mockContext = createMockContext();
+      RawLogFoldingProvider.apply(mockContext as unknown as import('../../Context.js').Context);
+
+      const registeredProvider = (languages.registerFoldingRangeProvider as jest.Mock).mock
+        .calls[0]?.[1] as RawLogFoldingProvider;
+      const openHandler = (workspace.onDidOpenTextDocument as jest.Mock).mock.calls[0]?.[0] as (
+        doc: unknown,
+      ) => void;
+      const activeEditorHandler = (window.onDidChangeActiveTextEditor as jest.Mock).mock
+        .calls[0]?.[0] as (editor: unknown) => void;
+
+      return { registeredProvider, openHandler, activeEditorHandler };
+    }
+
+    const flush = () => new Promise((resolve) => setImmediate(resolve));
+
+    it('warms the cache and fires onDidChangeFoldingRanges when an apex log opens', async () => {
+      const { registeredProvider, openHandler } = applyAndCapture();
+      const fired = jest.fn();
+      registeredProvider.onDidChangeFoldingRanges?.(fired);
+
+      mockGetApexLog.mockResolvedValueOnce(createMockApexLog({ children: [] }));
+      const doc = createMockTextDocument({ lines: apexLogLines, uri: '/test/file.log' });
+      openHandler(doc);
+      await flush();
+
+      expect(mockGetApexLog).toHaveBeenCalledWith('/test/file.log');
+      expect(fired).toHaveBeenCalledTimes(1);
+    });
+
+    it('warms the cache and fires when an apex log editor becomes active (reopen)', async () => {
+      const { registeredProvider, activeEditorHandler } = applyAndCapture();
+      const fired = jest.fn();
+      registeredProvider.onDidChangeFoldingRanges?.(fired);
+
+      mockGetApexLog.mockResolvedValueOnce(createMockApexLog({ children: [] }));
+      const doc = createMockTextDocument({ lines: apexLogLines, uri: '/test/file.log' });
+      activeEditorHandler({ document: doc });
+      await flush();
+
+      expect(mockGetApexLog).toHaveBeenCalledWith('/test/file.log');
+      expect(fired).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not warm or signal for a non-apex-log document', async () => {
+      const { registeredProvider, openHandler } = applyAndCapture();
+      const fired = jest.fn();
+      registeredProvider.onDidChangeFoldingRanges?.(fired);
+
+      const doc = createMockTextDocument({ lines: ['just some text'], uri: '/test/notes.log' });
+      openHandler(doc);
+      await flush();
+
+      expect(mockGetApexLog).not.toHaveBeenCalled();
+      expect(fired).not.toHaveBeenCalled();
+    });
+
+    it('does not fire when the log fails to parse', async () => {
+      const { registeredProvider, openHandler } = applyAndCapture();
+      const fired = jest.fn();
+      registeredProvider.onDidChangeFoldingRanges?.(fired);
+
+      mockGetApexLog.mockResolvedValueOnce(null);
+      const doc = createMockTextDocument({ lines: apexLogLines, uri: '/test/file.log' });
+      openHandler(doc);
+      await flush();
+
+      expect(mockGetApexLog).toHaveBeenCalledWith('/test/file.log');
+      expect(fired).not.toHaveBeenCalled();
     });
   });
 });

--- a/lana/src/symbols/RawLogSymbolProvider.ts
+++ b/lana/src/symbols/RawLogSymbolProvider.ts
@@ -1,0 +1,100 @@
+/*
+ * Copyright (c) 2026 Certinia Inc. All rights reserved.
+ */
+import {
+  DocumentSymbol,
+  languages,
+  Position,
+  Range,
+  SymbolKind,
+  type CancellationToken,
+  type DocumentSymbolProvider,
+  type TextDocument,
+} from 'vscode';
+
+import type { LogEvent } from 'apex-log-parser';
+
+import type { Context } from '../Context.js';
+import { LogEventCache } from '../cache/LogEventCache.js';
+import { formatDuration, TIMESTAMP_REGEX } from '../log-utils.js';
+
+/**
+ * Document symbols for raw Apex logs. Beyond populating the Outline/breadcrumbs, this is
+ * the source VS Code's sticky scroll prefers (the outline model). The folding provider
+ * alone only feeds sticky scroll via an unreliable fallback, so parent rows would not pin
+ * on scroll without these symbols.
+ */
+class RawLogSymbolProvider implements DocumentSymbolProvider {
+  async provideDocumentSymbols(
+    document: TextDocument,
+    _token: CancellationToken,
+  ): Promise<DocumentSymbol[]> {
+    const apexLog = await LogEventCache.getApexLog(document.uri.fsPath);
+
+    if (!apexLog) {
+      return [];
+    }
+
+    const timestampToLine = this.buildTimestampMap(document);
+    return this.collectSymbols(apexLog.children, timestampToLine, document);
+  }
+
+  private buildTimestampMap(document: TextDocument): Map<number, number> {
+    const map = new Map<number, number>();
+
+    for (let i = 0; i < document.lineCount; i++) {
+      const match = document.lineAt(i).text.match(TIMESTAMP_REGEX);
+      if (match?.[1]) {
+        const timestamp = parseInt(match[1], 10);
+        if (!map.has(timestamp)) {
+          map.set(timestamp, i);
+        }
+      }
+    }
+
+    return map;
+  }
+
+  private collectSymbols(
+    events: LogEvent[],
+    timestampToLine: Map<number, number>,
+    document: TextDocument,
+  ): DocumentSymbol[] {
+    const symbols: DocumentSymbol[] = [];
+
+    for (const event of events) {
+      const startLine = timestampToLine.get(event.timestamp);
+      const endLine = event.exitStamp !== null ? timestampToLine.get(event.exitStamp) : undefined;
+      const children = this.collectSymbols(event.children, timestampToLine, document);
+
+      if (startLine !== undefined && endLine !== undefined && endLine > startLine) {
+        // Prefer the parser's concise label (e.g. a method signature) over the raw line,
+        // which is prefixed with a timestamp and bloats breadcrumbs / sticky scroll.
+        const name =
+          event.text.trim() || event.type || document.lineAt(startLine).text.trim() || 'log';
+        const detail = formatDuration(event.duration.total);
+        const range = new Range(new Position(startLine, 0), document.lineAt(endLine).range.end);
+        const selectionRange = document.lineAt(startLine).range;
+
+        const symbol = new DocumentSymbol(name, detail, SymbolKind.Method, range, selectionRange);
+        symbol.children = children;
+        symbols.push(symbol);
+      } else {
+        // No foldable range for this event; lift its descendants to this level.
+        symbols.push(...children);
+      }
+    }
+
+    return symbols;
+  }
+
+  static apply(context: Context): void {
+    const docSelector = [{ scheme: 'file', language: 'apexlog' }];
+
+    context.context.subscriptions.push(
+      languages.registerDocumentSymbolProvider(docSelector, new RawLogSymbolProvider()),
+    );
+  }
+}
+
+export { RawLogSymbolProvider };

--- a/lana/src/symbols/__tests__/RawLogSymbolProvider.test.ts
+++ b/lana/src/symbols/__tests__/RawLogSymbolProvider.test.ts
@@ -1,0 +1,150 @@
+/*
+ * Copyright (c) 2026 Certinia Inc. All rights reserved.
+ */
+import { beforeEach, describe, expect, it } from '@jest/globals';
+
+import { SymbolKind, languages } from 'vscode';
+
+import {
+  createMockApexLog,
+  createMockContext,
+  createMockLogEvent,
+} from '../../__tests__/helpers/test-builders.js';
+import { createMockTextDocument } from '../../__tests__/mocks/vscode.js';
+import { LogEventCache } from '../../cache/LogEventCache.js';
+import { RawLogSymbolProvider } from '../RawLogSymbolProvider.js';
+
+jest.mock('../../cache/LogEventCache.js', () => ({
+  LogEventCache: {
+    getApexLog: jest.fn(),
+  },
+}));
+
+const mockGetApexLog = LogEventCache.getApexLog as jest.Mock;
+
+describe('RawLogSymbolProvider', () => {
+  let provider: RawLogSymbolProvider;
+
+  beforeEach(() => {
+    provider = new RawLogSymbolProvider();
+    mockGetApexLog.mockReset();
+  });
+
+  describe('provideDocumentSymbols', () => {
+    it('builds a symbol spanning the event, named by the parser label not the raw line', async () => {
+      const lines = [
+        '09:45:31.888 (1000)|METHOD_ENTRY|[1]|FooController.doWork',
+        '09:45:31.889 (1500)|STATEMENT_EXECUTE',
+        '09:45:31.890 (2000)|METHOD_EXIT',
+      ];
+      const doc = createMockTextDocument({ lines, uri: '/test/file.log' });
+      const event = createMockLogEvent({
+        timestamp: 1000,
+        exitStamp: 2000,
+        text: 'FooController.doWork',
+        children: [],
+      });
+      mockGetApexLog.mockResolvedValueOnce(createMockApexLog({ children: [event] }));
+
+      const symbols = await provider.provideDocumentSymbols(doc, {} as never);
+
+      expect(symbols.length).toBe(1);
+      expect(symbols[0]?.name).toBe('FooController.doWork');
+      expect(symbols[0]?.kind).toBe(SymbolKind.Method);
+      expect(symbols[0]?.range.start.line).toBe(0);
+      expect(symbols[0]?.range.end.line).toBe(2);
+    });
+
+    it('falls back to the event type when the parser label is empty', async () => {
+      const lines = [
+        '09:45:31.888 (1000)|CODE_UNIT_STARTED',
+        '09:45:31.890 (2000)|CODE_UNIT_FINISHED',
+      ];
+      const doc = createMockTextDocument({ lines, uri: '/test/file.log' });
+      const event = createMockLogEvent({
+        timestamp: 1000,
+        exitStamp: 2000,
+        text: '',
+        type: 'CODE_UNIT_STARTED',
+        children: [],
+      });
+      mockGetApexLog.mockResolvedValueOnce(createMockApexLog({ children: [event] }));
+
+      const symbols = await provider.provideDocumentSymbols(doc, {} as never);
+
+      expect(symbols[0]?.name).toBe('CODE_UNIT_STARTED');
+    });
+
+    it('nests child events under their parent', async () => {
+      const lines = [
+        '09:45:31.888 (1000)|CODE_UNIT_STARTED',
+        '09:45:31.889 (1500)|METHOD_ENTRY',
+        '09:45:31.890 (2000)|METHOD_EXIT',
+        '09:45:31.891 (3000)|CODE_UNIT_FINISHED',
+      ];
+      const doc = createMockTextDocument({ lines, uri: '/test/file.log' });
+      const child = createMockLogEvent({ timestamp: 1500, exitStamp: 2000, children: [] });
+      const parent = createMockLogEvent({ timestamp: 1000, exitStamp: 3000, children: [child] });
+      mockGetApexLog.mockResolvedValueOnce(createMockApexLog({ children: [parent] }));
+
+      const symbols = await provider.provideDocumentSymbols(doc, {} as never);
+
+      expect(symbols.length).toBe(1);
+      expect(symbols[0]?.children.length).toBe(1);
+      expect(symbols[0]?.children[0]?.range.start.line).toBe(1);
+      expect(symbols[0]?.children[0]?.range.end.line).toBe(2);
+    });
+
+    it('lifts descendants when an event has no foldable range', async () => {
+      const lines = [
+        '09:45:31.888 (1000)|EXECUTION_STARTED',
+        '09:45:31.889 (1500)|METHOD_ENTRY',
+        '09:45:31.890 (2000)|METHOD_EXIT',
+      ];
+      const doc = createMockTextDocument({ lines, uri: '/test/file.log' });
+      // Parent has no exitStamp -> not foldable; its child should surface at top level.
+      const child = createMockLogEvent({ timestamp: 1500, exitStamp: 2000, children: [] });
+      const parent = createMockLogEvent({ timestamp: 1000, exitStamp: null, children: [child] });
+      mockGetApexLog.mockResolvedValueOnce(createMockApexLog({ children: [parent] }));
+
+      const symbols = await provider.provideDocumentSymbols(doc, {} as never);
+
+      expect(symbols.length).toBe(1);
+      expect(symbols[0]?.range.start.line).toBe(1);
+    });
+
+    it('returns an empty array when the log fails to parse', async () => {
+      const doc = createMockTextDocument({ lines: [], uri: '/test/file.log' });
+      mockGetApexLog.mockResolvedValueOnce(null);
+
+      const symbols = await provider.provideDocumentSymbols(doc, {} as never);
+
+      expect(symbols).toEqual([]);
+    });
+
+    it('omits events whose timestamps are not in the document', async () => {
+      const lines = ['09:45:31.888 (1000)|METHOD_ENTRY'];
+      const doc = createMockTextDocument({ lines, uri: '/test/file.log' });
+      const event = createMockLogEvent({ timestamp: 9999, exitStamp: 10000, children: [] });
+      mockGetApexLog.mockResolvedValueOnce(createMockApexLog({ children: [event] }));
+
+      const symbols = await provider.provideDocumentSymbols(doc, {} as never);
+
+      expect(symbols).toEqual([]);
+    });
+  });
+
+  describe('apply', () => {
+    it('registers a document symbol provider for apexlog', () => {
+      const mockContext = createMockContext();
+
+      RawLogSymbolProvider.apply(mockContext as unknown as import('../../Context.js').Context);
+
+      expect(languages.registerDocumentSymbolProvider).toHaveBeenCalledTimes(1);
+      expect(languages.registerDocumentSymbolProvider).toHaveBeenCalledWith(
+        [{ scheme: 'file', language: 'apexlog' }],
+        expect.any(RawLogSymbolProvider),
+      );
+    });
+  });
+});


### PR DESCRIPTION
# 📝 PR Overview

Brings structure-aware navigation to raw Apex `.log` files: an Outline view, breadcrumbs, and sticky scroll that pins the enclosing parent events to the top as you scroll. Also fixes the long-standing folding delay where folds only appeared after the analysis webview had been opened.

## 🛠️ Changes made

- Add `RawLogSymbolProvider`, a `DocumentSymbolProvider` built from the parsed `LogEvent` tree. This is the source VS Code's sticky scroll prefers (the outline model) — the folding-range fallback alone was unreliable, so parent rows never pinned on a plain file open. Symbol names use the parser's concise event label rather than the raw timestamped line to keep breadcrumbs short.
- Fix folding reliability in `RawLogFoldingProvider`: expose `onDidChangeFoldingRanges` and fire it after warming the parse cache on document open **and** editor activation. A slow first parse otherwise lost the race against VS Code's initial folding request (large logs), and reopening a closed file re-attaches the retained model without re-firing `onDidOpenTextDocument`.
- Register the new provider in `Context.ts`; extend the vscode test mock with `EventEmitter`, `DocumentSymbol`/`SymbolKind`, `workspace.textDocuments`, and `registerDocumentSymbolProvider`.
- Document the new editor capabilities in `CHANGELOG.md`.

## 🧩 Type of change (check all applicable)

- [x] 🐛 Bug fix - something not working as expected
- [x] ✨ New feature – adds new functionality
- [ ] ♻️ Refactor - internal changes with no user impact
- [ ] ⚡ Performance Improvement
- [ ] 📝 Documentation - README or documentation site changes
- [ ] 🔧 Chore - dev tooling, CI, config
- [ ] 💥 Breaking change

## 📷 Screenshots / gifs / video [optional]

_Editor-only UX (Outline, breadcrumbs, sticky scroll on raw `.log` files); no in-app UI components changed._

## 🔗 Related Issues

related #204

## ✅ Tests added?

- [x] 👍 yes

## 📚 Docs updated?

- [x] 🔖 CHANGELOG.md
- [ ] 🙅 not needed

## Anything else we need to know? [optional]

Reviewer guidance:
- `RawLogSymbolProvider` and `RawLogFoldingProvider` share the same timestamp→line mapping intentionally; `log-utils.ts` is kept `vscode`-free, so the small helper is duplicated rather than hoisted there.
- Verified in the Extension Development Host: folding appears shortly after opening a large raw log (no webview round-trip), survives close/reopen, and sticky scroll pins parent events on first open.
- `pnpm lint` and the `lana` jest suite pass.