### PR TITLE
build(deps): bump tabulator-tables to 6.5.2

### DIFF
--- a/log-viewer/package.json
+++ b/log-viewer/package.json
@@ -14,7 +14,7 @@
     "antlr4": "4.13.2",
     "lit": "^3.3.3",
     "pixi.js": "^8.19.0",
-    "tabulator-tables": "^6.5.1"
+    "tabulator-tables": "^6.5.2"
   },
   "devDependencies": {
     "@types/jest": "^30.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -208,8 +208,8 @@ importers:
         specifier: ^8.19.0
         version: 8.19.0
       tabulator-tables:
-        specifier: ^6.5.1
-        version: 6.5.1
+        specifier: ^6.5.2
+        version: 6.5.2
     devDependencies:
       '@types/jest':
         specifier: ^30.0.0
@@ -8135,8 +8135,8 @@ packages:
     resolution: {integrity: sha512-eNRKgb3z66Yp3D2CixVujOUvXLFUTij/zVnV8KRyvFdQwpz7I5DS8UfRkTeLzb64u+dkzDSdelE24izu+zSSUg==}
     engines: {node: ^14.18.0 || >=16.0.0}
 
-  tabulator-tables@6.5.1:
-    resolution: {integrity: sha512-hTbw97QbUmh33d/87xdPFQUdm+1W2+l0WQuafYvqw95tEjC4o0sMLMd/Ie7KJ5u7/QlfpM03ZCqjw3TuEiPrdw==}
+  tabulator-tables@6.5.2:
+    resolution: {integrity: sha512-cRL3xsaaf5RzND8KPbn4C9Ce5tzyiQUE01E/10zN50MjdRKl/Gl5nXkzLN6cvEyRfWHCPuqBF92y50CBw20WYA==}
 
   tapable@2.3.3:
     resolution: {integrity: sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A==}
@@ -18789,7 +18789,7 @@ snapshots:
     dependencies:
       '@pkgr/core': 0.3.6
 
-  tabulator-tables@6.5.1: {}
+  tabulator-tables@6.5.2: {}
 
   tapable@2.3.3: {}
 


### PR DESCRIPTION
Patch bump of `tabulator-tables` 6.5.1 → 6.5.2 in `log-viewer/`, run as the **pristine released package** (no `node_modules` edits).

### No scroll/render impact
6.5.2 contains two **editor-only** fixes (select-range enter-to-edit #4912, multiselect duplicate selections #4862). Diffing the `tabulator_esm.mjs` bundle 6.5.1→6.5.2 shows all 36 changed lines are in the list/select editor module; the virtual DOM renderer and scroll path are byte-identical. The log-viewer uses read-only grids (no editors), so these changes are inert for us. Source-level scroll CSS (`DataGrid.scss`) is unaffected.

### Verification
typecheck ✓ · lint ✓ · 962 tests ✓ · rollup build ✓ · rolldown build ✓.