### PR TITLE
refactor(log-viewer): replace webview-ui-toolkit with vscode-elements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+- ♻️ Replaced the deprecated `webview-ui-toolkit` with [vscode-elements](https://github.com/vscode-elements/elements) for all UI controls. ([#576])
+
 ## [1.20.0] 2026-06-18
 
 ### Added
@@ -484,6 +490,10 @@ Skipped due to adopting odd numbering for pre releases and even number for relea
 - Misc Visual tweaks.
 - Add explorer menu item.
 - Provide more information when selecting log to download.
+
+<!-- Unreleased -->
+
+[#576]: https://github.com/certinia/debug-log-analyzer/issues/576
 
 <!-- v1.20.0 -->
 

--- a/lana/src/commands/LogView.ts
+++ b/lana/src/commands/LogView.ts
@@ -53,9 +53,12 @@ export class LogView {
     const logViewerRoot = join(context.context.extensionPath, 'out');
     const index = join(logViewerRoot, 'index.html');
     const bundleUri = panel.webview.asWebviewUri(Uri.file(join(logViewerRoot, 'bundle.js')));
+    const codiconUri = panel.webview.asWebviewUri(Uri.file(join(logViewerRoot, 'codicon.css')));
     const indexSrc = await this.getFile(index);
     panel.iconPath = Uri.file(join(logViewerRoot, 'certinia-icon-color.png'));
-    panel.webview.html = indexSrc.replace(/bundle\.js/gi, bundleUri.toString(true));
+    panel.webview.html = indexSrc
+      .replace(/bundle\.js/gi, bundleUri.toString(true))
+      .replace(/codicon\.css/gi, codiconUri.toString(true));
 
     panel.onDidDispose(
       () => {

--- a/log-viewer/index.html
+++ b/log-viewer/index.html
@@ -8,6 +8,9 @@
       name="description"
       content="Analyze Salesforce Apex Debug logs - Instantly visualize and debug Apex logs with interactive flame charts, dynamic call trees, and detailed SOQL/DML breakdowns. Identify performance bottlenecks, gain deep insight into complex transactions and optimize slow Apex methods"
     />
+    <!-- href is rewritten to a webview URI by the extension (see LogView.ts); required by
+         @vscode-elements' vscode-icon, which reads this link by id for the codicon font -->
+    <link rel="stylesheet" id="vscode-codicon-stylesheet" href="codicon.css" />
     <style>
       html {
         width: 100%;

--- a/log-viewer/package.json
+++ b/log-viewer/package.json
@@ -4,10 +4,13 @@
   "private": true,
   "scripts": {},
   "version": "0.1.0",
+  "imports": {
+    "#vscode-elements/*.js": "@vscode-elements/elements/dist/*/index.js"
+  },
   "dependencies": {
     "@apexdevtools/apex-parser": "5.1.0-beta.1",
+    "@vscode-elements/elements": "^2.5.1",
     "@vscode/codicons": "^0.0.45",
-    "@vscode/webview-ui-toolkit": "^1.4.0",
     "antlr4": "4.13.2",
     "lit": "^3.3.3",
     "pixi.js": "^8.19.0",

--- a/log-viewer/src/Main.ts
+++ b/log-viewer/src/Main.ts
@@ -3,27 +3,10 @@
  */
 import { html, render } from 'lit';
 
-// styles
-import codiconStyles from '@vscode/codicons/dist/codicon.css';
-
 // web components
 import './features/app/LogViewer';
 
-/**
- * vscode-icon requires a page-level stylesheet link with this id, which it
- * clones into its shadow root for the codicon font. Serve the bundled css
- * (font inlined as a data URI) via a blob URL so no external asset is needed.
- */
-function injectCodiconStylesheet(): void {
-  const link = document.createElement('link');
-  link.id = 'vscode-codicon-stylesheet';
-  link.rel = 'stylesheet';
-  link.href = URL.createObjectURL(new Blob([String(codiconStyles)], { type: 'text/css' }));
-  document.head.appendChild(link);
-}
-
 function onInit(): void {
-  injectCodiconStylesheet();
   render(html`<log-viewer></log-viewer>`, document.body);
 }
 

--- a/log-viewer/src/Main.ts
+++ b/log-viewer/src/Main.ts
@@ -3,10 +3,27 @@
  */
 import { html, render } from 'lit';
 
+// styles
+import codiconStyles from '@vscode/codicons/dist/codicon.css';
+
 // web components
 import './features/app/LogViewer';
 
+/**
+ * vscode-icon requires a page-level stylesheet link with this id, which it
+ * clones into its shadow root for the codicon font. Serve the bundled css
+ * (font inlined as a data URI) via a blob URL so no external asset is needed.
+ */
+function injectCodiconStylesheet(): void {
+  const link = document.createElement('link');
+  link.id = 'vscode-codicon-stylesheet';
+  link.rel = 'stylesheet';
+  link.href = URL.createObjectURL(new Blob([String(codiconStyles)], { type: 'text/css' }));
+  document.head.appendChild(link);
+}
+
 function onInit(): void {
+  injectCodiconStylesheet();
   render(html`<log-viewer></log-viewer>`, document.body);
 }
 

--- a/log-viewer/src/components/BadgeBase.ts
+++ b/log-viewer/src/components/BadgeBase.ts
@@ -1,15 +1,13 @@
 /*
  * Copyright (c) 2021 Certinia Inc. All rights reserved.
  */
-import { provideVSCodeDesignSystem, vsCodeTag } from '@vscode/webview-ui-toolkit';
+import '#vscode-elements/vscode-badge.js';
 import { LitElement, css, html } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
 
 // styles
 import { globalStyles } from '../styles/global.styles.js';
 import { skeletonStyles } from '../styles/skeleton.styles.js';
-
-provideVSCodeDesignSystem().register(vsCodeTag());
 
 @customElement('badge-base')
 export class BadgeBase extends LitElement {
@@ -28,35 +26,30 @@ export class BadgeBase extends LitElement {
     globalStyles,
     skeletonStyles,
     css`
-      :host {
-      }
-
       .tag {
+        --vscode-font-family: monospace;
+        --vscode-badge-background: var(--vscode-toolbar-hoverBackground, rgba(90, 93, 94, 0.31));
+        --vscode-badge-foreground: var(--vscode-editor-foreground);
+
         font-family: monospace;
         font-size: inherit;
       }
 
-      .tag::part(control) {
-        color: var(--vscode-editor-foreground);
-        background-color: var(--button-icon-hover-background, rgba(90, 93, 94, 0.31));
-        text-transform: inherit;
-        border: none;
-      }
-      .success-tag::part(control) {
-        background-color: rgba(128, 255, 128, 0.2);
+      .success-tag {
+        --vscode-badge-background: rgba(128, 255, 128, 0.2);
       }
 
-      .failure-tag::part(control) {
-        background-color: var(--notification-error-background);
+      .failure-tag {
+        --vscode-badge-background: var(--notification-error-background);
       }
     `,
   ];
 
   render() {
     if (this.isloading) {
-      return html`<vscode-tag class="tag skeleton">&nbsp;</vscode-tag>`;
+      return html`<vscode-badge class="tag skeleton">&nbsp;</vscode-badge>`;
     }
     const statusTag = this.colorMap.get(this.status);
-    return html`<vscode-tag class="tag ${statusTag}"><slot></slot></vscode-tag>`;
+    return html`<vscode-badge class="tag ${statusTag}"><slot></slot></vscode-badge>`;
   }
 }

--- a/log-viewer/src/components/IconButton.ts
+++ b/log-viewer/src/components/IconButton.ts
@@ -1,33 +1,24 @@
 /*
  * Copyright (c) 2025 Certinia Inc. All rights reserved.
  */
-import { provideVSCodeDesignSystem, vsCodeBadge, vsCodeButton } from '@vscode/webview-ui-toolkit';
-import { LitElement, css, html, unsafeCSS } from 'lit';
+import '#vscode-elements/vscode-toolbar-button.js';
+import { LitElement, css, html } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
 
 // styles
-import codiconStyles from '@vscode/codicons/dist/codicon.css';
 import { globalStyles } from '../styles/global.styles.js';
-
-provideVSCodeDesignSystem().register(vsCodeButton(), vsCodeBadge());
 
 @customElement('icon-button')
 export class IconButton extends LitElement {
   static styles = [
     globalStyles,
-    unsafeCSS(codiconStyles),
     css`
-      vscode-button {
-        --button-icon-hover-background: var(--vscode-toolbar-hoverBackground);
-
-        height: 22px;
-        width: 22px;
+      .menu-container {
+        position: relative;
+        display: inline-flex;
       }
 
-      .badge-indicator::part(control) {
-        --design-unit: 0;
-        --border-width: 0;
-
+      .badge-indicator {
         background-color: var(--vscode-activityBarBadge-background);
         color: var(--vscode-activityBarBadge-foreground);
         position: absolute;
@@ -43,6 +34,7 @@ export class IconButton extends LitElement {
         text-align: center;
         display: inline-block;
         box-sizing: border-box;
+        pointer-events: none;
       }
     `,
   ];
@@ -62,14 +54,17 @@ export class IconButton extends LitElement {
   render() {
     const indicator =
       this.badgeCount !== null && this.badgeCount !== undefined
-        ? html`<vscode-badge class="badge-indicator">${this.badgeCount}</vscode-badge> `
+        ? html`<span class="badge-indicator">${this.badgeCount}</span>`
         : ``;
 
     return html`<div class="menu-container">
-      <vscode-button appearance="icon" aria-label="${this.ariaLabel}" title="${this.title}">
-        <span class="codicon ${this.icon}"></span>
-        ${indicator}
-      </vscode-button>
+      <!-- keep the element empty: whitespace counts as slotted content and adds text padding -->
+      <vscode-toolbar-button
+        icon="${this.icon}"
+        label="${this.ariaLabel}"
+        title="${this.title}"
+      ></vscode-toolbar-button>
+      ${indicator}
     </div>`;
   }
 }

--- a/log-viewer/src/components/LogLevels.ts
+++ b/log-viewer/src/components/LogLevels.ts
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2023 Certinia Inc. All rights reserved.
  */
+import '#vscode-elements/vscode-badge.js';
 import { LitElement, css, html } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
 import { repeat } from 'lit/directives/repeat.js';
@@ -32,10 +33,11 @@ export class LogLevels extends LitElement {
         font-family: var(--vscode-editor-font-family);
       }
 
-      vscode-tag::part(control) {
-        --badge-background: var(--vscode-textBlockQuote-background);
-        --button-border: none;
-        --badge-foreground: none;
+      vscode-badge {
+        --vscode-badge-background: var(--vscode-textBlockQuote-background);
+        --vscode-badge-foreground: var(--vscode-editor-foreground);
+        --vscode-font-family: var(--vscode-editor-font-family);
+
         font-family: var(--vscode-editor-font-family);
         font-size: 0.9rem;
       }
@@ -70,10 +72,10 @@ export class LogLevels extends LitElement {
     return html`${repeat(
       this.logSettings,
       ({ logCategory, logLevel }) =>
-        html`<vscode-tag>
+        html`<vscode-badge>
           <span class="setting__title">${logCategory}:</span>
           <span class="setting__level">${logLevel}</span>
-        </vscode-tag>`,
+        </vscode-badge>`,
     )}`;
   }
 }

--- a/log-viewer/src/components/LogProblems.ts
+++ b/log-viewer/src/components/LogProblems.ts
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2023 Certinia Inc. All rights reserved.
  */
-import { provideVSCodeDesignSystem, vsCodeBadge, vsCodeButton } from '@vscode/webview-ui-toolkit';
+import '#vscode-elements/vscode-button.js';
 import { LitElement, css, html, type TemplateResult } from 'lit';
 import { customElement, property, state } from 'lit/decorators.js';
 
@@ -18,8 +18,6 @@ import './BadgeBase.js';
 import './Divider.js';
 import './IconButton.js';
 import './IconButtonSkeleton.js';
-
-provideVSCodeDesignSystem().register(vsCodeButton(), vsCodeBadge());
 
 @customElement('log-problems')
 export class NotificationTag extends LitElement {
@@ -55,8 +53,6 @@ export class NotificationTag extends LitElement {
     skeletonStyles,
     css`
       :host {
-        --button-icon-hover-background: var(--vscode-toolbar-hoverBackground);
-
         ${notificationStyles}
         display: inline-flex;
         flex: 0 0 auto;
@@ -125,7 +121,7 @@ export class NotificationTag extends LitElement {
       <icon-button
         ariaLabel="${title}"
         title="${title}"
-        icon="codicon-warning"
+        icon="warning"
         .badgeCount="${count}"
         @click=${this._togglePanel}
       ></icon-button>

--- a/log-viewer/src/components/LogTitle.ts
+++ b/log-viewer/src/components/LogTitle.ts
@@ -1,7 +1,6 @@
 /*
  * Copyright (c) 2021 Certinia Inc. All rights reserved.
  */
-import { provideVSCodeDesignSystem, vsCodeButton } from '@vscode/webview-ui-toolkit';
 import { LitElement, css, html } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
 
@@ -10,8 +9,6 @@ import { vscodeMessenger } from '../core/messaging/VSCodeExtensionMessenger.js';
 import { globalStyles } from '../styles/global.styles.js';
 import { skeletonStyles } from '../styles/skeleton.styles.js';
 
-provideVSCodeDesignSystem().register(vsCodeButton());
-
 @customElement('log-title')
 export class LogTitle extends LitElement {
   @property()
@@ -19,9 +16,7 @@ export class LogTitle extends LitElement {
 
   @property()
   logPath = '';
-  /**
-   * --button-icon styles come from @vscode/webview-ui-toolkit as they are hardcoded in vscode at the moment. @vscode/webview-ui-toolkit needs to be in use for these to work.
-   */
+
   static styles = [
     globalStyles,
     skeletonStyles,
@@ -40,8 +35,8 @@ export class LogTitle extends LitElement {
       .title-item {
         padding-block: 2px;
         padding-inline: 6px;
-        background: var(--button-icon-background, rgba(90, 93, 94, 0.31));
-        border-radius: var(--button-icon-corner-radius, 5px);
+        background: transparent;
+        border-radius: 5px;
         font-weight: var(--text-weight-semibold, 600);
         font-size: 1.1rem;
         overflow: hidden;

--- a/log-viewer/src/components/NavBar.ts
+++ b/log-viewer/src/components/NavBar.ts
@@ -1,8 +1,8 @@
 /*
  * Copyright (c) 2023 Certinia Inc. All rights reserved.
  */
-import { provideVSCodeDesignSystem, vsCodeButton } from '@vscode/webview-ui-toolkit';
-import { LitElement, css, html, unsafeCSS } from 'lit';
+import '#vscode-elements/vscode-toolbar-button.js';
+import { LitElement, css, html } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
 
 import { vscodeMessenger } from '../core/messaging/VSCodeExtensionMessenger.js';
@@ -10,7 +10,6 @@ import { formatDuration } from '../core/utility/Util.js';
 import type { Notification } from '../features/notifications/components/NotificationPanel.js';
 
 // styles
-import codiconStyles from '@vscode/codicons/dist/codicon.css';
 import { globalStyles } from '../styles/global.styles.js';
 import { notificationStyles } from '../styles/notification.styles.js';
 
@@ -23,8 +22,6 @@ import './DotSeparator.js';
 import './LogMeta.js';
 import './LogProblems.js';
 import './LogTitle.js';
-
-provideVSCodeDesignSystem().register(vsCodeButton());
 
 @customElement('nav-bar')
 export class NavBar extends LitElement {
@@ -48,21 +45,13 @@ export class NavBar extends LitElement {
 
   static styles = [
     globalStyles,
-    unsafeCSS(codiconStyles),
     css`
       :host {
-        --button-icon-hover-background: var(--vscode-toolbar-hoverBackground);
-
         display: flex;
         flex-direction: column;
         justify-content: center;
         color: var(--vscode-editor-foreground);
         ${notificationStyles}
-      }
-
-      vscode-button {
-        height: 22px;
-        width: 22px;
       }
 
       .navbar {
@@ -117,16 +106,14 @@ export class NavBar extends LitElement {
         </div>
         <div class="navbar--right">
           <notification-button .notifications="${this.parserIssues}"></notification-button>
-          <vscode-button
-            appearance="icon"
-            aria-label="Help"
+          <vscode-toolbar-button
+            icon="question"
+            label="Help"
             title="Help"
             @click=${() => {
               vscodeMessenger.send('openHelp');
             }}
-          >
-            <span class="codicon codicon-question"></span>
-          </vscode-button>
+          ></vscode-toolbar-button>
         </div>
       </div>
     `;

--- a/log-viewer/src/components/VsIconCheckbox.ts
+++ b/log-viewer/src/components/VsIconCheckbox.ts
@@ -1,60 +1,38 @@
-import { provideVSCodeDesignSystem, vsCodeButton } from '@vscode/webview-ui-toolkit';
-import { LitElement, css, html, unsafeCSS } from 'lit';
+import '#vscode-elements/vscode-toolbar-button.js';
+import { LitElement, css, html } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
 
 // styles
-import codiconStyles from '@vscode/codicons/dist/codicon.css';
 import { globalStyles } from '../styles/global.styles.js';
-
-provideVSCodeDesignSystem().register(vsCodeButton());
 
 @customElement('vs-icon-checkbox')
 export class VsIconCheckbox extends LitElement {
   static shadowRootOptions = { ...LitElement.shadowRootOptions, delegatesFocus: true };
 
+  @property() icon = '';
   @property() showSelected = false;
   @property() checked = false;
   @property() title = '';
 
   static styles = [
     globalStyles,
-    unsafeCSS(codiconStyles),
     css`
       :host {
-        --button-icon-hover-background: var(--vscode-toolbar-hoverBackground);
-
         display: flex;
-      }
-
-      .icon-checkbox.checked {
-        color: var(--vscode-inputOption-activeForeground);
-        border: 1px solid var(--vscode-inputOption-activeBorder);
-        background: var(--vscode-inputOption-activeBackground);
-      }
-
-      .icon-checkbox {
-        border: 1px solid transparent;
-        cursor: pointer;
-        user-select: none;
-        -webkit-user-select: none;
-        justify-content: center;
-        box-sizing: border-box;
-        width: 22px;
-        height: 22px;
       }
     `,
   ];
 
   render() {
-    return html`<vscode-button
-      appearance="icon"
-      class="icon-checkbox ${this.checked && this.showSelected ? 'checked' : ''}"
-      aria-label="${this.title}"
+    // keep the element empty: whitespace counts as slotted content and adds text padding
+    return html`<vscode-toolbar-button
+      icon="${this.icon}"
+      ?toggleable="${this.showSelected}"
+      ?checked="${this.checked && this.showSelected}"
+      label="${this.title}"
       title="${this.title}"
       @click="${this._toggleChecked}"
-    >
-      <slot></slot>
-    </vscode-button>`;
+    ></vscode-toolbar-button>`;
   }
 
   _toggleChecked() {

--- a/log-viewer/src/components/VsSelect.ts
+++ b/log-viewer/src/components/VsSelect.ts
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2026 Certinia Inc. All rights reserved.
+ */
+import { VscodeSingleSelect } from '#vscode-elements/vscode-single-select.js';
+import { css } from 'lit';
+import { customElement } from 'lit/decorators.js';
+
+/** Reusable for a `VscodeMultiSelect` subclass if multi-select is ever needed. */
+export const selectSizingStyles = css`
+  :host {
+    width: fit-content;
+  }
+
+  .dropdown {
+    /* widens the popup past the control width the base sets as an inline
+       style: used width = max(width, min-width) */
+    min-width: max-content;
+  }
+`;
+
+/** vscode-single-select where the control fits the selected value and the popup its widest option. */
+@customElement('vs-select')
+export class VsSelect extends VscodeSingleSelect {
+  static styles = [...VscodeSingleSelect.styles, selectSizingStyles];
+}

--- a/log-viewer/src/components/datagrid-filter-bar.ts
+++ b/log-viewer/src/components/datagrid-filter-bar.ts
@@ -1,14 +1,11 @@
 /*
  * Copyright (c) 2021 Certinia Inc. All rights reserved.
  */
-import { provideVSCodeDesignSystem } from '@vscode/webview-ui-toolkit';
 import { LitElement, css, html } from 'lit';
 import { customElement } from 'lit/decorators.js';
 
 // styles
 import { globalStyles } from '../styles/global.styles.js';
-
-provideVSCodeDesignSystem().register();
 
 @customElement('datagrid-filter-bar')
 export class DatagridFilterBar extends LitElement {

--- a/log-viewer/src/features/analysis/components/AnalysisView.ts
+++ b/log-viewer/src/features/analysis/components/AnalysisView.ts
@@ -24,7 +24,6 @@ import { expandCollapseAll } from '../../call-tree/utils/ExpandCollapse.js';
 import dataGridStyles from '../../../tabulator/style/DataGrid.scss';
 
 // styles
-import codiconStyles from '@vscode/codicons/dist/codicon.css';
 import { globalStyles } from '../../../styles/global.styles.js';
 import { soqlSyntaxStyles } from '../../soql/styles/soql-syntax.css.js';
 
@@ -36,7 +35,6 @@ import '../../../components/datagrid-filter-bar.js';
 export class AnalysisView extends LitElement {
   static styles = [
     unsafeCSS(dataGridStyles),
-    unsafeCSS(codiconStyles),
     unsafeCSS(soqlSyntaxStyles),
     globalStyles,
     css`

--- a/log-viewer/src/features/analysis/components/AnalysisView.ts
+++ b/log-viewer/src/features/analysis/components/AnalysisView.ts
@@ -1,13 +1,11 @@
 /*
  * Copyright (c) 2022 Certinia Inc. All rights reserved.
  */
-import {
-  provideVSCodeDesignSystem,
-  vsCodeButton,
-  vsCodeCheckbox,
-  vsCodeDropdown,
-  vsCodeOption,
-} from '@vscode/webview-ui-toolkit';
+import '#vscode-elements/vscode-button.js';
+import '#vscode-elements/vscode-checkbox.js';
+import '#vscode-elements/vscode-option.js';
+import '../../../components/VsSelect.js';
+import '#vscode-elements/vscode-toolbar-button.js';
 import { LitElement, css, html, unsafeCSS, type PropertyValues } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
 import type { RowComponent, Tabulator } from 'tabulator-tables';
@@ -34,13 +32,6 @@ import { soqlSyntaxStyles } from '../../soql/styles/soql-syntax.css.js';
 import '../../../components/GridSkeleton.js';
 import '../../../components/datagrid-filter-bar.js';
 
-provideVSCodeDesignSystem().register(
-  vsCodeButton(),
-  vsCodeCheckbox(),
-  vsCodeDropdown(),
-  vsCodeOption(),
-);
-
 @customElement('analysis-view')
 export class AnalysisView extends LitElement {
   static styles = [
@@ -50,8 +41,6 @@ export class AnalysisView extends LitElement {
     globalStyles,
     css`
       :host {
-        --button-icon-hover-background: var(--vscode-toolbar-hoverBackground);
-
         height: 100%;
         width: 100%;
         display: flex;
@@ -93,6 +82,12 @@ export class AnalysisView extends LitElement {
         align-items: end;
       }
 
+      /* cancel the checkbox's built-in 4px vertical margins so it bottom-aligns
+         like the previous 18px-tall toolkit checkbox */
+      vscode-checkbox {
+        margin: -4px 0;
+      }
+
       .dropdown-container {
         box-sizing: border-box;
         display: flex;
@@ -110,10 +105,6 @@ export class AnalysisView extends LitElement {
           margin-bottom: 4px;
           user-select: none;
         }
-      }
-
-      vscode-dropdown::part(listbox) {
-        width: auto;
       }
     `,
     categoryColoringStyles,
@@ -177,14 +168,14 @@ export class AnalysisView extends LitElement {
         <datagrid-filter-bar>
           <div slot="filters" class="filter-container align__end">
             <vscode-button
-              appearance="secondary"
+              secondary
               aria-label="Expand all"
               title="Expand all"
               @click=${this._expandButtonClick}
               >Expand</vscode-button
             >
             <vscode-button
-              appearance="secondary"
+              secondary
               aria-label="Collapse all"
               title="Collapse all"
               @click=${this._collapseButtonClick}
@@ -197,37 +188,28 @@ export class AnalysisView extends LitElement {
 
             <div class="dropdown-container">
               <label id="groupby-dropdown-label" for="groupby-dropdown">Group by</label>
-              <vscode-dropdown
-                id="groupby-dropdown"
-                aria-label="Group by"
-                aria-labelledby="groupby-dropdown-label"
-                @change="${this._groupBy}"
-              >
+              <vs-select id="groupby-dropdown" label="Group by" @change="${this._groupBy}">
                 <vscode-option>None</vscode-option>
                 <vscode-option>Namespace</vscode-option>
                 <vscode-option>Caller Namespace</vscode-option>
                 <vscode-option>Type</vscode-option>
-              </vscode-dropdown>
+              </vs-select>
             </div>
           </div>
 
           <div slot="actions">
-            <vscode-button
-              appearance="icon"
-              aria-label="Export to CSV"
+            <vscode-toolbar-button
+              icon="desktop-download"
+              label="Export to CSV"
               title="Export to CSV"
               @click=${this._exportToCSV}
-            >
-              <span class="codicon codicon-desktop-download"></span>
-            </vscode-button>
-            <vscode-button
-              appearance="icon"
-              aria-label="Copy to clipboard"
+            ></vscode-toolbar-button>
+            <vscode-toolbar-button
+              icon="copy"
+              label="Copy to clipboard"
               title="Copy to clipboard"
               @click=${this._copyToClipboard}
-            >
-              <span class="codicon codicon-copy"></span>
-            </vscode-button>
+            ></vscode-toolbar-button>
           </div>
         </datagrid-filter-bar>
 

--- a/log-viewer/src/features/app/AppHeader.ts
+++ b/log-viewer/src/features/app/AppHeader.ts
@@ -1,12 +1,6 @@
 /*
  * Copyright (c) 2023 Certinia Inc. All rights reserved.
  */
-import {
-  provideVSCodeDesignSystem,
-  vsCodePanelTab,
-  vsCodePanelView,
-  vsCodePanels,
-} from '@vscode/webview-ui-toolkit';
 import { LitElement, css, html, unsafeCSS } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
 
@@ -25,8 +19,6 @@ import '../timeline/components/TimelineView.js';
 // styles
 import codiconStyles from '@vscode/codicons/dist/codicon.css';
 import { globalStyles } from '../../styles/global.styles.js';
-
-provideVSCodeDesignSystem().register(vsCodePanelTab(), vsCodePanelView(), vsCodePanels());
 
 @customElement('app-header')
 export class AppHeader extends LitElement {
@@ -58,7 +50,6 @@ export class AppHeader extends LitElement {
     `,
   ];
 
-  // TODO: use @change on vscode-panels to detect tab change instead of @click on <vscode-panel-tab
   render() {
     return html`
       <nav-bar

--- a/log-viewer/src/features/app/AppHeader.ts
+++ b/log-viewer/src/features/app/AppHeader.ts
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2023 Certinia Inc. All rights reserved.
  */
-import { LitElement, css, html, unsafeCSS } from 'lit';
+import { LitElement, css, html } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
 
 import type { ApexLog } from 'apex-log-parser';
@@ -17,7 +17,6 @@ import '../find/components/FindWidget.js';
 import '../timeline/components/TimelineView.js';
 
 // styles
-import codiconStyles from '@vscode/codicons/dist/codicon.css';
 import { globalStyles } from '../../styles/global.styles.js';
 
 @customElement('app-header')
@@ -39,7 +38,6 @@ export class AppHeader extends LitElement {
 
   static styles = [
     globalStyles,
-    unsafeCSS(codiconStyles),
     css`
       :host {
         background-color: var(--vscode-tab-activeBackground);

--- a/log-viewer/src/features/app/LogViewer.ts
+++ b/log-viewer/src/features/app/LogViewer.ts
@@ -1,11 +1,12 @@
 /*
  * Copyright (c) 2023 Certinia Inc. All rights reserved.
  */
+import '#vscode-elements/vscode-icon.js';
 import '#vscode-elements/vscode-tab-header.js';
 import '#vscode-elements/vscode-tab-panel.js';
 import '#vscode-elements/vscode-tabs.js';
 import type { VscTabsSelectEvent } from '@vscode-elements/elements/dist/vscode-tabs/vscode-tabs.js';
-import { LitElement, css, html, unsafeCSS } from 'lit';
+import { LitElement, css, html } from 'lit';
 import { customElement, property, state } from 'lit/decorators.js';
 
 import { parse, type ApexLog } from 'apex-log-parser';
@@ -20,7 +21,6 @@ import {
 } from '../notifications/components/NotificationPanel.js';
 
 // styles
-import codiconStyles from '@vscode/codicons/dist/codicon.css';
 import { globalStyles } from '../../styles/global.styles.js';
 
 // web components
@@ -65,7 +65,6 @@ export class LogViewer extends LitElement {
 
   static styles = [
     globalStyles,
-    unsafeCSS(codiconStyles),
     css`
       :host {
         display: flex;
@@ -146,16 +145,16 @@ export class LogViewer extends LitElement {
         @vsc-tabs-select="${this._onTabSelect}"
       >
         <vscode-tab-header slot="header">
-          <span class="tab-header"><span class="codicon codicon-graph"></span>Timeline</span>
+          <span class="tab-header"><vscode-icon name="graph"></vscode-icon>Timeline</span>
         </vscode-tab-header>
         <vscode-tab-header slot="header">
-          <span class="tab-header"><span class="codicon codicon-list-tree"></span>Call Tree</span>
+          <span class="tab-header"><vscode-icon name="list-tree"></vscode-icon>Call Tree</span>
         </vscode-tab-header>
         <vscode-tab-header slot="header">
-          <span class="tab-header"><span class="codicon codicon-code"></span>Analysis</span>
+          <span class="tab-header"><vscode-icon name="code"></vscode-icon>Analysis</span>
         </vscode-tab-header>
         <vscode-tab-header slot="header">
-          <span class="tab-header"><span class="codicon codicon-database"></span>Database</span>
+          <span class="tab-header"><vscode-icon name="database"></vscode-icon>Database</span>
         </vscode-tab-header>
 
         <vscode-tab-panel>

--- a/log-viewer/src/features/app/LogViewer.ts
+++ b/log-viewer/src/features/app/LogViewer.ts
@@ -1,6 +1,10 @@
 /*
  * Copyright (c) 2023 Certinia Inc. All rights reserved.
  */
+import '#vscode-elements/vscode-tab-header.js';
+import '#vscode-elements/vscode-tab-panel.js';
+import '#vscode-elements/vscode-tabs.js';
+import type { VscTabsSelectEvent } from '@vscode-elements/elements/dist/vscode-tabs/vscode-tabs.js';
 import { LitElement, css, html, unsafeCSS } from 'lit';
 import { customElement, property, state } from 'lit/decorators.js';
 
@@ -25,6 +29,10 @@ import './AppHeader.js';
 interface NavigateToTimelinePayload {
   timestamp: number;
 }
+
+// Tab ids in display order; vscode-tabs is index based so this maps
+// index <-> id for the string-id based 'show-tab' events used app-wide.
+const TAB_IDS = ['timeline-tab', 'tree-tab', 'analysis-tab', 'database-tab'];
 
 @customElement('log-viewer')
 export class LogViewer extends LitElement {
@@ -61,32 +69,38 @@ export class LogViewer extends LitElement {
         flex-direction: column;
         height: 100%;
         padding: 0px 8px 0px 8px;
-
-        --button-icon-hover-background: var(--vscode-toolbar-hoverBackground);
-        --panel-tab-active-foreground: var(--vscode-panelTitle-activeBorder);
-        --panel-tab-selected-text: var(--vscode-panelTitle-activeForeground, #e7e7e7);
       }
 
-      vscode-panels {
+      vscode-tabs {
+        --vscode-panel-background: var(--vscode-editor-background);
+
+        display: flex;
+        flex-direction: column;
         height: 100%;
+        min-height: 0;
       }
 
-      vscode-panels::part(tabpanel) {
+      vscode-tab-panel {
+        flex: 1;
+        min-height: 0;
         overflow: auto;
+        box-sizing: border-box;
+        /* the toolkit's vscode-panel-view padding */
+        padding: 10px 6px;
         box-shadow: inset 0 calc(max(1px, 0.0625rem) * 1)
           var(--vscode-panelSectionHeader-background);
       }
 
-      vscode-panel-view {
-        height: 100%;
-      }
-
-      vscode-panel-tab[aria-selected='true'] {
-        color: var(--panel-tab-selected-text);
-      }
-
-      vscode-panel-tab:hover {
-        color: var(--panel-tab-selected-text);
+      /* icon + label as one flex row, like the toolkit's tabs; also restores
+         the previous label styling — vscode-tab-header's panel mode defaults
+         to 11px uppercase */
+      vscode-tab-header .tab-header {
+        display: flex;
+        align-items: center;
+        column-gap: 0.3em;
+        font-family: var(--vscode-font-family);
+        font-size: var(--vscode-font-size, 13px);
+        text-transform: none;
       }
     `,
   ];
@@ -123,58 +137,48 @@ export class LogViewer extends LitElement {
         .timelineRoot=${this.timelineRoot}
       ></app-header>
 
-      <vscode-panels activeid="${this._selectedTab}">
-        <vscode-panel-tab
-          id="timeline-tab"
-          data-show="timeline-view"
-          @click="${this._showTabHTMLElem}"
-        >
-          <span class="codicon codicon-graph">&nbsp;</span>
-          <span>Timeline</span>
-        </vscode-panel-tab>
-        <vscode-panel-tab
-          id="tree-tab"
-          data-show="call-tree-view"
-          @click="${this._showTabHTMLElem}"
-        >
-          <span class="codicon codicon-list-tree">&nbsp;</span>
-          <span>Call Tree</span>
-        </vscode-panel-tab>
-        <vscode-panel-tab
-          id="analysis-tab"
-          data-show="analysis-view"
-          @click="${this._showTabHTMLElem}"
-        >
-          <span class="codicon codicon-code">&nbsp;</span>
-          <span>Analysis</span>
-        </vscode-panel-tab>
-        <vscode-panel-tab id="database-tab" data-show="db-view" @click="${this._showTabHTMLElem}">
-          <span class="codicon codicon-database">&nbsp;</span>
-          <span>Database</span>
-        </vscode-panel-tab>
+      <vscode-tabs
+        panel
+        .selectedIndex="${TAB_IDS.indexOf(this._selectedTab)}"
+        @vsc-tabs-select="${this._onTabSelect}"
+      >
+        <vscode-tab-header slot="header">
+          <span class="tab-header"><span class="codicon codicon-graph"></span>Timeline</span>
+        </vscode-tab-header>
+        <vscode-tab-header slot="header">
+          <span class="tab-header"><span class="codicon codicon-list-tree"></span>Call Tree</span>
+        </vscode-tab-header>
+        <vscode-tab-header slot="header">
+          <span class="tab-header"><span class="codicon codicon-code"></span>Analysis</span>
+        </vscode-tab-header>
+        <vscode-tab-header slot="header">
+          <span class="tab-header"><span class="codicon codicon-database"></span>Database</span>
+        </vscode-tab-header>
 
-        <vscode-panel-view id="view1">
+        <vscode-tab-panel>
           <timeline-view
             .timelineRoot="${this.timelineRoot}"
             .navigateToEventIndex="${this._navigateToEventIndex}"
             .navigateToTimestamp="${this._navigateToTimestamp}"
           ></timeline-view>
-        </vscode-panel-view>
-        <vscode-panel-view id="view2">
+        </vscode-tab-panel>
+        <vscode-tab-panel>
           <call-tree-view .timelineRoot="${this.timelineRoot}"></call-tree-view>
-        </vscode-panel-view>
-        <vscode-panel-view id="view3">
+        </vscode-tab-panel>
+        <vscode-tab-panel>
           <analysis-view .timelineRoot="${this.timelineRoot}"> </analysis-view>
-        </vscode-panel-view>
-        <vscode-panel-view id="view4">
+        </vscode-tab-panel>
+        <vscode-tab-panel>
           <database-view .timelineRoot="${this.timelineRoot}"></database-view>
-        </vscode-panel-view>
-      </vscode-panels>`;
+        </vscode-tab-panel>
+      </vscode-tabs>`;
   }
 
-  _showTabHTMLElem(e: Event) {
-    const input = e.currentTarget as HTMLElement;
-    this._showTab(input.id);
+  _onTabSelect(e: VscTabsSelectEvent) {
+    const tabId = TAB_IDS[e.detail.selectedIndex];
+    if (tabId) {
+      this._showTab(tabId);
+    }
   }
 
   _showTabEvent(e: Event) {

--- a/log-viewer/src/features/app/LogViewer.ts
+++ b/log-viewer/src/features/app/LogViewer.ts
@@ -55,6 +55,9 @@ export class LogViewer extends LitElement {
   _selectedTab = 'timeline-tab';
 
   @state()
+  _selectedIndex = 0;
+
+  @state()
   private _navigateToEventIndex: number | undefined = undefined;
 
   @state()
@@ -139,7 +142,7 @@ export class LogViewer extends LitElement {
 
       <vscode-tabs
         panel
-        .selectedIndex="${TAB_IDS.indexOf(this._selectedTab)}"
+        .selectedIndex="${this._selectedIndex}"
         @vsc-tabs-select="${this._onTabSelect}"
       >
         <vscode-tab-header slot="header">
@@ -189,6 +192,10 @@ export class LogViewer extends LitElement {
   _showTab(tabId: string) {
     if (this._selectedTab !== tabId) {
       this._selectedTab = tabId;
+      const index = TAB_IDS.indexOf(tabId);
+      if (index !== -1) {
+        this._selectedIndex = index;
+      }
 
       // Not really happy this is here, find needs a refactor
       const findEvt = {

--- a/log-viewer/src/features/call-tree/components/CalltreeView.ts
+++ b/log-viewer/src/features/call-tree/components/CalltreeView.ts
@@ -41,8 +41,6 @@ import { createAggregatedTable } from './AggregatedTable.js';
 import { createBottomUpTable } from './BottomUpTable.js';
 import { createTimeOrderTable } from './TimeOrderTable.js';
 
-import codiconStyles from '@vscode/codicons/dist/codicon.css';
-
 type ViewMode = 'time-order' | 'aggregated' | 'bottom-up';
 
 const DEBUG_VALUE_TYPES: ReadonlySet<string> = new Set([
@@ -146,7 +144,6 @@ export class CalltreeView extends LitElement {
 
   static styles = [
     unsafeCSS(dataGridStyles),
-    unsafeCSS(codiconStyles),
     unsafeCSS(soqlSyntaxStyles),
     globalStyles,
     css`

--- a/log-viewer/src/features/call-tree/components/CalltreeView.ts
+++ b/log-viewer/src/features/call-tree/components/CalltreeView.ts
@@ -1,13 +1,10 @@
 /*
  * Copyright (c) 2022 Certinia Inc. All rights reserved.
  */
-import {
-  provideVSCodeDesignSystem,
-  vsCodeButton,
-  vsCodeCheckbox,
-  vsCodeDropdown,
-  vsCodeOption,
-} from '@vscode/webview-ui-toolkit';
+import '#vscode-elements/vscode-button.js';
+import '#vscode-elements/vscode-checkbox.js';
+import '#vscode-elements/vscode-option.js';
+import '../../../components/VsSelect.js';
 import { css, html, LitElement, unsafeCSS, type PropertyValues } from 'lit';
 import { customElement, property, state } from 'lit/decorators.js';
 import { repeat } from 'lit/directives/repeat.js';
@@ -45,13 +42,6 @@ import { createBottomUpTable } from './BottomUpTable.js';
 import { createTimeOrderTable } from './TimeOrderTable.js';
 
 import codiconStyles from '@vscode/codicons/dist/codicon.css';
-
-provideVSCodeDesignSystem().register(
-  vsCodeButton(),
-  vsCodeCheckbox(),
-  vsCodeDropdown(),
-  vsCodeOption(),
-);
 
 type ViewMode = 'time-order' | 'aggregated' | 'bottom-up';
 
@@ -161,8 +151,6 @@ export class CalltreeView extends LitElement {
     globalStyles,
     css`
       :host {
-        --button-icon-hover-background: var(--vscode-toolbar-hoverBackground);
-
         height: 100%;
         width: 100%;
         display: flex;
@@ -216,12 +204,14 @@ export class CalltreeView extends LitElement {
         }
       }
 
-      vscode-dropdown::part(listbox) {
-        width: auto;
-      }
-
       .align__end {
         align-items: end;
+      }
+
+      /* cancel the checkbox's built-in 4px vertical margins so it bottom-aligns
+         like the previous 18px-tall toolkit checkbox */
+      vscode-checkbox {
+        margin: -4px 0;
       }
 
       .view-mode-buttons {
@@ -234,19 +224,23 @@ export class CalltreeView extends LitElement {
         height: 26px;
       }
 
-      .view-mode-buttons vscode-button::part(control) {
-        border-radius: 0;
-        min-width: auto;
+      .view-mode-buttons vscode-button::part(base) {
         padding: 0 8px;
-        height: 100%;
       }
 
-      .view-mode-buttons vscode-button:first-child::part(control) {
-        border-radius: 2px 0 0 2px;
+      .view-mode-buttons vscode-button:first-child {
+        --vsc-border-left-radius: 2px;
+        --vsc-border-right-radius: 0;
       }
 
-      .view-mode-buttons vscode-button:last-child::part(control) {
-        border-radius: 0 2px 2px 0;
+      .view-mode-buttons vscode-button:not(:first-child):not(:last-child) {
+        --vsc-border-left-radius: 0;
+        --vsc-border-right-radius: 0;
+      }
+
+      .view-mode-buttons vscode-button:last-child {
+        --vsc-border-left-radius: 0;
+        --vsc-border-right-radius: 2px;
       }
 
       #call-tree-table,
@@ -283,27 +277,25 @@ export class CalltreeView extends LitElement {
           <div class="header-bar">
             <div class="view-mode-buttons" role="radiogroup" aria-label="View mode">
               <vscode-button
-                appearance="${this.viewMode === 'time-order' ? '' : 'secondary'}"
+                ?secondary="${this.viewMode !== 'time-order'}"
                 @click="${() => this._setViewMode('time-order')}"
                 >Time Order</vscode-button
               >
               <vscode-button
-                appearance="${this.viewMode === 'aggregated' ? '' : 'secondary'}"
+                ?secondary="${this.viewMode !== 'aggregated'}"
                 @click="${() => this._setViewMode('aggregated')}"
                 >Aggregated</vscode-button
               >
               <vscode-button
-                appearance="${this.viewMode === 'bottom-up' ? '' : 'secondary'}"
+                ?secondary="${this.viewMode !== 'bottom-up'}"
                 @click="${() => this._setViewMode('bottom-up')}"
                 >Bottom-Up</vscode-button
               >
             </div>
 
             <div class="filter-container align__end">
-              <vscode-button appearance="secondary" @click="${this._expandButtonClick}"
-                >Expand</vscode-button
-              >
-              <vscode-button appearance="secondary" @click="${this._collapseButtonClick}"
+              <vscode-button secondary @click="${this._expandButtonClick}">Expand</vscode-button>
+              <vscode-button secondary @click="${this._collapseButtonClick}"
                 >Collapse</vscode-button
               >
             </div>
@@ -321,7 +313,7 @@ export class CalltreeView extends LitElement {
 
                     <div class="dropdown-container">
                       <label for="types">Type:</label>
-                      <vscode-dropdown @change="${this._handleTypeFilter}">
+                      <vs-select label="Type" @change="${this._handleTypeFilter}">
                         <vscode-option>None</vscode-option>
                         ${this.isVisible
                           ? repeat(
@@ -329,7 +321,7 @@ export class CalltreeView extends LitElement {
                               (type, _index) => html`<vscode-option>${type}</vscode-option>`,
                             )
                           : ''}
-                      </vscode-dropdown>
+                      </vs-select>
                     </div>
                   `
                 : ''}
@@ -339,16 +331,17 @@ export class CalltreeView extends LitElement {
               ? html`
                   <div class="dropdown-container">
                     <label for="bottomup-groupby">Group by:</label>
-                    <vscode-dropdown
+                    <vs-select
                       id="bottomup-groupby"
+                      label="Group by"
                       @change="${this._handleBottomUpGroupBy}"
-                      current-value="${this.bottomUpGroupBy}"
+                      .value="${this.bottomUpGroupBy}"
                     >
                       <vscode-option>None</vscode-option>
                       <vscode-option>Namespace</vscode-option>
                       <vscode-option>Caller Namespace</vscode-option>
                       <vscode-option>Type</vscode-option>
-                    </vscode-dropdown>
+                    </vs-select>
                   </div>
                 `
               : ''}
@@ -490,8 +483,9 @@ export class CalltreeView extends LitElement {
     }
   }
 
-  _handleTypeFilter(event: CustomEvent<{ selectedOptions: [{ value: string }] }>) {
-    this.filterState.selectedTypes = new Set(event.detail.selectedOptions.map((e) => e.value));
+  _handleTypeFilter(event: Event) {
+    const target = event.target as HTMLInputElement;
+    this.filterState.selectedTypes = new Set(target.value ? [target.value] : []);
     this._updateFiltering();
   }
 

--- a/log-viewer/src/features/database/components/DMLView.ts
+++ b/log-viewer/src/features/database/components/DMLView.ts
@@ -1,12 +1,9 @@
 /*
  * Copyright (c) 2022 Certinia Inc. All rights reserved.
  */
-import {
-  provideVSCodeDesignSystem,
-  vsCodeButton,
-  vsCodeDropdown,
-  vsCodeOption,
-} from '@vscode/webview-ui-toolkit';
+import '#vscode-elements/vscode-option.js';
+import '../../../components/VsSelect.js';
+import '#vscode-elements/vscode-toolbar-button.js';
 import { LitElement, css, html, render, unsafeCSS, type PropertyValues } from 'lit';
 import { customElement, property, state } from 'lit/decorators.js';
 import { Tabulator, type GroupComponent, type RowComponent } from 'tabulator-tables';
@@ -37,8 +34,6 @@ import databaseViewStyles from './DatabaseView.scss';
 import '../../../components/CallStack.js';
 import '../../../components/datagrid-filter-bar.js';
 import './DatabaseSection.js';
-
-provideVSCodeDesignSystem().register(vsCodeButton(), vsCodeDropdown(), vsCodeOption());
 
 const groupLabelsToFields = new Map<string, string>([
   ['DML', 'dml'],
@@ -107,8 +102,6 @@ export class DMLView extends LitElement {
     globalStyles,
     css`
       :host {
-        --button-icon-hover-background: var(--vscode-toolbar-hoverBackground);
-
         display: flex;
         flex-direction: column;
         width: 100%;
@@ -143,10 +136,6 @@ export class DMLView extends LitElement {
           user-select: none;
         }
       }
-
-      vscode-dropdown::part(listbox) {
-        width: auto;
-      }
     `,
   ];
 
@@ -159,35 +148,26 @@ export class DMLView extends LitElement {
       <datagrid-filter-bar>
         <div slot="filters" class="dropdown-container">
           <label for="dml-groupby-dropdown">Group by</label>
-          <vscode-dropdown
-            id="dml-groupby-dropdown"
-            aria-label="Group by"
-            aria-labelledby="dml-groupby-dropdown"
-            @change="${this._dmlGroupBy}"
-          >
+          <vs-select id="dml-groupby-dropdown" label="Group by" @change="${this._dmlGroupBy}">
             <vscode-option>DML</vscode-option>
             <vscode-option>Caller Namespace</vscode-option>
             <vscode-option>None</vscode-option>
-          </vscode-dropdown>
+          </vs-select>
         </div>
 
         <div slot="actions">
-          <vscode-button
-            appearance="icon"
-            aria-label="Export to CSV"
+          <vscode-toolbar-button
+            icon="desktop-download"
+            label="Export to CSV"
             title="Export to CSV"
             @click=${this._exportToCSV}
-          >
-            <span class="codicon codicon-desktop-download"></span>
-          </vscode-button>
-          <vscode-button
-            appearance="icon"
-            aria-label="Copy to clipboard"
+          ></vscode-toolbar-button>
+          <vscode-toolbar-button
+            icon="copy"
+            label="Copy to clipboard"
             title="Copy to clipboard"
             @click=${this._copyToClipboard}
-          >
-            <span class="codicon codicon-copy"></span>
-          </vscode-button>
+          ></vscode-toolbar-button>
         </div>
       </datagrid-filter-bar>
 

--- a/log-viewer/src/features/database/components/DMLView.ts
+++ b/log-viewer/src/features/database/components/DMLView.ts
@@ -26,7 +26,6 @@ import { RowNavigation } from '../../../tabulator/module/RowNavigation.js';
 import dataGridStyles from '../../../tabulator/style/DataGrid.scss';
 
 // styles
-import codiconStyles from '@vscode/codicons/dist/codicon.css';
 import { globalStyles } from '../../../styles/global.styles.js';
 import databaseViewStyles from './DatabaseView.scss';
 
@@ -98,7 +97,6 @@ export class DMLView extends LitElement {
   static styles = [
     unsafeCSS(dataGridStyles),
     unsafeCSS(databaseViewStyles),
-    unsafeCSS(codiconStyles),
     globalStyles,
     css`
       :host {

--- a/log-viewer/src/features/database/components/SOQLView.ts
+++ b/log-viewer/src/features/database/components/SOQLView.ts
@@ -32,7 +32,6 @@ import { RowNavigation } from '../../../tabulator/module/RowNavigation.js';
 import dataGridStyles from '../../../tabulator/style/DataGrid.scss';
 
 // styles
-import codiconStyles from '@vscode/codicons/dist/codicon.css';
 import { globalStyles } from '../../../styles/global.styles.js';
 import databaseViewStyles from './DatabaseView.scss';
 
@@ -102,7 +101,6 @@ export class SOQLView extends LitElement {
   static styles = [
     unsafeCSS(dataGridStyles),
     unsafeCSS(databaseViewStyles),
-    unsafeCSS(codiconStyles),
     unsafeCSS(soqlSyntaxStyles),
     globalStyles,
     css`

--- a/log-viewer/src/features/database/components/SOQLView.ts
+++ b/log-viewer/src/features/database/components/SOQLView.ts
@@ -1,12 +1,9 @@
 /*
  * Copyright (c) 2022 Certinia Inc. All rights reserved.
  */
-import {
-  provideVSCodeDesignSystem,
-  vsCodeButton,
-  vsCodeDropdown,
-  vsCodeOption,
-} from '@vscode/webview-ui-toolkit';
+import '#vscode-elements/vscode-option.js';
+import '../../../components/VsSelect.js';
+import '#vscode-elements/vscode-toolbar-button.js';
 import { LitElement, css, html, render, unsafeCSS, type PropertyValues } from 'lit';
 import { customElement, property, state } from 'lit/decorators.js';
 import {
@@ -44,8 +41,6 @@ import '../../../components/CallStack.js';
 import '../../../components/datagrid-filter-bar.js';
 import './DatabaseSOQLDetailPanel.js';
 import './DatabaseSection.js';
-
-provideVSCodeDesignSystem().register(vsCodeButton(), vsCodeDropdown(), vsCodeOption());
 
 @customElement('soql-view')
 export class SOQLView extends LitElement {
@@ -112,8 +107,6 @@ export class SOQLView extends LitElement {
     globalStyles,
     css`
       :host {
-        --button-icon-hover-background: var(--vscode-toolbar-hoverBackground);
-
         display: flex;
         flex-direction: column;
         width: 100%;
@@ -147,10 +140,6 @@ export class SOQLView extends LitElement {
           user-select: none;
         }
       }
-
-      vscode-dropdown::part(listbox) {
-        width: auto;
-      }
     `,
   ];
 
@@ -162,35 +151,26 @@ export class SOQLView extends LitElement {
       <datagrid-filter-bar>
         <div slot="filters" class="dropdown-container">
           <label for="soql-groupby-dropdown">Group by</label>
-          <vscode-dropdown
-            id="soql-groupby-dropdown"
-            aria-label="Group by"
-            aria-labelledby="soql-groupby-dropdown"
-            @change="${this._soqlGroupBy}"
-          >
+          <vs-select id="soql-groupby-dropdown" label="Group by" @change="${this._soqlGroupBy}">
             <vscode-option>SOQL</vscode-option>
             <vscode-option>Namespace</vscode-option>
             <vscode-option>None</vscode-option>
-          </vscode-dropdown>
+          </vs-select>
         </div>
 
         <div slot="actions">
-          <vscode-button
-            appearance="icon"
-            aria-label="Export to CSV"
+          <vscode-toolbar-button
+            icon="desktop-download"
+            label="Export to CSV"
             title="Export to CSV"
             @click=${this._exportToCSV}
-          >
-            <span class="codicon codicon-desktop-download"></span>
-          </vscode-button>
-          <vscode-button
-            appearance="icon"
-            aria-label="Copy to clipboard"
+          ></vscode-toolbar-button>
+          <vscode-toolbar-button
+            icon="copy"
+            label="Copy to clipboard"
             title="Copy to clipboard"
             @click=${this._copyToClipboard}
-          >
-            <span class="codicon codicon-copy"></span>
-          </vscode-button>
+          ></vscode-toolbar-button>
         </div>
       </datagrid-filter-bar>
 

--- a/log-viewer/src/features/find/components/FindWidget.ts
+++ b/log-viewer/src/features/find/components/FindWidget.ts
@@ -1,17 +1,16 @@
 //totod: event types
 
-import { provideVSCodeDesignSystem, vsCodeTextField } from '@vscode/webview-ui-toolkit';
-import { LitElement, css, html, unsafeCSS } from 'lit';
+import '#vscode-elements/vscode-textfield.js';
+import '#vscode-elements/vscode-toolbar-button.js';
+import type { VscodeTextfield } from '#vscode-elements/vscode-textfield.js';
+import { LitElement, css, html } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
 
 // styles
-import codiconStyles from '@vscode/codicons/dist/codicon.css';
 import { globalStyles } from '../../../styles/global.styles.js';
 
 // web components
 import '../../../components/VsIconCheckbox.js';
-
-provideVSCodeDesignSystem().register(vsCodeTextField());
 
 @customElement('find-widget')
 export class FindWidget extends LitElement {
@@ -38,11 +37,8 @@ export class FindWidget extends LitElement {
 
   static styles = [
     globalStyles,
-    unsafeCSS(codiconStyles),
     css`
       :host {
-        --button-icon-hover-background: var(--vscode-toolbar-hoverBackground);
-
         font-size: 12px;
       }
 
@@ -83,6 +79,7 @@ export class FindWidget extends LitElement {
       }
 
       .find-input-box {
+        width: 197px;
         height: 25px;
         vertical-align: middle;
         box-sizing: border-box;
@@ -102,8 +99,9 @@ export class FindWidget extends LitElement {
         height: 25px;
       }
 
-      .find-button:focus {
-        border: 1px solid transparent;
+      .find-button:focus-within {
+        color: var(--vscode-inputOption-activeForeground);
+        border: 1px solid var(--vscode-inputOption-activeBorder);
         cursor: pointer;
         user-select: none;
         -webkit-user-select: none;
@@ -111,11 +109,6 @@ export class FindWidget extends LitElement {
         box-sizing: border-box;
         width: 22px;
         height: 22px;
-      }
-
-      .find-button:focus {
-        color: var(--vscode-inputOption-activeForeground);
-        border: 1px solid var(--vscode-inputOption-activeBorder);
       }
 
       .matches-count {
@@ -135,43 +128,46 @@ export class FindWidget extends LitElement {
 
   render() {
     return html`<div class="wrapper ${this.isVisble ? 'visible' : ''}">
-      <vscode-text-field
+      <vscode-textfield
         placeholder="Find"
-        aria-label="Find"
+        label="Find"
         class="find-input-box"
         @click=${this._findInputClick}
       >
-        <section slot="end" class="find-input__controls">
+        <section slot="content-after" class="find-input__controls">
           <vs-icon-checkbox
+            icon="case-sensitive"
             showSelected="true"
             title="Match Case"
             class="find-control"
             @click=${this._matchCase}
-          >
-            <span class="codicon codicon-case-sensitive"></span>
-          </vs-icon-checkbox>
+          ></vs-icon-checkbox>
         </section>
-      </vscode-text-field>
+      </vscode-textfield>
       <div class="matches-count">${this._getMatchesText()}</div>
 
       <div class="find-actions">
-        <vscode-button
-          appearance="icon"
+        <vscode-toolbar-button
+          icon="arrow-up"
+          label="Previous Match"
           title="Previous Match"
           class="find-button"
           @click=${this._previousMatch}
-          ><span class="codicon codicon-arrow-up"></span
-        ></vscode-button>
-        <vscode-button
-          appearance="icon"
+        ></vscode-toolbar-button>
+        <vscode-toolbar-button
+          icon="arrow-down"
+          label="Next Match"
           title="Next Match"
           class="find-button"
           @click=${this._nextMatch}
-          ><span class="codicon codicon-arrow-down"></span
-        ></vscode-button>
-        <vscode-button appearance="icon" title="Close" class="find-button" @click=${this._closeFind}
-          ><span class="codicon codicon-close"></span
-        ></vscode-button>
+        ></vscode-toolbar-button>
+        <vscode-toolbar-button
+          icon="close"
+          label="Close"
+          title="Close"
+          class="find-button"
+          @click=${this._closeFind}
+        ></vscode-toolbar-button>
       </div>
     </div>`;
   }
@@ -205,7 +201,7 @@ export class FindWidget extends LitElement {
       this.isVisble = true;
       this.nextMatchDirection = true; // Reset to forward direction
       inputBox.focus();
-      inputBox.select();
+      inputBox.wrappedElement.select();
     }
   }
 
@@ -246,7 +242,7 @@ export class FindWidget extends LitElement {
   }
 
   get inputbox() {
-    return this.shadowRoot?.querySelector<HTMLInputElement>('.find-input-box');
+    return this.shadowRoot?.querySelector<VscodeTextfield>('.find-input-box');
   }
 
   _updateCounts(e: { detail: { totalMatches: number; count?: number } }) {

--- a/log-viewer/src/features/find/components/FindWidget.ts
+++ b/log-viewer/src/features/find/components/FindWidget.ts
@@ -201,7 +201,7 @@ export class FindWidget extends LitElement {
       this.isVisble = true;
       this.nextMatchDirection = true; // Reset to forward direction
       inputBox.focus();
-      inputBox.wrappedElement.select();
+      inputBox.wrappedElement?.select();
     }
   }
 

--- a/log-viewer/src/features/notifications/components/NotificationButton.ts
+++ b/log-viewer/src/features/notifications/components/NotificationButton.ts
@@ -1,12 +1,7 @@
 /*
  * Copyright (c) 2023 Certinia Inc. All rights reserved.
  */
-import {
-  provideVSCodeDesignSystem,
-  vsCodeBadge,
-  vsCodeButton,
-  vsCodeDivider,
-} from '@vscode/webview-ui-toolkit';
+import '#vscode-elements/vscode-divider.js';
 import { LitElement, css, html, type TemplateResult } from 'lit';
 import { customElement, property, state } from 'lit/decorators.js';
 
@@ -15,9 +10,8 @@ import { globalStyles } from '../../../styles/global.styles.js';
 import { notificationStyles } from '../../../styles/notification.styles.js';
 
 // web components
+import '../../../components/IconButton.js';
 import './NotificationPanel.js';
-
-provideVSCodeDesignSystem().register(vsCodeButton(), vsCodeDivider(), vsCodeBadge());
 
 @customElement('notification-button')
 export class NotificationButton extends LitElement {
@@ -122,7 +116,7 @@ export class NotificationButton extends LitElement {
       <icon-button
         ariaLabel="Notifications"
         title="Notifications"
-        icon="codicon-bell"
+        icon="bell"
         .badgeCount="${count}"
         @click=${this._toggleNotifications}
       ></icon-button>

--- a/log-viewer/src/features/notifications/components/NotificationPanel.ts
+++ b/log-viewer/src/features/notifications/components/NotificationPanel.ts
@@ -1,15 +1,12 @@
 /*
  * Copyright (c) 2023 Certinia Inc. All rights reserved.
  */
-import { provideVSCodeDesignSystem, vsCodeButton, vsCodeDivider } from '@vscode/webview-ui-toolkit';
 import { LitElement, css, html, type TemplateResult } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
 
 // styles
 import { globalStyles } from '../../../styles/global.styles.js';
 import { notificationStyles } from '../../../styles/notification.styles.js';
-
-provideVSCodeDesignSystem().register(vsCodeButton(), vsCodeDivider());
 
 @customElement('notification-panel')
 export class NotificationPanel extends LitElement {
@@ -28,7 +25,7 @@ export class NotificationPanel extends LitElement {
         max-height: 540px;
         width: 320px;
         padding: 8px 4px 8px 4px;
-        border: calc(var(--border-width) * 1px) solid var(--divider-background);
+        border: 1px solid var(--divider-background);
         box-shadow: rgba(0, 0, 0, 0.5) 0px 4px 20px;
         border-radius: 4px;
         overflow: scroll;

--- a/log-viewer/src/features/timeline/components/TimelineView.ts
+++ b/log-viewer/src/features/timeline/components/TimelineView.ts
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2023 Certinia Inc. All rights reserved.
  */
+import '#vscode-elements/vscode-toolbar-button.js';
 import { LitElement, css, html, unsafeCSS } from 'lit';
 import { customElement, property, query, state } from 'lit/decorators.js';
 
@@ -119,8 +120,6 @@ export class TimelineView extends LitElement {
         /* Toolbar */
         --tl-toolbar-hover-background: var(--vscode-toolbar-hoverBackground);
 
-        --button-icon-hover-background: var(--tl-toolbar-hover-background);
-
         display: flex;
         flex-direction: column;
         flex: 1;
@@ -135,11 +134,6 @@ export class TimelineView extends LitElement {
         justify-content: flex-end;
         gap: 4px;
         flex: 0 0 auto;
-      }
-
-      vscode-button {
-        height: 22px;
-        width: 22px;
       }
     `,
   ];
@@ -180,16 +174,12 @@ export class TimelineView extends LitElement {
 
       return html`${hasWallClock
           ? html`<div class="timeline-toolbar">
-              <vscode-button
-                appearance="icon"
-                aria-label="${isWallClock ? 'Show elapsed time' : 'Show wall-clock time'}"
+              <vscode-toolbar-button
+                icon="${isWallClock ? 'history' : 'clockface'}"
+                label="${isWallClock ? 'Show elapsed time' : 'Show wall-clock time'}"
+                title="${isWallClock ? 'Show elapsed time' : 'Show wall-clock time'}"
                 @click=${() => this.toggleTimeDisplay()}
-              >
-                <span
-                  class="codicon ${isWallClock ? 'codicon-history' : 'codicon-clockface'}"
-                  title="${isWallClock ? 'Show elapsed time' : 'Show wall-clock time'}"
-                ></span>
-              </vscode-button>
+              ></vscode-toolbar-button>
             </div>`
           : ''}
         <timeline-flame-chart

--- a/log-viewer/src/features/timeline/components/TimelineView.ts
+++ b/log-viewer/src/features/timeline/components/TimelineView.ts
@@ -2,7 +2,7 @@
  * Copyright (c) 2023 Certinia Inc. All rights reserved.
  */
 import '#vscode-elements/vscode-toolbar-button.js';
-import { LitElement, css, html, unsafeCSS } from 'lit';
+import { LitElement, css, html } from 'lit';
 import { customElement, property, query, state } from 'lit/decorators.js';
 
 import type { ApexLog } from 'apex-log-parser';
@@ -17,7 +17,6 @@ import type { TimeDisplayMode } from '../types/flamechart.types.js';
 import type { TimelineFlameChart } from './TimelineFlameChart.js';
 
 // styles
-import codiconStyles from '@vscode/codicons/dist/codicon.css';
 import { globalStyles } from '../../../styles/global.styles.js';
 
 // web components
@@ -71,7 +70,6 @@ export class TimelineView extends LitElement {
 
   static styles = [
     globalStyles,
-    unsafeCSS(codiconStyles),
     css`
       :host {
         /* Editor */

--- a/log-viewer/src/styles/global.styles.ts
+++ b/log-viewer/src/styles/global.styles.ts
@@ -40,4 +40,19 @@ export const globalStyles = css`
     color: var(--vscode-editor-findMatchHighlightForeground);
     background-color: var(--vscode-editor-findMatchBackground, #8b8000);
   }
+
+  /* vscode-button shows its focus ring + hover background on any focus
+     (including mouse click); restrict that to keyboard focus like the
+     native VS Code button */
+  vscode-button:focus:not(:focus-visible)::part(base) {
+    outline: none;
+  }
+
+  vscode-button:focus:not(:hover)::part(base) {
+    background-color: var(--vscode-button-background);
+  }
+
+  vscode-button[secondary]:focus:not(:hover)::part(base) {
+    background-color: var(--vscode-button-secondaryBackground);
+  }
 `;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -195,12 +195,12 @@ importers:
       '@apexdevtools/apex-parser':
         specifier: 5.1.0-beta.1
         version: 5.1.0-beta.1
+      '@vscode-elements/elements':
+        specifier: ^2.5.1
+        version: 2.5.1(@vscode/codicons@0.0.45)
       '@vscode/codicons':
         specifier: ^0.0.45
         version: 0.0.45
-      '@vscode/webview-ui-toolkit':
-        specifier: ^1.4.0
-        version: 1.4.0(react@19.2.7)
       antlr4:
         specifier: 4.13.2
         version: 4.13.2
@@ -1989,6 +1989,9 @@ packages:
   '@lit-labs/ssr-dom-shim@1.6.0':
     resolution: {integrity: sha512-VHb0ALPMTlgKjM6yIxxoQNnpKyUKLD04VzeQdsiXkMqkvYlAHxq9glGLmgbb889/1GsohSOAjvQYoiBppXFqrQ==}
 
+  '@lit/context@1.1.6':
+    resolution: {integrity: sha512-M26qDE6UkQbZA2mQ3RjJ3Gzd8TxP+/0obMgE5HfkfLhEEyYE3Bui4A5XHiGPjy0MUGAyxB3QgVuw2ciS0kHn6A==}
+
   '@lit/reactive-element@2.1.2':
     resolution: {integrity: sha512-pbCDiVMnne1lYUIaYNN5wrwQXDtHaYtg7YEFPeW+hws6U47WeFvISGUWekPGKWOP1ygrs0ef0o1VJMk1exos5A==}
 
@@ -2000,20 +2003,6 @@ packages:
     peerDependencies:
       '@types/react': '>=16'
       react: '>=16'
-
-  '@microsoft/fast-element@1.14.0':
-    resolution: {integrity: sha512-zXvuSOzvsu8zDTy9eby8ix8VqLop2rwKRgp++ZN2kTCsoB3+QJVoaGD2T/Cyso2ViZQFXNpiNCVKfnmxBvmWkQ==}
-
-  '@microsoft/fast-foundation@2.50.0':
-    resolution: {integrity: sha512-8mFYG88Xea1jZf2TI9Lm/jzZ6RWR8x29r24mGuLojNYqIR2Bl8+hnswoV6laApKdCbGMPKnsAL/O68Q0sRxeVg==}
-
-  '@microsoft/fast-react-wrapper@0.3.25':
-    resolution: {integrity: sha512-jKzmk2xJV93RL/jEFXEZgBvXlKIY4N4kXy3qrjmBfFpqNi3VjY+oUTWyMnHRMC5EUhIFxD+Y1VD4u9uIPX3jQw==}
-    peerDependencies:
-      react: '>=16.9.0'
-
-  '@microsoft/fast-web-utilities@5.4.1':
-    resolution: {integrity: sha512-ReWYncndjV3c8D8iq9tp7NcFNc1vbVHvcBFPME2nNFKNbS1XCesYZGlIlf3ot5EmuOXPlrzUHOWzQ2vFpIkqDg==}
 
   '@module-federation/error-codes@0.22.0':
     resolution: {integrity: sha512-xF9SjnEy7vTdx+xekjPCV5cIHOGCkdn3pIxo9vU7gEZMIw0SvAEdsy6Uh17xaCpm8V0FWvR0SZoK9Ik6jGOaug==}
@@ -3537,14 +3526,13 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@vscode-elements/elements@2.5.1':
+    resolution: {integrity: sha512-HiKgIj9GwlfYkw1LrxG7dM5bMQUr8/GkOqG1HU1+npGHd51nRKCF6ZZ9FtnfoC2wujNN0lc+m0emH/wMpAseYQ==}
+    peerDependencies:
+      '@vscode/codicons': '>=0.0.40'
+
   '@vscode/codicons@0.0.45':
     resolution: {integrity: sha512-1KAZ7XCMagp5Gdrlr4bbbcAqgcIL623iO1wW6rfcSVGAVUQvR0WP7bQx1SbJ11gmV3fdQTSEFIJQ/5C+HuVasw==}
-
-  '@vscode/webview-ui-toolkit@1.4.0':
-    resolution: {integrity: sha512-modXVHQkZLsxgmd5yoP3ptRC/G8NBDD+ob+ngPiWNQdlrH6H1xR/qgOBD85bfU3BhOB5sZzFWBwwhp9/SfoHww==}
-    deprecated: This package has been deprecated, https://github.com/microsoft/vscode-webview-ui-toolkit/issues/561
-    peerDependencies:
-      react: '>=16.9.0'
 
   '@webassemblyjs/ast@1.14.1':
     resolution: {integrity: sha512-nuBEDgQfm1ccRp/8bCQrx1frohyufl4JlbMMZ4P1wpeOfDhF6FQkxZJ1b/e+PLwr6X1Nhw6OLme5usuBWYBvuQ==}
@@ -4848,9 +4836,6 @@ packages:
   execa@5.1.1:
     resolution: {integrity: sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==}
     engines: {node: '>=10'}
-
-  exenv-es6@1.1.1:
-    resolution: {integrity: sha512-vlVu3N8d6yEMpMsEm+7sUBAI81aqYYuEvfK0jNqmdb/OPXzzH7QWDDnVjMvDSY47JdHEqx/dfC/q8WkfoTmpGQ==}
 
   exit-x@0.2.2:
     resolution: {integrity: sha512-+I6B/IkJc1o/2tiURyz/ivu/O0nKNEArIUB5O7zBrlDVJr22SCLH3xTeEry428LvFhRzIA1g8izguxJ/gbNcVQ==}
@@ -8088,9 +8073,6 @@ packages:
   synckit@0.11.13:
     resolution: {integrity: sha512-eNRKgb3z66Yp3D2CixVujOUvXLFUTij/zVnV8KRyvFdQwpz7I5DS8UfRkTeLzb64u+dkzDSdelE24izu+zSSUg==}
     engines: {node: ^14.18.0 || >=16.0.0}
-
-  tabbable@5.3.3:
-    resolution: {integrity: sha512-QD9qKY3StfbZqWOPLp0++pOrAVb/HbUi5xCc8cUo4XjP19808oaMiDzn0leBY5mCespIBM0CIZePzZjgzR83kA==}
 
   tabulator-tables@6.5.1:
     resolution: {integrity: sha512-hTbw97QbUmh33d/87xdPFQUdm+1W2+l0WQuafYvqw95tEjC4o0sMLMd/Ie7KJ5u7/QlfpM03ZCqjw3TuEiPrdw==}
@@ -11864,6 +11846,10 @@ snapshots:
 
   '@lit-labs/ssr-dom-shim@1.6.0': {}
 
+  '@lit/context@1.1.6':
+    dependencies:
+      '@lit/reactive-element': 2.1.2
+
   '@lit/reactive-element@2.1.2':
     dependencies:
       '@lit-labs/ssr-dom-shim': 1.6.0
@@ -11903,25 +11889,6 @@ snapshots:
       '@types/mdx': 2.0.13
       '@types/react': 19.2.15
       react: 19.2.7
-
-  '@microsoft/fast-element@1.14.0': {}
-
-  '@microsoft/fast-foundation@2.50.0':
-    dependencies:
-      '@microsoft/fast-element': 1.14.0
-      '@microsoft/fast-web-utilities': 5.4.1
-      tabbable: 5.3.3
-      tslib: 1.14.1
-
-  '@microsoft/fast-react-wrapper@0.3.25(react@19.2.7)':
-    dependencies:
-      '@microsoft/fast-element': 1.14.0
-      '@microsoft/fast-foundation': 2.50.0
-      react: 19.2.7
-
-  '@microsoft/fast-web-utilities@5.4.1':
-    dependencies:
-      exenv-es6: 1.1.1
 
   '@module-federation/error-codes@0.22.0': {}
 
@@ -13241,15 +13208,13 @@ snapshots:
   '@unrs/resolver-binding-win32-x64-msvc@1.12.2':
     optional: true
 
-  '@vscode/codicons@0.0.45': {}
-
-  '@vscode/webview-ui-toolkit@1.4.0(react@19.2.7)':
+  '@vscode-elements/elements@2.5.1(@vscode/codicons@0.0.45)':
     dependencies:
-      '@microsoft/fast-element': 1.14.0
-      '@microsoft/fast-foundation': 2.50.0
-      '@microsoft/fast-react-wrapper': 0.3.25(react@19.2.7)
-      react: 19.2.7
-      tslib: 2.8.1
+      '@lit/context': 1.1.6
+      '@vscode/codicons': 0.0.45
+      lit: 3.3.3
+
+  '@vscode/codicons@0.0.45': {}
 
   '@webassemblyjs/ast@1.14.1':
     dependencies:
@@ -14690,8 +14655,6 @@ snapshots:
       onetime: 5.1.2
       signal-exit: 3.0.7
       strip-final-newline: 2.0.0
-
-  exenv-es6@1.1.1: {}
 
   exit-x@0.2.2: {}
 
@@ -18764,8 +18727,6 @@ snapshots:
   synckit@0.11.13:
     dependencies:
       '@pkgr/core': 0.3.6
-
-  tabbable@5.3.3: {}
 
   tabulator-tables@6.5.1: {}
 

--- a/rolldown.config.ts
+++ b/rolldown.config.ts
@@ -1,3 +1,5 @@
+import { createRequire } from 'node:module';
+import path from 'node:path';
 import process from 'node:process';
 
 import { defineConfig } from 'rolldown';
@@ -9,6 +11,11 @@ import nodePolyfills from '@rolldown/plugin-node-polyfills';
 import postcssUrl from 'postcss-url';
 import copy from 'rollup-plugin-copy';
 import postcss from 'rollup-plugin-postcss';
+
+// Resolve the codicons dist dir via Node resolution so it works regardless of
+// pnpm hoisting (avoids a hard-coded node_modules path).
+const nodeRequire = createRequire(import.meta.url);
+const codiconsDist = path.dirname(nodeRequire.resolve('@vscode/codicons/dist/codicon.css'));
 
 const production = process.env.NODE_ENV === 'production';
 export default defineConfig([
@@ -58,6 +65,10 @@ export default defineConfig([
         targets: [
           {
             src: ['log-viewer/out/*', 'log-viewer/index.html', 'lana/certinia-icon-color.png'],
+            dest: 'lana/out',
+          },
+          {
+            src: path.join(codiconsDist, 'codicon.{css,ttf}'),
             dest: 'lana/out',
           },
         ],

--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -1,3 +1,4 @@
+import { createRequire } from 'node:module';
 import path from 'node:path';
 import process from 'node:process';
 import { fileURLToPath } from 'node:url';
@@ -15,6 +16,11 @@ import { defineRollupSwcOption, swc } from 'rollup-plugin-swc3';
 
 const _filename = fileURLToPath(import.meta.url);
 const _dirname = path.dirname(_filename);
+
+// Resolve the codicons dist dir via Node resolution so it works regardless of
+// pnpm hoisting (avoids a hard-coded node_modules path).
+const nodeRequire = createRequire(import.meta.url);
+const codiconsDist = path.dirname(nodeRequire.resolve('@vscode/codicons/dist/codicon.css'));
 
 const production = process.env.NODE_ENV === 'production';
 export default [
@@ -137,6 +143,10 @@ export default [
         targets: [
           {
             src: ['log-viewer/out/*', 'log-viewer/index.html', 'lana/certinia-icon-color.png'],
+            dest: 'lana/out',
+          },
+          {
+            src: path.join(codiconsDist, 'codicon.{css,ttf}'),
             dest: 'lana/out',
           },
         ],

--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -1,4 +1,5 @@
 import { createRequire } from 'node:module';
+import path from 'node:path';
 import process from 'node:process';
 
 // Rollup plugins
@@ -79,6 +80,11 @@ export default [
   },
   {
     input: { bundle: './log-viewer/src/Main.ts' },
+    // @vscode-elements ships tsc output with the inline `(this && this.__decorate)` helper.
+    // Declaring a top-level `this` for those files stops rollup's THIS_IS_UNDEFINED warning; use
+    // `globalThis` (a real binding rollup won't flag) — `globalThis.__decorate` is undefined so the
+    // guard still falls back to the inline helper, i.e. no behaviour change.
+    moduleContext: (id) => (id.includes('/@vscode-elements/elements/') ? 'globalThis' : undefined),
     output: [
       {
         format: 'es',


### PR DESCRIPTION
# 📝 PR Overview

Replaces the deprecated (archived) `@vscode/webview-ui-toolkit` with the community-maintained, lit-based [`@vscode-elements/elements`](https://github.com/vscode-elements/elements). This also removes the transitive `@microsoft/fast-*` packages, leaving lit as the webview's only component framework, and trims the production bundle by ~86 KB. Rendering and behaviour are like-for-like with the previous toolkit (verified side by side against `main`).

## 🛠️ Changes made

- Register components via `#vscode-elements/*` subpath imports (package.json `imports` field) — the package has no `exports` map, and importing its root barrel would bundle all 38 components (+121 KB)
- Map components: icon buttons → `vscode-toolbar-button`, panels → index-based `vscode-tabs`, tag/badge → styled `vscode-badge`, text field → `vscode-textfield`, dropdowns → `vscode-single-select`
- Add `vs-select`, a styles-only `vscode-single-select` subclass that sizes the control to the selected value and the popup to its widest option (`min-width: max-content` outranks the inline popup width)
- Serve the codicon stylesheet for `vscode-icon` via a blob URL built from the bundled CSS, so no page-level asset, `index.html`, or extension-host change is needed
- Restrict `vscode-button`'s focus ring to keyboard focus (`:focus-visible`) in global styles, matching the previous click behaviour

## 🧩 Type of change (check all applicable)

- [ ] 🐛 Bug fix - something not working as expected
- [ ] ✨ New feature – adds new functionality
- [x] ♻️ Refactor - internal changes with no user impact
- [ ] ⚡ Performance Improvement
- [ ] 📝 Documentation - README or documentation site changes
- [ ] 🔧 Chore - dev tooling, CI, config
- [ ] 💥 Breaking change

## 📷 Screenshots / gifs / video [optional]

<img width="1919" height="888" alt="image" src="https://github.com/user-attachments/assets/82c983c8-2a86-479b-bf74-9a193f74c2da" />

## 🔗 Related Issues

closes #576

## ✅ Tests added?

- [ ] 👍 yes
- [x] 🙅 no, not needed
- [ ] 🙋 no, I need help

## 📚 Docs updated?

- [ ] 🔖 README.md
- [ ] 🔖 CHANGELOG.md
- [ ] 📖 help site
- [ ] 🧪 Marked any pre-release-only features (README `🧪` badge — see [RELEASING.md](../RELEASING.md#-marking-pre-release-only-features))
- [ ] 🙅 not needed

## Anything else we need to know? [optional]

Fidelity was verified per control against a `main` build served side by side (tab strip, segmented view-mode buttons, checkboxes, dropdowns incl. popup widths, find widget, badges, panel padding/border). Existing suite (962 tests) passes; a real-VS Code smoke test is still worthwhile since the harness approximates theme variables.