### PR TITLE
feat(log-viewer): modernise group-by and filter dropdowns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- 🗂️ **Call Tree + Database styling**: VS Code style tree icons, and rows indent under their group headings. ([#832])
-- ♻️ Replaced the deprecated `webview-ui-toolkit` with [vscode-elements](https://github.com/vscode-elements/elements) for all UI controls. ([#576])
+- 🎛️ **Modernised dropdowns**: searchable, compact controls that carry the field and value in one place (e.g. `Group: Namespace`, `Type: All`) ([#848]).
+- 🗂️ **Call Tree + Database styling**: VS Code style tree icons, and rows indent under their group headings. ([#832]).
+- ♻️ Replaced the deprecated `webview-ui-toolkit` with [vscode-elements](https://github.com/vscode-elements/elements) for all UI controls. ([#576]).
 
 ## [1.20.0] 2026-06-18
 
@@ -496,6 +497,7 @@ Skipped due to adopting odd numbering for pre releases and even number for relea
 
 [#576]: https://github.com/certinia/debug-log-analyzer/issues/576
 [#832]: https://github.com/certinia/debug-log-analyzer/issues/832
+[#848]: https://github.com/certinia/debug-log-analyzer/issues/848
 
 <!-- v1.20.0 -->
 

--- a/log-viewer/src/components/VsSelect.ts
+++ b/log-viewer/src/components/VsSelect.ts
@@ -2,8 +2,31 @@
  * Copyright (c) 2026 Certinia Inc. All rights reserved.
  */
 import { VscodeSingleSelect } from '#vscode-elements/vscode-single-select.js';
-import { css } from 'lit';
-import { customElement } from 'lit/decorators.js';
+import { css, html, type TemplateResult } from 'lit';
+import { customElement, property } from 'lit/decorators.js';
+import { classMap } from 'lit/directives/class-map.js';
+import { ifDefined } from 'lit/directives/if-defined.js';
+
+import { selectFaceText } from './selectFaceText.js';
+
+/** Chevron matching the vscode-elements select face (base `.icon` styles position it). */
+const chevronDownIcon = html`
+  <span class="icon">
+    <svg
+      width="16"
+      height="16"
+      viewBox="0 0 16 16"
+      xmlns="http://www.w3.org/2000/svg"
+      fill="currentColor"
+    >
+      <path
+        fill-rule="evenodd"
+        clip-rule="evenodd"
+        d="M7.976 10.072l4.357-4.357.62.618L8.284 11h-.618L3 6.333l.619-.618 4.357 4.357z"
+      />
+    </svg>
+  </span>
+`;
 
 /** Reusable for a `VscodeMultiSelect` subclass if multi-select is ever needed. */
 export const selectSizingStyles = css`
@@ -15,6 +38,52 @@ export const selectSizingStyles = css`
     /* widens the popup past the control width the base sets as an inline
        style: used width = max(width, min-width) */
     min-width: max-content;
+    box-shadow: 0 4px 16px rgba(0, 0, 0, 0.28);
+  }
+
+  .face {
+    cursor: pointer;
+  }
+
+  .face:hover {
+    background-color: var(--vscode-toolbar-hoverBackground);
+  }
+
+  /* Combobox face: size to placeholder/value (like the select face's fit-content
+     host) and vertically centre prefix / input / chevron. */
+  .combobox-face {
+    align-items: center;
+  }
+
+  .combobox-input {
+    field-sizing: content;
+    width: auto;
+    min-width: 3ch;
+  }
+
+  .face-prefix {
+    color: var(--vscode-descriptionForeground);
+  }
+
+  .face-value {
+    color: var(--vscode-foreground);
+  }
+
+  .face.active .face-value {
+    font-weight: 600;
+  }
+
+  /* Inactive placeholder is muted. */
+  .face:not(.active) .face-value {
+    color: var(--vscode-descriptionForeground);
+  }
+
+  .face-prefix + .face-value {
+    margin-left: 4px;
+  }
+
+  .combobox-face .face-prefix {
+    padding-left: 4px;
   }
 `;
 
@@ -22,4 +91,96 @@ export const selectSizingStyles = css`
 @customElement('vs-select')
 export class VsSelect extends VscodeSingleSelect {
   static styles = [...VscodeSingleSelect.styles, selectSizingStyles];
+
+  /** Field name shown before the value when active, e.g. `Group` → `Group: Namespace`. */
+  @property({ type: String })
+  prefix = '';
+
+  /** Value treated as "no selection" — renders the placeholder rather than an active value. */
+  @property({ type: String })
+  emptyValue = 'None';
+
+  private _faceContent(): TemplateResult {
+    const { prefixText, valueText } = selectFaceText({
+      prefix: this.prefix,
+      placeholder: this.label ?? '',
+      value: this.value,
+      emptyValue: this.emptyValue,
+    });
+    return html`${prefixText ? html`<span class="face-prefix">${prefixText}</span>` : ''}<span
+        class="face-value"
+        >${valueText}</span
+      >`;
+  }
+
+  protected override _renderSelectFace(): TemplateResult {
+    const activeDescendant = this._opts.activeIndex > -1 ? `op-${this._opts.activeIndex}` : '';
+    const { active } = selectFaceText({
+      prefix: this.prefix,
+      placeholder: this.label ?? '',
+      value: this.value,
+      emptyValue: this.emptyValue,
+    });
+    return html`
+      <div
+        aria-activedescendant=${activeDescendant}
+        aria-controls="select-listbox"
+        aria-expanded=${this.open ? 'true' : 'false'}
+        aria-haspopup="listbox"
+        aria-label=${ifDefined(this.label)}
+        class=${classMap({ 'select-face': true, face: true, active })}
+        @click=${this._onFaceClick}
+        role="combobox"
+        tabindex="0"
+      >
+        <span class="text">${this._faceContent()}</span> ${chevronDownIcon}
+      </div>
+    `;
+  }
+
+  protected override _renderComboboxFace(): TemplateResult {
+    const inputVal = this._isBeingFiltered ? this._opts.filterPattern : this.value;
+    const activeDescendant = this._opts.activeIndex > -1 ? `op-${this._opts.activeIndex}` : '';
+    const { prefixText, active } = selectFaceText({
+      prefix: this.prefix,
+      placeholder: this.label ?? '',
+      value: this.value,
+      emptyValue: this.emptyValue,
+    });
+    return html`
+      <div class=${classMap({ 'combobox-face': true, face: true, active })}>
+        ${prefixText ? html`<span class="face-prefix">${prefixText}</span>` : ''}
+        <input
+          aria-activedescendant=${activeDescendant}
+          aria-autocomplete="list"
+          aria-controls="select-listbox"
+          aria-expanded=${this.open ? 'true' : 'false'}
+          aria-haspopup="listbox"
+          aria-label=${ifDefined(this.label)}
+          class="combobox-input"
+          role="combobox"
+          spellcheck="false"
+          type="text"
+          autocomplete="off"
+          placeholder=${active ? '' : ifDefined(this.label)}
+          .value=${inputVal}
+          @focus=${this._onComboboxInputFocus}
+          @blur=${this._onComboboxInputBlur}
+          @input=${this._onComboboxInputInput}
+          @click=${this._onComboboxInputClick}
+          @keydown=${this._onComboboxInputSpaceKeyDown}
+        />
+        <button
+          aria-label="Open the list of options"
+          class="combobox-button"
+          type="button"
+          @click=${this._onComboboxButtonClick}
+          @keydown=${this._onComboboxButtonKeyDown}
+          tabindex="-1"
+        >
+          ${chevronDownIcon}
+        </button>
+      </div>
+    `;
+  }
 }

--- a/log-viewer/src/components/__tests__/selectFaceText.test.ts
+++ b/log-viewer/src/components/__tests__/selectFaceText.test.ts
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2026 Certinia Inc. All rights reserved.
+ */
+import { selectFaceText } from '../selectFaceText.js';
+
+describe('selectFaceText', () => {
+  it('shows the placeholder muted when there is no value', () => {
+    expect(
+      selectFaceText({ prefix: 'Group', placeholder: 'Group by', value: '', emptyValue: 'None' }),
+    ).toEqual({ prefixText: '', valueText: 'Group by', active: false });
+  });
+
+  it('treats the empty value as inactive', () => {
+    expect(
+      selectFaceText({
+        prefix: 'Group',
+        placeholder: 'Group by',
+        value: 'None',
+        emptyValue: 'None',
+      }),
+    ).toEqual({ prefixText: '', valueText: 'Group by', active: false });
+  });
+
+  it('shows `Prefix: Value` when a real value is selected', () => {
+    expect(
+      selectFaceText({
+        prefix: 'Group',
+        placeholder: 'Group by',
+        value: 'Namespace',
+        emptyValue: 'None',
+      }),
+    ).toEqual({ prefixText: 'Group:', valueText: 'Namespace', active: true });
+  });
+
+  it('omits the colon when no prefix is given', () => {
+    expect(
+      selectFaceText({ prefix: '', placeholder: 'Type', value: 'Apex Code', emptyValue: 'None' }),
+    ).toEqual({ prefixText: '', valueText: 'Apex Code', active: true });
+  });
+});

--- a/log-viewer/src/components/datagrid-filter-bar.ts
+++ b/log-viewer/src/components/datagrid-filter-bar.ts
@@ -2,7 +2,7 @@
  * Copyright (c) 2021 Certinia Inc. All rights reserved.
  */
 import { LitElement, css, html } from 'lit';
-import { customElement } from 'lit/decorators.js';
+import { customElement, state } from 'lit/decorators.js';
 
 // styles
 import { globalStyles } from '../styles/global.styles.js';
@@ -24,17 +24,39 @@ export class DatagridFilterBar extends LitElement {
         display: flex;
         .filter-bar__filters {
           display: flex;
+          align-items: flex-end;
         }
       }
 
       .filter-bar .filter-bar__actions--right {
-        align-items: center;
+        align-items: flex-end;
         display: flex;
         flex: 1 1 auto;
+        gap: 8px;
         justify-content: flex-end;
+      }
+
+      .filter-bar__group {
+        align-items: flex-end;
+        display: flex;
+      }
+
+      /* Divider between the grouping control and the action buttons. */
+      .filter-bar__group.has-group::after {
+        align-self: stretch;
+        border-right: 1px solid var(--vscode-widget-border, transparent);
+        content: '';
+        margin: 2px 8px;
       }
     `,
   ];
+
+  @state()
+  private _hasGroup = false;
+
+  private _onGroupSlotChange(event: Event) {
+    this._hasGroup = (event.target as HTMLSlotElement).assignedElements().length > 0;
+  }
 
   render() {
     return html`<div class="filter-bar">
@@ -44,6 +66,9 @@ export class DatagridFilterBar extends LitElement {
       </div>
 
       <div class="filter-bar__actions--right">
+        <div class="filter-bar__group ${this._hasGroup ? 'has-group' : ''}">
+          <slot name="group" @slotchange=${this._onGroupSlotChange}></slot>
+        </div>
         <slot name="actions"></slot>
       </div>
     </div>`;

--- a/log-viewer/src/components/selectFaceText.ts
+++ b/log-viewer/src/components/selectFaceText.ts
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2026 Certinia Inc. All rights reserved.
+ */
+
+export interface FaceText {
+  prefixText: string;
+  valueText: string;
+  active: boolean;
+}
+
+/**
+ * Trigger text for a select face. Inactive (no value, or the empty value) shows the
+ * placeholder muted; active shows `Prefix: Value` with the value emphasized.
+ */
+export function selectFaceText(opts: {
+  prefix: string;
+  placeholder: string;
+  value: string;
+  emptyValue: string;
+}): FaceText {
+  const { prefix, placeholder, value, emptyValue } = opts;
+  const active = !!value && value !== emptyValue;
+  return active
+    ? { prefixText: prefix ? `${prefix}:` : '', valueText: value, active: true }
+    : { prefixText: '', valueText: placeholder, active: false };
+}

--- a/log-viewer/src/features/analysis/components/AnalysisView.ts
+++ b/log-viewer/src/features/analysis/components/AnalysisView.ts
@@ -74,35 +74,7 @@ export class AnalysisView extends LitElement {
       .filter-container {
         display: flex;
         gap: 4px;
-      }
-
-      .align__end {
-        align-items: end;
-      }
-
-      /* cancel the checkbox's built-in 4px vertical margins so it bottom-aligns
-         like the previous 18px-tall toolkit checkbox */
-      vscode-checkbox {
-        margin: -4px 0;
-      }
-
-      .dropdown-container {
-        box-sizing: border-box;
-        display: flex;
-        flex-flow: column nowrap;
-        align-items: flex-start;
-        justify-content: flex-start;
-
-        label {
-          display: block;
-          color: var(--vscode-descriptionForeground);
-          cursor: pointer;
-          font-size: calc(var(--vscode-font-size) * 0.9);
-          font-weight: 400;
-          line-height: 1.4;
-          margin-bottom: 4px;
-          user-select: none;
-        }
+        align-items: flex-end;
       }
     `,
     categoryColoringStyles,
@@ -164,7 +136,7 @@ export class AnalysisView extends LitElement {
     return html`
       <div class="analysis-view">
         <datagrid-filter-bar>
-          <div slot="filters" class="filter-container align__end">
+          <div slot="filters" class="filter-container">
             <vscode-button
               secondary
               aria-label="Expand all"
@@ -180,20 +152,21 @@ export class AnalysisView extends LitElement {
               >Collapse</vscode-button
             >
 
-            <vscode-checkbox class="align__end" @change="${this._handleShowDetailsChange}"
-              >Details</vscode-checkbox
-            >
-
-            <div class="dropdown-container">
-              <label id="groupby-dropdown-label" for="groupby-dropdown">Group by</label>
-              <vs-select id="groupby-dropdown" label="Group by" @change="${this._groupBy}">
-                <vscode-option>None</vscode-option>
-                <vscode-option>Namespace</vscode-option>
-                <vscode-option>Caller Namespace</vscode-option>
-                <vscode-option>Type</vscode-option>
-              </vs-select>
-            </div>
+            <vscode-checkbox @change="${this._handleShowDetailsChange}">Details</vscode-checkbox>
           </div>
+
+          <vs-select
+            slot="group"
+            id="groupby-dropdown"
+            prefix="Group"
+            label="Group by"
+            @change="${this._groupBy}"
+          >
+            <vscode-option>None</vscode-option>
+            <vscode-option>Namespace</vscode-option>
+            <vscode-option>Caller Namespace</vscode-option>
+            <vscode-option>Type</vscode-option>
+          </vs-select>
 
           <div slot="actions">
             <vscode-toolbar-button

--- a/log-viewer/src/features/call-tree/components/CalltreeView.ts
+++ b/log-viewer/src/features/call-tree/components/CalltreeView.ts
@@ -75,6 +75,7 @@ export class CalltreeView extends LitElement {
     selectedTypes: new Set<string>(),
   };
   bottomUpGroupBy = 'None';
+  typeFilter = 'All';
   debugOnlyFilterCache = new Map<number, boolean>();
   typeFilterCache = new Map<number, boolean>();
 
@@ -171,50 +172,27 @@ export class CalltreeView extends LitElement {
       .header-bar {
         display: flex;
         gap: 10px;
+        align-items: flex-end;
       }
 
       .filter-container {
         display: flex;
         gap: 4px;
+        align-items: flex-end;
       }
 
       .filter-section {
         display: block;
       }
 
-      .dropdown-container {
-        box-sizing: border-box;
-        display: flex;
-        flex-flow: column nowrap;
-        align-items: flex-start;
-        justify-content: flex-start;
-
-        label {
-          display: block;
-          color: var(--vscode-descriptionForeground);
-          cursor: pointer;
-          font-size: calc(var(--vscode-font-size) * 0.9);
-          font-weight: 400;
-          line-height: 1.4;
-          margin-bottom: 4px;
-          user-select: none;
-        }
-      }
-
-      .align__end {
-        align-items: end;
-      }
-
-      /* cancel the checkbox's built-in 4px vertical margins so it bottom-aligns
-         like the previous 18px-tall toolkit checkbox */
-      vscode-checkbox {
-        margin: -4px 0;
+      /* push the grouping control to the right edge of the header bar */
+      .group-end {
+        margin-left: auto;
       }
 
       .view-mode-buttons {
         display: flex;
         gap: 0;
-        align-self: flex-end;
       }
 
       .view-mode-buttons vscode-button {
@@ -290,39 +268,44 @@ export class CalltreeView extends LitElement {
               >
             </div>
 
-            <div class="filter-container align__end">
+            <div class="filter-container">
               <vscode-button secondary @click="${this._expandButtonClick}">Expand</vscode-button>
               <vscode-button secondary @click="${this._collapseButtonClick}"
                 >Collapse</vscode-button
               >
             </div>
 
-            <div class="filter-container align__end">
-              <vscode-checkbox class="align__end" @change="${this._handleShowDetailsChange}"
-                >Details</vscode-checkbox
-              >
+            <div class="filter-container">
+              <vscode-checkbox @change="${this._handleShowDetailsChange}">Details</vscode-checkbox>
 
               ${
                 isTimeOrder || this.viewMode === 'aggregated'
                   ? html`
-                      <vscode-checkbox class="align__end" @change="${this._handleDebugOnlyChange}"
+                      <vscode-checkbox @change="${this._handleDebugOnlyChange}"
                         >Debug Only</vscode-checkbox
                       >
 
-                      <div class="dropdown-container">
-                        <label for="types">Type:</label>
-                        <vs-select label="Type" @change="${this._handleTypeFilter}">
-                          <vscode-option>None</vscode-option>
-                          ${
-                            this.isVisible
-                              ? repeat(
-                                  this._getAllTypes(this.timelineRoot?.children ?? []),
-                                  (type, _index) => html`<vscode-option>${type}</vscode-option>`,
-                                )
-                              : ''
-                          }
-                        </vs-select>
-                      </div>
+                      <vs-select
+                        prefix="Type"
+                        label="Type"
+                        emptyValue=""
+                        combobox
+                        filter="fuzzy"
+                        @change="${this._handleTypeFilter}"
+                      >
+                        <vscode-option ?selected="${this.typeFilter === 'All'}">All</vscode-option>
+                        ${
+                          this.isVisible
+                            ? repeat(
+                                this._getAllTypes(this.timelineRoot?.children ?? []),
+                                (type, _index) =>
+                                  html`<vscode-option ?selected="${this.typeFilter === type}"
+                                    >${type}</vscode-option
+                                  >`,
+                              )
+                            : ''
+                        }
+                      </vs-select>
                     `
                   : ''
               }
@@ -331,20 +314,19 @@ export class CalltreeView extends LitElement {
             ${
               this.viewMode === 'bottom-up'
                 ? html`
-                    <div class="dropdown-container">
-                      <label for="bottomup-groupby">Group by:</label>
-                      <vs-select
-                        id="bottomup-groupby"
-                        label="Group by"
-                        @change="${this._handleBottomUpGroupBy}"
-                        .value="${this.bottomUpGroupBy}"
-                      >
-                        <vscode-option>None</vscode-option>
-                        <vscode-option>Namespace</vscode-option>
-                        <vscode-option>Caller Namespace</vscode-option>
-                        <vscode-option>Type</vscode-option>
-                      </vs-select>
-                    </div>
+                    <vs-select
+                      class="group-end"
+                      id="bottomup-groupby"
+                      prefix="Group"
+                      label="Group by"
+                      @change="${this._handleBottomUpGroupBy}"
+                      .value="${this.bottomUpGroupBy}"
+                    >
+                      <vscode-option>None</vscode-option>
+                      <vscode-option>Namespace</vscode-option>
+                      <vscode-option>Caller Namespace</vscode-option>
+                      <vscode-option>Type</vscode-option>
+                    </vs-select>
                   `
                 : ''
             }
@@ -488,6 +470,7 @@ export class CalltreeView extends LitElement {
 
   _handleTypeFilter(event: Event) {
     const target = event.target as HTMLInputElement;
+    this.typeFilter = target.value || 'All';
     this.filterState.selectedTypes = new Set(target.value ? [target.value] : []);
     this._updateFiltering();
   }
@@ -511,7 +494,7 @@ export class CalltreeView extends LitElement {
       if (
         !isBottomUp &&
         this.filterState.selectedTypes.size > 0 &&
-        !this.filterState.selectedTypes.has('None')
+        !this.filterState.selectedTypes.has('All')
       ) {
         filtersToAdd.push(this._typeFilter);
       }

--- a/log-viewer/src/features/database/components/DMLView.ts
+++ b/log-viewer/src/features/database/components/DMLView.ts
@@ -116,25 +116,6 @@ export class DMLView extends LitElement {
         width: 100%;
         margin-bottom: 1rem;
       }
-
-      .dropdown-container {
-        box-sizing: border-box;
-        display: flex;
-        flex-flow: column nowrap;
-        align-items: flex-start;
-        justify-content: flex-start;
-
-        label {
-          display: block;
-          color: var(--vscode-descriptionForeground);
-          cursor: pointer;
-          font-size: calc(var(--vscode-font-size) * 0.9);
-          font-weight: 400;
-          line-height: 1.4;
-          margin-bottom: 4px;
-          user-select: none;
-        }
-      }
     `,
   ];
 
@@ -145,14 +126,17 @@ export class DMLView extends LitElement {
       <database-section title="DML Statements" .dbLines="${this.dmlLines}"></database-section>
 
       <datagrid-filter-bar>
-        <div slot="filters" class="dropdown-container">
-          <label for="dml-groupby-dropdown">Group by</label>
-          <vs-select id="dml-groupby-dropdown" label="Group by" @change="${this._dmlGroupBy}">
-            <vscode-option>DML</vscode-option>
-            <vscode-option>Caller Namespace</vscode-option>
-            <vscode-option>None</vscode-option>
-          </vs-select>
-        </div>
+        <vs-select
+          slot="filters"
+          id="dml-groupby-dropdown"
+          prefix="Group"
+          label="Group by"
+          @change="${this._dmlGroupBy}"
+        >
+          <vscode-option>DML</vscode-option>
+          <vscode-option>Caller Namespace</vscode-option>
+          <vscode-option>None</vscode-option>
+        </vs-select>
 
         <div slot="actions">
           <vscode-toolbar-button

--- a/log-viewer/src/features/database/components/SOQLView.ts
+++ b/log-viewer/src/features/database/components/SOQLView.ts
@@ -120,25 +120,6 @@ export class SOQLView extends LitElement {
         table-layout: fixed;
         margin-bottom: 1rem;
       }
-
-      .dropdown-container {
-        box-sizing: border-box;
-        display: flex;
-        flex-flow: column nowrap;
-        align-items: flex-start;
-        justify-content: flex-start;
-
-        label {
-          display: block;
-          color: var(--vscode-descriptionForeground);
-          cursor: pointer;
-          font-size: calc(var(--vscode-font-size) * 0.9);
-          font-weight: 400;
-          line-height: 1.4;
-          margin-bottom: 4px;
-          user-select: none;
-        }
-      }
     `,
   ];
 
@@ -148,14 +129,17 @@ export class SOQLView extends LitElement {
       <database-section title="SOQL Statements" .dbLines="${this.soqlLines}"></database-section>
 
       <datagrid-filter-bar>
-        <div slot="filters" class="dropdown-container">
-          <label for="soql-groupby-dropdown">Group by</label>
-          <vs-select id="soql-groupby-dropdown" label="Group by" @change="${this._soqlGroupBy}">
-            <vscode-option>SOQL</vscode-option>
-            <vscode-option>Namespace</vscode-option>
-            <vscode-option>None</vscode-option>
-          </vs-select>
-        </div>
+        <vs-select
+          slot="filters"
+          id="soql-groupby-dropdown"
+          prefix="Group"
+          label="Group by"
+          @change="${this._soqlGroupBy}"
+        >
+          <vscode-option>SOQL</vscode-option>
+          <vscode-option>Namespace</vscode-option>
+          <vscode-option>None</vscode-option>
+        </vs-select>
 
         <div slot="actions">
           <vscode-toolbar-button


### PR DESCRIPTION
# 📝 PR Overview

Modernises the Group By / filter dropdowns (`vs-select`) so they keep the VS Code look while gaining the feel and features of modern UI libraries. The field name now lives in the trigger (`Group: Namespace`, `Type: All`), long lists are searchable, and the stacked label above each control is gone — reclaiming vertical space and removing CSS duplicated across four views.

## 🛠️ Changes made

- **Field name in the trigger** — `VsSelect` renders `Group: Namespace` / `Type: All` (muted prefix + emphasised value) via overridable select/combobox faces; the stacked `<label>` and its duplicated `.dropdown-container` CSS are removed from the Analysis, Call Tree, DML and SOQL views.
- **Typeahead search** — native combobox search on the long call-tree Type filter; the ghost placeholder is suppressed while a value is shown (no more `Type: Type`).
- **Content-width sizing** — the combobox uses `field-sizing: content` to match the select's `fit-content`, so the control is only as wide as its content.
- **Grouping placement** — `datagrid-filter-bar` gains a right-aligned group slot with a divider; group-by sits left when it is the sole control (Database), right otherwise (Analysis, Call Tree).
- **Alignment + polish** — filter rows bottom-align via flexbox (drops the checkbox negative-margin hack); the Type filter's neutral option is renamed `None` → `All` and selected by default.
- Extracts a pure `selectFaceText` helper with unit tests.

## 🧩 Type of change (check all applicable)

- [ ] 🐛 Bug fix - something not working as expected
- [x] ✨ New feature – adds new functionality
- [ ] ♻️ Refactor - internal changes with no user impact
- [ ] ⚡ Performance Improvement
- [ ] 📝 Documentation - README or documentation site changes
- [ ] 🔧 Chore - dev tooling, CI, config
- [ ] 💥 Breaking change

## 📷 Screenshots / gifs / video [optional]

<img width="867" height="385" alt="image" src="https://github.com/user-attachments/assets/f892be73-d5b8-4be1-9d69-87d1cb9768e9" />

## 🔗 Related Issues

closes #848

## ✅ Tests added?

- [x] 👍 yes

## 📚 Docs updated?

- [x] 🔖 CHANGELOG.md
- [ ] 🙅 not needed

## Anything else we need to know? [optional]

Feature docs describe filtering/grouping conceptually and remain accurate. The release-versioned view screenshots (`lana/assets/1_20/*.png`) still show the older dropdowns and will be refreshed for the next release per the usual manual capture process.
