### PR TITLE
refactor(log-viewer): remove unused params and unreachable code

### DIFF
--- a/log-viewer/src/features/database/components/DMLView.ts
+++ b/log-viewer/src/features/database/components/DMLView.ts
@@ -345,14 +345,12 @@ export class DMLView extends LitElement {
         headerTooltip: true,
         headerWordWrap: true,
       },
-      headerSortElement: function (column, dir) {
+      headerSortElement: function (_column, dir) {
         switch (dir) {
           case 'asc':
             return "<div class='sort-by--top'></div>";
-            break;
           case 'desc':
             return "<div class='sort-by--bottom'></div>";
-            break;
           default:
             return "<div class='sort-by'><div class='sort-by--top'></div><div class='sort-by--bottom'></div></div>";
         }
@@ -429,7 +427,7 @@ export class DMLView extends LitElement {
       },
     });
 
-    this.dmlTable.on('groupClick', (e: UIEvent, group: GroupComponent) => {
+    this.dmlTable.on('groupClick', (_e: UIEvent, group: GroupComponent) => {
       const { type } = window.getSelection() ?? {};
       if (type === 'Range') {
         return;
@@ -447,7 +445,7 @@ export class DMLView extends LitElement {
       }
     });
 
-    this.dmlTable.on('rowClick', function (e, row) {
+    this.dmlTable.on('rowClick', function (_e, row) {
       const { type } = window.getSelection() ?? {};
       if (type === 'Range') {
         return;

--- a/log-viewer/src/features/database/components/SOQLView.ts
+++ b/log-viewer/src/features/database/components/SOQLView.ts
@@ -354,14 +354,12 @@ export class SOQLView extends LitElement {
         headerTooltip: true,
         headerWordWrap: true,
       },
-      headerSortElement: function (column, dir) {
+      headerSortElement: function (_column, dir) {
         switch (dir) {
           case 'asc':
             return "<div class='sort-by--top'></div>";
-            break;
           case 'desc':
             return "<div class='sort-by--bottom'></div>";
-            break;
           default:
             return "<div class='sort-by'><div class='sort-by--top'></div><div class='sort-by--bottom'></div></div>";
         }
@@ -411,7 +409,7 @@ export class SOQLView extends LitElement {
 
             return (aRowData.relativeCost || 0) - (bRowData.relativeCost || 0);
           },
-          tooltip: function (e, cell, _onRendered) {
+          tooltip: function (_e, cell, _onRendered) {
             const { isSelective, relativeCost } = cell.getData() as GridSOQLData;
             let title;
             if (isSelective === null) {
@@ -510,7 +508,7 @@ export class SOQLView extends LitElement {
       },
     });
 
-    this.soqlTable.on('groupClick', (e: UIEvent, group: GroupComponent) => {
+    this.soqlTable.on('groupClick', (_e: UIEvent, group: GroupComponent) => {
       const { type } = window.getSelection() ?? {};
       if (type === 'Range') {
         return;
@@ -528,7 +526,7 @@ export class SOQLView extends LitElement {
       }
     });
 
-    this.soqlTable.on('rowClick', function (e, row) {
+    this.soqlTable.on('rowClick', function (_e, row) {
       const { type } = window.getSelection() ?? {};
       if (type === 'Range') {
         return;

--- a/log-viewer/src/features/soql/services/SOQLLinter.ts
+++ b/log-viewer/src/features/soql/services/SOQLLinter.ts
@@ -173,7 +173,7 @@ class TriggerNonSelectiveQuery implements SOQLLinterRule {
     'An exception will occur when a non-selective query in a trigger executes against an object that contains more than 1 million records. To avoid this error, ensure that the query is selective';
   severity: Severity = 'Warning';
 
-  test(soqlTree: SOQLTree, stack: Stack): boolean {
+  test(_soqlTree: SOQLTree, stack: Stack): boolean {
     const inTriggerCtxt = stack.find((entry) => {
       return entry.text.includes(' trigger event ');
     });


### PR DESCRIPTION
# 📝 PR Overview

Clears TypeScript diagnostics (unused parameters and unreachable code) in the database and SOQL views. No behaviour change — purely internal cleanup.

## 🛠️ Changes made

- Prefix unused callback params with `_` in `DMLView.ts` / `SOQLView.ts` (`headerSortElement` column arg; `groupClick` / `rowClick` / `tooltip` event args) and in `SOQLLinter.ts` (`test` `soqlTree` arg).
- Drop dead `break;` statements after `return` in the `headerSortElement` switch blocks (unreachable code).

## 🧩 Type of change (check all applicable)

- [ ] 🐛 Bug fix - something not working as expected
- [ ] ✨ New feature – adds new functionality
- [x] ♻️ Refactor - internal changes with no user impact
- [ ] ⚡ Performance Improvement
- [ ] 📝 Documentation - README or documentation site changes
- [ ] 🔧 Chore - dev tooling, CI, config
- [ ] 💥 Breaking change

## ✅ Tests added?

- [ ] 👍 yes
- [x] 🙅 no, not needed
- [ ] 🙋 no, I need help

## 📚 Docs updated?

- [ ] 🔖 README.md
- [ ] 🔖 CHANGELOG.md
- [ ] 📖 help site
- [ ] 🧪 Marked any pre-release-only features (README `🧪` badge)
- [x] 🙅 not needed