### PR TITLE
build(rollup): fix swc node_modules exclude and drop antlr4 aliases

### DIFF
--- a/lana/package.json
+++ b/lana/package.json
@@ -336,8 +336,7 @@
     "@apexdevtools/apex-ls": "^6.0.2",
     "@apexdevtools/apex-parser": "5.1.0-beta.1",
     "@salesforce/apex-node": "^8.4.28",
-    "@salesforce/core": "^8.31.2",
-    "antlr4": "4.13.2"
+    "@salesforce/core": "^8.31.2"
   },
   "devDependencies": {
     "@types/jest": "^30.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -130,9 +130,6 @@ importers:
       '@salesforce/core':
         specifier: ^8.31.2
         version: 8.31.2
-      antlr4:
-        specifier: 4.13.2
-        version: 4.13.2
     devDependencies:
       '@types/jest':
         specifier: ^30.0.0

--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -1,9 +1,6 @@
-import path from 'node:path';
 import process from 'node:process';
-import { fileURLToPath } from 'node:url';
 
 // Rollup plugins
-import alias from '@rollup/plugin-alias';
 import commonjs from '@rollup/plugin-commonjs';
 import json from '@rollup/plugin-json';
 import { nodeResolve } from '@rollup/plugin-node-resolve';
@@ -12,9 +9,6 @@ import copy from 'rollup-plugin-copy';
 import nodePolyfills from 'rollup-plugin-polyfill-node';
 import postcss from 'rollup-plugin-postcss';
 import { defineRollupSwcOption, swc } from 'rollup-plugin-swc3';
-
-const _filename = fileURLToPath(import.meta.url);
-const _dirname = path.dirname(_filename);
 
 const production = process.env.NODE_ENV === 'production';
 export default [
@@ -29,21 +23,16 @@ export default [
 
     external: ['vscode'],
     plugins: [
-      alias({
-        entries: [
-          {
-            find: 'antlr4',
-            replacement: path.resolve(_dirname, 'node_modules/antlr4/dist/antlr4.node.mjs'),
-          },
-        ],
-      }),
-      nodeResolve({ preferBuiltins: true }),
+      // 'node' isn't applied by default, but antlr4's exports map has only node/browser
+      // conditions (no default) so it fails to resolve without it (rolldown gets this
+      // from platform: 'node').
+      nodeResolve({ preferBuiltins: true, exportConditions: ['node'] }),
       commonjs(),
       json(),
       swc(
         defineRollupSwcOption({
           include: /\.[mc]?[jt]sx?$/,
-          exclude: 'node_modules',
+          exclude: /node_modules/,
           tsconfig: production ? './lana/tsconfig.json' : './lana/tsconfig-dev.json',
           jsc: {
             minify: {
@@ -93,14 +82,6 @@ export default [
       },
     ],
     plugins: [
-      alias({
-        entries: [
-          {
-            find: 'antlr4',
-            replacement: path.resolve(_dirname, 'node_modules/antlr4/dist/antlr4.web.mjs'),
-          },
-        ],
-      }),
       nodeResolve({
         browser: true,
         preferBuiltins: false,
@@ -111,8 +92,7 @@ export default [
         defineRollupSwcOption({
           // All options are optional
           include: /\.[mc]?[jt]sx?$/,
-
-          exclude: 'node_modules',
+          exclude: /node_modules/,
           tsconfig: production ? './log-viewer/tsconfig.json' : './log-viewer/tsconfig-dev.json',
           jsc: {
             transform: { useDefineForClassFields: false },


### PR DESCRIPTION
# 📝 PR Overview

Fixes the production webview crashing at eval with `TypeError: Class extends value undefined` when built with rollup (`pnpm build` / `pnpm build:dev`), and removes the antlr4 aliases so the rollup config needs no resolution workarounds — matching the rolldown config.

## 🛠️ Changes made

- Change the swc plugin `exclude` from the string `'node_modules'` to the regex `/node_modules/` in both bundles: a string is a cwd-anchored picomatch glob that matches nothing *inside* node_modules, so swc's TS-style `resolveId` was rewriting package-internal imports — eventemitter3's `index.mjs -> ./index.js` hit swc's extension priority (`.mjs` before `.js`) and resolved back to `index.mjs`, collapsing into a self-circular module (`var EventEmitter = EventEmitter`) that left every pixi `class X extends EventEmitter` extending `undefined`
- Add `exportConditions: ['node']` to the lana bundle's `nodeResolve`: antlr4's `exports` map has only `node`/`browser` conditions with no `default` fallback, which is the actual reason the alias was added — rolldown gets the condition automatically from `platform: 'node'`
- Remove both antlr4 aliases and lana's `antlr4` direct dep: the node bundle now resolves apex-parser's own bundled antlr4 copy (it's a `bundledDependency`), and the browser bundle never imports antlr4 at all (apex-parser's browser build inlines it — output is byte-identical with the alias removed)

## 🧩 Type of change (check all applicable)

- [x] 🐛 Bug fix - something not working as expected
- [ ] ✨ New feature – adds new functionality
- [ ] ♻️ Refactor - internal changes with no user impact
- [ ] ⚡ Performance Improvement
- [ ] 📝 Documentation - README or documentation site changes
- [x] 🔧 Chore - dev tooling, CI, config
- [ ] 💥 Breaking change

## ✅ Tests added?

- [ ] 👍 yes
- [x] 🙅 no, not needed

Build-config fix; verified with the existing suite (962 tests green) plus a browser smoke test of the dev and production bundles (bundle evaluates, `app-header`/`log-viewer` custom elements register) and bundle inspection (no `var EventEmitter = EventEmitter` self-assignment, single antlr4 copy in the lana bundle, byte-identical log-viewer output).

## 📚 Docs updated?

- [ ] 🔖 README.md
- [ ] 🔖 CHANGELOG.md
- [ ] 📖 help site
- [ ] 🧪 Marked any pre-release-only features (README `🧪` badge — see [RELEASING.md](../RELEASING.md#-marking-pre-release-only-features))
- [x] 🙅 not needed

## Anything else we need to know? [optional]

The regression came from #829, which removed the eventemitter3 alias on the assumption the resolution workaround was obsolete — the rollup `eventemitter3 index.mjs -> index.mjs` circular-dependency warning it accepted as benign was actually the symptom. That warning is gone with this fix. Only the rollup path was affected; rolldown (`build:fast`) was always fine.