### PR TITLE
build(rollup): externalize Node.js built-in modules for compatibility

### DIFF
--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -30,6 +30,15 @@ export default [
 
     external: ['vscode'],
     plugins: [
+      // Externalize every `node:` builtin. preferBuiltins covers the ones in
+      // module.builtinModules, but experimental builtins (e.g. node:sqlite, pulled in
+      // transitively via undici's optional SqliteCacheStore) are excluded from that list,
+      // so rollup can't resolve them. They're runtime builtins on the Node extension host —
+      // this declares them external, matching rolldown's platform: 'node' behaviour.
+      {
+        name: 'external-node-builtins',
+        resolveId: (id) => (id.startsWith('node:') ? { id, external: true } : null),
+      },
       // 'node' isn't applied by default, but antlr4's exports map has only node/browser
       // conditions (no default) so it fails to resolve without it (rolldown gets this
       // from platform: 'node').


### PR DESCRIPTION
# 📝 PR Overview

`pnpm build:dev` (rollup) emitted an `Unresolved dependencies: node:sqlite` warning. `node:sqlite` is an experimental Node built-in pulled in transitively via undici's optional `SqliteCacheStore` (undici ← jsforce ← `@salesforce/core` / `apex-node`); it is excluded from `module.builtinModules`, so `@rollup/plugin-node-resolve`'s `preferBuiltins` doesn't recognise it and rollup can't resolve it. This externalizes every `node:` specifier for the Node-targeted extension bundle so rollup treats them as runtime built-ins — matching what rolldown already does via `platform: 'node'`.

## 🛠️ Changes made

- Add an `external-node-builtins` rollup plugin to the lana bundle: any `node:*` import resolves as external.
- Silences the `node:sqlite` unresolved-dependency warning without bundling an experimental built-in.
- No runtime impact — `node:sqlite` is only referenced inside undici's opt-in `SqliteCacheStore`, which nothing in the extension constructs.

## 🧩 Type of change (check all applicable)

- [ ] 🐛 Bug fix - something not working as expected
- [ ] ✨ New feature – adds new functionality
- [ ] ♻️ Refactor - internal changes with no user impact
- [ ] ⚡ Performance Improvement
- [ ] 📝 Documentation - README or documentation site changes
- [x] 🔧 Chore - dev tooling, CI, config
- [ ] 💥 Breaking change

## ✅ Tests added?

- [ ] 👍 yes
- [x] 🙅 no, not needed
- [ ] 🙋 no, I need help

## 📚 Docs updated?

- [ ] 🔖 README.md
- [ ] 🔖 CHANGELOG.md
- [ ] 📖 help site
- [ ] 🧪 Marked any pre-release-only features (README `🧪` badge)
- [x] 🙅 not needed