### PR TITLE
fix(RetrieveLogFile): dispose loading picker on error

### DIFF
--- a/lana/src/commands/RetrieveLogFile.ts
+++ b/lana/src/commands/RetrieveLogFile.ts
@@ -4,7 +4,12 @@
 import type { LogRecord } from '@salesforce/apex-node';
 import { existsSync } from 'fs';
 import { join, parse } from 'path';
-import { window, type WebviewPanel } from 'vscode';
+import {
+  window,
+  type QuickPick as VSCodeQuickPick,
+  type QuickPickItem,
+  type WebviewPanel,
+} from 'vscode';
 
 import { appName } from '../AppSettings.js';
 import type { Context } from '../Context.js';
@@ -50,20 +55,21 @@ export class RetrieveLogFile {
 
   private static async command(context: Context): Promise<WebviewPanel | void> {
     const ws = await QuickPickWorkspace.pickOrReturn(context);
-    const [logFiles] = await Promise.all([
-      GetLogFiles.apply(ws),
-      RetrieveLogFile.showLoadingPicker(),
-    ]);
-
-    const logFileId = await RetrieveLogFile.getLogFile(logFiles);
-    if (logFileId) {
-      const logFilePath = this.getLogFilePath(ws, logFileId);
-      const writeLogFile = this.writeLogFile(ws, logFilePath);
-      return LogView.createView(context, writeLogFile, logFilePath);
+    const loadingPicker = RetrieveLogFile.showLoadingPicker();
+    try {
+      const logFiles = await GetLogFiles.apply(ws);
+      const logFileId = await RetrieveLogFile.getLogFile(logFiles);
+      if (logFileId) {
+        const logFilePath = this.getLogFilePath(ws, logFileId);
+        const writeLogFile = this.writeLogFile(ws, logFilePath);
+        return LogView.createView(context, writeLogFile, logFilePath);
+      }
+    } finally {
+      loadingPicker.dispose();
     }
   }
 
-  private static async showLoadingPicker(): Promise<QuickPick> {
+  private static showLoadingPicker(): VSCodeQuickPick<QuickPickItem> {
     const qp = window.createQuickPick();
     qp.placeholder = 'Select a logfile';
     qp.busy = true;


### PR DESCRIPTION
# 📝 PR Overview

Closes the busy "Select a logfile" QuickPick when log retrieval fails. Previously, if `GetLogFiles.apply` rejected, the loading picker was never disposed and stayed open indefinitely, and the error never surfaced to the user.

## 🛠️ Changes made

- Wrap the fetch + selection flow in `try`/`finally` so the loading picker is always disposed — on success, error, or if `LogView.createView` throws.
- Drop the `Promise.all` that discarded the picker handle; the fetch rejection now bubbles to `safeCommand`'s `catch`, which shows an actionable error message.
- Return the real `vscode.QuickPick` from `showLoadingPicker` (was a vacuous `Promise<QuickPick>` referencing the local class) so `dispose()` is callable.

## 🧩 Type of change (check all applicable)

- [x] 🐛 Bug fix - something not working as expected
- [ ] ✨ New feature – adds new functionality
- [ ] ♻️ Refactor - internal changes with no user impact
- [ ] ⚡ Performance Improvement
- [ ] 📝 Documentation - README or documentation site changes
- [ ] 🔧 Chore - dev tooling, CI, config
- [ ] 💥 Breaking change

## 📷 Screenshots / gifs / video [optional]

_No visible UI change beyond the picker now closing on error._

## 🔗 Related Issues

_None_

## ✅ Tests added?

- [ ] 👍 yes
- [x] 🙅 no, not needed
- [ ] 🙋 no, I need help

## 📚 Docs updated?

- [ ] 🔖 README.md
- [ ] 🔖 CHANGELOG.md
- [ ] 📖 help site
- [ ] 🧪 Marked any pre-release-only features (README `🧪` badge — see [RELEASING.md](../RELEASING.md#-marking-pre-release-only-features))
- [x] 🙅 not needed

## Anything else we need to know? [optional]