### PR TITLE
build(deps): bump @apexdevtools/apex-parser to 5.1.0

### DIFF
--- a/lana/package.json
+++ b/lana/package.json
@@ -334,7 +334,7 @@
   },
   "dependencies": {
     "@apexdevtools/apex-ls": "^6.0.2",
-    "@apexdevtools/apex-parser": "5.1.0-beta.1",
+    "@apexdevtools/apex-parser": "5.1.0",
     "@salesforce/apex-node": "^8.4.34",
     "@salesforce/core": "^8.32.2"
   },

--- a/log-viewer/package.json
+++ b/log-viewer/package.json
@@ -8,7 +8,7 @@
     "#vscode-elements/*.js": "@vscode-elements/elements/dist/*/index.js"
   },
   "dependencies": {
-    "@apexdevtools/apex-parser": "5.1.0-beta.1",
+    "@apexdevtools/apex-parser": "5.1.0",
     "@vscode-elements/elements": "^2.5.1",
     "@vscode/codicons": "^0.0.45",
     "antlr4": "4.13.2",

--- a/log-viewer/src/features/soql/services/SOQLLinter.ts
+++ b/log-viewer/src/features/soql/services/SOQLLinter.ts
@@ -66,10 +66,10 @@ class LeadingPercentWildcardRule implements SOQLLinterRule {
     const whereClause = qryCtxt.whereClause();
     if (whereClause) {
       const hasLeadingWildcard = whereClause
-        .logicalExpression()
-        .conditionalExpression_list()
+        .whereLogicalExpression()
+        .whereConditionalExpression_list()
         .find((exp) => {
-          const fieldExp = exp.fieldExpression();
+          const fieldExp = exp.whereFieldExpression()?.fieldExpression();
           if (
             fieldExp?.comparisonOperator().LIKE() &&
             fieldExp.value().StringLiteral()?.getText().startsWith("'%")
@@ -96,12 +96,12 @@ class NegativeFilterOperatorRule implements SOQLLinterRule {
     const qryCtxt = soqlTree._queryContext;
     const whereClause = qryCtxt.whereClause();
     if (whereClause) {
-      const exp = whereClause.logicalExpression();
+      const exp = whereClause.whereLogicalExpression();
 
       const hasNegativeOp =
         exp.NOT() ||
-        exp.conditionalExpression_list().find((exp) => {
-          const operator = exp.fieldExpression()?.comparisonOperator();
+        exp.whereConditionalExpression_list().find((exp) => {
+          const operator = exp.whereFieldExpression()?.fieldExpression()?.comparisonOperator();
 
           if (
             operator &&
@@ -148,10 +148,10 @@ class LastModifiedDateSystemModStampIndexRule implements SOQLLinterRule {
     const whereClause = qryCtxt.whereClause();
     if (whereClause) {
       const result = whereClause
-        .logicalExpression()
-        .conditionalExpression_list()
+        .whereLogicalExpression()
+        .whereConditionalExpression_list()
         .find((exp) => {
-          const fieldExp = exp.fieldExpression();
+          const fieldExp = exp.whereFieldExpression()?.fieldExpression();
           if (
             fieldExp?.fieldName()?.getText().toLowerCase().endsWith('lastmodifieddate') &&
             fieldExp.comparisonOperator().LT()

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -122,8 +122,8 @@ importers:
         specifier: ^6.0.2
         version: 6.0.2
       '@apexdevtools/apex-parser':
-        specifier: 5.1.0-beta.1
-        version: 5.1.0-beta.1
+        specifier: 5.1.0
+        version: 5.1.0
       '@salesforce/apex-node':
         specifier: ^8.4.34
         version: 8.4.34
@@ -190,8 +190,8 @@ importers:
   log-viewer:
     dependencies:
       '@apexdevtools/apex-parser':
-        specifier: 5.1.0-beta.1
-        version: 5.1.0-beta.1
+        specifier: 5.1.0
+        version: 5.1.0
       '@vscode-elements/elements':
         specifier: ^2.5.1
         version: 2.5.1(@vscode/codicons@0.0.45)
@@ -324,8 +324,8 @@ packages:
     resolution: {integrity: sha512-RlaWpAFudE0GvUcim/xLBNw5ipNgT0Yd1eM7jeZJS0R9qn5DxeUGY3636zfgKgWkK04075y1fgNbPsIi/EjKiw==}
     engines: {node: '>=8.0.0'}
 
-  '@apexdevtools/apex-parser@5.1.0-beta.1':
-    resolution: {integrity: sha512-IBuDgIMNypFJ9KXQDPZ44tbroj7Qi+to+l7fTqz+PiiXSw1MRFJfIPznO0oZcY68rohyEaMfeLWG2fYAPNc7hQ==}
+  '@apexdevtools/apex-parser@5.1.0':
+    resolution: {integrity: sha512-DPThB5oMnJ9b62weMpufGQfJjtZ+5UHP5Ne8nOqsDDCAVP3P2yRL80p1qX5BpPxyOowhTJ9RF/3qhat0vCrv4g==}
     engines: {node: ^20.19.0 || ^22.13.0 || >=24}
     bundledDependencies:
       - antlr4
@@ -8962,7 +8962,7 @@ snapshots:
       antlr4ts: 0.5.0-alpha.4
       node-dir: 0.1.17
 
-  '@apexdevtools/apex-parser@5.1.0-beta.1': {}
+  '@apexdevtools/apex-parser@5.1.0': {}
 
   '@apexdevtools/vf-parser@1.1.0':
     dependencies:


### PR DESCRIPTION
Move `@apexdevtools/apex-parser` from `5.1.0-beta.1` to the `5.1.0` stable release in both `lana/` and `log-viewer/`.

### Breaking change handled
5.1.0 adds SOQL `FORMULA()` support, which restructured the WHERE-clause grammar: the conditional tree now nests under `where`-prefixed rules. `whereClause.logicalExpression()` no longer exists (broke 12 SOQL-linter tests).

Migrated `SOQLLinter.ts` (4 call sites):
- `logicalExpression()` → `whereLogicalExpression()`
- `conditionalExpression_list()` → `whereConditionalExpression_list()`
- `exp.fieldExpression()` → `exp.whereFieldExpression()?.fieldExpression()`

`FieldExpressionContext` is unchanged, so `.fieldName()`/`.comparisonOperator()`/`.value()` calls are untouched.

### New capability (not yet adopted)
SOQL `FORMULA()` in WHERE clauses now parses — available if we want a linter/formatter rule later.

### Verification
typecheck ✓ · lint ✓ · 962 tests ✓ (12 previously-failing SOQL-linter tests pass) · rollup build ✓ · rolldown build ✓.