### PR TITLE
chore(deps): bump tabulator-tables to 6.5.1

### DIFF
--- a/log-viewer/package.json
+++ b/log-viewer/package.json
@@ -11,7 +11,7 @@
     "antlr4": "4.13.2",
     "lit": "^3.3.3",
     "pixi.js": "^8.19.0",
-    "tabulator-tables": "^6.4.0"
+    "tabulator-tables": "^6.5.1"
   },
   "devDependencies": {
     "@types/jest": "^30.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -211,8 +211,8 @@ importers:
         specifier: ^8.19.0
         version: 8.19.0
       tabulator-tables:
-        specifier: ^6.4.0
-        version: 6.4.0
+        specifier: ^6.5.1
+        version: 6.5.1
     devDependencies:
       '@types/jest':
         specifier: ^30.0.0
@@ -7840,8 +7840,8 @@ packages:
   tabbable@5.3.3:
     resolution: {integrity: sha512-QD9qKY3StfbZqWOPLp0++pOrAVb/HbUi5xCc8cUo4XjP19808oaMiDzn0leBY5mCespIBM0CIZePzZjgzR83kA==}
 
-  tabulator-tables@6.4.0:
-    resolution: {integrity: sha512-Lxh+leFNoBo/Yyr4USs6gxqbfo8anYUaUMmoT91pfVLtoUgl/dE+qV7ahnFrKVMCYYqGG33aIMPR7FzpPBaNYA==}
+  tabulator-tables@6.5.1:
+    resolution: {integrity: sha512-hTbw97QbUmh33d/87xdPFQUdm+1W2+l0WQuafYvqw95tEjC4o0sMLMd/Ie7KJ5u7/QlfpM03ZCqjw3TuEiPrdw==}
 
   tapable@2.3.3:
     resolution: {integrity: sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A==}
@@ -18338,7 +18338,7 @@ snapshots:
 
   tabbable@5.3.3: {}
 
-  tabulator-tables@6.4.0: {}
+  tabulator-tables@6.5.1: {}
 
   tapable@2.3.3: {}
 


### PR DESCRIPTION
# 📝 PR Overview

Bumps `tabulator-tables` 6.4.0 → 6.5.1. 6.5.1 restored `src/` to its
published package, fixing the regression that forced holding at 6.4.0 in
#811 — so the SCSS-source import
(`~tabulator-tables/src/scss/tabulator.scss`) used to theme the grid
with VS Code CSS vars resolves again.

## 🛠️  Changes made

- `tabulator-tables` 6.4.0 → 6.5.1 in `log-viewer` (+ lockfile)
- Unblocks the bump deferred in #811: 6.5.1's published `files` include
`src/` again, so the SCSS theming import no longer breaks the build
- Picks up 6.5.x fixes including variable-height-row vertical scroll
jumping and scrolling errors when all groups are collapsed

## 🧩 Type of change (check all applicable)

- [x] 🔧 Chore - dev tooling, CI, config

## 🔗 Related Issues

related #811

## ✅ Tests added?

- [x] 🙅 no, not needed

## 📚 Docs updated?

- [x] 🙅 not needed