### PR TITLE
fix(timeline): guard minimap density against fractional display width (#863) v1.20.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.20.1] 2026-07-22
+
+### Fixed
+
+- 🪟 **Timeline on Windows**: fixed the Flame Chart failing to load — with zoom, pan and keyboard navigation all appearing unresponsive — under fractional display scaling (125% / 150% / 175%). ([#863])
+
 ## [1.20.0] 2026-06-18
 
 ### Added
@@ -659,3 +665,4 @@ Skipped due to adopting odd numbering for pre releases and even number for relea
 [#242]: https://github.com/certinia/debug-log-analyzer/issues/242
 [#235]: https://github.com/certinia/debug-log-analyzer/issues/235
 [#264]: https://github.com/certinia/debug-log-analyzer/issues/264
+[#863]: https://github.com/certinia/debug-log-analyzer/issues/863

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [1.20.1] 2026-07-22
+## [1.20.1] 2026-07-23
 
 ### Fixed
 
-- 🪟 **Timeline on Windows**: fixed the Flame Chart failing to load — with zoom, pan and keyboard navigation all appearing unresponsive — under fractional display scaling (125% / 150% / 175%). ([#863])
+- 🪟 **Timeline on Windows**: fixed the Flame Chart failing to load due to fractional display scaling (125% / 150% / 175%) - zoom, pan and keyboard navigation all appeared unresponsive ([#863]).
 
 ## [1.20.0] 2026-06-18
 
@@ -491,6 +491,10 @@ Skipped due to adopting odd numbering for pre releases and even number for relea
 - Add explorer menu item.
 - Provide more information when selecting log to download.
 
+<!-- v1.20.1 -->
+
+[#863]: https://github.com/certinia/debug-log-analyzer/issues/863
+
 <!-- v1.20.0 -->
 
 [#605]: https://github.com/certinia/debug-log-analyzer/issues/605
@@ -665,4 +669,3 @@ Skipped due to adopting odd numbering for pre releases and even number for relea
 [#242]: https://github.com/certinia/debug-log-analyzer/issues/242
 [#235]: https://github.com/certinia/debug-log-analyzer/issues/235
 [#264]: https://github.com/certinia/debug-log-analyzer/issues/264
-[#863]: https://github.com/certinia/debug-log-analyzer/issues/863

--- a/lana/package.json
+++ b/lana/package.json
@@ -1,7 +1,7 @@
 {
   "name": "lana",
   "displayName": "Apex Log Analyzer",
-  "version": "1.20.0",
+  "version": "1.20.1",
   "description": "Salesforce Apex Debug Log Analyzer: Blazing-fast VS Code extension for Salesforce. Visualize and debug Apex logs with interactive flame charts, dynamic call trees, and detailed SOQL/DML breakdowns. Identify performance bottlenecks, gain deep transaction insights and optimize slow Apex.",
   "keywords": [
     "analysis",

--- a/log-viewer/src/features/timeline/__tests__/minimap-density.test.ts
+++ b/log-viewer/src/features/timeline/__tests__/minimap-density.test.ts
@@ -196,4 +196,39 @@ describe('MinimapDensityQuery', () => {
       expect(result.buckets).toHaveLength(0);
     });
   });
+
+  describe('fractional bucket count (Windows fractional DPI scaling)', () => {
+    // Regression: getBoundingClientRect().width is non-integer under Windows
+    // 125%/150% display scaling; a fractional/NaN count previously threw
+    // "Invalid array length" and aborted timeline init.
+    const rects = [createRect('Method', 0, 1000, 0)];
+
+    it('floors a fractional bucket count instead of throwing (segment tree path)', () => {
+      const rectsByCategory = buildRectsByCategory(rects);
+      const segmentTree = new TemporalSegmentTree(rectsByCategory);
+      const query = new MinimapDensityQuery(rectsByCategory, 1000, 0, segmentTree);
+
+      const fractional = query.query(10.6);
+      const floored = query.query(10);
+
+      expect(fractional.buckets).toHaveLength(10);
+      expect(fractional.buckets).toEqual(floored.buckets);
+    });
+
+    it('floors a fractional bucket count instead of throwing (fallback path)', () => {
+      const rectsByCategory = buildRectsByCategory(rects);
+      const query = new MinimapDensityQuery(rectsByCategory, 1000, 0);
+
+      expect(() => query.query(1536.6667)).not.toThrow();
+      expect(query.query(1536.6667).buckets).toHaveLength(1536);
+    });
+
+    it('treats a non-finite bucket count as empty instead of throwing', () => {
+      const rectsByCategory = buildRectsByCategory(rects);
+      const query = new MinimapDensityQuery(rectsByCategory, 1000, 0);
+
+      expect(() => query.query(Number.NaN)).not.toThrow();
+      expect(query.query(Number.NaN).buckets).toHaveLength(0);
+    });
+  });
 });

--- a/log-viewer/src/features/timeline/optimised/minimap/MinimapDensityQuery.ts
+++ b/log-viewer/src/features/timeline/optimised/minimap/MinimapDensityQuery.ts
@@ -164,6 +164,14 @@ export class MinimapDensityQuery {
    * @returns MinimapDensityData for rendering
    */
   public query(bucketCount: number): MinimapDensityData {
+    // bucketCount is the display width from getBoundingClientRect(), which is
+    // fractional under non-integer OS display scaling (Windows 125%/150% DPI).
+    // A fractional/NaN count crashes the Array/typed-array constructors below
+    // with "Invalid array length" (the `<= 0` guards do not catch it), which
+    // aborts timeline init and leaves interaction handlers unwired. Normalise
+    // here, the single entry point feeding both compute paths and the cache.
+    bucketCount = Number.isFinite(bucketCount) ? Math.floor(bucketCount) : 0;
+
     // Fast path: exact match in cache
     const cached = this.densityCache.get(bucketCount);
     if (cached) {


### PR DESCRIPTION
# 📝 PR Overview

Backport of the #863 fix to the **1.20.1** patch release line. The Timeline failed to load on Windows under fractional display scaling; this makes it robust.

## 🛠️ Changes made

- Floor/normalise the minimap density bucket count at the single `MinimapDensityQuery.query()` entry point, so a fractional or `NaN` display width (from `getBoundingClientRect()` under non-integer DPI) can no longer throw `RangeError: Invalid array length` and abort timeline init.
- Bump `lana` to `1.20.1` and add the `## [1.20.1]` changelog entry.

## 🧩 Type of change (check all applicable)

- [x] 🐛 Bug fix - something not working as expected

## 🔗 Related Issues

related #863

## ✅ Tests added?

- [x] 👍 yes — fractional / `NaN` bucket-count regression tests in `minimap-density.test.ts`.

## 📚 Docs updated?

- [x] 🔖 CHANGELOG.md
