### PR TITLE
feat(database): governor-limit visibility, SOSL table, redesigned tab (#162)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,25 +9,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- 🗄️ **Database tab: governor-limit visibility + SOSL**. ([#162])
-  - 📏 **Limit gauge strip**: SOQL, SOSL, DML, query/DML rows, CPU and heap shown as `used / limit`, colored as they approach the limit.
-  - 🧮 **Found vs Counted**: each section reconciles statements found in the log against the governor-counted total, flagging queries that didn't consume the limit (e.g. custom metadata).
-  - 🏷️ **Object column** (SOQL/DML): the queried SObject, with grouping by object. Custom metadata (`__mdt`) is visible via its suffix — a reminder those queries may be free (they don't count toward the SOQL limit unless they select a long text area field or run in a Flow).
-  - 🔎 **SOSL table**: a dedicated, searchable table with column views, grouping and CSV export.
+- 🗄️ **Database tab + configurable table columns**: governor-limit visibility, a SOSL table, and column views across tables. ([#162] [#298])
+  - 📏 **Governor-limit overview** (Database): SOQL, SOSL, DML and query/DML rows shown as `used / limit`, colored as they approach the limit.
+  - 🧮 **Found vs Counted** (Database): each section reconciles statements found in the log against the governor-counted total, flagging queries that didn't consume the limit (e.g. custom metadata, which is free unless it selects a long text area field or runs in a Flow).
+  - 🔎 **SOSL table**: a dedicated, searchable Database table.
+  - 🗂️ **Column views** (Call Tree, Analysis, Database): switch preset column sets, show/hide columns from the **Columns** button or the header right-click menu, inline **reset** to restore defaults; choices persist per view.
+  - 🏷️ **New columns**: **Object** (queried/target SObject, with group-by) on SOQL/DML; **SOSL Count/Rows**, **Avg Self Time** and optional **Self** variants for every governor metric; **Heap Allocated** (+ Self) via the `Memory` view and Timeline strip; and a SOQL **Query Plan** view (Relative Cost, Leading Operation, SObject Type, Cardinality).
 - 🔴 **Timeline exception markers**: exceptions show as red lines, with a **Throws** count in method tooltips. ([#828])
-- 🧩 **Call Tree, Analysis and Database tables** gain configurable columns and views. ([#298])
-  - 🗂️ **Column views**: switch each table between column sets (`General`, `Time`, `Governor Limits`, `Database`, `Memory`); edit a view by showing/hiding columns from the **Columns** toolbar button or the header right-click menu, with inline **reset** to restore defaults; choices persist per view.
-  - 📊 **New columns**: **SOSL Count/Rows**, **Avg Self Time**, and optional **Self** variants for every governor metric.
-  - 🧠 **Heap / memory analysis**: **Heap Allocated** (+ Self) columns, surfaced through the `Memory` view and the Timeline governor limit strip.
-  - 🔎 **SOQL Query Plan** view: Relative Cost, Leading Operation, SObject Type and Cardinality.
 
 ### Changed
 
+- ♻️ Replaced the deprecated `webview-ui-toolkit` with [vscode-elements](https://github.com/vscode-elements/elements) for all UI controls. ([#576]).
+- 🎛️ **Modernised dropdowns**: searchable, compact controls that carry the field and value in one place (e.g. `Group: Namespace`, `Type: All`) ([#848]).
 - 📊 **Timeline governor limits**: tooltip rows keep a stable order and always show the `used / limit` value, so figures no longer jump around as you move the pointer. ([#827])
 - 🚧 **Timeline truncation markers** now end where the log recovers, so trusted sections are no longer greyed out. ([#828])
-- 🎛️ **Modernised dropdowns**: searchable, compact controls that carry the field and value in one place (e.g. `Group: Namespace`, `Type: All`) ([#848]).
 - 🗂️ **Call Tree + Database styling**: VS Code style tree icons, and rows indent under their group headings. ([#832]).
-- ♻️ Replaced the deprecated `webview-ui-toolkit` with [vscode-elements](https://github.com/vscode-elements/elements) for all UI controls. ([#576]).
 
 ## [1.20.0] 2026-06-18
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- 🗄️ **Database tab: governor-limit visibility + SOSL**. ([#162])
+  - 📏 **Limit gauge strip**: SOQL, SOSL, DML, query/DML rows, CPU and heap shown as `used / limit`, colored as they approach the limit.
+  - 🧮 **Found vs Counted**: each section reconciles statements found in the log against the governor-counted total, flagging queries that didn't consume the limit (e.g. custom metadata).
+  - 🏷️ **Object column** (SOQL/DML): the queried SObject, with grouping by object. Custom metadata (`__mdt`) is visible via its suffix — a reminder those queries may be free (they don't count toward the SOQL limit unless they select a long text area field or run in a Flow).
+  - 🔎 **SOSL table**: a dedicated, searchable table with column views, grouping and CSV export.
 - 🔴 **Timeline exception markers**: exceptions show as red lines, with a **Throws** count in method tooltips. ([#828])
 - 🧩 **Call Tree, Analysis and Database tables** gain configurable columns and views. ([#298])
   - 🗂️ **Column views**: switch each table between column sets (`General`, `Time`, `Governor Limits`, `Database`, `Memory`); edit a view by showing/hiding columns from the **Columns** toolbar button or the header right-click menu, with inline **reset** to restore defaults; choices persist per view.
@@ -511,6 +516,7 @@ Skipped due to adopting odd numbering for pre releases and even number for relea
 [#848]: https://github.com/certinia/debug-log-analyzer/issues/848
 [#827]: https://github.com/certinia/debug-log-analyzer/issues/827
 [#298]: https://github.com/certinia/debug-log-analyzer/issues/298
+[#162]: https://github.com/certinia/debug-log-analyzer/issues/162
 [#32]: https://github.com/certinia/debug-log-analyzer/issues/32
 
 <!-- v1.20.0 -->

--- a/README.md
+++ b/README.md
@@ -124,15 +124,17 @@ See which methods are the slowest, most frequent. or expensive.
 
 ## 🗄️ Database Analysis
 
-Highlight slow Salesforce SOQL queries, non-selective filters, and DML issues.
+Highlight slow Salesforce SOQL queries, non-selective filters, and DML issues, and see how each contributes to governor limits.
 
-- **SOQL + DML Duration, Selectivity, Aggregates, Row Count**
-- **Group by Namespace, Caller Namespace or Query**
+- **Governor limit overview** – SOQL, SOSL, DML and query/DML rows shown as `used / limit` at the top of the tab.
+- **Tracked vs consumed** – each section reconciles statements seen in the log against the governor-counted total, so you can spot queries that didn't count (e.g. custom metadata).
+- **Separate SOQL, DML and SOSL tables** – SOSL is fully searchable, with its rows metered against the 2,000-per-query cap.
+- **Object column + Group by Object / Namespace / Caller Namespace / Query**
+- **SOQL Duration, Selectivity, Aggregates, Row Count**
 - **Column Views** – Preset column sets (incl. a SOQL Query Plan view), show/hide columns, reset to defaults
-- **View the Call Stack**
-- **SOQL Optimization Tips**
-- **Sort by SOQL or DML, Duration, Selectivity, Aggregates, Row Count**
-- **Copy or Export to CSV**
+- **View the Call Stack**, **SOQL Optimization Tips**, **Sort**, **Copy or Export to CSV**
+
+<!-- TODO: re-capture database.png for the redesigned Database tab (governor strip, DML/SOQL/SOSL sections). Optionally add a sosl.png. -->
 
 ![Database](https://raw.githubusercontent.com/certinia/debug-log-analyzer/main/lana/assets/1_20/database.png)
 

--- a/apex-log-parser/__tests__/EventMetadata.test.ts
+++ b/apex-log-parser/__tests__/EventMetadata.test.ts
@@ -1,8 +1,8 @@
 /*
  * Copyright (c) 2026 Certinia Inc. All rights reserved.
  */
-import { describe, expect } from '@jest/globals';
-import { getLogEventClass, parse } from '../src/index.js';
+import { describe, expect, it } from '@jest/globals';
+import { DMLBeginLine, getLogEventClass, parse } from '../src/index.js';
 
 describe('Event debugLevel and debugCategory', () => {
   describe('new events are parsed (not null from getLogEventClass)', () => {
@@ -87,6 +87,20 @@ describe('Event debugLevel and debugCategory', () => {
       const line = log.children[0];
       expect(line).toBeDefined();
       expect(line!.debugLevel).toBe(expectedLevel);
+    });
+  });
+
+  describe('DMLBeginLine.sObjectType', () => {
+    it.each([
+      ['15:20:52.222 (100)|DML_BEGIN|[1]|Op:Insert|Type:Account|Rows:1', 'Account'],
+      [
+        '15:20:52.222 (100)|DML_BEGIN|[1]|Op:Update|Type:ns2__MyObject__c|Rows:1',
+        'ns2__MyObject__c',
+      ],
+    ])('parses the target object from %s', (logLine, expected) => {
+      const line = parse(logLine).children[0];
+      expect(line).toBeInstanceOf(DMLBeginLine);
+      expect((line as DMLBeginLine).sObjectType).toBe(expected);
     });
   });
 });

--- a/apex-log-parser/src/LogEvents.ts
+++ b/apex-log-parser/src/LogEvents.ts
@@ -962,11 +962,17 @@ export class DMLBeginLine extends DurationLogEvent {
     total: 1,
   };
   namespace = 'default';
+  /** The SObject the DML targets (e.g. `Account`), from the `Type:` field. Null if absent. */
+  sObjectType: string | null = null;
 
   constructor(parser: ApexLogParser, parts: string[]) {
     super(parser, parts, ['DML_END'], LOG_CATEGORY.DML, 'free');
     this.lineNumber = this.parseLineNumber(parts[2]);
     this.text = 'DML ' + parts[3] + ' ' + parts[4];
+    const typePart = parts[4];
+    if (typePart?.startsWith('Type:')) {
+      this.sObjectType = typePart.slice('Type:'.length);
+    }
     const rowCountString = parts[5];
     this.dmlRowCount.total = this.dmlRowCount.self = rowCountString ? parseRows(rowCountString) : 0;
   }

--- a/apex-log-parser/src/index.ts
+++ b/apex-log-parser/src/index.ts
@@ -38,6 +38,7 @@ export {
   MethodEntryLine,
   SOQLExecuteBeginLine,
   SOQLExecuteExplainLine,
+  SOSLExecuteBeginLine,
   parseObjectNamespace,
   parseRows,
   parseVfNamespace,

--- a/lana-docs/docs/docs/features/database.md
+++ b/lana-docs/docs/docs/features/database.md
@@ -5,8 +5,11 @@ description: Database insights help Salesforce developers analyze SOQL and DML o
 keywords:
   [
     salesforce database analysis,
-    soql optimization,
-    dml performance,
+    soql,
+    sosl,
+    dml,
+    optimization,
+    performance,
     apex query tuning,
     salesforce log analysis,
     database insights,
@@ -19,9 +22,19 @@ hide_title: true
 
 ## 💾 Database
 
-Database insights help Salesforce developers analyze SOQL and DML operations, assess query selectivity, performance, and aggregations, and optimize Apex code using advanced sorting, grouping, filtering, call stack tracing, and CSV export tools.
+Database insights help Salesforce developers analyze DML, SOQL and SOSL operations, assess query selectivity, performance, and aggregations, and optimize Apex code using advanced sorting, grouping, filtering, call stack tracing, and CSV export tools.
 
-![Database view screenshot displaying SOQL and DML operations with row counts, execution times, selectivity indicators, and aggregation details for Salesforce log analysis.](https://raw.githubusercontent.com/certinia/debug-log-analyzer/main/lana/assets/1_20/database.png)
+![Database view screenshot displaying DML, SOQL and SOSL operations with row counts, execution times, selectivity indicators, and aggregation details for Salesforce log analysis.](https://raw.githubusercontent.com/certinia/debug-log-analyzer/main/lana/assets/1_20/database.png)
+
+The tab has separate **DML**, **SOQL** and **SOSL** sections
+
+### Governor limits
+
+- **Overview strip** — SOQL, SOSL, DML and query/DML rows as `used / limit`, coloured as they near the limit.
+- **Tracked vs consumed** — per section, statements seen in the log vs the number Salesforce counted (`CUMULATIVE_LIMIT_USAGE`). A gap is usually custom metadata (`__mdt`), which is free unless the query selects a long text area field or runs in a Flow.
+- **SOSL rows** — metered per query against the 2,000-rows-per-query cap.
+
+> Consumed figures need the Apex Profiling log category. Without it, sections show the tracked count and mark the limit _n/a_.
 
 The _Selectivity_ column will have a green tick if the query is selective, a red cross if it is not and will be blank if the selectivity could not be determine. Sorting on this column will sort the rows by relative query cost, this number can be seen by hovering the cell on the selectivity column.
 
@@ -39,15 +52,15 @@ If the grouping is removed the sorting applies the same but across all rows inst
 
 ### Column Views
 
-Switch column sets from the **Columns** button in the toolbar (or the header right-click menu). SOQL offers **General**, **Performance** and **Query Plan** (Relative Cost, Leading Operation, SObject Type, Cardinality); DML offers **General** and **Timing**. Show or hide individual columns there; an edited view shows a **reset** icon. Choices persist per table.
+Switch column sets from the **Columns** button in the toolbar (or the header right-click menu). SOQL offers **General** (incl. the **Object** column), **Performance**, **Query Plan** (Relative Cost, Leading Operation, SObject Type, Cardinality) and **Limits**; DML offers **General**, **Timing** and **Limits**; SOSL offers **General** and **Timing**. Show or hide individual columns there; an edited view shows a **reset** icon. Choices persist per table.
 
 ### Group
 
-By default rows are grouped by the SOQL/ DML text, grouping can be removed and the rows shows as a flat list using the _Group by_ item in the header menu. The groups are default sorted with the groups with the most items at the top.
+By default rows are grouped by the SOQL/ DML text, grouping can be removed and the rows shows as a flat list using the _Group by_ dropdown. The groups are default sorted with the groups with the most items at the top.
 
-SOQL Statements can also be grouped by package namespace including the default namespace
+SOQL and DML can be grouped by **Object** (the queried/target SObject), **Namespace**, or **Caller Namespace**, as well as the statement text. SOSL can be grouped by Namespace or Caller Namespace.
 
-Rows can also be grouped by **Caller Namespace** — the namespace of the direct caller that issued the DML. This makes it easy to see which package's code is responsible for that DML, even though the time is attributed to the default namespace.
+**Caller Namespace** is the namespace of the direct caller that issued the statement — handy for seeing which package's code is responsible, even when the time is attributed to the default namespace.
 
 ### DML / SOQL Call Stack
 

--- a/lana/package.json
+++ b/lana/package.json
@@ -354,7 +354,8 @@
             "enum": [
               "General",
               "Performance",
-              "Query Plan"
+              "Query Plan",
+              "Limits"
             ],
             "markdownDescription": "The column view applied to the Database SOQL table. Default: `General`",
             "order": 0
@@ -365,10 +366,22 @@
             "default": "General",
             "enum": [
               "General",
-              "Timing"
+              "Timing",
+              "Limits"
             ],
             "markdownDescription": "The column view applied to the Database DML table. Default: `General`",
             "order": 2
+          },
+          "lana.database.sosl.columnView": {
+            "title": "SOSL column view",
+            "type": "string",
+            "default": "General",
+            "enum": [
+              "General",
+              "Timing"
+            ],
+            "markdownDescription": "The column view applied to the Database SOSL table. Default: `General`",
+            "order": 4
           }
         }
       }

--- a/lana/src/commands/LogView.ts
+++ b/lana/src/commands/LogView.ts
@@ -113,6 +113,7 @@ export class LogView {
             config.callTree.columnOverrides = overrides['callTree.columnOverrides'] ?? {};
             config.database.soql.columnOverrides = overrides['database.soql.columnOverrides'] ?? {};
             config.database.dml.columnOverrides = overrides['database.dml.columnOverrides'] ?? {};
+            config.database.sosl.columnOverrides = overrides['database.sosl.columnOverrides'] ?? {};
             panel.webview.postMessage({
               requestId,
               cmd: 'getConfig',

--- a/lana/src/workspace/AppConfig.ts
+++ b/lana/src/workspace/AppConfig.ts
@@ -41,6 +41,7 @@ interface Config {
   database: {
     soql: { columnView: string; columnOverrides: Record<string, string[]> };
     dml: { columnView: string; columnOverrides: Record<string, string[]> };
+    sosl: { columnView: string; columnOverrides: Record<string, string[]> };
   };
 }
 
@@ -75,6 +76,7 @@ export const COLUMN_OVERRIDE_SECTIONS = [
   'callTree.columnOverrides',
   'database.soql.columnOverrides',
   'database.dml.columnOverrides',
+  'database.sosl.columnOverrides',
 ] as const;
 
 type ColumnOverrides = Record<string, string[]>;

--- a/log-viewer/src/__tests__/Database.test.ts
+++ b/log-viewer/src/__tests__/Database.test.ts
@@ -26,6 +26,24 @@ describe('Analyse database tests', () => {
 
     const firstDML = result.getDMLLines()[0];
     expect(firstDML?.text).toEqual('DML Op:Insert Type:codaCompany__c');
+    expect(firstDML?.sObjectType).toEqual('codaCompany__c');
+  });
+
+  it('collects SOSL statements', async () => {
+    const log =
+      '09:18:22.6 (6574780)|EXECUTION_STARTED\n' +
+      '09:18:22.6 (6586704)|CODE_UNIT_STARTED|[EXTERNAL]|066d0000002m8ij|apex://pkg.Entry\n' +
+      '17:33:36.2 (1672655920)|SOSL_EXECUTE_BEGIN|[12]|FIND :searchQuery RETURNING Account(Id, Name)\n' +
+      '17:33:36.2 (1678684460)|SOSL_EXECUTE_END|[12]|Rows:5\n' +
+      '09:18:22.6 (7300000)|CODE_UNIT_FINISHED|apex://pkg.Entry\n' +
+      '09:18:22.6 (7400000)|EXECUTION_FINISHED\n';
+
+    const apexLog = parse(log);
+    const result = await DatabaseAccess.create(apexLog);
+
+    const soslLines = result.getSOSLLines();
+    expect(soslLines.length).toEqual(1);
+    expect(soslLines[0]?.soslRowCount.self).toEqual(5);
   });
 
   it('resolves stack by eventIndex when timestamps are duplicated', async () => {

--- a/log-viewer/src/features/call-tree/utils/GovernorCost.ts
+++ b/log-viewer/src/features/call-tree/utils/GovernorCost.ts
@@ -43,8 +43,9 @@ interface CostMetric {
  * Metrics that are attributed per call-tree node (and therefore comparable to
  * their limit per path). CPU time and callouts are intentionally excluded —
  * they are only tracked globally, not per node. SOSL rows are also excluded:
- * they have no governor limit (only SOSL *queries* is limited, to 20) and do
- * not count against the SOQL query-rows limit.
+ * they have no per-transaction limit to accumulate against (the 2,000-row cap
+ * is per query) and don't count against the SOQL query-rows limit; only SOSL
+ * *queries* is a transaction total (limited to 20).
  */
 const COST_METRICS: CostMetric[] = [
   { label: 'SOQL', used: (r) => r.soqlCount.total, limit: (l) => l.soqlQueries.limit },

--- a/log-viewer/src/features/database/__tests__/limits.test.ts
+++ b/log-viewer/src/features/database/__tests__/limits.test.ts
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2026 Certinia Inc. All rights reserved.
+ */
+import { SOSL_ROWS_PER_QUERY_LIMIT, soslRowsMetric } from '../limits.js';
+
+describe('soslRowsMetric', () => {
+  it('degrades to "limit n/a" (used null, no ceiling, no note) with no cumulative snapshot', () => {
+    const metric = soslRowsMetric(500, 0, false);
+    expect(metric.used).toBeNull();
+    expect(metric.limit).toBe(0);
+    expect(metric.note).toBeUndefined();
+  });
+
+  it('derives the ceiling from soslQueries.limit × per-query cap when a snapshot is present', () => {
+    const metric = soslRowsMetric(500, 20, true);
+    expect(metric.used).toBe(500);
+    expect(metric.limit).toBe(20 * SOSL_ROWS_PER_QUERY_LIMIT);
+    expect(metric.note).toContain('max per transaction');
+  });
+
+  it('shows no ceiling when a snapshot exists but the SOSL-query limit is 0', () => {
+    const metric = soslRowsMetric(500, 0, true);
+    expect(metric.used).toBe(500); // count is trusted (snapshot present)
+    expect(metric.limit).toBe(0); // but no meaningful ceiling to meter against
+    expect(metric.note).toBeUndefined();
+  });
+});

--- a/log-viewer/src/features/database/components/DMLView.ts
+++ b/log-viewer/src/features/database/components/DMLView.ts
@@ -13,7 +13,6 @@ import { vscodeMessenger } from '../../../core/messaging/VSCodeExtensionMessenge
 import { getCallerNamespace } from '../../../core/utility/CallerNamespace.js';
 import { isVisible } from '../../../core/utility/Util.js';
 import { getSettings, updateSetting } from '../../settings/Settings.js';
-import { DatabaseAccess } from '../services/Database.js';
 import {
   applyColumnView,
   buildColumnMenuItems,
@@ -46,13 +45,13 @@ import '../../../components/CallStack.js';
 import '../../../components/ContextMenu.js';
 import type { ContextMenu } from '../../../components/ContextMenu.js';
 import '../../../components/datagrid-filter-bar.js';
-import './DatabaseSection.js';
 
 /** The DML column is always shown in the DML table. */
 const ALWAYS_VISIBLE = ['dml'];
 
 const groupLabelsToFields = new Map<string, string>([
   ['DML', 'dml'],
+  ['Object', 'objectType'],
   ['Namespace', 'namespace'],
   ['Caller Namespace', 'callerNamespace'],
   ['None', ''],
@@ -69,8 +68,9 @@ export class DMLView extends LitElement {
   @property()
   oldIndex: number = 0;
 
-  @state()
-  dmlLines: DMLBeginLine[] = [];
+  /** DML lines to display; supplied by the parent DatabaseView. */
+  @property({ attribute: false })
+  lines: DMLBeginLine[] = [];
 
   dmlTable: Tabulator | null = null;
   holder: HTMLElement | null = null;
@@ -119,8 +119,7 @@ export class DMLView extends LitElement {
   updated(changedProperties: PropertyValues): void {
     if (
       this.timelineRoot &&
-      changedProperties.has('timelineRoot') &&
-      !changedProperties.get('timelineRoot')
+      (changedProperties.has('lines') || changedProperties.has('timelineRoot'))
     ) {
       this._appendTableWhenVisible();
     }
@@ -158,8 +157,6 @@ export class DMLView extends LitElement {
     const dmlSkeleton = !this.timelineRoot ? html`<grid-skeleton></grid-skeleton>` : ``;
 
     return html`
-      <database-section title="DML Statements" .dbLines="${this.dmlLines}"></database-section>
-
       <datagrid-filter-bar>
         <vs-select
           slot="table-actions"
@@ -187,6 +184,8 @@ export class DMLView extends LitElement {
           @change="${this._dmlGroupBy}"
         >
           <vscode-option>DML</vscode-option>
+          <vscode-option>Object</vscode-option>
+          <vscode-option>Namespace</vscode-option>
           <vscode-option>Caller Namespace</vscode-option>
           <vscode-option>None</vscode-option>
         </vs-select>
@@ -234,7 +233,9 @@ export class DMLView extends LitElement {
 
   private _setColumnView(id: string) {
     this.columnView = id;
-    if (this.dmlTable) {
+    // Only apply once the table is laid out; otherwise tableBuilt → _initTableColumns
+    // applies the current view (redraw on an unrendered table throws).
+    if (this.dmlTable?.element?.clientHeight) {
       applyColumnView(this.dmlTable, this._columnViewFields(id), ALWAYS_VISIBLE);
     }
   }
@@ -366,13 +367,9 @@ export class DMLView extends LitElement {
       return;
     }
 
-    isVisible(this).then(async (isVisible) => {
-      const treeRoot = this.timelineRoot;
+    isVisible(this).then((isVisible) => {
       const tableWrapper = this._dmlTableWrapper;
-      if (tableWrapper && treeRoot && isVisible) {
-        const dbAccess = await DatabaseAccess.create(treeRoot);
-        this.dmlLines = dbAccess.getDMLLines();
-
+      if (tableWrapper && this.timelineRoot && isVisible) {
         Tabulator.registerModule(Object.values(CommonModules));
         Tabulator.registerModule([
           RowKeyboardNavigation,
@@ -382,7 +379,7 @@ export class DMLView extends LitElement {
           GroupChildIndent,
           GroupSort,
         ]);
-        this._renderDMLTable(tableWrapper, this.dmlLines);
+        this._renderDMLTable(tableWrapper, this.lines);
       }
     });
   }
@@ -448,6 +445,7 @@ export class DMLView extends LitElement {
         dmlData.push({
           id: ++nextRowId,
           dml: dml.text,
+          objectType: dml.sObjectType,
           namespace: dml.namespace,
           callerNamespace: getCallerNamespace(dml),
           rowCount: dml.dmlRowCount.self,
@@ -547,6 +545,22 @@ export class DMLView extends LitElement {
             multiselect: true,
           },
           headerFilterLiveFilter: false,
+        },
+        {
+          title: 'Object',
+          field: 'objectType',
+          sorter: 'string',
+          width: 150,
+          visible: false,
+          headerFilter: 'list',
+          headerFilterFunc: 'in',
+          headerFilterParams: {
+            valuesLookup: 'all',
+            clearable: true,
+            multiselect: true,
+          },
+          headerFilterLiveFilter: false,
+          formatter: (cell) => (cell.getValue() as string | null) ?? '—',
         },
         {
           title: 'Namespace',
@@ -743,6 +757,7 @@ type VSCodeSaveFile = {
 interface DMLRow {
   id: number;
   dml?: string;
+  objectType?: string | null;
   namespace?: string;
   callerNamespace?: string;
   rowCount?: number;

--- a/log-viewer/src/features/database/components/DatabaseMetricCard.ts
+++ b/log-viewer/src/features/database/components/DatabaseMetricCard.ts
@@ -157,7 +157,7 @@ export class DatabaseMetricCard extends LitElement {
     if (metric.used === null) {
       return html`<span
         class="stat__used na"
-        title="The consumed figure needs cumulative limit usage in the log — raise the database log level to FINE or above."
+        title="The consumed figure needs cumulative limit usage in the log. Raise the database log level to FINE or above."
         >limit n/a</span
       >`;
     }

--- a/log-viewer/src/features/database/components/DatabaseMetricCard.ts
+++ b/log-viewer/src/features/database/components/DatabaseMetricCard.ts
@@ -1,0 +1,194 @@
+/*
+ * Copyright (c) 2026 Certinia Inc. All rights reserved.
+ */
+import { LitElement, css, html, nothing } from 'lit';
+import { customElement, property } from 'lit/decorators.js';
+
+import { globalStyles } from '../../../styles/global.styles.js';
+
+const integer = new Intl.NumberFormat(undefined, { maximumFractionDigits: 0 });
+
+/** A single database limit metric: what the tables tracked vs what the limit is. */
+export interface DatabaseMetric {
+  /** Metric name, e.g. `Statements`, `Rows`, `Searches`. */
+  label: string;
+  /** Count seen in the log and shown in the table. */
+  found: number;
+  /** The governor-consumed total, or `null` when cumulative limits weren't logged. */
+  used: number | null;
+  /** The governor limit (0 when none applies / unknown). */
+  limit: number;
+  /**
+   * Overrides the default seen-vs-used reconciliation tooltip. Set when the limit
+   * is a derived ceiling that needs explaining (e.g. SOSL rows: 2,000/query × 20).
+   */
+  note?: string;
+}
+
+/** Fill tier: safe under 80%, warning from 80%, danger at or over 100%. */
+function tier(percent: number): 'safe' | 'warn' | 'danger' {
+  if (percent >= 100) {
+    return 'danger';
+  }
+  return percent >= 80 ? 'warn' : 'safe';
+}
+
+/**
+ * One database limit metric as a small stacked stat: a `LABEL  N seen · used /
+ * limit` line over a thin full-width bar. Shares the section header's language
+ * (no box or fill). Two states:
+ * - known → `used / limit` + proportional bar (tooltip: {@link DatabaseMetric.note}
+ *   if set, else the seen-vs-used reconciliation);
+ * - unknown → `limit n/a` + empty bar, whole stat muted (never a guess).
+ */
+@customElement('database-metric-card')
+export class DatabaseMetricCard extends LitElement {
+  @property({ attribute: false })
+  metric: DatabaseMetric | null = null;
+
+  static styles = [
+    globalStyles,
+    css`
+      :host {
+        display: inline-flex;
+      }
+
+      .stat {
+        display: inline-flex;
+        flex-direction: column;
+        gap: 4px;
+        min-width: 8rem;
+      }
+
+      /* Unknown limit (no cumulative usage in the log): de-emphasised so an
+         empty bar reads as "no data", not "0%". */
+      .stat.unknown {
+        opacity: 0.6;
+      }
+
+      .stat__line {
+        display: inline-flex;
+        align-items: baseline;
+        gap: 6px;
+        white-space: nowrap;
+        font-size: 0.85rem;
+      }
+
+      .stat__label {
+        font-size: 0.72rem;
+        letter-spacing: 0.06em;
+        text-transform: uppercase;
+        color: var(--vscode-descriptionForeground);
+      }
+
+      .stat__seen {
+        font-family: var(--vscode-editor-font-family, monospace);
+        font-variant-numeric: tabular-nums;
+      }
+
+      .stat__used {
+        font-family: var(--vscode-editor-font-family, monospace);
+        font-variant-numeric: tabular-nums;
+        font-size: 0.8rem;
+        color: var(--vscode-descriptionForeground);
+      }
+
+      .stat__used.na {
+        font-style: italic;
+      }
+
+      .stat__sep {
+        color: var(--vscode-descriptionForeground);
+      }
+
+      .stat__track {
+        display: block;
+        width: 100%;
+        height: 3px;
+        border-radius: 2px;
+        background: var(--vscode-editorWidget-border, var(--vscode-panel-border));
+        overflow: hidden;
+      }
+
+      .stat__fill {
+        display: block;
+        height: 100%;
+        border-radius: 2px;
+        transition: width 150ms ease;
+      }
+
+      .stat__fill--safe {
+        background: var(--vscode-charts-green, #388a34);
+      }
+      .stat__fill--warn {
+        background: var(--vscode-charts-yellow, var(--vscode-editorWarning-foreground));
+      }
+      .stat__fill--danger {
+        background: var(--vscode-errorForeground, #f14c4c);
+      }
+
+      @media (prefers-reduced-motion: reduce) {
+        .stat__fill {
+          transition: none;
+        }
+      }
+    `,
+  ];
+
+  render() {
+    const metric = this.metric;
+    if (!metric) {
+      return nothing;
+    }
+
+    const unknown = metric.used === null && metric.limit <= 0;
+    return html`<span class="stat ${unknown ? 'unknown' : ''}">
+      <span class="stat__line">
+        <span class="stat__label">${metric.label}</span>
+        <span class="stat__seen">${integer.format(metric.found)} seen</span>
+        <span class="stat__sep">·</span>
+        ${this._renderConsumed(metric)}
+      </span>
+      ${this._renderBar(metric)}
+    </span>`;
+  }
+
+  private _renderConsumed(metric: DatabaseMetric) {
+    if (metric.used === null) {
+      return html`<span
+        class="stat__used na"
+        title="The consumed figure needs cumulative limit usage in the log — raise the database log level to FINE or above."
+        >limit n/a</span
+      >`;
+    }
+
+    const delta = metric.found - metric.used;
+    const title =
+      metric.note ??
+      (delta > 0
+        ? `${delta} seen but not counted toward the limit (e.g. custom metadata).`
+        : delta < 0
+          ? `${-delta} counted by Salesforce but not emitted as log lines (e.g. managed-package internals).`
+          : 'Every statement seen counted toward the limit.');
+    return html`<span class="stat__used" title="${title}"
+      >${integer.format(metric.used)} / ${integer.format(metric.limit)} used</span
+    >`;
+  }
+
+  private _renderBar(metric: DatabaseMetric) {
+    // The track always renders — even when the limit is unknown, where it stays
+    // empty — so every metric block is the same height and their text lines up.
+    const hasFill = metric.used !== null && metric.limit > 0;
+    const percent = hasFill && metric.used !== null ? (metric.used / metric.limit) * 100 : 0;
+    return html`<span class="stat__track"
+      >${
+        hasFill
+          ? html`<span
+              class="stat__fill stat__fill--${tier(percent)}"
+              style="width: ${Math.min(percent, 100)}%"
+            ></span>`
+          : nothing
+      }</span
+    >`;
+  }
+}

--- a/log-viewer/src/features/database/components/DatabaseSection.ts
+++ b/log-viewer/src/features/database/components/DatabaseSection.ts
@@ -4,51 +4,126 @@
 import { LitElement, css, html } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
 
-import type { LogEvent } from 'apex-log-parser';
-
 // web components
-import '../../../components/BadgeBase.js';
+import './DatabaseMetricCard.js';
+import type { DatabaseMetric } from './DatabaseMetricCard.js';
 
 // styles
 import { globalStyles } from '../../../styles/global.styles.js';
 
+/**
+ * A database section header: a collapsible title row carrying its limit metrics
+ * inline as flat stat chips. Clicking the header toggles the section; the host
+ * (DatabaseView) owns the accent bar, left inset, collapsed state and the table.
+ */
 @customElement('database-section')
 export class DatabaseSection extends LitElement {
+  /** Short section name, e.g. `DML`. */
   @property({ type: String })
   title = '';
-  @property({ type: Object, attribute: false })
-  dbLines: LogEvent[] = [];
+
+  @property({ type: Boolean, reflect: true })
+  collapsed = false;
+
+  @property({ attribute: false })
+  metrics: DatabaseMetric[] = [];
 
   static styles = [
     globalStyles,
     css`
-      .dbSection {
-        padding: 10px 5px 5px 0px;
+      :host {
+        display: block;
       }
-      .dbTitle {
-        font-weight: bold;
-        font-size: 1.2em;
+
+      .header {
+        display: flex;
+        align-items: center;
+        flex-wrap: wrap;
+        gap: 8px 18px;
+        width: 100%;
+        box-sizing: border-box;
+        /* Accent bar lives on the header only; the 12px inset puts the title on
+           the same 15px edge as the toolbar and table below. */
+        padding: 8px 6px 8px 12px;
+        background: none;
+        border: none;
+        border-left: 3px solid var(--accent, transparent);
+        color: inherit;
+        cursor: pointer;
+        text-align: left;
       }
-      .dbBlock {
-        margin-left: 10px;
-        font-weight: normal;
+
+      .header:hover {
+        background: var(--vscode-list-hoverBackground);
+      }
+
+      .title-group {
+        display: flex;
+        align-items: center;
+        gap: 8px;
+      }
+
+      .chevron {
+        flex: 0 0 auto;
+        color: var(--vscode-descriptionForeground);
+        transition: transform 150ms ease;
+      }
+
+      :host([collapsed]) .chevron {
+        transform: rotate(-90deg);
+      }
+
+      .title {
+        font-weight: 600;
+        font-size: 1.05rem;
+        letter-spacing: 0.02em;
+      }
+
+      .metrics {
+        display: flex;
+        flex-wrap: wrap;
+        align-items: center;
+        gap: 8px 18px;
+      }
+
+      @media (prefers-reduced-motion: reduce) {
+        .chevron {
+          transition: none;
+        }
       }
     `,
   ];
 
   render() {
-    const totalCount = this.dbLines.length;
-    let totalRows = 0;
-    this.dbLines.forEach((value) => {
-      totalRows += value.dmlRowCount.self || value.soqlRowCount.self || 0;
-    });
+    return html`<button class="header" aria-expanded="${!this.collapsed}" @click="${this._toggle}">
+      <span class="title-group">
+        <svg
+          class="chevron"
+          width="14"
+          height="14"
+          viewBox="0 0 16 16"
+          fill="none"
+          aria-hidden="true"
+        >
+          <path d="M4 6l4 4 4-4" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" />
+        </svg>
+        <span class="title">${this.title}</span>
+      </span>
+      <span class="metrics"
+        >${this.metrics.map(
+          (metric) => html`<database-metric-card .metric="${metric}"></database-metric-card>`,
+        )}</span
+      >
+    </button>`;
+  }
 
-    return html`
-      <div class="dbSection">
-        <span class="dbTitle">${this.title}</span>
-        <badge-base>Count: ${totalCount}</badge-base>
-        <badge-base>Rows: ${totalRows}</badge-base>
-      </div>
-    `;
+  private _toggle() {
+    this.dispatchEvent(
+      new CustomEvent('section-toggle', {
+        bubbles: true,
+        composed: true,
+        detail: { collapsed: !this.collapsed },
+      }),
+    );
   }
 }

--- a/log-viewer/src/features/database/components/DatabaseView.ts
+++ b/log-viewer/src/features/database/components/DatabaseView.ts
@@ -2,10 +2,20 @@
  * Copyright (c) 2022 Certinia Inc. All rights reserved.
  */
 
-import { LitElement, css, html } from 'lit';
+import { LitElement, css, html, nothing, type PropertyValues } from 'lit';
 import { customElement, property, state } from 'lit/decorators.js';
 
-import type { ApexLog } from 'apex-log-parser';
+import type {
+  ApexLog,
+  DMLBeginLine,
+  Limits,
+  SOQLExecuteBeginLine,
+  SOSLExecuteBeginLine,
+} from 'apex-log-parser';
+
+import { isVisible } from '../../../core/utility/Util.js';
+import { SOSL_ROWS_PER_QUERY_LIMIT } from '../limits.js';
+import { DatabaseAccess } from '../services/Database.js';
 
 // styles
 import { globalStyles } from '../../../styles/global.styles.js';
@@ -15,27 +25,44 @@ import '../../../components/CallStack.js';
 import './DMLView.js';
 import './DatabaseSOQLDetailPanel.js';
 import './DatabaseSection.js';
+import type { DatabaseMetric } from './DatabaseMetricCard.js';
+import './GovernorSummary.js';
+import type { GaugeMetric } from './GovernorSummary.js';
 import './SOQLView.js';
+import './SOSLView.js';
+
+type SectionKind = 'dml' | 'soql' | 'sosl';
 
 @customElement('database-view')
 export class DatabaseView extends LitElement {
   @property()
   timelineRoot: ApexLog | null = null;
 
+  @state()
+  private dmlLines: DMLBeginLine[] = [];
+  @state()
+  private soqlLines: SOQLExecuteBeginLine[] = [];
+  @state()
+  private soslLines: SOSLExecuteBeginLine[] = [];
+  @state()
+  private loaded = false;
+
+  /** Per-section collapsed state; empty types default to collapsed once loaded. */
+  @state()
+  private collapsed: Record<SectionKind, boolean> = { dml: false, soql: false, sosl: false };
+
+  // Match totals per table, routing the shared find widget's current match to the
+  // right table, accumulated in view order: DML, then SOQL, then SOSL.
   dmlMatches = 0;
   soqlMatches = 0;
+  soslMatches = 0;
 
   @state()
   dmlHighlightIndex = 0;
   @state()
   soqlHighlightIndex = 0;
-
-  findArgs: { text: string; count: number; options: { matchCase: boolean } } = {
-    text: '',
-    count: 0,
-    options: { matchCase: false },
-  };
-  findMap = {};
+  @state()
+  soslHighlightIndex = 0;
 
   constructor() {
     super();
@@ -52,6 +79,34 @@ export class DatabaseView extends LitElement {
     document.removeEventListener('lv-find', this._findHandler as EventListener);
   }
 
+  updated(changed: PropertyValues): void {
+    if (this.timelineRoot && changed.has('timelineRoot') && !this.loaded) {
+      void this._loadData();
+    }
+  }
+
+  private async _loadData(): Promise<void> {
+    const root = this.timelineRoot;
+    if (!root) {
+      return;
+    }
+    const visible = await isVisible(this);
+    if (!visible || this.loaded) {
+      return;
+    }
+    const db = await DatabaseAccess.create(root);
+    this.dmlLines = db.getDMLLines();
+    this.soqlLines = db.getSOQLLines();
+    this.soslLines = db.getSOSLLines();
+    this.loaded = true;
+    // Collapse types the transaction never touched (usually SOSL).
+    this.collapsed = {
+      dml: this._isEmpty('dml'),
+      soql: this._isEmpty('soql'),
+      sosl: this._isEmpty('sosl'),
+    };
+  }
+
   static styles = [
     globalStyles,
     css`
@@ -61,20 +116,188 @@ export class DatabaseView extends LitElement {
         height: 100%;
         width: 100%;
       }
+
+      governor-summary {
+        border-bottom: 1px solid var(--vscode-panel-border);
+      }
+
+      .db-panel {
+        display: flex;
+        flex-direction: column;
+      }
+
+      /* The accent bar lives on the section header (inherits --accent); the grid
+         view is inset to the same 15px content edge (3px bar + 12px header pad)
+         so header, toolbar and table line up on one left edge. */
+      .db-panel--dml {
+        --accent: var(--vscode-charts-blue, #4e94ce);
+      }
+      .db-panel--soql {
+        --accent: var(--vscode-charts-purple, #b180d7);
+      }
+      .db-panel--sosl {
+        --accent: var(--vscode-charts-orange, #d18616);
+      }
+
+      .db-panel dml-view,
+      .db-panel soql-view,
+      .db-panel sosl-view {
+        box-sizing: border-box;
+        padding-left: 15px;
+      }
+
+      .db-panel + .db-panel {
+        margin-top: 16px;
+        border-top: 1px solid var(--vscode-panel-border);
+        padding-top: 8px;
+      }
     `,
   ];
 
   render() {
     return html`
-      <dml-view
-        .timelineRoot="${this.timelineRoot}"
-        .highlightIndex="${this.dmlHighlightIndex}"
-      ></dml-view>
-      <soql-view
-        .timelineRoot="${this.timelineRoot}"
-        .highlightIndex="${this.soqlHighlightIndex}"
-      ></soql-view>
+      <governor-summary .metrics="${this._stripMetrics()}"></governor-summary>
+      ${this._renderSection('dml')} ${this._renderSection('soql')} ${this._renderSection('sosl')}
     `;
+  }
+
+  private _renderSection(kind: SectionKind) {
+    const collapsed = this.collapsed[kind];
+    return html`<div class="db-panel db-panel--${kind}">
+      <database-section
+        title="${SECTION_META[kind].title}"
+        ?collapsed="${collapsed}"
+        .metrics="${this._sectionMetrics(kind)}"
+        @section-toggle="${() => this._toggle(kind)}"
+      ></database-section>
+      ${collapsed || !this.loaded ? nothing : this._renderTable(kind)}
+    </div>`;
+  }
+
+  private _renderTable(kind: SectionKind) {
+    switch (kind) {
+      case 'dml':
+        return html`<dml-view
+          .timelineRoot="${this.timelineRoot}"
+          .lines="${this.dmlLines}"
+          .highlightIndex="${this.dmlHighlightIndex}"
+        ></dml-view>`;
+      case 'soql':
+        return html`<soql-view
+          .timelineRoot="${this.timelineRoot}"
+          .lines="${this.soqlLines}"
+          .highlightIndex="${this.soqlHighlightIndex}"
+        ></soql-view>`;
+      case 'sosl':
+        return html`<sosl-view
+          .timelineRoot="${this.timelineRoot}"
+          .lines="${this.soslLines}"
+          .highlightIndex="${this.soslHighlightIndex}"
+        ></sosl-view>`;
+    }
+  }
+
+  private _toggle(kind: SectionKind) {
+    this.collapsed = { ...this.collapsed, [kind]: !this.collapsed[kind] };
+  }
+
+  private get _limits(): Limits | undefined {
+    return this.timelineRoot?.governorLimits;
+  }
+
+  /** Cumulative limits are only present when the log recorded a usage snapshot. */
+  private get _hasLimits(): boolean {
+    return (this.timelineRoot?.governorLimits.snapshots.length ?? 0) > 0;
+  }
+
+  private _rows(kind: SectionKind): number {
+    switch (kind) {
+      case 'dml':
+        return this.dmlLines.reduce((sum, l) => sum + l.dmlRowCount.self, 0);
+      case 'soql':
+        return this.soqlLines.reduce((sum, l) => sum + l.soqlRowCount.self, 0);
+      case 'sosl':
+        return this.soslLines.reduce((sum, l) => sum + l.soslRowCount.self, 0);
+    }
+  }
+
+  private _count(kind: SectionKind): number {
+    return kind === 'dml'
+      ? this.dmlLines.length
+      : kind === 'soql'
+        ? this.soqlLines.length
+        : this.soslLines.length;
+  }
+
+  private _used(value: number): number | null {
+    return this._hasLimits ? value : null;
+  }
+
+  private _isEmpty(kind: SectionKind): boolean {
+    const limits = this._limits;
+    const consumed = limits ? SECTION_META[kind].statement(limits).used : 0;
+    return this._count(kind) === 0 && consumed === 0;
+  }
+
+  /** The tracked-vs-consumed cards for a section. */
+  private _sectionMetrics(kind: SectionKind): DatabaseMetric[] {
+    const limits = this._limits;
+    const statement = limits ? SECTION_META[kind].statement(limits) : { used: 0, limit: 0 };
+    const rows = limits ? SECTION_META[kind].rows(limits) : { used: 0, limit: 0 };
+    const metrics: DatabaseMetric[] = [
+      {
+        label: SECTION_META[kind].statementLabel,
+        found: this._count(kind),
+        used: this._used(statement.used),
+        limit: statement.limit,
+      },
+    ];
+    if (kind === 'sosl') {
+      // SOSL rows aren't reported as a transaction total, but there's a hard
+      // ceiling: at most 2,000 rows per query × the SOSL-query limit (20). Meter
+      // the total against that derived ceiling; the per-query cap is on hover and
+      // metered per row in the table.
+      const maxQueries = limits?.soslQueries.limit || 20;
+      const total = this._rows(kind);
+      metrics.push({
+        label: 'Rows',
+        found: total,
+        used: total,
+        limit: maxQueries * SOSL_ROWS_PER_QUERY_LIMIT,
+        note: `Up to ${SOSL_ROWS_PER_QUERY_LIMIT.toLocaleString()} rows per SOSL query × ${maxQueries} queries = ${(maxQueries * SOSL_ROWS_PER_QUERY_LIMIT).toLocaleString()} max per transaction.`,
+      });
+    } else {
+      metrics.push({
+        label: 'Rows',
+        found: this._rows(kind),
+        used: this._used(rows.used),
+        limit: rows.limit,
+      });
+    }
+    return metrics;
+  }
+
+  /**
+   * The overview strip gauges: statement counts then row counts. The full core
+   * set is always shown (even at zero) so gauge positions stay stable across
+   * logs and confirm coverage; fully-zero gauges are muted by the component.
+   */
+  private _stripMetrics(): GaugeMetric[] {
+    if (!this.loaded) {
+      return [];
+    }
+    const limits = this._limits;
+    const gauges: GaugeMetric[] = [];
+    const add = (label: string, found: number, metric: { used: number; limit: number }) => {
+      gauges.push({ label, found, used: this._used(metric.used), limit: metric.limit });
+    };
+    const z = { used: 0, limit: 0 };
+    add('DML', this._count('dml'), limits?.dmlStatements ?? z);
+    add('SOQL', this._count('soql'), limits?.soqlQueries ?? z);
+    add('SOSL', this._count('sosl'), limits?.soslQueries ?? z);
+    add('DML Rows', this._rows('dml'), limits?.dmlRows ?? z);
+    add('Query Rows', this._rows('soql'), limits?.queryRows ?? z);
+    return gauges;
   }
 
   _findHandler = (
@@ -88,25 +311,63 @@ export class DatabaseView extends LitElement {
     if (matchIndex <= this.dmlMatches) {
       this.dmlHighlightIndex = matchIndex;
       this.soqlHighlightIndex = 0;
-    } else {
+      this.soslHighlightIndex = 0;
+    } else if (matchIndex <= this.dmlMatches + this.soqlMatches) {
       this.soqlHighlightIndex = matchIndex - this.dmlMatches;
       this.dmlHighlightIndex = 0;
+      this.soslHighlightIndex = 0;
+    } else {
+      this.soslHighlightIndex = matchIndex - this.dmlMatches - this.soqlMatches;
+      this.dmlHighlightIndex = 0;
+      this.soqlHighlightIndex = 0;
     }
   };
 
-  _findResults = (e: CustomEvent<{ totalMatches: number; type: 'dml' | 'soql' }>) => {
+  _findResults = (e: CustomEvent<{ totalMatches: number; type: SectionKind }>) => {
     if (e.detail.type === 'dml') {
       this.dmlMatches = e.detail.totalMatches;
     } else if (e.detail.type === 'soql') {
       this.soqlMatches = e.detail.totalMatches;
+    } else if (e.detail.type === 'sosl') {
+      this.soslMatches = e.detail.totalMatches;
     }
 
     this._find({ count: 1 });
 
     document.dispatchEvent(
       new CustomEvent('lv-find-results', {
-        detail: { totalMatches: this.dmlMatches + this.soqlMatches },
+        detail: { totalMatches: this.dmlMatches + this.soqlMatches + this.soslMatches },
       }),
     );
   };
 }
+
+interface SectionSpec {
+  title: string;
+  statementLabel: string;
+  statement: (limits: Limits) => { used: number; limit: number };
+  rows: (limits: Limits) => { used: number; limit: number };
+}
+
+// Which governor each type reconciles against. Order of use is DML, SOQL, SOSL —
+// DML first (as it always has been), SOSL last (usually absent).
+const SECTION_META: Record<SectionKind, SectionSpec> = {
+  dml: {
+    title: 'DML',
+    statementLabel: 'Statements',
+    statement: (l) => l.dmlStatements,
+    rows: (l) => l.dmlRows,
+  },
+  soql: {
+    title: 'SOQL',
+    statementLabel: 'Queries',
+    statement: (l) => l.soqlQueries,
+    rows: (l) => l.queryRows,
+  },
+  sosl: {
+    title: 'SOSL',
+    statementLabel: 'Searches',
+    statement: (l) => l.soslQueries,
+    rows: (l) => l.queryRows,
+  },
+};

--- a/log-viewer/src/features/database/components/DatabaseView.ts
+++ b/log-viewer/src/features/database/components/DatabaseView.ts
@@ -14,7 +14,7 @@ import type {
 } from 'apex-log-parser';
 
 import { isVisible } from '../../../core/utility/Util.js';
-import { SOSL_ROWS_PER_QUERY_LIMIT } from '../limits.js';
+import { soslRowsMetric } from '../limits.js';
 import { DatabaseAccess } from '../services/Database.js';
 
 // styles
@@ -253,18 +253,14 @@ export class DatabaseView extends LitElement {
       },
     ];
     if (kind === 'sosl') {
-      // SOSL rows aren't reported as a transaction total, but there's a hard
-      // ceiling: at most 2,000 rows per query × the SOSL-query limit (20). Meter
-      // the total against that derived ceiling; the per-query cap is on hover and
-      // metered per row in the table.
-      const maxQueries = limits?.soslQueries.limit || 20;
+      // SOSL rows aren't a transaction total — the ceiling is derived from the
+      // SOSL-query limit; without a snapshot it degrades to "limit n/a". The
+      // per-query cap is shown on hover and metered per row in the table.
       const total = this._rows(kind);
       metrics.push({
         label: 'Rows',
         found: total,
-        used: total,
-        limit: maxQueries * SOSL_ROWS_PER_QUERY_LIMIT,
-        note: `Up to ${SOSL_ROWS_PER_QUERY_LIMIT.toLocaleString()} rows per SOSL query × ${maxQueries} queries = ${(maxQueries * SOSL_ROWS_PER_QUERY_LIMIT).toLocaleString()} max per transaction.`,
+        ...soslRowsMetric(total, limits?.soslQueries.limit ?? 0, this._hasLimits),
       });
     } else {
       metrics.push({

--- a/log-viewer/src/features/database/components/GovernorSummary.ts
+++ b/log-viewer/src/features/database/components/GovernorSummary.ts
@@ -1,0 +1,166 @@
+/*
+ * Copyright (c) 2026 Certinia Inc. All rights reserved.
+ */
+import { LitElement, css, html, nothing } from 'lit';
+import { customElement, property } from 'lit/decorators.js';
+
+import { globalStyles } from '../../../styles/global.styles.js';
+
+const integer = new Intl.NumberFormat(undefined, { maximumFractionDigits: 0 });
+
+/** One at-a-glance governor gauge for the overview strip. */
+export interface GaugeMetric {
+  label: string;
+  /** Count found in the log (fallback display when limits aren't available). */
+  found: number;
+  /** Governor-consumed count, or `null` when cumulative limits weren't logged. */
+  used: number | null;
+  /** Governor limit (0 when none applies). */
+  limit: number;
+}
+
+function tier(percent: number): 'safe' | 'warn' | 'danger' {
+  if (percent >= 100) {
+    return 'danger';
+  }
+  return percent >= 80 ? 'warn' : 'safe';
+}
+
+/**
+ * The database overview strip: a single compact row of governor gauges
+ * (`used / limit`) for an at-a-glance read across statement types. Fully
+ * controlled — the host passes the metrics to show, already filtered and
+ * ordered.
+ */
+@customElement('governor-summary')
+export class GovernorSummary extends LitElement {
+  @property({ attribute: false })
+  metrics: GaugeMetric[] = [];
+
+  static styles = [
+    globalStyles,
+    css`
+      :host {
+        display: block;
+      }
+
+      .gauges {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 8px 22px;
+        /* Left inset matches the sections' content edge (3px accent + 12px). */
+        padding: 10px 12px 12px 15px;
+      }
+
+      .gauge {
+        display: flex;
+        flex-direction: column;
+        gap: 4px;
+        min-width: 6.5rem;
+        flex: 1 1 6.5rem;
+        max-width: 12rem;
+      }
+
+      /* A governor with no activity and nothing consumed — kept for stable
+         positions but de-emphasised. */
+      .gauge.muted {
+        opacity: 0.5;
+      }
+
+      .gauge__label {
+        font-size: 0.7rem;
+        letter-spacing: 0.06em;
+        text-transform: uppercase;
+        color: var(--vscode-descriptionForeground);
+        white-space: nowrap;
+      }
+
+      .gauge__value {
+        font-family: var(--vscode-editor-font-family, monospace);
+        font-variant-numeric: tabular-nums;
+        font-size: 0.95rem;
+        white-space: nowrap;
+      }
+
+      .gauge__limit,
+      .gauge__na {
+        color: var(--vscode-descriptionForeground);
+      }
+
+      .gauge__na {
+        font-size: 0.78rem;
+        font-style: italic;
+      }
+
+      .gauge__track {
+        height: 5px;
+        border-radius: 3px;
+        background: var(--vscode-editorWidget-border, var(--vscode-panel-border));
+        overflow: hidden;
+      }
+
+      .gauge__fill {
+        height: 100%;
+        border-radius: 3px;
+        transition: width 150ms ease;
+      }
+
+      .gauge__fill--safe {
+        background: var(--vscode-charts-green, #388a34);
+      }
+      .gauge__fill--warn {
+        background: var(--vscode-charts-yellow, var(--vscode-editorWarning-foreground));
+      }
+      .gauge__fill--danger {
+        background: var(--vscode-errorForeground, #f14c4c);
+      }
+
+      @media (prefers-reduced-motion: reduce) {
+        .gauge__fill {
+          transition: none;
+        }
+      }
+    `,
+  ];
+
+  render() {
+    if (!this.metrics.length) {
+      return nothing;
+    }
+    return html`<div class="gauges">${this.metrics.map((m) => this._renderGauge(m))}</div>`;
+  }
+
+  private _renderGauge(metric: GaugeMetric) {
+    const muted = metric.found === 0 && (metric.used ?? 0) === 0;
+
+    if (metric.used === null || metric.limit <= 0) {
+      return html`<div class="gauge ${muted ? 'muted' : ''}">
+        <span class="gauge__label">${metric.label}</span>
+        <span class="gauge__value"
+          >${integer.format(metric.found)} <span class="gauge__na">seen</span></span
+        >
+      </div>`;
+    }
+
+    const percent = (metric.used / metric.limit) * 100;
+    return html`<div
+      class="gauge ${muted ? 'muted' : ''}"
+      role="meter"
+      aria-label="${metric.label}"
+      aria-valuenow="${metric.used}"
+      aria-valuemax="${metric.limit}"
+    >
+      <span class="gauge__label">${metric.label}</span>
+      <span class="gauge__value"
+        >${integer.format(metric.used)}
+        <span class="gauge__limit">/ ${integer.format(metric.limit)}</span></span
+      >
+      <div class="gauge__track">
+        <div
+          class="gauge__fill gauge__fill--${tier(percent)}"
+          style="width: ${Math.min(percent, 100)}%"
+        ></div>
+      </div>
+    </div>`;
+  }
+}

--- a/log-viewer/src/features/database/components/SOSLView.ts
+++ b/log-viewer/src/features/database/components/SOSLView.ts
@@ -1,25 +1,17 @@
 /*
- * Copyright (c) 2022 Certinia Inc. All rights reserved.
+ * Copyright (c) 2026 Certinia Inc. All rights reserved.
  */
 import '#vscode-elements/vscode-option.js';
 import '../../../components/VsSelect.js';
 import '#vscode-elements/vscode-toolbar-button.js';
 import { LitElement, css, html, render, unsafeCSS, type PropertyValues } from 'lit';
 import { customElement, property, state } from 'lit/decorators.js';
-import {
-  Tabulator,
-  type ColumnComponent,
-  type GroupComponent,
-  type RowComponent,
-} from 'tabulator-tables';
+import { Tabulator, type GroupComponent, type RowComponent } from 'tabulator-tables';
 
-import type { ApexLog, SOQLExecuteBeginLine } from 'apex-log-parser';
+import type { ApexLog, SOSLExecuteBeginLine } from 'apex-log-parser';
 import { vscodeMessenger } from '../../../core/messaging/VSCodeExtensionMessenger.js';
-import { isVisible } from '../../../core/utility/Util.js';
 import { getCallerNamespace } from '../../../core/utility/CallerNamespace.js';
-import { deriveSoqlObject } from '../services/sobjectClassification.js';
-import { soqlGroupHeader } from '../../soql/format/groupHeader.js';
-import { soqlSyntaxStyles } from '../../soql/styles/soql-syntax.css.js';
+import { isVisible } from '../../../core/utility/Util.js';
 import { getSettings, updateSetting } from '../../settings/Settings.js';
 import {
   applyColumnView,
@@ -27,7 +19,7 @@ import {
   getColumnView,
   getTableFields,
   resolveColumnView,
-  SOQL_VIEWS,
+  SOSL_VIEWS,
   toggleField,
 } from '../../../tabulator/ColumnViews.js';
 
@@ -35,6 +27,7 @@ import {
 import NumberAccessor from '../../../tabulator/dataaccessor/Number.js';
 import Number from '../../../tabulator/format/Number.js';
 import { progressFormatter } from '../../../tabulator/format/Progress.js';
+import { SOSL_ROWS_PER_QUERY_LIMIT } from '../limits.js';
 import { GroupCalcs } from '../../../tabulator/groups/GroupCalcs.js';
 import { GroupChildIndent } from '../../../tabulator/groups/GroupChildIndent.js';
 import { GroupSort } from '../../../tabulator/groups/GroupSort.js';
@@ -53,47 +46,37 @@ import '../../../components/CallStack.js';
 import '../../../components/ContextMenu.js';
 import type { ContextMenu } from '../../../components/ContextMenu.js';
 import '../../../components/datagrid-filter-bar.js';
-import './DatabaseSOQLDetailPanel.js';
 
-/** The SOQL column is always shown in the SOQL table. */
-const ALWAYS_VISIBLE = ['soql'];
+/** The SOSL column is always shown in the SOSL table. */
+const ALWAYS_VISIBLE = ['sosl'];
 
-// Group-by dropdown label → row field. Labels that don't map 1:1 to a field
-// name (Object, Caller Namespace) need this indirection.
 const groupLabelsToFields = new Map<string, string>([
-  ['SOQL', 'soql'],
-  ['Object', 'objectType'],
+  ['SOSL', 'sosl'],
   ['Namespace', 'namespace'],
   ['Caller Namespace', 'callerNamespace'],
   ['None', ''],
 ]);
 
-@customElement('soql-view')
-export class SOQLView extends LitElement {
+const countFormat = new Intl.NumberFormat(undefined, { maximumFractionDigits: 0 });
+
+@customElement('sosl-view')
+export class SOSLView extends LitElement {
   @property()
   timelineRoot: ApexLog | null = null;
 
   @property()
   highlightIndex: number = 0;
 
-  /** SOQL lines to display; supplied by the parent DatabaseView. */
-  @property({ attribute: false })
-  lines: SOQLExecuteBeginLine[] = [];
-
-  @state()
+  @property()
   oldIndex: number = 0;
 
-  soqlTable: Tabulator | null = null;
+  /** SOSL lines to display; supplied by the parent DatabaseView. */
+  @property({ attribute: false })
+  lines: SOSLExecuteBeginLine[] = [];
+
+  soslTable: Tabulator | null = null;
   holder: HTMLElement | null = null;
   table: HTMLElement | null = null;
-
-  @state()
-  columnView = 'General';
-
-  /** Per-view column overrides (view id → visible fields); empty until edited. */
-  @state()
-  private columnOverrides: Record<string, string[]> = {};
-  private contextMenu: ContextMenu | null = null;
   findArgs: { text: string; count: number; options: { matchCase: boolean } } = {
     text: '',
     count: 0,
@@ -103,9 +86,13 @@ export class SOQLView extends LitElement {
   totalMatches = 0;
   blockClearHighlights = true;
 
-  get _soqlTableWrapper(): HTMLDivElement | null {
-    return this.renderRoot?.querySelector('#db-soql-table');
-  }
+  @state()
+  columnView = 'General';
+
+  /** Per-view column overrides (view id → visible fields); empty until edited. */
+  @state()
+  private columnOverrides: Record<string, string[]> = {};
+  private contextMenu: ContextMenu | null = null;
 
   constructor() {
     super();
@@ -127,8 +114,8 @@ export class SOQLView extends LitElement {
 
   private async _loadColumnSettings(): Promise<void> {
     const settings = await getSettings();
-    this.columnOverrides = settings.database?.soql?.columnOverrides ?? {};
-    this._setColumnView(resolveColumnView(SOQL_VIEWS, settings.database?.soql?.columnView));
+    this.columnOverrides = settings.database?.sosl?.columnOverrides ?? {};
+    this._setColumnView(resolveColumnView(SOSL_VIEWS, settings.database?.sosl?.columnView));
   }
 
   updated(changedProperties: PropertyValues): void {
@@ -147,7 +134,6 @@ export class SOQLView extends LitElement {
   static styles = [
     unsafeCSS(dataGridStyles),
     unsafeCSS(databaseViewStyles),
-    unsafeCSS(soqlSyntaxStyles),
     globalStyles,
     css`
       :host {
@@ -156,25 +142,27 @@ export class SOQLView extends LitElement {
         width: 100%;
       }
 
-      #soql-table-container {
+      #sosl-table-container {
         height: 100%;
       }
 
-      #db-soql-table {
+      #db-sosl-table {
         overflow: hidden;
         table-layout: fixed;
+        width: 100%;
         margin-bottom: 1rem;
       }
     `,
   ];
 
   render() {
-    const soqlSkeleton = !this.timelineRoot ? html`<grid-skeleton></grid-skeleton>` : ``;
+    const soslSkeleton = !this.timelineRoot ? html`<grid-skeleton></grid-skeleton>` : ``;
+
     return html`
       <datagrid-filter-bar>
         <vs-select
           slot="table-actions"
-          id="soql-column-view"
+          id="sosl-column-view"
           prefix="Columns"
           label="Column view"
           @change="${this._handleColumnViewChange}"
@@ -182,7 +170,7 @@ export class SOQLView extends LitElement {
           .value="${this.columnView}"
           .resettableValues="${Object.keys(this.columnOverrides)}"
         >
-          ${SOQL_VIEWS.map(
+          ${SOSL_VIEWS.map(
             (view) =>
               html`<vscode-option value="${view.id}" ?selected="${this.columnView === view.id}"
                 >${view.id}</vscode-option
@@ -192,13 +180,12 @@ export class SOQLView extends LitElement {
 
         <vs-select
           slot="group"
-          id="soql-groupby-dropdown"
+          id="sosl-groupby-dropdown"
           prefix="Group"
           label="Group by"
-          @change="${this._soqlGroupBy}"
+          @change="${this._soslGroupBy}"
         >
-          <vscode-option>SOQL</vscode-option>
-          <vscode-option>Object</vscode-option>
+          <vscode-option>SOSL</vscode-option>
           <vscode-option>Namespace</vscode-option>
           <vscode-option>Caller Namespace</vscode-option>
           <vscode-option>None</vscode-option>
@@ -226,9 +213,9 @@ export class SOQLView extends LitElement {
         </div>
       </datagrid-filter-bar>
 
-      <div id="soql-table-container">
-        ${soqlSkeleton}
-        <div id="db-soql-table"></div>
+      <div id="sosl-table-container">
+        ${soslSkeleton}
+        <div id="db-sosl-table"></div>
       </div>
       <context-menu @menu-select="${this._handleColumnMenuSelect}"></context-menu>
     `;
@@ -237,20 +224,20 @@ export class SOQLView extends LitElement {
   private _handleColumnViewChange(event: Event) {
     const id = (event.target as HTMLInputElement).value || 'General';
     this._setColumnView(id);
-    updateSetting('database.soql.columnView', id);
+    updateSetting('database.sosl.columnView', id);
   }
 
   /** Effective fields for a view id: the user override, else the built-in preset. */
   private _columnViewFields(id: string): string[] | null {
-    return this.columnOverrides[id] ?? getColumnView(SOQL_VIEWS, id)?.fields ?? null;
+    return this.columnOverrides[id] ?? getColumnView(SOSL_VIEWS, id)?.fields ?? null;
   }
 
   private _setColumnView(id: string) {
     this.columnView = id;
     // Only apply once the table is laid out; otherwise tableBuilt → _initTableColumns
     // applies the current view (redraw on an unrendered table throws).
-    if (this.soqlTable?.element?.clientHeight) {
-      applyColumnView(this.soqlTable, this._columnViewFields(id), ALWAYS_VISIBLE);
+    if (this.soslTable?.element?.clientHeight) {
+      applyColumnView(this.soslTable, this._columnViewFields(id), ALWAYS_VISIBLE);
     }
   }
 
@@ -265,14 +252,14 @@ export class SOQLView extends LitElement {
   }
 
   private _showColumnMenu(x: number, y: number) {
-    if (!this.contextMenu || !this.soqlTable) {
+    if (!this.contextMenu || !this.soslTable) {
       return;
     }
     this.contextMenu.show(
       buildColumnMenuItems(
-        this.soqlTable,
+        this.soslTable,
         this.columnView,
-        SOQL_VIEWS,
+        SOSL_VIEWS,
         ALWAYS_VISIBLE,
         Object.keys(this.columnOverrides),
       ),
@@ -288,13 +275,13 @@ export class SOQLView extends LitElement {
 
   /** Rebuilds the open column menu so checkmarks/reset icons reflect current state. */
   private _refreshColumnMenu() {
-    if (!this.contextMenu?.isVisible() || !this.soqlTable) {
+    if (!this.contextMenu?.isVisible() || !this.soslTable) {
       return;
     }
     this.contextMenu.items = buildColumnMenuItems(
-      this.soqlTable,
+      this.soslTable,
       this.columnView,
-      SOQL_VIEWS,
+      SOSL_VIEWS,
       ALWAYS_VISIBLE,
       Object.keys(this.columnOverrides),
     );
@@ -302,14 +289,14 @@ export class SOQLView extends LitElement {
 
   private _handleColumnMenuSelect(e: CustomEvent<{ itemId: string }>) {
     const { itemId } = e.detail;
-    const table = this.soqlTable;
+    const table = this.soslTable;
     if (!table) {
       return;
     }
     if (itemId.startsWith('view:')) {
       const id = itemId.slice('view:'.length);
       this._setColumnView(id);
-      updateSetting('database.soql.columnView', id);
+      updateSetting('database.sosl.columnView', id);
       this._refreshColumnMenu();
       return;
     }
@@ -322,7 +309,7 @@ export class SOQLView extends LitElement {
       );
       this.columnOverrides = { ...this.columnOverrides, [this.columnView]: fields };
       applyColumnView(table, fields, ALWAYS_VISIBLE);
-      updateSetting('database.soql.columnOverrides', this.columnOverrides);
+      updateSetting('database.sosl.columnOverrides', this.columnOverrides);
       this._refreshColumnMenu();
       return;
     }
@@ -338,7 +325,7 @@ export class SOQLView extends LitElement {
 
   /** Clears a view's override, restoring its built-in columns (defaults to the active view). */
   private _resetColumns(id: string = this.columnView) {
-    const table = this.soqlTable;
+    const table = this.soslTable;
     if (!table || !this.columnOverrides[id]) {
       return;
     }
@@ -347,38 +334,42 @@ export class SOQLView extends LitElement {
     if (id === this.columnView) {
       applyColumnView(table, this._columnViewFields(id), ALWAYS_VISIBLE);
     }
-    updateSetting('database.soql.columnOverrides', this.columnOverrides);
+    updateSetting('database.sosl.columnOverrides', this.columnOverrides);
   }
 
   _copyToClipboard() {
-    this.soqlTable?.copyToClipboard('all');
+    this.soslTable?.copyToClipboard('all');
   }
 
   _exportToCSV() {
-    this.soqlTable?.download('csv', 'soql.csv', { bom: true, delimiter: ',' });
+    this.soslTable?.download('csv', 'sosl.csv', { bom: true, delimiter: ',' });
   }
 
   _findEvt = ((event: FindEvt) => {
     this._find(event);
   }) as EventListener;
 
-  _soqlGroupBy(event: Event) {
-    if (!this.soqlTable) {
+  _soslGroupBy(event: Event) {
+    if (!this.soslTable) {
       return;
     }
     const target = event.target as HTMLInputElement;
     const groupValue = groupLabelsToFields.get(target.value) ?? '';
     //@ts-expect-error This is a custom function added in the GroupSort custom module
-    this.soqlTable.setSortedGroupBy(groupValue);
+    this.soslTable.setSortedGroupBy(groupValue);
+  }
+
+  get _soslTableWrapper(): HTMLDivElement | null {
+    return this.renderRoot?.querySelector('#db-sosl-table');
   }
 
   _appendTableWhenVisible() {
-    if (this.soqlTable) {
+    if (this.soslTable) {
       return;
     }
 
     isVisible(this).then((isVisible) => {
-      const tableWrapper = this._soqlTableWrapper;
+      const tableWrapper = this._soslTableWrapper;
       if (tableWrapper && this.timelineRoot && isVisible) {
         Tabulator.registerModule(Object.values(CommonModules));
         Tabulator.registerModule([
@@ -389,13 +380,13 @@ export class SOQLView extends LitElement {
           GroupChildIndent,
           GroupSort,
         ]);
-        this._renderSOQLTable(tableWrapper, this.lines);
+        this._renderSOSLTable(tableWrapper, this.lines);
       }
     });
   }
 
   async _highlightMatches(highlightIndex: number) {
-    if (!this.soqlTable?.element?.clientHeight) {
+    if (!this.soslTable?.element?.clientHeight) {
       return;
     }
 
@@ -403,17 +394,16 @@ export class SOQLView extends LitElement {
     const currentRow = this.findMap[highlightIndex];
     this.blockClearHighlights = true;
     //@ts-expect-error This is a custom function added in by Find custom module
-    await this.soqlTable.setCurrentMatch(highlightIndex, currentRow, {
+    await this.soslTable.setCurrentMatch(highlightIndex, currentRow, {
       scrollIfVisible: false,
       focusRow: false,
     });
     this.blockClearHighlights = false;
-
     this.oldIndex = highlightIndex;
   }
 
   async _find(e: CustomEvent<{ text: string; count: number; options: { matchCase: boolean } }>) {
-    const isTableVisible = !!this.soqlTable?.element?.clientHeight;
+    const isTableVisible = !!this.soslTable?.element?.clientHeight;
     if (!isTableVisible && !this.totalMatches) {
       return;
     }
@@ -431,7 +421,7 @@ export class SOQLView extends LitElement {
     if (newSearch || clearHighlights) {
       this.blockClearHighlights = true;
       //@ts-expect-error This is a custom function added in by Find custom module
-      const result = await this.soqlTable.find(this.findArgs);
+      const result = await this.soslTable.find(this.findArgs);
       this.blockClearHighlights = false;
       this.totalMatches = result.totalMatches;
       this.findMap = result.matchIndexes;
@@ -439,47 +429,30 @@ export class SOQLView extends LitElement {
       if (!clearHighlights) {
         document.dispatchEvent(
           new CustomEvent('db-find-results', {
-            detail: { totalMatches: result.totalMatches, type: 'soql' },
+            detail: { totalMatches: result.totalMatches, type: 'sosl' },
           }),
         );
       }
     }
   }
 
-  _renderSOQLTable(soqlTableContainer: HTMLElement, soqlLines: SOQLExecuteBeginLine[]) {
-    const eventIndexToSOQL = new Map<number, SOQLExecuteBeginLine>();
-    const queryRowLimit = this.timelineRoot?.governorLimits.queryRows.limit ?? 0;
+  _renderSOSLTable(soslTableContainer: HTMLElement, soslLines: SOSLExecuteBeginLine[]) {
+    const soslData: SOSLRow[] = [];
     let nextRowId = 0;
-
-    soqlLines?.forEach((line) => {
-      eventIndexToSOQL.set(line.eventIndex, line);
-    });
-
-    const soqlData: GridSOQLData[] = [];
-    if (soqlLines) {
-      for (const soql of soqlLines) {
-        const explainLine = soql.children[0];
-        soqlData.push({
+    if (soslLines) {
+      for (const sosl of soslLines) {
+        soslData.push({
           id: ++nextRowId,
-          isSelective: explainLine?.relativeCost ? explainLine.relativeCost <= 1 : null,
-          relativeCost: explainLine?.relativeCost,
-          soql: soql.text,
-          namespace: soql.namespace,
-          callerNamespace: getCallerNamespace(soql),
-          rowCount: soql.soqlRowCount.self,
-          timeTaken: soql.duration.total,
-          aggregations: soql.aggregations,
-          objectType: deriveSoqlObject(soql),
-          leadingOperationType: explainLine?.leadingOperationType ?? null,
-          sObjectType: explainLine?.sObjectType ?? null,
-          cardinality: explainLine?.cardinality ?? null,
-          sObjectCardinality: explainLine?.sObjectCardinality ?? null,
-          fields: explainLine?.fields?.join(', ') ?? null,
-          eventIndex: soql.eventIndex,
+          sosl: sosl.text,
+          namespace: sosl.namespace,
+          callerNamespace: getCallerNamespace(sosl),
+          rowCount: sosl.soslRowCount.self,
+          timeTaken: sosl.duration.total,
+          eventIndex: sosl.eventIndex,
           _children: [
             {
               id: ++nextRowId,
-              eventIndex: soql.eventIndex,
+              eventIndex: sosl.eventIndex,
               isDetail: true,
             },
           ],
@@ -487,16 +460,11 @@ export class SOQLView extends LitElement {
       }
     }
 
-    this.soqlTable = new Tabulator(soqlTableContainer, {
+    this.soslTable = new Tabulator(soslTableContainer, {
       index: 'id',
       height: '100%',
-      rowKeyboardNavigation: true,
-      data: soqlData,
-      layout: 'fitColumns',
-      placeholder: 'No SOQL queries found',
-      columnCalcs: 'table',
       clipboard: true,
-      downloadEncoder: this.downlodEncoder('soql.csv'),
+      downloadEncoder: this.downlodEncoder('sosl.csv'),
       downloadRowRange: 'all',
       downloadConfig: {
         columnHeaders: true,
@@ -508,16 +476,20 @@ export class SOQLView extends LitElement {
       //@ts-expect-error types need update array is valid
       keybindings: { copyToClipboard: ['ctrl + 67', 'meta + 67'] },
       clipboardCopyRowRange: 'all',
+      rowKeyboardNavigation: true,
+      data: soslData,
+      layout: 'fitColumns',
+      placeholder: 'No SOSL queries found',
+      columnCalcs: 'table',
       groupCalcs: true,
-      groupHeader: soqlGroupHeader,
       groupSort: true,
       groupClosedShowCalcs: true,
       groupStartOpen: false,
       groupToggleElement: false,
-      selectableRows: 'highlight',
       selectableRowsCheck: function (row: RowComponent) {
         return !row.getData().isDetail;
       },
+      selectableRows: 'highlight',
       dataTree: true,
       dataTreeBranchElement: false,
       dataTreeStartExpanded: false,
@@ -540,11 +512,9 @@ export class SOQLView extends LitElement {
       },
       columns: [
         {
-          title: 'SOQL',
-          field: 'soql',
-          headerSortStartingDir: 'asc',
+          title: 'SOSL',
+          field: 'sosl',
           sorter: 'string',
-          tooltip: true,
           bottomCalc: () => {
             return 'Total';
           },
@@ -552,89 +522,13 @@ export class SOQLView extends LitElement {
           cssClass: 'datagrid-textarea datagrid-code-text',
           variableHeight: true,
           formatter: (cell, _formatterParams, _onRendered) => {
-            const data = cell.getData() as GridSOQLData;
+            const data = cell.getData() as SOSLRow;
             return `<call-stack
-            eventIndex=${data.eventIndex}
+            eventIndex="${data.eventIndex}"
             startDepth="0"
             endDepth="1"
           ></call-stack>`;
           },
-        },
-        {
-          title: 'Selective',
-          field: 'isSelective',
-          formatter: 'tickCross',
-          formatterParams: {
-            allowEmpty: true,
-          },
-          width: 40,
-          hozAlign: 'center',
-          vertAlign: 'top',
-          sorter: function (a, b, aRow, bRow, _column, dir, _sorterParams) {
-            // Always Sort null values to the bottom (when we do not have selectivity)
-            if (a === null) {
-              return dir === 'asc' ? 1 : -1;
-            } else if (b === null) {
-              return dir === 'asc' ? -1 : 1;
-            }
-
-            const aRowData = aRow.getData();
-            const bRowData = bRow.getData();
-
-            return (aRowData.relativeCost || 0) - (bRowData.relativeCost || 0);
-          },
-          tooltip: function (_e, cell, _onRendered) {
-            const { isSelective, relativeCost } = cell.getData() as GridSOQLData;
-            let title;
-            if (isSelective === null) {
-              title = 'Selectivity could not be determined.';
-            } else if (isSelective) {
-              title = 'Query is selective.';
-            } else {
-              title = 'Query is not selective.';
-            }
-
-            if (relativeCost) {
-              title += `<br>Relative cost: ${relativeCost}`;
-            }
-            return title;
-          },
-          accessorDownload: function (
-            _value: unknown,
-            data: GridSOQLData,
-            _type: 'data' | 'download' | 'clipboard',
-            _accessorParams: unknown,
-            _column?: ColumnComponent,
-            _row?: RowComponent,
-          ): number | null | undefined {
-            return data.relativeCost;
-          },
-          accessorClipboard: function (
-            _value: unknown,
-            data: GridSOQLData,
-            _type: 'data' | 'download' | 'clipboard',
-            _accessorParams: unknown,
-            _column?: ColumnComponent,
-            _row?: RowComponent,
-          ): number | null | undefined {
-            return data.relativeCost;
-          },
-        },
-        {
-          title: 'Object',
-          field: 'objectType',
-          sorter: 'string',
-          width: 150,
-          visible: false,
-          headerFilter: 'list',
-          headerFilterFunc: 'in',
-          headerFilterParams: {
-            valuesLookup: 'all',
-            clearable: true,
-            multiselect: true,
-          },
-          headerFilterLiveFilter: false,
-          formatter: (cell) => (cell.getValue() as string | null) ?? '—',
         },
         {
           title: 'Namespace',
@@ -658,6 +552,8 @@ export class SOQLView extends LitElement {
           visible: false,
         },
         {
+          // SOSL's row limit is per query (2,000), not a transaction total — so
+          // each row meters against that per-query cap; the footer is a plain sum.
           title: 'Row Count',
           field: 'rowCount',
           sorter: 'number',
@@ -666,84 +562,23 @@ export class SOQLView extends LitElement {
           hozAlign: 'right',
           headerHozAlign: 'right',
           formatter: progressFormatter,
-          formatterParams: { precision: 0, totalValue: queryRowLimit, showPercentageText: false },
-          bottomCalc: 'sum',
-          bottomCalcFormatter: progressFormatter,
-          bottomCalcFormatterParams: {
+          formatterParams: {
             precision: 0,
-            totalValue: queryRowLimit,
+            totalValue: SOSL_ROWS_PER_QUERY_LIMIT,
             showPercentageText: false,
           },
-          tooltip: (_e, cell) => cell.getValue() + (queryRowLimit > 0 ? '/' + queryRowLimit : ''),
-        },
-        {
-          title: 'Aggregations',
-          field: 'aggregations',
-          sorter: 'number',
-          cssClass: 'number-cell',
-          width: 100,
-          hozAlign: 'right',
-          headerHozAlign: 'right',
+          // The group/total is a plain sum (a per-query bar there would be
+          // meaningless); use an integer formatter, NOT the ns→ms `Number` one.
           bottomCalc: 'sum',
+          bottomCalcFormatter: (cell) => countFormat.format((cell.getValue() as number) ?? 0),
+          tooltip: (_e, cell) => `${cell.getValue()} / ${SOSL_ROWS_PER_QUERY_LIMIT} per query`,
         },
-        {
-          title: 'Relative Cost',
-          field: 'relativeCost',
-          sorter: 'number',
-          cssClass: 'number-cell',
-          width: 110,
-          hozAlign: 'right',
-          headerHozAlign: 'right',
-          visible: false,
-        },
-        {
-          title: 'Leading Operation',
-          field: 'leadingOperationType',
-          sorter: 'string',
-          width: 140,
-          visible: false,
-        },
-        {
-          title: 'SObject Type',
-          field: 'sObjectType',
-          sorter: 'string',
-          width: 130,
-          visible: false,
-        },
-        {
-          title: 'Cardinality',
-          field: 'cardinality',
-          sorter: 'number',
-          cssClass: 'number-cell',
-          width: 110,
-          hozAlign: 'right',
-          headerHozAlign: 'right',
-          visible: false,
-        },
-        {
-          title: 'SObject Cardinality',
-          field: 'sObjectCardinality',
-          sorter: 'number',
-          cssClass: 'number-cell',
-          width: 140,
-          hozAlign: 'right',
-          headerHozAlign: 'right',
-          visible: false,
-        },
-        {
-          title: 'Indexed Fields',
-          field: 'fields',
-          sorter: 'string',
-          width: 140,
-          visible: false,
-        },
-        // Time column sits at the far right.
         {
           title: 'Time Taken (ms)',
           field: 'timeTaken',
           sorter: 'number',
           cssClass: 'number-cell',
-          width: 120,
+          width: 110,
           hozAlign: 'right',
           headerHozAlign: 'right',
           formatter: Number,
@@ -760,129 +595,121 @@ export class SOQLView extends LitElement {
       rowFormatter: (row) => {
         const data = row.getData();
         if (data.isDetail && data.eventIndex !== undefined) {
-          const detailContainer = this.createSOQLDetailPanel(data.eventIndex, eventIndexToSOQL);
+          const detailContainer = this.createDetailPanel(data.eventIndex);
           row.getElement().replaceChildren(detailContainer);
         }
       },
     });
 
-    this.soqlTable.on('groupClick', (_e: UIEvent, group: GroupComponent) => {
+    this.soslTable.on('groupClick', (_e: UIEvent, group: GroupComponent) => {
       const { type } = window.getSelection() ?? {};
       if (type === 'Range') {
         return;
       }
-      group.toggle();
 
-      if (this.soqlTable && group.isVisible()) {
-        this.soqlTable.blockRedraw();
+      group.toggle();
+      if (this.soslTable && group.isVisible()) {
+        this.soslTable.blockRedraw();
         for (const row of group.getRows()) {
           if (row.getTreeChildren() && !row.isTreeExpanded()) {
             row.treeExpand();
           }
         }
-        this.soqlTable.restoreRedraw();
+        this.soslTable.restoreRedraw();
       }
     });
 
-    this.soqlTable.on('rowClick', function (_e, row) {
+    this.soslTable.on('rowClick', function (_e, row) {
       const { type } = window.getSelection() ?? {};
       if (type === 'Range') {
         return;
       }
 
       const data = row.getData();
-      if (!(data.eventIndex !== undefined && data.soql)) {
+      if (!(data.eventIndex !== undefined && data.sosl)) {
         return;
       }
 
       const origRowHeight = row.getElement().offsetHeight;
       row.treeToggle();
-      row.getCell('soql').getElement().style.height = origRowHeight + 'px';
+      row.getCell('sosl').getElement().style.height = origRowHeight + 'px';
     });
 
-    this.soqlTable.on('tableBuilt', () => {
+    this.soslTable.on('tableBuilt', () => {
       const holder = this._getTableHolder();
       holder.style.overflowAnchor = 'none';
       //@ts-expect-error This is a custom function added in the GroupSort custom module
-      this.soqlTable?.setSortedGroupBy('soql');
-      if (this.soqlTable) {
-        this._initTableColumns(this.soqlTable);
+      this.soslTable?.setSortedGroupBy('sosl');
+      if (this.soslTable) {
+        this._initTableColumns(this.soslTable);
       }
     });
 
-    this.soqlTable.on('dataSorted', () => {
-      if (!this.blockClearHighlights && this.totalMatches > 0) {
-        this._resetFindWidget();
-        this._clearSearchHighlights();
-      }
-    });
-
-    this.soqlTable.on('dataGrouped', () => {
-      if (!this.blockClearHighlights && this.totalMatches > 0) {
-        this._resetFindWidget();
-        this._clearSearchHighlights();
-      }
-    });
-
-    this.soqlTable.on('dataFiltering', () => {
-      if (!this.blockClearHighlights && this.totalMatches > 0) {
-        this._resetFindWidget();
-        this._clearSearchHighlights();
-      }
-    });
-
-    this.soqlTable.on('renderComplete', () => {
+    this.soslTable.on('renderComplete', () => {
       const holder = this._getTableHolder();
       const table = this._getTable();
       holder.style.minHeight = Math.min(holder.clientHeight, table.clientHeight) + 'px';
+    });
+
+    this.soslTable.on('dataSorted', () => {
+      if (!this.blockClearHighlights && this.totalMatches > 0) {
+        this._resetFindWidget();
+        this._clearSearchHighlights();
+      }
+    });
+
+    this.soslTable.on('dataGrouped', () => {
+      if (!this.blockClearHighlights && this.totalMatches > 0) {
+        this._resetFindWidget();
+        this._clearSearchHighlights();
+      }
+    });
+
+    this.soslTable.on('dataFiltering', () => {
+      if (!this.blockClearHighlights && this.totalMatches > 0) {
+        this._resetFindWidget();
+        this._clearSearchHighlights();
+      }
     });
   }
 
   _resetFindWidget() {
     document.dispatchEvent(
       new CustomEvent('db-find-results', {
-        detail: { totalMatches: 0, type: 'soql' },
+        detail: { totalMatches: 0, type: 'sosl' },
       }),
     );
   }
 
-  _clearSearchHighlights() {
+  private _clearSearchHighlights() {
     this.findArgs.text = '';
     this.findArgs.count = 0;
     //@ts-expect-error This is a custom function added in by Find custom module
-    this.soqlTable.clearFindHighlights();
+    this.soslTable.clearFindHighlights();
     this.findMap = {};
     this.totalMatches = 0;
 
     document.dispatchEvent(
       new CustomEvent('db-find-results', {
-        detail: { totalMatches: this.totalMatches, type: 'soql' },
+        detail: { totalMatches: this.totalMatches, type: 'sosl' },
       }),
     );
   }
 
   _getTable() {
-    this.table ??= this.soqlTable?.element.querySelector('.tabulator-table') as HTMLElement;
+    this.table ??= this.soslTable?.element.querySelector('.tabulator-table') as HTMLElement;
     return this.table;
   }
 
   _getTableHolder() {
-    this.holder ??= this.soqlTable?.element.querySelector('.tabulator-tableholder') as HTMLElement;
+    this.holder = this.soslTable?.element.querySelector('.tabulator-tableholder') as HTMLElement;
     return this.holder;
   }
 
-  createSOQLDetailPanel(eventIndex: number, eventIndexToSOQL: Map<number, SOQLExecuteBeginLine>) {
+  createDetailPanel(eventIndex: number) {
     const detailContainer = document.createElement('div');
     detailContainer.className = 'row__details-container';
-
-    const soqlLine = eventIndexToSOQL.get(eventIndex);
-    render(
-      html`<db-soql-detail-panel
-        eventIndex=${eventIndex}
-        soql=${soqlLine?.text}
-      ></db-soql-detail-panel>`,
-      detailContainer,
-    );
+    render(html`<call-stack eventIndex=${eventIndex}></call-stack>`, detailContainer);
 
     return detailContainer;
   }
@@ -912,25 +739,16 @@ type VSCodeSaveFile = {
   };
 };
 
-interface GridSOQLData {
+interface SOSLRow {
   id: number;
-  isSelective?: boolean | null;
-  relativeCost?: number | null;
-  soql?: string;
+  sosl?: string;
   namespace?: string;
   callerNamespace?: string;
-  rowCount?: number | null;
-  timeTaken?: number | null;
-  aggregations?: number;
-  objectType?: string | null;
-  leadingOperationType?: string | null;
-  sObjectType?: string | null;
-  cardinality?: number | null;
-  sObjectCardinality?: number | null;
-  fields?: string | null;
+  rowCount?: number;
+  timeTaken?: number;
   eventIndex?: number;
   isDetail?: boolean;
-  _children?: GridSOQLData[];
+  _children?: SOSLRow[];
 }
 
 type FindEvt = CustomEvent<{ text: string; count: number; options: { matchCase: boolean } }>;

--- a/log-viewer/src/features/database/limits.ts
+++ b/log-viewer/src/features/database/limits.ts
@@ -20,3 +20,32 @@ export const APEX_GOVERNOR_LIMITS_DOC =
  * table, not summed against a transaction limit.
  */
 export const SOSL_ROWS_PER_QUERY_LIMIT = 2000;
+
+/** Derived SOSL-rows metric fields (label/found are supplied by the caller). */
+export interface SoslRowsMetric {
+  used: number | null;
+  limit: number;
+  note?: string;
+}
+
+/**
+ * SOSL rows aren't reported as a transaction total, so the ceiling is derived:
+ * {@link SOSL_ROWS_PER_QUERY_LIMIT} × the SOSL-query limit. Only meaningful when the
+ * log captured that limit (`hasLimits`); otherwise this degrades to "limit n/a"
+ * (`used` null, no ceiling, no note) like every other metric.
+ */
+export function soslRowsMetric(
+  seenRows: number,
+  soslQueriesLimit: number,
+  hasLimits: boolean,
+): SoslRowsMetric {
+  const limit = soslQueriesLimit * SOSL_ROWS_PER_QUERY_LIMIT;
+  return {
+    used: hasLimits ? seenRows : null,
+    limit,
+    note:
+      limit > 0
+        ? `Up to ${SOSL_ROWS_PER_QUERY_LIMIT.toLocaleString()} rows per SOSL query × ${soslQueriesLimit} queries = ${limit.toLocaleString()} max per transaction.`
+        : undefined,
+  };
+}

--- a/log-viewer/src/features/database/limits.ts
+++ b/log-viewer/src/features/database/limits.ts
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2026 Certinia Inc. All rights reserved.
+ */
+
+/**
+ * Canonical reference for the numbers used across the Database tab. Check here
+ * when a limit looks wrong or Salesforce changes one.
+ *
+ * Per-transaction limits (tracked in CUMULATIVE_LIMIT_USAGE): SOQL queries 100,
+ * SOSL queries 20, SOQL query rows 50,000, DML statements 150, DML rows 10,000.
+ * Per-query limit (NOT a transaction total): a single SOSL query returns at most
+ * 2,000 rows — see {@link SOSL_ROWS_PER_QUERY_LIMIT}.
+ */
+export const APEX_GOVERNOR_LIMITS_DOC =
+  'https://developer.salesforce.com/docs/atlas.en-us.apexcode.meta/apexcode/apex_gov_limits.htm';
+
+/**
+ * Maximum records returned by a *single* SOSL query. This is a per-query cap,
+ * not a cumulative per-transaction total — so it's metered per row in the SOSL
+ * table, not summed against a transaction limit.
+ */
+export const SOSL_ROWS_PER_QUERY_LIMIT = 2000;

--- a/log-viewer/src/features/database/services/Database.ts
+++ b/log-viewer/src/features/database/services/Database.ts
@@ -1,7 +1,13 @@
 /*
  * Copyright (c) 2020 Certinia Inc. All rights reserved.
  */
-import { type ApexLog, DMLBeginLine, type LogEvent, SOQLExecuteBeginLine } from 'apex-log-parser';
+import {
+  type ApexLog,
+  DMLBeginLine,
+  type LogEvent,
+  SOQLExecuteBeginLine,
+  SOSLExecuteBeginLine,
+} from 'apex-log-parser';
 
 export type Stack = LogEvent[];
 
@@ -75,6 +81,25 @@ export class DatabaseAccess {
       if (child?.isParent) {
         // results = results.concat(this.getDMLLines(child));
         Array.prototype.push.apply(results, this.getDMLLines(child));
+      }
+    }
+
+    return results;
+  }
+
+  public getSOSLLines(line: LogEvent = DatabaseAccess._treeRoot): SOSLExecuteBeginLine[] {
+    const results: SOSLExecuteBeginLine[] = [];
+
+    const children = line.children;
+    const len = children.length;
+    for (let i = 0; i < len; ++i) {
+      const child = children[i];
+      if (child instanceof SOSLExecuteBeginLine) {
+        results.push(child);
+      }
+
+      if (child?.isParent) {
+        Array.prototype.push.apply(results, this.getSOSLLines(child));
       }
     }
 

--- a/log-viewer/src/features/database/services/__tests__/sobjectClassification.test.ts
+++ b/log-viewer/src/features/database/services/__tests__/sobjectClassification.test.ts
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2026 Certinia Inc. All rights reserved.
+ */
+import { describe, expect, it } from '@jest/globals';
+import type { SOQLExecuteBeginLine } from 'apex-log-parser';
+
+import { deriveSoqlObject, parseFromObject } from '../sobjectClassification.js';
+
+/** Minimal SOQL line stub — only the fields deriveSoqlObject reads. */
+function soqlLine(text: string, explainSObject?: string): SOQLExecuteBeginLine {
+  return {
+    text,
+    children: explainSObject ? [{ sObjectType: explainSObject }] : [],
+  } as unknown as SOQLExecuteBeginLine;
+}
+
+describe('parseFromObject', () => {
+  it('reads a simple FROM clause', () => {
+    expect(parseFromObject('SELECT Id FROM Account')).toBe('Account');
+  });
+
+  it('is case-insensitive on the FROM keyword', () => {
+    expect(parseFromObject('select Id from Contact')).toBe('Contact');
+  });
+
+  it('reads namespaced custom / metadata objects', () => {
+    expect(parseFromObject('SELECT Id FROM ns__Config__mdt')).toBe('ns__Config__mdt');
+    expect(parseFromObject('SELECT Id FROM ns2__MyObject__c')).toBe('ns2__MyObject__c');
+  });
+
+  it('ignores a subquery FROM and returns the outer object', () => {
+    expect(parseFromObject('SELECT Id, (SELECT Id FROM Contacts) FROM Account')).toBe('Account');
+  });
+
+  it('handles nested subqueries', () => {
+    const query = 'SELECT Id, (SELECT Id, (SELECT Id FROM Notes) FROM Contacts) FROM Account';
+    expect(parseFromObject(query)).toBe('Account');
+  });
+
+  it('returns null when there is no FROM', () => {
+    expect(parseFromObject('DELETE something')).toBeNull();
+    expect(parseFromObject(undefined)).toBeNull();
+  });
+});
+
+describe('deriveSoqlObject', () => {
+  it('prefers the query-plan sObjectType when present', () => {
+    const line = soqlLine('SELECT Id FROM Account', 'Contact');
+    expect(deriveSoqlObject(line)).toBe('Contact');
+  });
+
+  it('falls back to the FROM clause without a query plan', () => {
+    expect(deriveSoqlObject(soqlLine('SELECT Id FROM Opportunity'))).toBe('Opportunity');
+  });
+});

--- a/log-viewer/src/features/database/services/sobjectClassification.ts
+++ b/log-viewer/src/features/database/services/sobjectClassification.ts
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2026 Certinia Inc. All rights reserved.
+ */
+import type { SOQLExecuteBeginLine } from 'apex-log-parser';
+
+/**
+ * Derives the queried SObject name for the Database SOQL view. (An earlier
+ * revision also classified whether the object counts toward the SOQL limit —
+ * dropped because it's a 1:1 function of the object name, so the name alone
+ * carries the signal, e.g. the `__mdt` suffix.)
+ */
+
+/**
+ * The outermost `FROM` object of a SOQL string, best-effort. Parenthesised
+ * groups (inner SELECTs, function args) are stripped first so a subquery's
+ * `FROM` can't be mistaken for the main object. Returns `null` when no `FROM`
+ * is found.
+ */
+export function parseFromObject(soql: string | undefined): string | null {
+  if (!soql) {
+    return null;
+  }
+  // Collapse nested parentheses from the inside out until none remain.
+  let stripped = soql;
+  let previous: string;
+  do {
+    previous = stripped;
+    stripped = stripped.replace(/\([^()]*\)/g, ' ');
+  } while (stripped !== previous);
+
+  const match = /\bFROM\s+([A-Za-z0-9_]+)/i.exec(stripped);
+  return match?.[1] ?? null;
+}
+
+/**
+ * The queried SObject name for a SOQL line. Prefers the query-plan `sObjectType`
+ * (accurate, present only at Database=FINEST); otherwise falls back to a
+ * best-effort parse of the query text's `FROM` clause.
+ */
+export function deriveSoqlObject(soql: SOQLExecuteBeginLine): string | null {
+  return soql.children[0]?.sObjectType ?? parseFromObject(soql.text);
+}

--- a/log-viewer/src/features/settings/Settings.ts
+++ b/log-viewer/src/features/settings/Settings.ts
@@ -37,6 +37,7 @@ export type LanaSettings = {
   database: {
     soql: { columnView: string; columnOverrides: Record<string, string[]> };
     dml: { columnView: string; columnOverrides: Record<string, string[]> };
+    sosl: { columnView: string; columnOverrides: Record<string, string[]> };
   };
 };
 

--- a/log-viewer/src/tabulator/ColumnViews.ts
+++ b/log-viewer/src/tabulator/ColumnViews.ts
@@ -90,17 +90,31 @@ export const CALL_TREE_VIEWS: ColumnView[] = [
 
 /** Column views for the SOQL database table. */
 export const SOQL_VIEWS: ColumnView[] = [
-  { id: 'General', fields: ['isSelective', 'namespace', 'rowCount', 'timeTaken', 'aggregations'] },
+  {
+    // Object is visible by default (its __mdt suffix flags the "does this count
+    // toward the SOQL limit?" case of #162). The derived Counts column lives in
+    // the focused Limits view to avoid duplicating that signal.
+    id: 'General',
+    fields: ['isSelective', 'objectType', 'namespace', 'rowCount', 'timeTaken', 'aggregations'],
+  },
   { id: 'Performance', fields: ['isSelective', 'relativeCost', 'rowCount', 'timeTaken'] },
   {
     id: 'Query Plan',
     fields: ['relativeCost', 'leadingOperationType', 'sObjectType', 'cardinality'],
   },
+  { id: 'Limits', fields: ['objectType', 'namespace', 'rowCount', 'timeTaken'] },
 ];
 
 /** Column views for the DML database table. */
 export const DML_VIEWS: ColumnView[] = [
-  { id: 'General', fields: ['callerNamespace', 'rowCount', 'timeTaken'] },
+  { id: 'General', fields: ['objectType', 'callerNamespace', 'rowCount', 'timeTaken'] },
+  { id: 'Timing', fields: ['rowCount', 'timeTaken'] },
+  { id: 'Limits', fields: ['objectType', 'callerNamespace', 'rowCount'] },
+];
+
+/** Column views for the SOSL database table. */
+export const SOSL_VIEWS: ColumnView[] = [
+  { id: 'General', fields: ['namespace', 'callerNamespace', 'rowCount', 'timeTaken'] },
   { id: 'Timing', fields: ['rowCount', 'timeTaken'] },
 ];
 

--- a/log-viewer/src/tabulator/__tests__/ColumnViews.test.ts
+++ b/log-viewer/src/tabulator/__tests__/ColumnViews.test.ts
@@ -14,6 +14,7 @@ import {
   getVisibleFields,
   resolveColumnView,
   SOQL_VIEWS,
+  SOSL_VIEWS,
   toggleField,
 } from '../ColumnViews.js';
 
@@ -231,8 +232,17 @@ describe('view sets', () => {
     );
   });
 
-  it('SOQL views are General/Performance/Query Plan (no redundant Rows & Time)', () => {
-    expect(SOQL_VIEWS.map((v) => v.id)).toEqual(['General', 'Performance', 'Query Plan']);
+  it('SOQL views are General/Performance/Query Plan/Limits', () => {
+    expect(SOQL_VIEWS.map((v) => v.id)).toEqual(['General', 'Performance', 'Query Plan', 'Limits']);
+  });
+
+  it('SOQL and DML expose the object-type column by default', () => {
+    expect(getColumnView(SOQL_VIEWS, 'General')?.fields).toContain('objectType');
+    expect(getColumnView(DML_VIEWS, 'General')?.fields).toContain('objectType');
+  });
+
+  it('SOSL views are General/Timing', () => {
+    expect(SOSL_VIEWS.map((v) => v.id)).toEqual(['General', 'Timing']);
   });
 
   it('getTableFields returns every column field in order', () => {


### PR DESCRIPTION
# 📝 PR Overview

Reworks the **Database** tab to answer the core question in #162 — *which SOQL/DML actually consume governor limits* — and adds first-class SOSL support with a redesigned, coherent layout.

Not every SOQL query counts (custom metadata is free unless it selects a long text area field or runs in a Flow; cached custom settings issue no query). The log records the statements and cumulative totals but never per-statement attribution, so the tab surfaces the honest signal: the queried **Object** per row plus a per-section **tracked vs consumed** reconciliation, backed by a governor-limit overview.

## 🛠️ Changes made

- **Governor overview strip** — SOQL, SOSL, DML and query/DML rows as `used / limit`, coloured as they approach the limit.
- **Tracked vs consumed** per section — statements seen in the log vs the governor-counted total (`CUMULATIVE_LIMIT_USAGE`), flagging queries that didn't count.
- **Object column + group-by** (Object / Namespace / Caller Namespace / statement) on SOQL & DML; parser gains structured `DMLBeginLine.sObjectType`.
- **SOSL table** — new, searchable, with column views, grouping and CSV export; rows metered per query against the 2,000-rows-per-query cap; cross-table find spans SOQL/DML/SOSL.
- **Redesigned tab** — DML → SOQL → SOSL sections, each an accent-headed collapsible panel (empty types auto-collapse) with inline metric stats on a shared inset; `limit n/a` when cumulative limits aren't logged.
- `database/limits.ts` documents the governor numbers + doc URL for future reference.

## 🧩 Type of change (check all applicable)

- [x] ✨ New feature – adds new functionality
- [x] 📝 Documentation - README or documentation site changes

## 📷 Screenshots / gifs / video [optional]

<img width="1920" height="767" alt="db-design" src="https://github.com/user-attachments/assets/d45b3a66-cb36-4fe9-b10d-3b97311ad7a8" />

## 🔗 Related Issues

closes #162

## ✅ Tests added?

- [x] 👍 yes

## 📚 Docs updated?

- [x] 🔖 README.md
- [x] 🔖 CHANGELOG.md
- [x] 📖 help site

## Anything else we need to know? [optional]

- **Known limit (log constraint):** custom-metadata (`__mdt`) SOQL is marked _Uncertain_ — whether it counts depends on selecting a long text area field or running in a Flow, which the debug log doesn't expose. Verified in an org (same object: `Limits.getQueries()` delta `0` without the long-text field, `1` with it). Raised a Salesforce Idea for per-statement limit attribution: https://ideas.salesforce.com/s/idea/a0BHp000017Jly5MAC
- **Pre-existing parser limitation (not addressed here):** `addGovernorLimits` sums `used` across namespaces but reports a single namespace's `limit`, so multi-namespace logs can render e.g. `119 / 100`. Per-namespace limits aren't additive — flagged for a follow-up.
