### PR TITLE
feat(log-viewer): remember the inspector's layout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - **Details**: type, timing, and every governor metric the selection consumed as `used / limit`.
   - **Call stack**: the frames that led to the selection, with total and self time.
   - **Call tree**: the selected frames own subtree, switchable between **Time Order**, **Aggregated** and **Bottom-Up**.
-  - Dock it left, right or bottom, drag to resize, and collapse the sections you don't need — the layout is remembered, along with the call tree view mode and whether the Inspector is open.
+  - Dock it left, right or bottom, drag to resize, and collapse the sections you don't need — the layout is remembered.
   - Right-click a row for **Show in Call Tree**, **Copy Name**, **Copy Details** or **Copy Call Stack**; `Cmd/Ctrl+C` copies the table.
 - 🗄️ **Database Analysis**: governor-limit visibility and SOSL usage. ([#162])
   - 📏 **Governor-limit overview**: SOQL, SOSL, DML and query/DML rows shown as `used / limit`, colored as they approach the limit.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - **Details**: type, timing, and every governor metric the selection consumed as `used / limit`.
   - **Call stack**: the frames that led to the selection, with total and self time.
   - **Call tree**: the selected frames own subtree, switchable between **Time Order**, **Aggregated** and **Bottom-Up**.
-  - Dock it left, right or bottom, drag to resize, and collapse the sections you don't need — the layout is remembered.
+  - Dock it left, right or bottom, drag to resize, and collapse the sections you don't need — the layout is remembered, along with the call tree view mode and whether the Inspector is open.
   - Right-click a row for **Show in Call Tree**, **Copy Name**, **Copy Details** or **Copy Call Stack**; `Cmd/Ctrl+C` copies the table.
 - 🗄️ **Database Analysis**: governor-limit visibility and SOSL usage. ([#162])
   - 📏 **Governor-limit overview**: SOQL, SOSL, DML and query/DML rows shown as `used / limit`, colored as they approach the limit.

--- a/jest.config.js
+++ b/jest.config.js
@@ -10,6 +10,10 @@ const defaultConfig = {
         jsc: {
           target: 'esnext',
           parser: { decorators: true, syntax: 'typescript' },
+          // Match the bundles (and log-viewer/tsconfig.json): with `define`
+          // semantics a class field initializer shadows Lit's reactive
+          // accessor, so property assignments never trigger a re-render.
+          transform: { useDefineForClassFields: false },
         },
       },
     ],

--- a/lana-docs/docs/docs/features/inspector.md
+++ b/lana-docs/docs/docs/features/inspector.md
@@ -20,7 +20,7 @@ hide_title: true
 
 Select anything — a Timeline frame, a Call Tree or Analysis row, a SOQL/DML/SOSL statement — and the inspector shows it in depth without you leaving the tab you're working in.
 
-It docks to the **right**, **left** or **bottom**, resizes by dragging its edge, and is toggled from the button in the header. It opens automatically on your first selection; after that it stays as you left it. Position and size persist — see [Settings](../settings.mdx#inspector).
+It docks to the **right**, **left** or **bottom**, resizes by dragging its edge, and is toggled from the button in the header. It opens automatically on your first selection; once you have opened or closed it yourself, it stays that way — including the next time you open a log. Position and size persist — see [Settings](../settings.mdx#inspector).
 
 ### Sections
 
@@ -29,7 +29,7 @@ It docks to the **right**, **left** or **bottom**, resizes by dragging its edge,
 - **Call tree** – The selection scoped within its own execution, switchable between **Time Order**, **Aggregated** and **Bottom-Up** (as in the Chrome DevTools performance panel). Totals are relative to the selection, so a DML that fires triggers shows the triggered work beneath it. This scoping is what makes it different from the [Call Tree](./calltree.mdx) tab, which always shows the whole log.
 - **SOQL issues** – SOQL only: optimization tips describing the query's performance and how to improve it.
 
-Collapse any section you don't need by clicking its header; the collapsed state is remembered.
+Collapse any section you don't need by clicking its header, or drag the divider between two sections to resize them. Both are remembered, as is the Call tree's view mode — it's one panel, so the layout you set follows you from tab to tab.
 
 ### Row actions
 

--- a/lana-docs/docs/docs/features/inspector.md
+++ b/lana-docs/docs/docs/features/inspector.md
@@ -29,7 +29,7 @@ It docks to the **right**, **left** or **bottom**, resizes by dragging its edge,
 - **Call tree** – The selection scoped within its own execution, switchable between **Time Order**, **Aggregated** and **Bottom-Up** (as in the Chrome DevTools performance panel). Totals are relative to the selection, so a DML that fires triggers shows the triggered work beneath it. This scoping is what makes it different from the [Call Tree](./calltree.mdx) tab, which always shows the whole log.
 - **SOQL issues** – SOQL only: optimization tips describing the query's performance and how to improve it.
 
-Collapse any section by clicking its header, or drag the divider between two to resize them. It's one panel, so your layout follows you from tab to tab, and is restored next time along with the Call tree's view mode.
+Collapse any section by clicking its header, or drag the divider between two to resize them. It's one panel, so your layout follows you from tab to tab, and is restored next time.
 
 ### Row actions
 

--- a/lana-docs/docs/docs/features/inspector.md
+++ b/lana-docs/docs/docs/features/inspector.md
@@ -20,7 +20,7 @@ hide_title: true
 
 Select anything — a Timeline frame, a Call Tree or Analysis row, a SOQL/DML/SOSL statement — and the inspector shows it in depth without you leaving the tab you're working in.
 
-It docks to the **right**, **left** or **bottom**, resizes by dragging its edge, and is toggled from the button in the header. It opens automatically on your first selection; once you have opened or closed it yourself, it stays that way — including the next time you open a log. Position and size persist — see [Settings](../settings.mdx#inspector).
+It docks to the **right**, **left** or **bottom**, resizes by dragging its edge, and is toggled from the button in the header. It opens automatically on your first selection, then stays however you left it, including the next time you open a log. See [Settings](../settings.mdx#inspector).
 
 ### Sections
 
@@ -29,7 +29,7 @@ It docks to the **right**, **left** or **bottom**, resizes by dragging its edge,
 - **Call tree** – The selection scoped within its own execution, switchable between **Time Order**, **Aggregated** and **Bottom-Up** (as in the Chrome DevTools performance panel). Totals are relative to the selection, so a DML that fires triggers shows the triggered work beneath it. This scoping is what makes it different from the [Call Tree](./calltree.mdx) tab, which always shows the whole log.
 - **SOQL issues** – SOQL only: optimization tips describing the query's performance and how to improve it.
 
-Collapse any section you don't need by clicking its header, or drag the divider between two sections to resize them. Both are remembered, as is the Call tree's view mode — it's one panel, so the layout you set follows you from tab to tab.
+Collapse any section by clicking its header, or drag the divider between two to resize them. It's one panel, so your layout follows you from tab to tab, and is restored next time along with the Call tree's view mode.
 
 ### Row actions
 

--- a/lana-docs/docs/docs/settings.mdx
+++ b/lana-docs/docs/docs/settings.mdx
@@ -91,4 +91,4 @@ The [inspector](./features/inspector.md) remembers where you dock it and how big
 
 Both update as you drag or re-dock the inspector, so you rarely need to edit them by hand.
 
-Collapsed sections, their sizes, the Call tree's view mode and whether the inspector is open are remembered too, but aren't settings you edit.
+Collapsed sections, their sizes and whether the inspector is open are remembered too, but aren't settings you edit.

--- a/lana-docs/docs/docs/settings.mdx
+++ b/lana-docs/docs/docs/settings.mdx
@@ -90,3 +90,5 @@ The [inspector](./features/inspector.md) remembers where you dock it and how big
 - `lana.inspector.size` – its width (or height when docked to the bottom), in pixels.
 
 Both update as you drag or re-dock the inspector, so you rarely need to edit them by hand.
+
+Which sections are collapsed, their sizes, the Call tree's view mode and whether the inspector is open are also remembered, but aren't settings you edit — they follow whatever you last did.

--- a/lana-docs/docs/docs/settings.mdx
+++ b/lana-docs/docs/docs/settings.mdx
@@ -91,4 +91,4 @@ The [inspector](./features/inspector.md) remembers where you dock it and how big
 
 Both update as you drag or re-dock the inspector, so you rarely need to edit them by hand.
 
-Which sections are collapsed, their sizes, the Call tree's view mode and whether the inspector is open are also remembered, but aren't settings you edit — they follow whatever you last did.
+Collapsed sections, their sizes, the Call tree's view mode and whether the inspector is open are remembered too, but aren't settings you edit.

--- a/lana/src/commands/LogView.ts
+++ b/lana/src/commands/LogView.ts
@@ -16,7 +16,7 @@ import {
   getColumnOverrides,
   getColumnViews,
   getConfig,
-  getInspectorCollapsed,
+  getInspectorState,
   updateConfig,
   updatePrivateSection,
 } from '../workspace/AppConfig.js';
@@ -120,7 +120,7 @@ export class LogView {
             config.database.soql.columnView = columnViews['database.soql.columnView'] ?? 'General';
             config.database.dml.columnView = columnViews['database.dml.columnView'] ?? 'General';
             config.database.sosl.columnView = columnViews['database.sosl.columnView'] ?? 'General';
-            config.inspector.collapsed = getInspectorCollapsed(context.context.globalState);
+            Object.assign(config.inspector, getInspectorState(context.context.globalState));
             panel.webview.postMessage({
               requestId,
               cmd: 'getConfig',

--- a/lana/src/workspace/AppConfig.ts
+++ b/lana/src/workspace/AppConfig.ts
@@ -51,7 +51,6 @@ interface Config {
     collapsed: Record<string, boolean>;
     paneSizes: Record<string, number>;
     visible: boolean | null;
-    callTreeMode: string;
   };
 }
 
@@ -110,7 +109,6 @@ export const INSPECTOR_STATE_SECTIONS = [
   'inspector.collapsed',
   'inspector.paneSizes',
   'inspector.visible',
-  'inspector.callTreeMode',
 ] as const;
 
 /** All sections routed to globalState instead of editable `lana.*` settings. */
@@ -121,17 +119,13 @@ export const PRIVATE_SECTIONS = [
 ] as const;
 
 type ColumnOverrides = Record<string, string[]>;
-type InspectorState = Pick<
-  Config['inspector'],
-  'collapsed' | 'paneSizes' | 'visible' | 'callTreeMode'
->;
+type InspectorState = Pick<Config['inspector'], 'collapsed' | 'paneSizes' | 'visible'>;
 
 export function getInspectorState(globalState: Memento): InspectorState {
   return {
     collapsed: globalState.get<Record<string, boolean>>('inspector.collapsed', {}),
     paneSizes: globalState.get<Record<string, number>>('inspector.paneSizes', {}),
     visible: globalState.get<boolean | null>('inspector.visible', null),
-    callTreeMode: globalState.get<string>('inspector.callTreeMode', 'time-order'),
   };
 }
 

--- a/lana/src/workspace/AppConfig.ts
+++ b/lana/src/workspace/AppConfig.ts
@@ -47,8 +47,11 @@ interface Config {
   inspector: {
     position: 'left' | 'right' | 'bottom';
     size: number;
-    // Per-section collapsed state, keyed by section id — private globalState.
+    // The rest is private globalState (see INSPECTOR_STATE_SECTIONS), not settings.
     collapsed: Record<string, boolean>;
+    paneSizes: Record<string, number>;
+    visible: boolean | null;
+    callTreeMode: string;
   };
 }
 
@@ -97,17 +100,39 @@ export const COLUMN_VIEW_SECTIONS = [
   'database.sosl.columnView',
 ] as const;
 
+/**
+ * The inspector's layout state (which sections are collapsed, their sizes, the
+ * call tree's view mode, whether the panel is open) is remembered UI state
+ * rather than a preference, so it persists in globalState. Dock position and
+ * size stay public `lana.inspector.*` settings.
+ */
+export const INSPECTOR_STATE_SECTIONS = [
+  'inspector.collapsed',
+  'inspector.paneSizes',
+  'inspector.visible',
+  'inspector.callTreeMode',
+] as const;
+
 /** All sections routed to globalState instead of editable `lana.*` settings. */
 export const PRIVATE_SECTIONS = [
   ...COLUMN_OVERRIDE_SECTIONS,
   ...COLUMN_VIEW_SECTIONS,
-  'inspector.collapsed',
+  ...INSPECTOR_STATE_SECTIONS,
 ] as const;
 
 type ColumnOverrides = Record<string, string[]>;
+type InspectorState = Pick<
+  Config['inspector'],
+  'collapsed' | 'paneSizes' | 'visible' | 'callTreeMode'
+>;
 
-export function getInspectorCollapsed(globalState: Memento): Record<string, boolean> {
-  return globalState.get<Record<string, boolean>>('inspector.collapsed', {});
+export function getInspectorState(globalState: Memento): InspectorState {
+  return {
+    collapsed: globalState.get<Record<string, boolean>>('inspector.collapsed', {}),
+    paneSizes: globalState.get<Record<string, number>>('inspector.paneSizes', {}),
+    visible: globalState.get<boolean | null>('inspector.visible', null),
+    callTreeMode: globalState.get<string>('inspector.callTreeMode', 'time-order'),
+  };
 }
 
 export function getColumnOverrides(globalState: Memento): Record<string, ColumnOverrides> {

--- a/log-viewer/src/components/CallTreeDetail.ts
+++ b/log-viewer/src/components/CallTreeDetail.ts
@@ -34,13 +34,44 @@ import { buildScopedCallTree, type ScopedCallTree } from './scopedCallTree.js';
 import './ViewModeSwitch.js';
 import type { ViewModeOption } from './ViewModeSwitch.js';
 
-type ViewMode = 'time-order' | 'aggregated' | 'bottom-up';
-
-const VIEW_MODES: ViewModeOption[] = [
+// The switch options are the source of the union, so the guard below can't drift.
+const VIEW_MODES = [
   { value: 'time-order', label: 'Time Order' },
   { value: 'aggregated', label: 'Aggregated' },
   { value: 'bottom-up', label: 'Bottom-Up' },
-];
+] as const satisfies readonly ViewModeOption[];
+
+type ViewMode = (typeof VIEW_MODES)[number]['value'];
+
+function isViewMode(value: unknown): value is ViewMode {
+  return VIEW_MODES.some((option) => option.value === value);
+}
+
+/**
+ * The remembered view mode, shared by every instance: the pane is torn down and
+ * rebuilt on each collapse, tab hop and panel toggle, so reading it per instance
+ * would be one config round-trip per rebuild — and would render the default mode
+ * first, building a Tabulator the user never sees. Loaded once, lazily; a user's
+ * own pick supersedes a load still in flight (hence `??=`).
+ */
+let sharedViewMode: ViewMode | undefined;
+let viewModeLoad: Promise<void> | undefined;
+
+function loadSharedViewMode(): Promise<void> {
+  viewModeLoad ??= getSettings()
+    .then((settings) => {
+      const mode = settings?.inspector?.callTreeMode;
+      if (isViewMode(mode)) {
+        sharedViewMode ??= mode;
+      }
+    })
+    .catch(() => {
+      // Settings unavailable (e.g. outside the extension host): keep the default
+      // and drop the memo, so the next pane retries instead of never restoring.
+      viewModeLoad = undefined;
+    });
+  return viewModeLoad;
+}
 
 // SOQL/DML frames already read as their statement text, so don't prefix the type.
 const EXCLUDED_TYPES = new Set<LogEventType>(['SOQL_EXECUTE_BEGIN', 'DML_BEGIN']);
@@ -96,6 +127,11 @@ export class CallTreeDetail extends LitElement {
   @state()
   private viewMode: ViewMode = 'time-order';
 
+  // False only while the remembered mode is still loading; building before it
+  // lands would make a Tabulator for the default mode the user never sees.
+  @state()
+  private _modeReady = true;
+
   private _tables: Record<ViewMode, Tabulator | null> = {
     'time-order': null,
     aggregated: null,
@@ -112,24 +148,22 @@ export class CallTreeDetail extends LitElement {
   private _contextMenu: ContextMenu | null = null;
   /** eventIndex of the row whose context menu is open. */
   private _menuEventIndex = -1;
-  // Set once the user picks a mode, so a late settings load can't overrule them.
-  private _modeIsUserChoice = false;
 
   constructor() {
     super();
     // The mode is remembered UI state, so it's read here rather than threaded
     // through the section builders.
-    getSettings()
-      .then((settings) => {
-        const mode = settings?.inspector?.callTreeMode;
-        if (!this._modeIsUserChoice && VIEW_MODES.some((option) => option.value === mode)) {
-          this.viewMode = mode as ViewMode;
-          this.requestUpdate();
+    if (sharedViewMode) {
+      this.viewMode = sharedViewMode;
+    } else {
+      this._modeReady = false;
+      void loadSharedViewMode().then(() => {
+        if (sharedViewMode) {
+          this.viewMode = sharedViewMode;
         }
-      })
-      .catch(() => {
-        /* settings unavailable (e.g. outside the extension host) — keep the default */
+        this._modeReady = true;
       });
+    }
   }
 
   firstUpdated(): void {
@@ -187,7 +221,7 @@ export class CallTreeDetail extends LitElement {
       this._destroyTables();
       this._scoped = buildScopedCallTree(this.eventIndex, this.instances);
     }
-    if (scopeChanged || changed.has('viewMode')) {
+    if (this._modeReady && (scopeChanged || changed.has('viewMode') || changed.has('_modeReady'))) {
       void this._showActive();
     }
   }
@@ -392,10 +426,8 @@ export class CallTreeDetail extends LitElement {
   }
 
   private _setViewMode(mode: ViewMode) {
-    this._modeIsUserChoice = true;
+    sharedViewMode = mode;
     this.viewMode = mode;
     updateSetting('inspector.callTreeMode', mode);
-    // @state field initializer shadows the accessor under @swc/jest; nudge it.
-    this.requestUpdate();
   }
 }

--- a/log-viewer/src/components/CallTreeDetail.ts
+++ b/log-viewer/src/components/CallTreeDetail.ts
@@ -21,7 +21,6 @@ import {
   waitForNextFrame,
 } from '../features/call-tree/components/TableShared.js';
 import { makeSumSelfTimeAllVisible } from '../features/call-tree/utils/BottomCalcs.js';
-import { getSettings, updateSetting } from '../features/settings/Settings.js';
 import { soqlInlineElement } from '../features/soql/format/inlineCell.js';
 import { soqlSyntaxStyles } from '../features/soql/styles/soql-syntax.css.js';
 import { globalStyles } from '../styles/global.styles.js';
@@ -48,30 +47,13 @@ function isViewMode(value: unknown): value is ViewMode {
 }
 
 /**
- * The remembered view mode, shared by every instance: the pane is torn down and
- * rebuilt on each collapse, tab hop and panel toggle, so reading it per instance
- * would be one config round-trip per rebuild — and would render the default mode
- * first, building a Tabulator the user never sees. Loaded once, lazily; a user's
- * own pick supersedes a load still in flight (hence `??=`).
+ * The picked view mode, shared by every instance: the pane is torn down and
+ * rebuilt on each collapse, tab hop and panel toggle, so without this the mode
+ * would reset on every selection. Deliberately not persisted — a log opens on
+ * Time Order, the mode that matches the Call Tree tab and the timeline, so an
+ * aggregated view is always something you chose in this log, not last week.
  */
 let sharedViewMode: ViewMode | undefined;
-let viewModeLoad: Promise<void> | undefined;
-
-function loadSharedViewMode(): Promise<void> {
-  viewModeLoad ??= getSettings()
-    .then((settings) => {
-      const mode = settings?.inspector?.callTreeMode;
-      if (isViewMode(mode)) {
-        sharedViewMode ??= mode;
-      }
-    })
-    .catch(() => {
-      // Settings unavailable (e.g. outside the extension host): keep the default
-      // and drop the memo, so the next pane retries instead of never restoring.
-      viewModeLoad = undefined;
-    });
-  return viewModeLoad;
-}
 
 // SOQL/DML frames already read as their statement text, so don't prefix the type.
 const EXCLUDED_TYPES = new Set<LogEventType>(['SOQL_EXECUTE_BEGIN', 'DML_BEGIN']);
@@ -127,11 +109,6 @@ export class CallTreeDetail extends LitElement {
   @state()
   private viewMode: ViewMode = 'time-order';
 
-  // False only while the remembered mode is still loading; building before it
-  // lands would make a Tabulator for the default mode the user never sees.
-  @state()
-  private _modeReady = true;
-
   private _tables: Record<ViewMode, Tabulator | null> = {
     'time-order': null,
     aggregated: null,
@@ -151,18 +128,10 @@ export class CallTreeDetail extends LitElement {
 
   constructor() {
     super();
-    // The mode is remembered UI state, so it's read here rather than threaded
-    // through the section builders.
+    // Session UI state, so it's read here rather than threaded through the
+    // section builders.
     if (sharedViewMode) {
       this.viewMode = sharedViewMode;
-    } else {
-      this._modeReady = false;
-      void loadSharedViewMode().then(() => {
-        if (sharedViewMode) {
-          this.viewMode = sharedViewMode;
-        }
-        this._modeReady = true;
-      });
     }
   }
 
@@ -221,7 +190,7 @@ export class CallTreeDetail extends LitElement {
       this._destroyTables();
       this._scoped = buildScopedCallTree(this.eventIndex, this.instances);
     }
-    if (this._modeReady && (scopeChanged || changed.has('viewMode') || changed.has('_modeReady'))) {
+    if (scopeChanged || changed.has('viewMode')) {
       void this._showActive();
     }
   }
@@ -405,7 +374,7 @@ export class CallTreeDetail extends LitElement {
         .options=${VIEW_MODES}
         value=${this.viewMode}
         @view-mode-change=${(e: CustomEvent<{ value: string }>) =>
-          this._setViewMode(e.detail.value as ViewMode)}
+          this._setViewMode(e.detail.value)}
       ></view-mode-switch>
       <div class="tables">
         <div class="table-host ${this.viewMode === 'time-order' ? '' : 'is-hidden'}">
@@ -425,9 +394,11 @@ export class CallTreeDetail extends LitElement {
     `;
   }
 
-  private _setViewMode(mode: ViewMode) {
+  private _setViewMode(mode: string) {
+    if (!isViewMode(mode)) {
+      return;
+    }
     sharedViewMode = mode;
     this.viewMode = mode;
-    updateSetting('inspector.callTreeMode', mode);
   }
 }

--- a/log-viewer/src/components/CallTreeDetail.ts
+++ b/log-viewer/src/components/CallTreeDetail.ts
@@ -21,6 +21,7 @@ import {
   waitForNextFrame,
 } from '../features/call-tree/components/TableShared.js';
 import { makeSumSelfTimeAllVisible } from '../features/call-tree/utils/BottomCalcs.js';
+import { getSettings, updateSetting } from '../features/settings/Settings.js';
 import { soqlInlineElement } from '../features/soql/format/inlineCell.js';
 import { soqlSyntaxStyles } from '../features/soql/styles/soql-syntax.css.js';
 import { globalStyles } from '../styles/global.styles.js';
@@ -111,6 +112,25 @@ export class CallTreeDetail extends LitElement {
   private _contextMenu: ContextMenu | null = null;
   /** eventIndex of the row whose context menu is open. */
   private _menuEventIndex = -1;
+  // Set once the user picks a mode, so a late settings load can't overrule them.
+  private _modeIsUserChoice = false;
+
+  constructor() {
+    super();
+    // The mode is remembered UI state, so it's read here rather than threaded
+    // through the section builders.
+    getSettings()
+      .then((settings) => {
+        const mode = settings?.inspector?.callTreeMode;
+        if (!this._modeIsUserChoice && VIEW_MODES.some((option) => option.value === mode)) {
+          this.viewMode = mode as ViewMode;
+          this.requestUpdate();
+        }
+      })
+      .catch(() => {
+        /* settings unavailable (e.g. outside the extension host) — keep the default */
+      });
+  }
 
   firstUpdated(): void {
     this._contextMenu = this.renderRoot.querySelector('context-menu');
@@ -372,7 +392,9 @@ export class CallTreeDetail extends LitElement {
   }
 
   private _setViewMode(mode: ViewMode) {
+    this._modeIsUserChoice = true;
     this.viewMode = mode;
+    updateSetting('inspector.callTreeMode', mode);
     // @state field initializer shadows the accessor under @swc/jest; nudge it.
     this.requestUpdate();
   }

--- a/log-viewer/src/components/DetailDock.ts
+++ b/log-viewer/src/components/DetailDock.ts
@@ -28,6 +28,13 @@ export class DetailDock extends LitElement {
   @property({ type: String })
   emptyText = 'Nothing selected.';
 
+  /** Collapsed sections and pane sizes, owned and persisted by the consumer. */
+  @property({ attribute: false })
+  collapsed: Record<string, boolean> = {};
+
+  @property({ attribute: false })
+  paneSizes: Record<string, number> = {};
+
   static styles = [
     globalStyles,
     panelTokens,
@@ -121,6 +128,8 @@ export class DetailDock extends LitElement {
           ? html`<pane-view
               orientation=${this.dock === 'bottom' ? 'horizontal' : 'vertical'}
               .sections=${this.sections}
+              .collapsed=${this.collapsed}
+              .paneSizes=${this.paneSizes}
             ></pane-view>`
           : html`<div class="empty">${this.emptyText}</div>`
       }

--- a/log-viewer/src/components/DetailDock.ts
+++ b/log-viewer/src/components/DetailDock.ts
@@ -28,7 +28,7 @@ export class DetailDock extends LitElement {
   @property({ type: String })
   emptyText = 'Nothing selected.';
 
-  /** Collapsed sections and pane sizes, owned and persisted by the consumer. */
+  /** Passed through to `<pane-view>`; the consumer owns them. */
   @property({ attribute: false })
   collapsed: Record<string, boolean> = {};
 

--- a/log-viewer/src/components/DockLayout.ts
+++ b/log-viewer/src/components/DockLayout.ts
@@ -39,7 +39,7 @@ export class DockLayout extends LitElement {
   @property({ type: String })
   emptyText = 'Nothing selected.';
 
-  /** Collapsed sections and pane sizes, owned and persisted by the consumer. */
+  /** Passed through to `<pane-view>`; the consumer owns them. */
   @property({ attribute: false })
   collapsed: Record<string, boolean> = {};
 
@@ -189,7 +189,6 @@ export class DockLayout extends LitElement {
       this._pendingCollapse = false;
       this._liveSize = Math.max(MIN_SIZE, Math.min(raw, Math.max(MIN_SIZE, max)));
     }
-    this.requestUpdate();
   };
 
   private _endResize = (e: PointerEvent) => {

--- a/log-viewer/src/components/DockLayout.ts
+++ b/log-viewer/src/components/DockLayout.ts
@@ -39,6 +39,13 @@ export class DockLayout extends LitElement {
   @property({ type: String })
   emptyText = 'Nothing selected.';
 
+  /** Collapsed sections and pane sizes, owned and persisted by the consumer. */
+  @property({ attribute: false })
+  collapsed: Record<string, boolean> = {};
+
+  @property({ attribute: false })
+  paneSizes: Record<string, number> = {};
+
   // Live drag state (transient); when set, overrides `size` while dragging.
   @state()
   private _liveSize: number | null = null;
@@ -125,6 +132,8 @@ export class DockLayout extends LitElement {
                   style=${this._dockSizeStyle()}
                   .sections=${this.sections}
                   .emptyText=${this.emptyText}
+                  .collapsed=${this.collapsed}
+                  .paneSizes=${this.paneSizes}
                   dock=${this.dock}
                 ></detail-dock>
               `

--- a/log-viewer/src/components/LogInspector.ts
+++ b/log-viewer/src/components/LogInspector.ts
@@ -39,13 +39,9 @@ export class LogInspector extends LitElement {
   @state()
   private dock: DockPosition = 'right';
   @state()
-  private panelVisible = false;
-  @state()
   private panelSize = 500;
 
-  // Collapse and pane sizes are keyed by section id and shared by every tab:
-  // it's one panel, so "I don't need the Call stack" and a divider drag are
-  // statements about the section, not about the tab that fed it.
+  // Keyed by section id and shared by every tab — one panel, one layout.
   @state()
   private collapsedSections: Record<string, boolean> = {};
   @state()
@@ -55,7 +51,14 @@ export class LogInspector extends LitElement {
   private _selections = new Map<DetailSource, DetailSelection>();
   // The user's last open/closed choice, or null if they've never made one —
   // which is the only state that lets a selection auto-open the panel.
+  @state()
   private _visiblePref: boolean | null = null;
+  // Set once a selection has opened the panel on the user's behalf.
+  @state()
+  private _autoOpened = false;
+  // Set as soon as the user docks, resizes or collapses anything, so a settings
+  // load still in flight can't overwrite what they just did.
+  private _userAdjusted = false;
   // Guards against a slow rebuild resolving after a newer selection.
   private _rebuildEpoch = 0;
   private _unsubscribe: Array<() => void> = [];
@@ -69,22 +72,27 @@ export class LogInspector extends LitElement {
     getSettings()
       .then((settings) => {
         const panel = settings?.inspector;
-        if (panel) {
+        if (!panel) {
+          return;
+        }
+        // The load can land after the user has already opened or laid out the
+        // panel, so their own choice always wins over the stored one.
+        this._visiblePref ??= panel.visible ?? null;
+        if (!this._userAdjusted) {
           this.dock = panel.position;
           this.panelSize = panel.size;
           this.collapsedSections = panel.collapsed ?? {};
           this.paneSizes = panel.paneSizes ?? {};
-          this._visiblePref = panel.visible ?? null;
-          // Settings can land after the first selection has already auto-opened
-          // the panel, so an explicit choice always overrides that.
-          if (this._visiblePref !== null) {
-            this.panelVisible = this._visiblePref;
-          }
         }
       })
       .catch(() => {
         /* settings unavailable (e.g. outside the extension host) — keep defaults */
       });
+  }
+
+  // Open when the user says so, else only if a selection auto-opened it.
+  private get _visible(): boolean {
+    return this._visiblePref ?? this._autoOpened;
   }
 
   disconnectedCallback(): void {
@@ -123,7 +131,7 @@ export class LogInspector extends LitElement {
       <dock-layout
         dock=${this.dock}
         .size=${this.panelSize}
-        ?visible=${this.panelVisible}
+        ?visible=${this._visible}
         .sections=${this.sections}
         .collapsed=${this.collapsedSections}
         .paneSizes=${this.paneSizes}
@@ -147,10 +155,9 @@ export class LogInspector extends LitElement {
   private _onSelect(detail: { source: DetailSource; selection: DetailSelection | null }): void {
     if (detail.selection) {
       this._selections.set(detail.source, detail.selection);
-      // Auto-open only for a user who has never opened or closed it themselves.
-      if (this._visiblePref === null) {
-        this.panelVisible = true;
-      }
+      // Only shows the panel while the user has never chosen for themselves,
+      // which `_visible` decides.
+      this._autoOpened = true;
     } else {
       this._selections.delete(detail.source);
     }
@@ -161,12 +168,11 @@ export class LogInspector extends LitElement {
   }
 
   private _onToggle(detail: { visible?: boolean }): void {
-    this._setVisible(detail.visible ?? !this.panelVisible);
+    this._setVisible(detail.visible ?? !this._visible);
   }
 
   /** Every open/close is the user's, so each one is remembered. */
   private _setVisible(visible: boolean): void {
-    this.panelVisible = visible;
     this._visiblePref = visible;
     updateSetting('inspector.visible', visible);
   }
@@ -183,8 +189,9 @@ export class LogInspector extends LitElement {
   private async _rebuild(): Promise<void> {
     const epoch = ++this._rebuildEpoch;
     const source = this._activeSource;
-    const selection = source ? (this._selections.get(source) ?? null) : null;
-    const sections = source ? await buildDetailSections(source, selection) : [];
+    const sections = source
+      ? await buildDetailSections(source, this._selections.get(source) ?? null)
+      : [];
     // Drop a slow build that a newer selection already superseded.
     if (epoch === this._rebuildEpoch) {
       this.sections = sections;
@@ -192,6 +199,7 @@ export class LogInspector extends LitElement {
   }
 
   private _onDockPositionChange = (e: CustomEvent<{ position: DockPosition }>) => {
+    this._userAdjusted = true;
     this.dock = e.detail.position;
     updateSetting('inspector.position', this.dock);
   };
@@ -199,17 +207,20 @@ export class LogInspector extends LitElement {
   // `dock-resize` fires once on pointer-up, so this write already lands on
   // interaction-end — no debounce needed.
   private _onDockResize = (e: CustomEvent<{ size: number }>) => {
+    this._userAdjusted = true;
     this.panelSize = e.detail.size;
     updateSetting('inspector.size', this.panelSize);
   };
 
   private _onPaneToggle = (e: CustomEvent<{ collapsed: Record<string, boolean> }>) => {
+    this._userAdjusted = true;
     this.collapsedSections = { ...this.collapsedSections, ...e.detail.collapsed };
     updateSetting('inspector.collapsed', this.collapsedSections);
   };
 
   // `pane-resize` fires on pointer-up, so this write lands on interaction-end.
   private _onPaneResize = (e: CustomEvent<{ sizes: Record<string, number> }>) => {
+    this._userAdjusted = true;
     this.paneSizes = { ...this.paneSizes, ...e.detail.sizes };
     updateSetting('inspector.paneSizes', this.paneSizes);
   };

--- a/log-viewer/src/components/LogInspector.ts
+++ b/log-viewer/src/components/LogInspector.ts
@@ -25,8 +25,8 @@ const TAB_TO_SOURCE: Record<string, DetailSource> = {
  * The app-wide inspector. Lives at the app root (sibling of the tab strip,
  * via a forwarded `main` slot) so it crosscuts every tab. It follows the active
  * tab: each source's latest selection is remembered, and it shows the active
- * tab's selection. Persists dock position/size (public settings) and per-section
- * collapse (private globalState); visibility is transient (opens on first select).
+ * tab's selection. Persists dock position/size (public settings) plus its
+ * open/closed state, section collapse and pane sizes (private globalState).
  */
 @customElement('log-inspector')
 export class LogInspector extends LitElement {
@@ -43,14 +43,21 @@ export class LogInspector extends LitElement {
   @state()
   private panelSize = 500;
 
+  // Collapse and pane sizes are keyed by section id and shared by every tab:
+  // it's one panel, so "I don't need the Call stack" and a divider drag are
+  // statements about the section, not about the tab that fed it.
+  @state()
+  private collapsedSections: Record<string, boolean> = {};
+  @state()
+  private paneSizes: Record<string, number> = {};
+
   // Latest selection per source; the bar renders the active tab's entry.
   private _selections = new Map<DetailSource, DetailSelection>();
-  // Auto-open only on the first selection; afterwards the user's toggle wins.
-  private _hasAutoOpened = false;
+  // The user's last open/closed choice, or null if they've never made one —
+  // which is the only state that lets a selection auto-open the panel.
+  private _visiblePref: boolean | null = null;
   // Guards against a slow rebuild resolving after a newer selection.
   private _rebuildEpoch = 0;
-  // Persisted per-section collapse (globalState), keyed by section id.
-  private _collapsedSections: Record<string, boolean> = {};
   private _unsubscribe: Array<() => void> = [];
 
   constructor() {
@@ -65,7 +72,14 @@ export class LogInspector extends LitElement {
         if (panel) {
           this.dock = panel.position;
           this.panelSize = panel.size;
-          this._collapsedSections = panel.collapsed ?? {};
+          this.collapsedSections = panel.collapsed ?? {};
+          this.paneSizes = panel.paneSizes ?? {};
+          this._visiblePref = panel.visible ?? null;
+          // Settings can land after the first selection has already auto-opened
+          // the panel, so an explicit choice always overrides that.
+          if (this._visiblePref !== null) {
+            this.panelVisible = this._visiblePref;
+          }
         }
       })
       .catch(() => {
@@ -111,36 +125,50 @@ export class LogInspector extends LitElement {
         .size=${this.panelSize}
         ?visible=${this.panelVisible}
         .sections=${this.sections}
+        .collapsed=${this.collapsedSections}
+        .paneSizes=${this.paneSizes}
         emptyText="Select a row to inspect it."
         @dock-position-change=${this._onDockPositionChange}
         @dock-resize=${this._onDockResize}
         @dock-hide=${this._hidePanel}
         @dock-collapse=${this._hidePanel}
         @pane-toggle=${this._onPaneToggle}
+        @pane-resize=${this._onPaneResize}
       >
         <slot slot="main" name="main"></slot>
       </dock-layout>
     `;
   }
 
+  private get _activeSource(): DetailSource | undefined {
+    return TAB_TO_SOURCE[this.activeTab];
+  }
+
   private _onSelect(detail: { source: DetailSource; selection: DetailSelection | null }): void {
     if (detail.selection) {
       this._selections.set(detail.source, detail.selection);
-      if (!this._hasAutoOpened) {
-        this._hasAutoOpened = true;
+      // Auto-open only for a user who has never opened or closed it themselves.
+      if (this._visiblePref === null) {
         this.panelVisible = true;
       }
     } else {
       this._selections.delete(detail.source);
     }
     // Only rebuild if the change is for the tab currently on screen.
-    if (TAB_TO_SOURCE[this.activeTab] === detail.source) {
+    if (this._activeSource === detail.source) {
       this._scheduleRebuild();
     }
   }
 
   private _onToggle(detail: { visible?: boolean }): void {
-    this.panelVisible = detail.visible ?? !this.panelVisible;
+    this._setVisible(detail.visible ?? !this.panelVisible);
+  }
+
+  /** Every open/close is the user's, so each one is remembered. */
+  private _setVisible(visible: boolean): void {
+    this.panelVisible = visible;
+    this._visiblePref = visible;
+    updateSetting('inspector.visible', visible);
   }
 
   /**
@@ -154,11 +182,9 @@ export class LogInspector extends LitElement {
 
   private async _rebuild(): Promise<void> {
     const epoch = ++this._rebuildEpoch;
-    const source = TAB_TO_SOURCE[this.activeTab];
+    const source = this._activeSource;
     const selection = source ? (this._selections.get(source) ?? null) : null;
-    const sections = selection
-      ? await buildDetailSections(source!, selection, this._collapsedSections)
-      : [];
+    const sections = source ? await buildDetailSections(source, selection) : [];
     // Drop a slow build that a newer selection already superseded.
     if (epoch === this._rebuildEpoch) {
       this.sections = sections;
@@ -178,12 +204,18 @@ export class LogInspector extends LitElement {
   };
 
   private _onPaneToggle = (e: CustomEvent<{ collapsed: Record<string, boolean> }>) => {
-    this._collapsedSections = { ...this._collapsedSections, ...e.detail.collapsed };
-    updateSetting('inspector.collapsed', this._collapsedSections);
+    this.collapsedSections = { ...this.collapsedSections, ...e.detail.collapsed };
+    updateSetting('inspector.collapsed', this.collapsedSections);
+  };
+
+  // `pane-resize` fires on pointer-up, so this write lands on interaction-end.
+  private _onPaneResize = (e: CustomEvent<{ sizes: Record<string, number> }>) => {
+    this.paneSizes = { ...this.paneSizes, ...e.detail.sizes };
+    updateSetting('inspector.paneSizes', this.paneSizes);
   };
 
   private _hidePanel = () => {
-    this.panelVisible = false;
+    this._setVisible(false);
   };
 }
 

--- a/log-viewer/src/components/PaneView.ts
+++ b/log-viewer/src/components/PaneView.ts
@@ -16,8 +16,6 @@ export interface PaneSection {
   content: TemplateResult;
   /** Optional count/label shown as a badge in the section header. */
   badge?: string;
-  /** Default collapsed state (vertical only), seeded on first render. */
-  collapsed?: boolean;
   /** Default flex-grow weight when open, seeded on first render (default 1). */
   weight?: number;
 }
@@ -40,19 +38,16 @@ export class PaneView extends LitElement {
   @property({ type: String })
   orientation: PaneOrientation = 'vertical';
 
-  /**
-   * Collapsed sections, keyed by section id — owned by the consumer, which is
-   * the only thing that knows how far the state should carry (per tab, per
-   * session). Overrides `section.collapsed`, which is only the default seed.
-   */
+  /** Collapsed sections, keyed by section id. Controlled by the consumer. */
   @property({ attribute: false })
   collapsed: Record<string, boolean> = {};
 
-  /** Persisted pane sizes (px, used as flex weights), keyed by section id. */
+  /** Pane sizes from the last drag (px), keyed by section id. Relative only. */
   @property({ attribute: false })
   paneSizes: Record<string, number> = {};
 
-  // Live drag sizes; supersede `paneSizes` until the consumer stores them.
+  // The rendered weights: seeded from `paneSizes`, then edited in place by a
+  // live drag until `pane-resize` hands the result back to the consumer.
   @state()
   private _weights: Record<string, number> = {};
 
@@ -62,6 +57,7 @@ export class PaneView extends LitElement {
     start: number;
     startA: number;
     startB: number;
+    moved: boolean;
   } | null = null;
 
   static styles = [
@@ -180,17 +176,17 @@ export class PaneView extends LitElement {
   ];
 
   willUpdate(changed: PropertyValues): void {
-    // The consumer has stored a new set, so the live drag sizes it supersedes
-    // must not keep masking it.
+    // Adopt whatever the consumer stored; a drag then edits this copy.
     if (changed.has('paneSizes')) {
-      this._weights = {};
+      this._weights = { ...this.paneSizes };
     }
   }
 
   render() {
+    const weights = this._flexWeights();
     const items: TemplateResult[] = [];
     this.sections.forEach((section, index) => {
-      items.push(this._renderPane(section));
+      items.push(this._renderPane(section, weights.get(section.id) ?? 1));
       const next = this.sections[index + 1];
       if (next && this._isOpen(section.id) && this._isOpen(next.id)) {
         items.push(this._renderSash(section.id, next.id));
@@ -200,10 +196,38 @@ export class PaneView extends LitElement {
     return html`<div class="pane-view" data-orientation=${this.orientation}>${items}</div>`;
   }
 
-  private _renderPane(section: PaneSection) {
+  /**
+   * Flex weights for the open panes, all on one scale. Stored sizes are pixel
+   * snapshots taken during a drag while `section.weight` is a small unit share,
+   * so the stored set is rescaled onto the unit scale: mixing the two would
+   * render a section with no stored size — one added after the drag, or
+   * collapsed during it — as a sliver beside its pixel-sized siblings.
+   */
+  private _flexWeights(): Map<string, number> {
+    const open = this.sections.filter((section) => this._isOpen(section.id));
+    let storedPx = 0;
+    let storedUnits = 0;
+    for (const section of open) {
+      const stored = this._weights[section.id];
+      if (stored !== undefined) {
+        storedPx += stored;
+        storedUnits += section.weight ?? 1;
+      }
+    }
+    // px → units, and 0 when nothing is stored so every pane falls back to units.
+    const scale = storedPx > 0 ? storedUnits / storedPx : 0;
+    return new Map(
+      open.map((section) => {
+        const stored = this._weights[section.id];
+        const weight = stored !== undefined && scale > 0 ? stored * scale : (section.weight ?? 1);
+        return [section.id, weight];
+      }),
+    );
+  }
+
+  private _renderPane(section: PaneSection, weight: number) {
     const open = this._isOpen(section.id);
     const collapsible = this._collapsible;
-    const weight = this._weights[section.id] ?? this.paneSizes[section.id] ?? section.weight ?? 1;
     const style = open ? `flex: ${weight} 1 0` : 'flex: 0 0 auto';
 
     return html`<div class="pane" data-id=${section.id} ?data-open=${open} style=${style}>
@@ -239,19 +263,13 @@ export class PaneView extends LitElement {
     return this.orientation === 'vertical';
   }
 
-  /** Section's `collapsed` default (when the user hasn't toggled it yet). */
-  private _defaultCollapsed(id: string): boolean {
-    return this.sections.find((s) => s.id === id)?.collapsed ?? false;
-  }
-
   private _isOpen(id: string) {
-    return this._collapsible ? !(this.collapsed[id] ?? this._defaultCollapsed(id)) : true;
+    return this._collapsible ? !this.collapsed[id] : true;
   }
 
   private _toggle(id: string) {
     // New collapsed state = the current open state (open → collapse, and vice
-    // versa), starting from the effective (possibly default) state. The consumer
-    // owns the record, so it re-renders us with the new one.
+    // versa). The consumer owns the record, so it re-renders us with the new one.
     this.dispatchEvent(
       new CustomEvent('pane-toggle', {
         detail: { collapsed: { ...this.collapsed, [id]: this._isOpen(id) } },
@@ -296,9 +314,12 @@ export class PaneView extends LitElement {
       start: this.orientation === 'vertical' ? e.clientY : e.clientX,
       startA: this._weights[aId] ?? 0,
       startB: this._weights[bId] ?? 0,
+      moved: false,
     };
     sash.addEventListener('pointermove', this._onSashMove);
     sash.addEventListener('pointerup', this._endSash);
+    sash.addEventListener('pointercancel', this._cancelSash);
+    sash.addEventListener('lostpointercapture', this._onLostCapture);
   }
 
   private _onSashMove = (e: PointerEvent) => {
@@ -310,25 +331,55 @@ export class PaneView extends LitElement {
     const total = sash.startA + sash.startB;
     const delta = pos - sash.start;
     const newA = Math.max(MIN_PANE_PX, Math.min(sash.startA + delta, total - MIN_PANE_PX));
+    sash.moved = true;
     this._weights = { ...this._weights, [sash.aId]: newA, [sash.bId]: total - newA };
-    this.requestUpdate();
   };
 
   private _endSash = (e: PointerEvent) => {
-    const sashEl = e.currentTarget as HTMLElement;
-    sashEl.releasePointerCapture(e.pointerId);
+    const moved = this._sash?.moved ?? false;
+    // A click that never moved changed no size, so it isn't worth persisting —
+    // and a double-click reset would otherwise emit three times.
+    if (this._teardownSash(e.currentTarget as HTMLElement, e.pointerId) && moved) {
+      this._emitResize();
+    }
+  };
+
+  /** An interrupted gesture (OS gesture, touch cancel) undoes the drag. */
+  private _cancelSash = (e: PointerEvent) => {
+    const sash = this._sash;
+    if (sash) {
+      this._weights = { ...this._weights, [sash.aId]: sash.startA, [sash.bId]: sash.startB };
+    }
+    this._teardownSash(e.currentTarget as HTMLElement, e.pointerId);
+  };
+
+  // Capture lost without a pointerup (window blur, another element capturing):
+  // stop tracking, or a later move would resize with no button held.
+  private _onLostCapture = (e: PointerEvent) => {
+    this._teardownSash(e.currentTarget as HTMLElement, e.pointerId);
+  };
+
+  /** Detaches the drag; false if it had already ended. */
+  private _teardownSash(sashEl: HTMLElement, pointerId: number): boolean {
+    if (!this._sash) {
+      return false;
+    }
+    this._sash = null;
+    if (sashEl.hasPointerCapture(pointerId)) {
+      sashEl.releasePointerCapture(pointerId);
+    }
     sashEl.classList.remove('pane-sash--active');
     sashEl.removeEventListener('pointermove', this._onSashMove);
     sashEl.removeEventListener('pointerup', this._endSash);
-    this._sash = null;
-    this._emitResize();
-  };
+    sashEl.removeEventListener('pointercancel', this._cancelSash);
+    sashEl.removeEventListener('lostpointercapture', this._onLostCapture);
+    return true;
+  }
 
   private _resetSash(aId: string, bId: string) {
     const total =
       (this._weights[aId] ?? this._paneSize(aId)) + (this._weights[bId] ?? this._paneSize(bId));
     this._weights = { ...this._weights, [aId]: total / 2, [bId]: total / 2 };
-    this.requestUpdate();
     this._emitResize();
   }
 

--- a/log-viewer/src/components/PaneView.ts
+++ b/log-viewer/src/components/PaneView.ts
@@ -3,7 +3,7 @@
  */
 import '#vscode-elements/vscode-icon.js';
 import '#vscode-elements/vscode-badge.js';
-import { LitElement, css, html, nothing, type TemplateResult } from 'lit';
+import { LitElement, css, html, nothing, type PropertyValues, type TemplateResult } from 'lit';
 import { customElement, property, state } from 'lit/decorators.js';
 
 // styles
@@ -40,9 +40,19 @@ export class PaneView extends LitElement {
   @property({ type: String })
   orientation: PaneOrientation = 'vertical';
 
-  // Transient per-session state.
-  @state()
-  private _collapsed: Record<string, boolean> = {};
+  /**
+   * Collapsed sections, keyed by section id — owned by the consumer, which is
+   * the only thing that knows how far the state should carry (per tab, per
+   * session). Overrides `section.collapsed`, which is only the default seed.
+   */
+  @property({ attribute: false })
+  collapsed: Record<string, boolean> = {};
+
+  /** Persisted pane sizes (px, used as flex weights), keyed by section id. */
+  @property({ attribute: false })
+  paneSizes: Record<string, number> = {};
+
+  // Live drag sizes; supersede `paneSizes` until the consumer stores them.
   @state()
   private _weights: Record<string, number> = {};
 
@@ -169,6 +179,14 @@ export class PaneView extends LitElement {
     `,
   ];
 
+  willUpdate(changed: PropertyValues): void {
+    // The consumer has stored a new set, so the live drag sizes it supersedes
+    // must not keep masking it.
+    if (changed.has('paneSizes')) {
+      this._weights = {};
+    }
+  }
+
   render() {
     const items: TemplateResult[] = [];
     this.sections.forEach((section, index) => {
@@ -185,7 +203,7 @@ export class PaneView extends LitElement {
   private _renderPane(section: PaneSection) {
     const open = this._isOpen(section.id);
     const collapsible = this._collapsible;
-    const weight = this._weights[section.id] ?? section.weight ?? 1;
+    const weight = this._weights[section.id] ?? this.paneSizes[section.id] ?? section.weight ?? 1;
     const style = open ? `flex: ${weight} 1 0` : 'flex: 0 0 auto';
 
     return html`<div class="pane" data-id=${section.id} ?data-open=${open} style=${style}>
@@ -227,21 +245,20 @@ export class PaneView extends LitElement {
   }
 
   private _isOpen(id: string) {
-    return this._collapsible ? !(this._collapsed[id] ?? this._defaultCollapsed(id)) : true;
+    return this._collapsible ? !(this.collapsed[id] ?? this._defaultCollapsed(id)) : true;
   }
 
   private _toggle(id: string) {
     // New collapsed state = the current open state (open → collapse, and vice
-    // versa), starting from the effective (possibly default) state.
-    this._collapsed = { ...this._collapsed, [id]: this._isOpen(id) };
+    // versa), starting from the effective (possibly default) state. The consumer
+    // owns the record, so it re-renders us with the new one.
     this.dispatchEvent(
       new CustomEvent('pane-toggle', {
-        detail: { collapsed: this._collapsed },
+        detail: { collapsed: { ...this.collapsed, [id]: this._isOpen(id) } },
         bubbles: true,
         composed: true,
       }),
     );
-    this.requestUpdate();
   }
 
   private _onHeaderKey(e: KeyboardEvent, id: string) {
@@ -304,6 +321,7 @@ export class PaneView extends LitElement {
     sashEl.removeEventListener('pointermove', this._onSashMove);
     sashEl.removeEventListener('pointerup', this._endSash);
     this._sash = null;
+    this._emitResize();
   };
 
   private _resetSash(aId: string, bId: string) {
@@ -311,5 +329,17 @@ export class PaneView extends LitElement {
       (this._weights[aId] ?? this._paneSize(aId)) + (this._weights[bId] ?? this._paneSize(bId));
     this._weights = { ...this._weights, [aId]: total / 2, [bId]: total / 2 };
     this.requestUpdate();
+    this._emitResize();
+  }
+
+  /** Fires on interaction-end only, so the consumer's write isn't per-frame. */
+  private _emitResize() {
+    this.dispatchEvent(
+      new CustomEvent('pane-resize', {
+        detail: { sizes: { ...this._weights } },
+        bubbles: true,
+        composed: true,
+      }),
+    );
   }
 }

--- a/log-viewer/src/components/PaneView.ts
+++ b/log-viewer/src/components/PaneView.ts
@@ -42,12 +42,18 @@ export class PaneView extends LitElement {
   @property({ attribute: false })
   collapsed: Record<string, boolean> = {};
 
-  /** Pane sizes from the last drag (px), keyed by section id. Relative only. */
+  /**
+   * Pane sizes from the last drag (px), keyed `<orientation>:<section id>`.
+   * Relative only, and per axis — a width dragged in the horizontal dock says
+   * nothing about heights in the vertical one, so each orientation keeps its own
+   * sizes and the other's are left untouched.
+   */
   @property({ attribute: false })
   paneSizes: Record<string, number> = {};
 
-  // The rendered weights: seeded from `paneSizes`, then edited in place by a
-  // live drag until `pane-resize` hands the result back to the consumer.
+  // The current axis' weights, keyed by section id: seeded from `paneSizes`,
+  // then edited in place by a live drag until `pane-resize` hands the result
+  // back to the consumer.
   @state()
   private _weights: Record<string, number> = {};
 
@@ -176,9 +182,16 @@ export class PaneView extends LitElement {
   ];
 
   willUpdate(changed: PropertyValues): void {
-    // Adopt whatever the consumer stored; a drag then edits this copy.
-    if (changed.has('paneSizes')) {
-      this._weights = { ...this.paneSizes };
+    // Adopt whatever the consumer stored for this axis; a drag then edits this
+    // copy. Re-docking flips the orientation on the same element, so that has to
+    // re-seed too or the previous axis' sizes would carry over.
+    if (changed.has('paneSizes') || changed.has('orientation')) {
+      const prefix = `${this.orientation}:`;
+      this._weights = Object.fromEntries(
+        Object.entries(this.paneSizes)
+          .filter(([key]) => key.startsWith(prefix))
+          .map(([key, size]) => [key.slice(prefix.length), size]),
+      );
     }
   }
 
@@ -385,12 +398,12 @@ export class PaneView extends LitElement {
 
   /** Fires on interaction-end only, so the consumer's write isn't per-frame. */
   private _emitResize() {
+    // Only this axis' keys, so merging keeps the other orientation's sizes.
+    const sizes = Object.fromEntries(
+      Object.entries(this._weights).map(([id, size]) => [`${this.orientation}:${id}`, size]),
+    );
     this.dispatchEvent(
-      new CustomEvent('pane-resize', {
-        detail: { sizes: { ...this._weights } },
-        bubbles: true,
-        composed: true,
-      }),
+      new CustomEvent('pane-resize', { detail: { sizes }, bubbles: true, composed: true }),
     );
   }
 }

--- a/log-viewer/src/components/ViewModeSwitch.ts
+++ b/log-viewer/src/components/ViewModeSwitch.ts
@@ -21,7 +21,7 @@ export interface ViewModeOption {
 @customElement('view-mode-switch')
 export class ViewModeSwitch extends LitElement {
   @property({ attribute: false })
-  options: ViewModeOption[] = [];
+  options: readonly ViewModeOption[] = [];
 
   @property()
   value = '';

--- a/log-viewer/src/components/__tests__/CallStackDetail.test.ts
+++ b/log-viewer/src/components/__tests__/CallStackDetail.test.ts
@@ -40,11 +40,6 @@ async function mount(eventIndex: number): Promise<CallStackDetail> {
   el.eventIndex = eventIndex;
   document.body.appendChild(el);
   await el.updateComplete;
-  // Under @swc/jest the `@property` field initializer shadows Lit's reactive
-  // accessor, so the assignment above never reaches `changedProperties` and the
-  // table is never built. Nudge the update the way the browser would.
-  el.requestUpdate('eventIndex', undefined);
-  await el.updateComplete;
   return el;
 }
 

--- a/log-viewer/src/components/__tests__/CallTreeDetail.test.ts
+++ b/log-viewer/src/components/__tests__/CallTreeDetail.test.ts
@@ -18,6 +18,11 @@ jest.mock('tabulator-tables', () => ({
 }));
 // vscode-button needs ElementInternals.setFormValue (absent in jsdom).
 jest.mock('#vscode-elements/vscode-button.js', () => ({}));
+// The view mode persists through the extension host, which isn't there.
+jest.mock('../../features/settings/Settings.js', () => ({
+  getSettings: () => Promise.resolve({}),
+  updateSetting: () => {},
+}));
 
 import type { CallTreeDetail } from '../CallTreeDetail.js';
 import '../CallTreeDetail.js';

--- a/log-viewer/src/components/__tests__/CallTreeDetail.test.ts
+++ b/log-viewer/src/components/__tests__/CallTreeDetail.test.ts
@@ -19,13 +19,6 @@ jest.mock('tabulator-tables', () => ({
 // vscode-button needs ElementInternals.setFormValue (absent in jsdom).
 jest.mock('#vscode-elements/vscode-button.js', () => ({}));
 
-const settings = { inspector: { callTreeMode: 'bottom-up' } };
-const written: Array<{ section: string; value: unknown }> = [];
-jest.mock('../../features/settings/Settings.js', () => ({
-  getSettings: () => Promise.resolve(settings),
-  updateSetting: (section: string, value: unknown) => written.push({ section, value }),
-}));
-
 import type { CallTreeDetail } from '../CallTreeDetail.js';
 import '../CallTreeDetail.js';
 
@@ -50,26 +43,22 @@ async function mount(): Promise<CallTreeDetail> {
   const el = document.createElement('call-tree-detail') as CallTreeDetail;
   el.eventIndex = -1; // no DatabaseAccess in the test — no table is built
   document.body.appendChild(el);
-  // The remembered mode arrives from a promise, so settle it then re-render.
-  await el.updateComplete;
-  await Promise.resolve();
   await el.updateComplete;
   return el;
 }
 
-// The remembered mode is module state loaded once, so the restore test must run
-// before anything picks a mode of its own.
+// The picked mode is module state, so these run in order: default, pick, share.
 describe('CallTreeDetail view mode', () => {
-  it('restores the remembered mode', async () => {
+  it('starts on time order', async () => {
     expect(customElements.get('call-tree-detail')).toBeDefined();
     const el = await mount();
 
-    expect(switchEl(el).getAttribute('value')).toBe('bottom-up');
-    expect(hidden(el, 'bottom-up-tree')).toBe(false);
-    expect(hidden(el, 'time-order-tree')).toBe(true);
+    expect(switchEl(el).getAttribute('value')).toBe('time-order');
+    expect(hidden(el, 'time-order-tree')).toBe(false);
+    expect(hidden(el, 'bottom-up-tree')).toBe(true);
   });
 
-  it('switches on view-mode-change and persists the pick', async () => {
+  it('switches on view-mode-change', async () => {
     const el = await mount();
 
     switchEl(el).dispatchEvent(
@@ -83,13 +72,12 @@ describe('CallTreeDetail view mode', () => {
 
     expect(switchEl(el).getAttribute('value')).toBe('aggregated');
     expect(hidden(el, 'aggregated-tree')).toBe(false);
-    expect(hidden(el, 'bottom-up-tree')).toBe(true);
-    expect(written).toEqual([{ section: 'inspector.callTreeMode', value: 'aggregated' }]);
+    expect(hidden(el, 'time-order-tree')).toBe(true);
   });
 
   it('shares the picked mode with a pane mounted later', async () => {
-    // The pane is torn down and rebuilt on every collapse and tab hop, so the
-    // mode has to survive without another settings round-trip.
+    // The pane is torn down and rebuilt on every collapse and tab hop, so a
+    // pick has to outlive the element — but only for this log, not the next.
     const el = await mount();
 
     expect(switchEl(el).getAttribute('value')).toBe('aggregated');

--- a/log-viewer/src/components/__tests__/CallTreeDetail.test.ts
+++ b/log-viewer/src/components/__tests__/CallTreeDetail.test.ts
@@ -18,10 +18,12 @@ jest.mock('tabulator-tables', () => ({
 }));
 // vscode-button needs ElementInternals.setFormValue (absent in jsdom).
 jest.mock('#vscode-elements/vscode-button.js', () => ({}));
-// The view mode persists through the extension host, which isn't there.
+
+const settings = { inspector: { callTreeMode: 'bottom-up' } };
+const written: Array<{ section: string; value: unknown }> = [];
 jest.mock('../../features/settings/Settings.js', () => ({
-  getSettings: () => Promise.resolve({}),
-  updateSetting: () => {},
+  getSettings: () => Promise.resolve(settings),
+  updateSetting: (section: string, value: unknown) => written.push({ section, value }),
 }));
 
 import type { CallTreeDetail } from '../CallTreeDetail.js';
@@ -36,25 +38,41 @@ function hidden(el: CallTreeDetail, id: string): boolean {
     ?.classList.contains('is-hidden');
 }
 
+function switchEl(el: CallTreeDetail): Element {
+  const found = el.shadowRoot?.querySelector('view-mode-switch');
+  if (!found) {
+    throw new Error('view-mode-switch not rendered');
+  }
+  return found;
+}
+
 async function mount(): Promise<CallTreeDetail> {
   const el = document.createElement('call-tree-detail') as CallTreeDetail;
   el.eventIndex = -1; // no DatabaseAccess in the test — no table is built
   document.body.appendChild(el);
+  // The remembered mode arrives from a promise, so settle it then re-render.
+  await el.updateComplete;
+  await Promise.resolve();
   await el.updateComplete;
   return el;
 }
 
+// The remembered mode is module state loaded once, so the restore test must run
+// before anything picks a mode of its own.
 describe('CallTreeDetail view mode', () => {
-  it('defaults to Time Order and switches on view-mode-change', async () => {
+  it('restores the remembered mode', async () => {
     expect(customElements.get('call-tree-detail')).toBeDefined();
     const el = await mount();
-    const view = el.shadowRoot?.querySelector('view-mode-switch');
 
-    expect(view?.getAttribute('value')).toBe('time-order');
-    expect(hidden(el, 'time-order-tree')).toBe(false);
-    expect(hidden(el, 'aggregated-tree')).toBe(true);
+    expect(switchEl(el).getAttribute('value')).toBe('bottom-up');
+    expect(hidden(el, 'bottom-up-tree')).toBe(false);
+    expect(hidden(el, 'time-order-tree')).toBe(true);
+  });
 
-    view?.dispatchEvent(
+  it('switches on view-mode-change and persists the pick', async () => {
+    const el = await mount();
+
+    switchEl(el).dispatchEvent(
       new CustomEvent('view-mode-change', {
         detail: { value: 'aggregated' },
         bubbles: true,
@@ -63,10 +81,18 @@ describe('CallTreeDetail view mode', () => {
     );
     await el.updateComplete;
 
-    expect(el.shadowRoot?.querySelector('view-mode-switch')?.getAttribute('value')).toBe(
-      'aggregated',
-    );
+    expect(switchEl(el).getAttribute('value')).toBe('aggregated');
     expect(hidden(el, 'aggregated-tree')).toBe(false);
-    expect(hidden(el, 'time-order-tree')).toBe(true);
+    expect(hidden(el, 'bottom-up-tree')).toBe(true);
+    expect(written).toEqual([{ section: 'inspector.callTreeMode', value: 'aggregated' }]);
+  });
+
+  it('shares the picked mode with a pane mounted later', async () => {
+    // The pane is torn down and rebuilt on every collapse and tab hop, so the
+    // mode has to survive without another settings round-trip.
+    const el = await mount();
+
+    expect(switchEl(el).getAttribute('value')).toBe('aggregated');
+    expect(hidden(el, 'aggregated-tree')).toBe(false);
   });
 });

--- a/log-viewer/src/components/__tests__/DockLayout.test.ts
+++ b/log-viewer/src/components/__tests__/DockLayout.test.ts
@@ -112,7 +112,6 @@ describe('DockLayout resize', () => {
   it('reports nothing while the panel is hidden, since there is no handle', async () => {
     const el = await mount('right');
     el.visible = false;
-    el.requestUpdate('visible', true);
     await el.updateComplete;
 
     expect(el.shadowRoot?.querySelector('.gutter')).toBeNull();

--- a/log-viewer/src/components/__tests__/LogInspector.test.ts
+++ b/log-viewer/src/components/__tests__/LogInspector.test.ts
@@ -102,7 +102,6 @@ describe('LogInspector', () => {
       collapsed: { callstack: true },
       paneSizes: {},
       visible: true,
-      callTreeMode: 'time-order',
     };
     const el = await mount('database-tab');
     select('database', 3);
@@ -148,7 +147,6 @@ describe('LogInspector', () => {
       collapsed: {},
       paneSizes: {},
       visible: false,
-      callTreeMode: 'time-order',
     };
     const el = await mount('timeline-tab');
     select('timeline', 1);
@@ -168,7 +166,6 @@ describe('LogInspector', () => {
       collapsed: { callstack: true },
       paneSizes: {},
       visible: false,
-      callTreeMode: 'time-order',
     };
     deferSettings = true;
     const el = document.createElement('log-inspector') as LogInspector;

--- a/log-viewer/src/components/__tests__/LogInspector.test.ts
+++ b/log-viewer/src/components/__tests__/LogInspector.test.ts
@@ -15,8 +15,17 @@ jest.mock('../../tabulator/format/Progress.css', () => ({}));
 
 const settings: { inspector?: unknown } = {};
 const written: Array<{ section: string; value: unknown }> = [];
+// Settings normally reply at once; `deferSettings` holds the reply so a test can
+// interact while the load is still in flight.
+let deferSettings = false;
+let releaseSettings: (() => void) | null = null;
 jest.mock('../../features/settings/Settings.js', () => ({
-  getSettings: () => Promise.resolve(settings),
+  getSettings: () =>
+    deferSettings
+      ? new Promise((resolve) => {
+          releaseSettings = () => resolve(settings);
+        })
+      : Promise.resolve(settings),
   updateSetting: (section: string, value: unknown) => written.push({ section, value }),
 }));
 
@@ -38,12 +47,16 @@ import type { LogInspector } from '../LogInspector.js';
 import type { PaneView } from '../PaneView.js';
 import '../LogInspector.js';
 
-/** Settles the rAF-debounced rebuild, the async section build and the render. */
+/**
+ * Settles the rAF-debounced rebuild, the async section build and the render.
+ * The build chain awaits more than once, so keep re-awaiting the render rather
+ * than counting microtasks.
+ */
 async function flush(el: LogInspector): Promise<void> {
   await new Promise((resolve) => requestAnimationFrame(resolve));
-  await Promise.resolve();
-  await Promise.resolve();
-  await el.updateComplete;
+  for (let i = 0; i < 5; i++) {
+    await el.updateComplete;
+  }
 }
 
 async function mount(activeTab: string): Promise<LogInspector> {
@@ -54,11 +67,19 @@ async function mount(activeTab: string): Promise<LogInspector> {
   return el;
 }
 
-function paneView(el: LogInspector): PaneView | null | undefined {
-  return el.shadowRoot
+function paneView(el: LogInspector): PaneView {
+  const found = el.shadowRoot
     ?.querySelector('dock-layout')
     ?.shadowRoot?.querySelector('detail-dock')
     ?.shadowRoot?.querySelector<PaneView>('pane-view');
+  if (!found) {
+    throw new Error('pane-view not rendered');
+  }
+  return found;
+}
+
+function visible(el: LogInspector): boolean {
+  return !!el.shadowRoot?.querySelector('dock-layout')?.hasAttribute('visible');
 }
 
 function select(source: 'timeline' | 'database', eventIndex: number): void {
@@ -69,6 +90,8 @@ describe('LogInspector', () => {
   beforeEach(() => {
     written.length = 0;
     delete settings.inspector;
+    deferSettings = false;
+    releaseSettings = null;
     document.body.replaceChildren();
   });
 
@@ -85,14 +108,14 @@ describe('LogInspector', () => {
     select('database', 3);
     await flush(el);
 
-    expect(paneView(el)?.collapsed).toEqual({ callstack: true });
+    expect(paneView(el).collapsed).toEqual({ callstack: true });
 
     // One panel, one layout: a section's collapse follows it across tabs.
     el.activeTab = 'timeline-tab';
     select('timeline', 9);
     await flush(el);
 
-    expect(paneView(el)?.collapsed).toEqual({ callstack: true });
+    expect(paneView(el).collapsed).toEqual({ callstack: true });
   });
 
   it('persists a collapse', async () => {
@@ -100,7 +123,7 @@ describe('LogInspector', () => {
     select('timeline', 1);
     await flush(el);
 
-    paneView(el)?.dispatchEvent(
+    paneView(el).dispatchEvent(
       new CustomEvent('pane-toggle', {
         detail: { collapsed: { callstack: true } },
         bubbles: true,
@@ -115,7 +138,7 @@ describe('LogInspector', () => {
     const el = await mount('timeline-tab');
     select('timeline', 1);
     await el.updateComplete;
-    expect(el.shadowRoot?.querySelector('dock-layout')?.hasAttribute('visible')).toBe(true);
+    expect(visible(el)).toBe(true);
   });
 
   it('stays closed when the user closed it before, and remembers each choice', async () => {
@@ -130,11 +153,47 @@ describe('LogInspector', () => {
     const el = await mount('timeline-tab');
     select('timeline', 1);
     await el.updateComplete;
-    expect(el.shadowRoot?.querySelector('dock-layout')?.hasAttribute('visible')).toBe(false);
+    expect(visible(el)).toBe(false);
 
     eventBus.emit('detail:toggle', { visible: true });
     await el.updateComplete;
-    expect(el.shadowRoot?.querySelector('dock-layout')?.hasAttribute('visible')).toBe(true);
+    expect(visible(el)).toBe(true);
     expect(written).toEqual([{ section: 'inspector.visible', value: true }]);
+  });
+
+  it('keeps what the user did while the settings load was still in flight', async () => {
+    settings.inspector = {
+      position: 'right',
+      size: 400,
+      collapsed: { callstack: true },
+      paneSizes: {},
+      visible: false,
+      callTreeMode: 'time-order',
+    };
+    deferSettings = true;
+    const el = document.createElement('log-inspector') as LogInspector;
+    el.activeTab = 'timeline-tab';
+    document.body.appendChild(el);
+    select('timeline', 1);
+    await flush(el);
+
+    // The user opens the panel and collapses a different section before the reply.
+    eventBus.emit('detail:toggle', { visible: true });
+    await flush(el);
+    paneView(el).dispatchEvent(
+      new CustomEvent('pane-toggle', {
+        detail: { collapsed: { vitals: true } },
+        bubbles: true,
+        composed: true,
+      }),
+    );
+    await flush(el);
+
+    releaseSettings?.();
+    await flush(el);
+
+    // The stored `visible: false` and `collapsed` don't undo either action.
+    expect(visible(el)).toBe(true);
+    expect(paneView(el).collapsed).toEqual({ vitals: true });
   });
 });

--- a/log-viewer/src/components/__tests__/LogInspector.test.ts
+++ b/log-viewer/src/components/__tests__/LogInspector.test.ts
@@ -1,0 +1,140 @@
+/*
+ * Copyright (c) 2026 Certinia Inc. All rights reserved.
+ *
+ * @jest-environment jsdom
+ */
+import { beforeEach, describe, expect, it } from '@jest/globals';
+import { html } from 'lit';
+
+jest.mock('#vscode-elements/vscode-icon.js', () => ({}));
+jest.mock('#vscode-elements/vscode-badge.js', () => ({}));
+jest.mock('#vscode-elements/vscode-button.js', () => ({}));
+// The swc transform can't parse `.scss`/`.css`; stub the stylesheet assets.
+jest.mock('../../tabulator/style/DataGrid.scss', () => ({ default: '' }));
+jest.mock('../../tabulator/format/Progress.css', () => ({}));
+
+const settings: { inspector?: unknown } = {};
+const written: Array<{ section: string; value: unknown }> = [];
+jest.mock('../../features/settings/Settings.js', () => ({
+  getSettings: () => Promise.resolve(settings),
+  updateSetting: (section: string, value: unknown) => written.push({ section, value }),
+}));
+
+// The real builders mount Tabulator tables; only the section ids matter here.
+jest.mock('../detailSections.js', () => ({
+  buildDetailSections: (_source: string, selection: unknown) =>
+    Promise.resolve(
+      selection
+        ? [
+            { id: 'vitals', title: 'Details', content: html`<div>v</div>` },
+            { id: 'callstack', title: 'Call stack', content: html`<div>c</div>` },
+          ]
+        : [],
+    ),
+}));
+
+import { eventBus } from '../../core/events/EventBus.js';
+import type { LogInspector } from '../LogInspector.js';
+import type { PaneView } from '../PaneView.js';
+import '../LogInspector.js';
+
+/** Settles the rAF-debounced rebuild, the async section build and the render. */
+async function flush(el: LogInspector): Promise<void> {
+  await new Promise((resolve) => requestAnimationFrame(resolve));
+  await Promise.resolve();
+  await Promise.resolve();
+  await el.updateComplete;
+}
+
+async function mount(activeTab: string): Promise<LogInspector> {
+  const el = document.createElement('log-inspector') as LogInspector;
+  el.activeTab = activeTab;
+  document.body.appendChild(el);
+  await flush(el);
+  return el;
+}
+
+function paneView(el: LogInspector): PaneView | null | undefined {
+  return el.shadowRoot
+    ?.querySelector('dock-layout')
+    ?.shadowRoot?.querySelector('detail-dock')
+    ?.shadowRoot?.querySelector<PaneView>('pane-view');
+}
+
+function select(source: 'timeline' | 'database', eventIndex: number): void {
+  eventBus.emit('detail:select', { source, selection: { kind: 'event', eventIndex } });
+}
+
+describe('LogInspector', () => {
+  beforeEach(() => {
+    written.length = 0;
+    delete settings.inspector;
+    document.body.replaceChildren();
+  });
+
+  it('applies the persisted collapse, and keeps it when the tab changes', async () => {
+    settings.inspector = {
+      position: 'right',
+      size: 400,
+      collapsed: { callstack: true },
+      paneSizes: {},
+      visible: true,
+      callTreeMode: 'time-order',
+    };
+    const el = await mount('database-tab');
+    select('database', 3);
+    await flush(el);
+
+    expect(paneView(el)?.collapsed).toEqual({ callstack: true });
+
+    // One panel, one layout: a section's collapse follows it across tabs.
+    el.activeTab = 'timeline-tab';
+    select('timeline', 9);
+    await flush(el);
+
+    expect(paneView(el)?.collapsed).toEqual({ callstack: true });
+  });
+
+  it('persists a collapse', async () => {
+    const el = await mount('timeline-tab');
+    select('timeline', 1);
+    await flush(el);
+
+    paneView(el)?.dispatchEvent(
+      new CustomEvent('pane-toggle', {
+        detail: { collapsed: { callstack: true } },
+        bubbles: true,
+        composed: true,
+      }),
+    );
+
+    expect(written).toEqual([{ section: 'inspector.collapsed', value: { callstack: true } }]);
+  });
+
+  it('auto-opens on the first selection only while the user has never chosen', async () => {
+    const el = await mount('timeline-tab');
+    select('timeline', 1);
+    await el.updateComplete;
+    expect(el.shadowRoot?.querySelector('dock-layout')?.hasAttribute('visible')).toBe(true);
+  });
+
+  it('stays closed when the user closed it before, and remembers each choice', async () => {
+    settings.inspector = {
+      position: 'right',
+      size: 400,
+      collapsed: {},
+      paneSizes: {},
+      visible: false,
+      callTreeMode: 'time-order',
+    };
+    const el = await mount('timeline-tab');
+    select('timeline', 1);
+    await el.updateComplete;
+    expect(el.shadowRoot?.querySelector('dock-layout')?.hasAttribute('visible')).toBe(false);
+
+    eventBus.emit('detail:toggle', { visible: true });
+    await el.updateComplete;
+    expect(el.shadowRoot?.querySelector('dock-layout')?.hasAttribute('visible')).toBe(true);
+    expect(written).toEqual([{ section: 'inspector.visible', value: true }]);
+  });
+});

--- a/log-viewer/src/components/__tests__/PaneView.test.ts
+++ b/log-viewer/src/components/__tests__/PaneView.test.ts
@@ -175,8 +175,9 @@ describe('PaneView', () => {
     handle.dispatchEvent(pointer('pointerup', 120));
     await el.updateComplete;
 
-    expect(sizes?.a).toBe(120);
-    expect(sizes?.b).toBe(80);
+    // Keyed by axis: a height dragged here is not a width in the bottom dock.
+    expect(sizes?.['vertical:a']).toBe(120);
+    expect(sizes?.['vertical:b']).toBe(80);
   });
 
   it('does not emit pane-resize for a sash click that never moved', async () => {
@@ -222,7 +223,7 @@ describe('PaneView', () => {
       { id: 'a', title: 'A', content: html`<div>A</div>` },
       { id: 'b', title: 'B', content: html`<div>B</div>` },
     ];
-    el.paneSizes = { a: 300, b: 100 };
+    el.paneSizes = { 'vertical:a': 300, 'vertical:b': 100 };
     document.body.appendChild(el);
     await el.updateComplete;
 
@@ -240,12 +241,36 @@ describe('PaneView', () => {
       { id: 'b', title: 'B', content: html`<div>B</div>` },
     ];
     // Only a was on screen when the drag happened; b must not become a sliver.
-    el.paneSizes = { a: 120 };
+    el.paneSizes = { 'vertical:a': 120 };
     document.body.appendChild(el);
     await el.updateComplete;
 
     const pane = (id: string) => el.shadowRoot?.querySelector(`.pane[data-id="${id}"]`);
     expect(pane('a')?.getAttribute('style')).toContain('flex: 3 1 0');
     expect(pane('b')?.getAttribute('style')).toContain('flex: 1 1 0');
+  });
+
+  it('ignores sizes dragged on the other axis, and re-seeds when re-docked', async () => {
+    const el = document.createElement('pane-view') as PaneView;
+    el.orientation = 'vertical';
+    el.sections = [
+      { id: 'a', title: 'A', content: html`<div>A</div>` },
+      { id: 'b', title: 'B', content: html`<div>B</div>` },
+    ];
+    // Widths from the bottom dock; replaying them as heights is a layout the
+    // user never chose, so the vertical dock falls back to even weights.
+    el.paneSizes = { 'horizontal:a': 300, 'horizontal:b': 100 };
+    document.body.appendChild(el);
+    await el.updateComplete;
+
+    const pane = (id: string) => el.shadowRoot?.querySelector(`.pane[data-id="${id}"]`);
+    expect(pane('a')?.getAttribute('style')).toContain('flex: 1 1 0');
+    expect(pane('b')?.getAttribute('style')).toContain('flex: 1 1 0');
+
+    // Re-docking flips orientation on the same element: its own sizes apply now.
+    el.orientation = 'horizontal';
+    await el.updateComplete;
+    expect(pane('a')?.getAttribute('style')).toContain('flex: 1.5 1 0');
+    expect(pane('b')?.getAttribute('style')).toContain('flex: 0.5 1 0');
   });
 });

--- a/log-viewer/src/components/__tests__/PaneView.test.ts
+++ b/log-viewer/src/components/__tests__/PaneView.test.ts
@@ -42,9 +42,33 @@ function body(el: PaneView, id: string): HTMLElement | null {
   return el.shadowRoot?.querySelector(`.pane[data-id="${id}"] .pane-body`) ?? null;
 }
 
+function sash(el: PaneView): HTMLElement {
+  const found = el.shadowRoot?.querySelector('.pane-sash');
+  if (!found) {
+    throw new Error('sash not rendered');
+  }
+  return found as HTMLElement;
+}
+
+// jsdom has no PointerEvent; the handlers only read the coordinate and pointerId.
+function pointer(type: string, clientY: number): Event {
+  return Object.assign(new MouseEvent(type, { clientY, bubbles: true, cancelable: true }), {
+    pointerId: 1,
+  });
+}
+
 describe('PaneView', () => {
   beforeAll(() => {
     expect(customElements.get('pane-view')).toBeDefined();
+    // jsdom has no pointer capture, and performs no layout — the sash handler
+    // calls the first and measures with the second.
+    Element.prototype.setPointerCapture = () => {};
+    Element.prototype.releasePointerCapture = () => {};
+    Element.prototype.hasPointerCapture = () => true;
+    Object.defineProperty(HTMLElement.prototype, 'offsetHeight', {
+      value: 100,
+      configurable: true,
+    });
   });
 
   it('renders a header per section with a twistie when vertical', async () => {
@@ -96,19 +120,6 @@ describe('PaneView', () => {
     expect(el.shadowRoot?.querySelectorAll('.pane-sash').length).toBe(2);
   });
 
-  it('seeds collapsed defaults from section.collapsed', async () => {
-    const el = document.createElement('pane-view') as PaneView;
-    el.orientation = 'vertical';
-    el.sections = [
-      { id: 'a', title: 'A', content: html`<div>A</div>` },
-      { id: 'b', title: 'B', content: html`<div>B</div>`, collapsed: true },
-    ];
-    document.body.appendChild(el);
-    await el.updateComplete;
-    expect(body(el, 'a')).not.toBeNull();
-    expect(body(el, 'b')).toBeNull();
-  });
-
   it('emits pane-toggle with the collapsed map and keeps state across same-id updates', async () => {
     const el = await mount('vertical');
     let last: Record<string, boolean> | undefined;
@@ -128,19 +139,15 @@ describe('PaneView', () => {
     expect(body(el, 'a')).toBeNull();
   });
 
-  it('takes collapse from the collapsed property, overriding section defaults', async () => {
+  it('takes collapse from the collapsed property', async () => {
     const el = document.createElement('pane-view') as PaneView;
     el.orientation = 'vertical';
-    el.sections = [
-      { id: 'a', title: 'A', content: html`<div>A</div>` },
-      { id: 'b', title: 'B', content: html`<div>B</div>`, collapsed: true },
-    ];
-    // Inverts both defaults: the consumer's record wins.
-    el.collapsed = { a: true, b: false };
+    el.sections = sections;
+    el.collapsed = { b: true };
     document.body.appendChild(el);
     await el.updateComplete;
-    expect(body(el, 'a')).toBeNull();
-    expect(body(el, 'b')).not.toBeNull();
+    expect(body(el, 'a')).not.toBeNull();
+    expect(body(el, 'b')).toBeNull();
   });
 
   it('does not collapse when the consumer ignores pane-toggle (fully controlled)', async () => {
@@ -155,20 +162,90 @@ describe('PaneView', () => {
     expect(body(el, 'a')).not.toBeNull();
   });
 
-  it('uses persisted pane sizes as the flex weights', async () => {
+  it('emits pane-resize on a sash drag, the pair sharing their combined size', async () => {
+    const el = await mount('vertical');
+    let sizes: Record<string, number> | undefined;
+    el.addEventListener('pane-resize', (e) => {
+      sizes = (e as CustomEvent<{ sizes: Record<string, number> }>).detail.sizes;
+    });
+
+    const handle = sash(el);
+    handle.dispatchEvent(pointer('pointerdown', 100));
+    handle.dispatchEvent(pointer('pointermove', 120));
+    handle.dispatchEvent(pointer('pointerup', 120));
+    await el.updateComplete;
+
+    expect(sizes?.a).toBe(120);
+    expect(sizes?.b).toBe(80);
+  });
+
+  it('does not emit pane-resize for a sash click that never moved', async () => {
+    const el = await mount('vertical');
+    let emitted = 0;
+    el.addEventListener('pane-resize', () => emitted++);
+
+    const handle = sash(el);
+    handle.dispatchEvent(pointer('pointerdown', 100));
+    handle.dispatchEvent(pointer('pointerup', 100));
+    await el.updateComplete;
+
+    expect(emitted).toBe(0);
+  });
+
+  it('does not emit pane-resize when the drag is cancelled, and restores the sizes', async () => {
+    const el = await mount('vertical');
+    let emitted = 0;
+    el.addEventListener('pane-resize', () => emitted++);
+
+    const handle = sash(el);
+    handle.dispatchEvent(pointer('pointerdown', 100));
+    handle.dispatchEvent(pointer('pointermove', 120));
+    handle.dispatchEvent(pointer('pointercancel', 120));
+    await el.updateComplete;
+
+    expect(emitted).toBe(0);
+    // Back to the measured 100/100, so a-and-b weigh the same again.
+    const style = (id: string) =>
+      el.shadowRoot?.querySelector(`.pane[data-id="${id}"]`)?.getAttribute('style');
+    expect(style('a')).toBe(style('b'));
+
+    // The gesture is over: a stray move can no longer resize.
+    handle.dispatchEvent(pointer('pointermove', 200));
+    await el.updateComplete;
+    expect(style('a')).toBe(style('b'));
+  });
+
+  it('keeps the persisted ratio when every open pane has a size', async () => {
+    const el = document.createElement('pane-view') as PaneView;
+    el.orientation = 'vertical';
+    el.sections = [
+      { id: 'a', title: 'A', content: html`<div>A</div>` },
+      { id: 'b', title: 'B', content: html`<div>B</div>` },
+    ];
+    el.paneSizes = { a: 300, b: 100 };
+    document.body.appendChild(el);
+    await el.updateComplete;
+
+    // 2 units over 400px → 3:1, the dragged ratio.
+    const pane = (id: string) => el.shadowRoot?.querySelector(`.pane[data-id="${id}"]`);
+    expect(pane('a')?.getAttribute('style')).toContain('flex: 1.5 1 0');
+    expect(pane('b')?.getAttribute('style')).toContain('flex: 0.5 1 0');
+  });
+
+  it('rescales persisted pane sizes onto the weight scale of a pane without one', async () => {
     const el = document.createElement('pane-view') as PaneView;
     el.orientation = 'vertical';
     el.sections = [
       { id: 'a', title: 'A', content: html`<div>A</div>`, weight: 3 },
       { id: 'b', title: 'B', content: html`<div>B</div>` },
     ];
+    // Only a was on screen when the drag happened; b must not become a sliver.
     el.paneSizes = { a: 120 };
     document.body.appendChild(el);
     await el.updateComplete;
 
     const pane = (id: string) => el.shadowRoot?.querySelector(`.pane[data-id="${id}"]`);
-    expect(pane('a')?.getAttribute('style')).toContain('flex: 120 1 0');
-    // No persisted size → the section's own default weight.
+    expect(pane('a')?.getAttribute('style')).toContain('flex: 3 1 0');
     expect(pane('b')?.getAttribute('style')).toContain('flex: 1 1 0');
   });
 });

--- a/log-viewer/src/components/__tests__/PaneView.test.ts
+++ b/log-viewer/src/components/__tests__/PaneView.test.ts
@@ -18,10 +18,17 @@ const sections: PaneSection[] = [
   { id: 'c', title: 'C', content: html`<div class="content-c">C body</div>` },
 ];
 
+/**
+ * Collapse is controlled: the consumer owns the record and feeds it back. Mount
+ * with that loop wired, the way the inspector does.
+ */
 async function mount(orientation: PaneOrientation): Promise<PaneView> {
   const el = document.createElement('pane-view') as PaneView;
   el.sections = sections;
   el.orientation = orientation;
+  el.addEventListener('pane-toggle', (e) => {
+    el.collapsed = (e as CustomEvent<{ collapsed: Record<string, boolean> }>).detail.collapsed;
+  });
   document.body.appendChild(el);
   await el.updateComplete;
   return el;
@@ -114,10 +121,54 @@ describe('PaneView', () => {
     expect(last?.a).toBe(true);
     expect(body(el, 'a')).toBeNull();
 
-    // A new selection re-supplies the same section ids — the user's collapse
-    // survives (defaults are only re-seeded when the id-set changes).
+    // A new selection re-supplies the same section ids — the consumer still owns
+    // the collapse record, so the user's collapse survives.
     el.sections = sections.map((s) => ({ ...s }));
     await el.updateComplete;
     expect(body(el, 'a')).toBeNull();
+  });
+
+  it('takes collapse from the collapsed property, overriding section defaults', async () => {
+    const el = document.createElement('pane-view') as PaneView;
+    el.orientation = 'vertical';
+    el.sections = [
+      { id: 'a', title: 'A', content: html`<div>A</div>` },
+      { id: 'b', title: 'B', content: html`<div>B</div>`, collapsed: true },
+    ];
+    // Inverts both defaults: the consumer's record wins.
+    el.collapsed = { a: true, b: false };
+    document.body.appendChild(el);
+    await el.updateComplete;
+    expect(body(el, 'a')).toBeNull();
+    expect(body(el, 'b')).not.toBeNull();
+  });
+
+  it('does not collapse when the consumer ignores pane-toggle (fully controlled)', async () => {
+    const el = document.createElement('pane-view') as PaneView;
+    el.orientation = 'vertical';
+    el.sections = sections;
+    document.body.appendChild(el);
+    await el.updateComplete;
+
+    header(el, 'a')?.click();
+    await el.updateComplete;
+    expect(body(el, 'a')).not.toBeNull();
+  });
+
+  it('uses persisted pane sizes as the flex weights', async () => {
+    const el = document.createElement('pane-view') as PaneView;
+    el.orientation = 'vertical';
+    el.sections = [
+      { id: 'a', title: 'A', content: html`<div>A</div>`, weight: 3 },
+      { id: 'b', title: 'B', content: html`<div>B</div>` },
+    ];
+    el.paneSizes = { a: 120 };
+    document.body.appendChild(el);
+    await el.updateComplete;
+
+    const pane = (id: string) => el.shadowRoot?.querySelector(`.pane[data-id="${id}"]`);
+    expect(pane('a')?.getAttribute('style')).toContain('flex: 120 1 0');
+    // No persisted size → the section's own default weight.
+    expect(pane('b')?.getAttribute('style')).toContain('flex: 1 1 0');
   });
 });

--- a/log-viewer/src/components/__tests__/detailSections.test.ts
+++ b/log-viewer/src/components/__tests__/detailSections.test.ts
@@ -58,13 +58,7 @@ describe('buildDetailSections', () => {
     expect(sections.map((s) => s.id)).toEqual(['vitals', 'callstack', 'calltree']);
   });
 
-  it('honours persisted collapsed state over the per-section default', async () => {
-    const sections = await buildDetailSections(
-      'calltree',
-      { kind: 'event', eventIndex: 4 },
-      { callstack: true },
-    );
-    expect(sections.find((s) => s.id === 'callstack')?.collapsed).toBe(true);
-    expect(sections.find((s) => s.id === 'calltree')?.collapsed).toBe(false);
+  it('builds no sections when nothing is selected', async () => {
+    expect(await buildDetailSections('calltree', null)).toEqual([]);
   });
 });

--- a/log-viewer/src/components/detailSections.ts
+++ b/log-viewer/src/components/detailSections.ts
@@ -20,19 +20,18 @@ import './EventVitals.js';
  */
 export async function buildDetailSections(
   source: DetailSource,
-  selection: DetailSelection,
-  collapsed: Record<string, boolean> = {},
+  selection: DetailSelection | null,
 ): Promise<PaneSection[]> {
-  // The Database grids resolve statement-specific vitals and SOQL lint issues.
-  if (source === 'database' && selection.kind === 'event' && selection.type) {
-    return buildDatabaseSections(
-      { eventIndex: selection.eventIndex, type: selection.type },
-      collapsed,
-    );
+  // Nothing selected: no sections yet, so the inspector shows its empty text.
+  if (!selection) {
+    return [];
   }
 
-  // Persisted collapsed state wins over the per-section default.
-  const isCollapsed = (id: string, fallback = false) => collapsed[id] ?? fallback;
+  // The Database grids resolve statement-specific vitals and SOQL lint issues.
+  if (source === 'database' && selection.kind === 'event' && selection.type) {
+    return buildDatabaseSections({ eventIndex: selection.eventIndex, type: selection.type });
+  }
+
   const isAggregate = selection.kind === 'aggregate';
   // An aggregate scopes to all its occurrences; a single frame to itself.
   const eventIndex = isAggregate ? (selection.instances[0] ?? -1) : selection.eventIndex;
@@ -44,7 +43,6 @@ export async function buildDetailSections(
       id: 'vitals',
       title: 'Details',
       weight: 3,
-      collapsed: isCollapsed('vitals'),
       content: html`<event-vitals
         eventIndex=${eventIndex}
         .instances=${instances}
@@ -55,14 +53,12 @@ export async function buildDetailSections(
       id: 'callstack',
       title: 'Call stack',
       weight: 3,
-      collapsed: isCollapsed('callstack'),
       content: html`<call-stack-detail eventIndex=${eventIndex}></call-stack-detail>`,
     },
     {
       id: 'calltree',
       title: 'Call tree',
       weight: 4,
-      collapsed: isCollapsed('calltree'),
       content: html`<call-tree-detail
         eventIndex=${eventIndex}
         .instances=${instances}

--- a/log-viewer/src/features/database/components/__tests__/databaseSections.test.ts
+++ b/log-viewer/src/features/database/components/__tests__/databaseSections.test.ts
@@ -25,7 +25,7 @@ describe('buildDatabaseSections', () => {
     expect(sections.map((s) => s.id)).toEqual(['vitals', 'callstack', 'calltree', 'issues']);
     expect(sections.find((s) => s.id === 'issues')?.badge).toBe('2');
     // SOQL issues open by default, but the smallest section.
-    expect(sections.find((s) => s.id === 'issues')?.collapsed).toBe(false);
+    expect(sections.find((s) => s.id === 'issues')?.collapsed).toBeUndefined();
     expect(sections.find((s) => s.id === 'issues')?.weight).toBe(1);
   });
 
@@ -37,13 +37,5 @@ describe('buildDatabaseSections', () => {
   it('builds vitals + call stack + call tree (no issues) for a SOSL selection', async () => {
     const sections = await buildDatabaseSections({ eventIndex: 7, type: 'sosl' });
     expect(sections.map((s) => s.id)).toEqual(['vitals', 'callstack', 'calltree']);
-  });
-
-  it('applies persisted collapsed state over the defaults', async () => {
-    const sections = await buildDatabaseSections(
-      { eventIndex: 3, type: 'soql' },
-      { callstack: true },
-    );
-    expect(sections.find((s) => s.id === 'callstack')?.collapsed).toBe(true);
   });
 });

--- a/log-viewer/src/features/database/components/__tests__/databaseSections.test.ts
+++ b/log-viewer/src/features/database/components/__tests__/databaseSections.test.ts
@@ -24,8 +24,7 @@ describe('buildDatabaseSections', () => {
     const sections = await buildDatabaseSections({ eventIndex: 3, type: 'soql' });
     expect(sections.map((s) => s.id)).toEqual(['vitals', 'callstack', 'calltree', 'issues']);
     expect(sections.find((s) => s.id === 'issues')?.badge).toBe('2');
-    // SOQL issues open by default, but the smallest section.
-    expect(sections.find((s) => s.id === 'issues')?.collapsed).toBeUndefined();
+    // The smallest section.
     expect(sections.find((s) => s.id === 'issues')?.weight).toBe(1);
   });
 

--- a/log-viewer/src/features/database/components/databaseSections.ts
+++ b/log-viewer/src/features/database/components/databaseSections.ts
@@ -22,13 +22,8 @@ export interface DetailSelection {
  * components resolve their own data from `DatabaseAccess` by eventIndex; only
  * the SOQL issue count is pre-resolved here so it can badge the section header.
  */
-export async function buildDatabaseSections(
-  selection: DetailSelection,
-  collapsed: Record<string, boolean> = {},
-): Promise<PaneSection[]> {
+export async function buildDatabaseSections(selection: DetailSelection): Promise<PaneSection[]> {
   const { eventIndex, type } = selection;
-  // Persisted collapsed state wins over the per-section default.
-  const isCollapsed = (id: string, fallback = false) => collapsed[id] ?? fallback;
 
   // Each section opens at its own default height (leftover-space share); the
   // call tree gets the most, SOQL issues the least (but still open).
@@ -37,21 +32,18 @@ export async function buildDatabaseSections(
       id: 'vitals',
       title: 'Details',
       weight: 3,
-      collapsed: isCollapsed('vitals'),
       content: html`<event-vitals eventIndex=${eventIndex} type=${type}></event-vitals>`,
     },
     {
       id: 'callstack',
       title: 'Call stack',
       weight: 3,
-      collapsed: isCollapsed('callstack'),
       content: html`<call-stack-detail eventIndex=${eventIndex}></call-stack-detail>`,
     },
     {
       id: 'calltree',
       title: 'Call tree',
       weight: 4,
-      collapsed: isCollapsed('calltree'),
       content: html`<call-tree-detail eventIndex=${eventIndex}></call-tree-detail>`,
     },
   ];
@@ -63,7 +55,6 @@ export async function buildDatabaseSections(
       title: 'SOQL issues',
       weight: 1,
       badge: issues.length ? String(issues.length) : undefined,
-      collapsed: isCollapsed('issues'),
       content: html`<soql-issues unbounded .issues=${issues}></soql-issues>`,
     });
   }

--- a/log-viewer/src/features/settings/Settings.ts
+++ b/log-viewer/src/features/settings/Settings.ts
@@ -43,7 +43,14 @@ export type LanaSettings = {
   inspector: {
     position: 'left' | 'right' | 'bottom';
     size: number;
+    /** Collapsed sections, keyed by section id — shared by every tab. */
     collapsed: Record<string, boolean>;
+    /** Pane sizes (px, used as flex weights), keyed by section id. */
+    paneSizes: Record<string, number>;
+    /** Last open/closed state; `null` means never toggled, so it may auto-open. */
+    visible: boolean | null;
+    /** Last Call tree view mode. */
+    callTreeMode: string;
   };
 };
 

--- a/log-viewer/src/features/settings/Settings.ts
+++ b/log-viewer/src/features/settings/Settings.ts
@@ -45,12 +45,10 @@ export type LanaSettings = {
     size: number;
     /** Collapsed sections, keyed by section id — shared by every tab. */
     collapsed: Record<string, boolean>;
-    /** Pane sizes (px, used as flex weights), keyed by section id. */
+    /** Pane sizes (px, used as flex weights), keyed `<orientation>:<section id>`. */
     paneSizes: Record<string, number>;
     /** Last open/closed state; `null` means never toggled, so it may auto-open. */
     visible: boolean | null;
-    /** Last Call tree view mode. */
-    callTreeMode: string;
   };
 };
 


### PR DESCRIPTION
Follow-up to #872. The inspector now remembers how you left it.

## What changed

- **Collapse and pane sizes persist**, shared across tabs. It is one panel, so the layout you set follows you from tab to tab — per-tab sizes would re-flow the panel on every tab switch. Sizes are keyed `<orientation>:<section id>`: a width dragged in the bottom dock is not a height in the left/right one, so each axis keeps its own. Stored px snapshots are rescaled onto the unit-weight scale, so a pane that had no size when the drag happened doesn't collapse to a sliver.
- **Open/closed persists across sessions.** `inspector.visible` is `true` / `false` / `null`, where `null` means "never toggled" and is the only state that auto-opens on first selection. Close it, reload the log, it stays closed. A user toggle made while the settings load is still in flight wins over the stored value.
- **The call tree's view mode is session state, deliberately not persisted.** The pane is rebuilt on every selection and tab hop, so the pick is shared across instances — but a log always opens on Time Order, the mode that matches the Call Tree tab and the timeline, so an aggregated or bottom-up tree is always something you chose in this log. (DevTools does the same: it reopens on Summary, not your last tree.)
- **`PaneView` is now controlled.** Its collapse record was internal session state keyed by section id, so it survived a tab switch regardless of what the owner passed in. `LogInspector` now owns the record and the `collapsed` argument to `buildDetailSections` / `buildDatabaseSections` is gone — one source of truth. Drag sizes emit on interaction-end, not per frame, and the drag tears down on `pointercancel` / `lostpointercapture` as well as `pointerup`.
- **`buildDetailSections` accepts a null selection** and returns `[]`. That is the seam the no-selection default states need next.

All of this is private `globalState` (`INSPECTOR_STATE_SECTIONS`), not `lana.*` settings — dock position and size stay the public settings. No `lana/package.json` change.

## Also here

`build(jest)`: swc defines class fields on the instance for target esnext, which shadows Lit's reactive accessors — assigning a `@property`/`@state` never reached `changedProperties`, so nothing re-rendered. Both bundlers already set `useDefineForClassFields: false`; jest did not, which made property-driven components untestable without sprinkling `requestUpdate()` through production code. One line in `jest.config.js`.

## Verified

- `tsc -b`, `eslint log-viewer/src lana/src`, `prettier --check`, `docusaurus build` — all clean
- `jest --runInBand` — 81 suites / 1199 tests (baseline 80 / 1186), covering the settings-load race, the view-mode default/switch/share path, the px rescale and the per-axis sizes
- Manually: collapse a section on Database, switch tabs, it stays collapsed; drag a sash and pick Bottom-Up, reload, both restored; close the panel, reopen the log, still closed
