### PR TITLE
chore(vscode): add worktree debug launch config

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -14,6 +14,20 @@
       "localRoot": "${workspaceFolder}/lana"
     },
     {
+      // Debug a worktree's build from the root window. Enter the worktree path,
+      // relative to the repo root, when prompted (the box pre-fills a common
+      // location). Run the "watch: worktree" task first for rebuild-on-change.
+      "name": "Run Extension (Worktree)",
+      "type": "extensionHost",
+      "request": "launch",
+      "args": [
+        "--extensionDevelopmentPath=${workspaceFolder}/${input:worktree}/lana",
+        "--disable-extensions"
+      ],
+      "outFiles": ["${workspaceFolder}/${input:worktree}/lana/out/**/*.js"],
+      "localRoot": "${workspaceFolder}/${input:worktree}/lana"
+    },
+    {
       "name": "Extension Tests",
       "type": "extensionHost",
       "request": "launch",
@@ -24,6 +38,14 @@
       "outFiles": ["${workspaceFolder}/lana/out/test/**/*.js"],
       "preLaunchTask": "${defaultBuildTask}",
       "localRoot": "${workspaceFolder}/lana"
+    }
+  ],
+  "inputs": [
+    {
+      "id": "worktree",
+      "type": "promptString",
+      "description": "Worktree path relative to the repo root (e.g. .claude/worktrees/<name> or ../<sibling>)",
+      "default": ".claude/worktrees/"
     }
   ]
 }


### PR DESCRIPTION
# 📝 PR Overview

Adds a **Run Extension (Worktree)** debug configuration so a git worktree's build can be launched and debugged from the root VS Code window, without opening each worktree in its own window.

## 🛠️ Changes made

- Add a `Run Extension (Worktree)` launch config that prompts for a worktree path and loads that checkout's `lana` in the Extension Development Host (breakpoints intact).
- Drive the path via a `${input:worktree}` promptString (`${workspaceFolder}/${input:worktree}/lana`) instead of hardcoding `.claude/worktrees/`, so Claude Code worktrees and `../sibling` checkouts both work.
- Pre-fill `.claude/worktrees/` as the input default for convenience — overridable per launch, so the config stays location-agnostic.

## 🧩 Type of change (check all applicable)

- [ ] 🐛 Bug fix - something not working as expected
- [ ] ✨ New feature – adds new functionality
- [ ] ♻️ Refactor - internal changes with no user impact
- [ ] ⚡ Performance Improvement
- [ ] 📝 Documentation - README or documentation site changes
- [x] 🔧 Chore - dev tooling, CI, config
- [ ] 💥 Breaking change

## 📷 Screenshots / gifs / video [optional]

_No UI changes._

## 🔗 Related Issues

_None._

## ✅ Tests added?

- [ ] 👍 yes
- [x] 🙅 no, not needed
- [ ] 🙋 no, I need help

## 📚 Docs updated?

- [ ] 🔖 README.md
- [ ] 🔖 CHANGELOG.md
- [ ] 📖 help site
- [ ] 🧪 Marked any pre-release-only features (README `🧪` badge — see [RELEASING.md](../RELEASING.md#-marking-pre-release-only-features))
- [x] 🙅 not needed

## Anything else we need to know? [optional]

The matching `watch: worktree` task lives in `.vscode/tasks.json`, which is git-ignored, so it is intentionally not part of this PR.