### PR TITLE
build: remove obsolete bundler resolution workarounds

### DIFF
--- a/apex-log-parser/package.json
+++ b/apex-log-parser/package.json
@@ -3,5 +3,8 @@
   "version": "0.1.0",
   "private": true,
   "description": "Apex debug log parser for Salesforce",
-  "type": "module"
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts"
+  }
 }

--- a/rolldown.config.ts
+++ b/rolldown.config.ts
@@ -1,6 +1,5 @@
 import process from 'node:process';
 
-import type { Plugin } from 'rolldown';
 import { defineConfig } from 'rolldown';
 
 // rolldown plugins
@@ -10,39 +9,6 @@ import nodePolyfills from '@rolldown/plugin-node-polyfills';
 import postcssUrl from 'postcss-url';
 import copy from 'rollup-plugin-copy';
 import postcss from 'rollup-plugin-postcss';
-
-import path from 'path';
-import { fileURLToPath } from 'url';
-
-const _filename = fileURLToPath(import.meta.url);
-const _dirname = path.dirname(_filename);
-
-/**
- * Workaround for oxc printer lone-surrogate bug (https://github.com/oxc-project/oxc/issues/3526).
- * The oxc codegen replaces lone surrogates (0xD800-0xDFFF) with U+FFFD in long CJS strings,
- * corrupting ANTLR ATN serialized data which uses surrogates as raw char codes.
- * This plugin converts the string literals to numeric char code arrays before the printer
- * sees them. Can be removed once the upstream fix fully covers CJS long strings.
- */
-function preserveAntlrATN(): Plugin {
-  const segmentPattern =
-    /(\w+\._serializedATNSegment\d+)\s*=\s*("(?:[^"\\]|\\.)*"(?:\s*\+\s*"(?:[^"\\]|\\.)*")*)\s*;/g;
-
-  return {
-    name: 'preserve-antlr-atn',
-    transform(code, id) {
-      if (!id.includes('node_modules') || !/_serializedATNSegment\d+\s*=/.test(code)) {
-        return;
-      }
-
-      return code.replace(segmentPattern, (_match, varName: string, expr: string) => {
-        const str = new Function(`return ${expr}`)() as string;
-        const charCodes = Array.from(str, (c) => c.charCodeAt(0));
-        return `${varName} = String.fromCharCode(${charCodes.join(',')});`;
-      });
-    },
-  };
-}
 
 const production = process.env.NODE_ENV === 'production';
 export default defineConfig([
@@ -59,14 +25,8 @@ export default defineConfig([
     },
     tsconfig: production ? './lana/tsconfig.json' : './lana/tsconfig-dev.json',
     platform: 'node',
-    resolve: {
-      alias: {
-        'apex-log-parser': path.resolve(_dirname, 'apex-log-parser/src/index.ts'),
-      },
-    },
 
     external: ['vscode'],
-    plugins: [preserveAntlrATN()],
   },
   {
     input: { bundle: './log-viewer/src/Main.ts' },
@@ -82,9 +42,6 @@ export default defineConfig([
       },
     ],
     platform: 'browser',
-    resolve: {
-      alias: { eventemitter3: path.resolve(_dirname, 'node_modules/eventemitter3/index.js') },
-    },
     moduleTypes: {
       '.css': 'js',
     },
@@ -94,7 +51,7 @@ export default defineConfig([
       postcss({
         extensions: ['.css', '.scss'],
         minimize: true,
-        plugins: [postcssUrl({ url: 'inline', encodeType: 'base64' })],
+        plugins: [postcssUrl({ url: 'inline' })],
       }),
       copy({
         hook: 'closeBundle',

--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -32,10 +32,6 @@ export default [
       alias({
         entries: [
           {
-            find: 'apex-log-parser',
-            replacement: path.resolve(_dirname, 'apex-log-parser/src/index.ts'),
-          },
-          {
             find: 'antlr4',
             replacement: path.resolve(_dirname, 'node_modules/antlr4/dist/antlr4.node.mjs'),
           },
@@ -100,10 +96,6 @@ export default [
       alias({
         entries: [
           {
-            find: 'eventemitter3',
-            replacement: path.resolve(_dirname, 'node_modules/eventemitter3/index.js'),
-          },
-          {
             find: 'antlr4',
             replacement: path.resolve(_dirname, 'node_modules/antlr4/dist/antlr4.web.mjs'),
           },
@@ -119,6 +111,7 @@ export default [
         defineRollupSwcOption({
           // All options are optional
           include: /\.[mc]?[jt]sx?$/,
+
           exclude: 'node_modules',
           tsconfig: production ? './log-viewer/tsconfig.json' : './log-viewer/tsconfig-dev.json',
           jsc: {
@@ -137,7 +130,7 @@ export default [
       postcss({
         extensions: ['.css', '.scss'],
         minimize: true,
-        plugins: [postcssUrl({ url: 'inline', encodeType: 'base64' })],
+        plugins: [postcssUrl({ url: 'inline' })],
       }),
       copy({
         hook: 'closeBundle',


### PR DESCRIPTION
# 📝 PR Overview

Removes three build-config workarounds that dependency upgrades have made obsolete or redundant, and resolves the internal `apex-log-parser` package via standard `exports` instead of per-bundler aliases. No behavioral change — both bundles verified byte-identical (except the intended alias/plugin removals).

## 🛠️ Changes made

- Add `exports` (`{ ".": "./src/index.ts" }`) to `apex-log-parser/package.json` so rollup and rolldown resolve the internal package via standard resolution; drop the per-bundler `apex-log-parser` aliases.
- Drop the `eventemitter3` alias from both bundlers — pixi v8 resolves it without CJS pinning. (Rollup now emits a benign `eventemitter3` self-circular-dependency warning; accepted.)
- Remove the inert `preserveAntlrATN` rolldown plugin (+ orphaned imports): `@apexdevtools/apex-parser` (antlr4 4.13) emits a number-array ATN, immune to the oxc lone-surrogate bug the plugin guarded.
- Drop redundant `postcss-url` `encodeType: 'base64'` — verified byte-identical output; it only affects file `url()` refs, which already default to base64.

## 🧩 Type of change (check all applicable)

- [ ] 🐛 Bug fix - something not working as expected
- [ ] ✨ New feature – adds new functionality
- [ ] ♻️ Refactor - internal changes with no user impact
- [ ] ⚡ Performance Improvement
- [ ] 📝 Documentation - README or documentation site changes
- [x] 🔧 Chore - dev tooling, CI, config
- [ ] 💥 Breaking change

## 📷 Screenshots / gifs / video [optional]

_N/A — build config only._

## ✅ Tests added?

- [ ] 👍 yes
- [x] 🙅 no, not needed
- [ ] 🙋 no, I need help

## 📚 Docs updated?

- [ ] 🔖 README.md
- [ ] 🔖 CHANGELOG.md
- [ ] 📖 help site
- [ ] 🧪 Marked any pre-release-only features (README `🧪` badge — see [RELEASING.md](../RELEASING.md#-marking-pre-release-only-features))
- [x] 🙅 not needed

## Anything else we need to know? [optional]

The `antlr4` alias is deliberately **kept**: rollup's `node-resolve` doesn't request the `node` export condition by default, and antlr4's `exports` have no `default` fallback, so removing it breaks the lana bundle's antlr4 resolution (verified). Verified locally: `pnpm build`, `pnpm build:fast`, 962 tests, prettier, and eslint (real source) all pass; both bundles byte-identical apart from the intended removals.