### PR TITLE
build(deps): bump actions/setup-node from 6 to 7

### DIFF
--- a/.github/workflows/cd-prerelease.yml
+++ b/.github/workflows/cd-prerelease.yml
@@ -67,7 +67,7 @@ jobs:
         with:
           version: 10
       - name: Set up Node
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v7
         with:
           node-version: '24'
           cache: 'pnpm'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
         with:
           version: 10
       - name: Set up Node
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v7
         with:
           node-version: '24'
           cache: 'pnpm'
@@ -49,7 +49,7 @@ jobs:
         with:
           version: 10
       - name: Set up Node
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v7
         with:
           node-version: '24'
           cache: 'pnpm'
@@ -69,7 +69,7 @@ jobs:
         with:
           version: 10
       - name: Set up Node
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v7
         with:
           node-version: '24'
           cache: 'pnpm'

--- a/.github/workflows/publish-gh-pages.yml
+++ b/.github/workflows/publish-gh-pages.yml
@@ -36,7 +36,7 @@ jobs:
         with:
           version: 10
       - name: Set up Node
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v7
         with:
           node-version: '24'
           cache: 'pnpm'

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,7 +20,7 @@ jobs:
         with:
           version: 10
       - name: Set up Node
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v7
         with:
           node-version: '24'
           cache: 'pnpm'


### PR DESCRIPTION
`actions/setup-node@v6` → `@v7` across all six call sites:

| File | Line |
|---|---|
| `.github/workflows/ci.yml` | 26, 52, 72 |
| `.github/workflows/cd-prerelease.yml` | 70 |
| `.github/workflows/publish.yml` | 23 |
| `.github/workflows/publish-gh-pages.yml` | 39 |

Its own PR because it is a major bump.

## Breaking changes — both inert here

v7 breaks in two ways: the action migrated to ESM, and it no longer exports a dummy
`NODE_AUTH_TOKEN`.

Neither affects this repo. Grepping `.github/` for `registry-url` and `NODE_AUTH_TOKEN`
returns nothing — the only input any of these steps passes is `cache: 'pnpm'`, still
supported. `node-version: '24'` is unchanged.

The npm Trusted Publisher (OIDC) guidance in the v7 notes is irrelevant here; this project
publishes to the VS Code Marketplace, not npm.

New `cache-primary-key` / `cache-matched-key` outputs are available but not needed.

## Other actions

Already current, no change required: `actions/checkout@v7`, `pnpm/action-setup@v6`,
`github/codeql-action@v4`, `actions/configure-pages@v6`, `actions/upload-pages-artifact@v5`,
`actions/deploy-pages@v5`, and `9sako6/imgcmp` SHA-pinned at v2.0.4.

## Verification

Not verifiable locally — **CI on this PR is the check**. Worth confirming the `pnpm` cache
still restores (look for a cache hit in the Set up Node step) rather than only that the
jobs go green.

Supersedes #859.