### PR TITLE
ci: group dependabot updates by dependency type

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,20 @@ updates:
     schedule:
       interval: 'daily'
     versioning-strategy: auto
+    # majors are deliberately left out of the groups so each one still arrives
+    # as its own PR - they need reading and are reverted individually
+    groups:
+      production-dependencies:
+        dependency-type: 'production'
+        update-types: ['minor', 'patch']
+      development-dependencies:
+        dependency-type: 'development'
+        update-types: ['minor', 'patch']
   - package-ecosystem: 'github-actions'
     directory: '/'
     schedule:
       interval: 'weekly'
+    groups:
+      github-actions:
+        patterns: ['*']
+        update-types: ['minor', 'patch']


### PR DESCRIPTION
`.github/dependabot.yml` had no `groups:`, so every outdated package opened its own PR — six
were open simultaneously (#854–#859) for what amounted to two coherent updates.

## Change

npm updates are grouped into `production-dependencies` and `development-dependencies`,
mirroring how they are actually reviewed and shipped. The `github-actions` ecosystem has no
`dependency-type`, so it groups with `patterns: ['*']`.

```yaml
groups:
  production-dependencies:
    dependency-type: 'production'
    update-types: ['minor', 'patch']
  development-dependencies:
    dependency-type: 'development'
    update-types: ['minor', 'patch']
```

## Majors stay ungrouped

Every group restricts `update-types` to `['minor', 'patch']`. That is deliberate: a major
bump needs its changelog read, may need code changes, and must be revertable on its own — so
it should keep arriving as a standalone PR. Anything outside a group's `update-types` falls
through to individual PRs, which is exactly the wanted behaviour.

This matches how the current sweep was handled — `@salesforce/core` v9 held back pending a
VS Code support-floor decision, `actions/setup-node` v7 in #882, `rolldown` in #881.

## Verification

Config-only; nothing to build. Parsed with `yq` and formatting confirmed with prettier. Takes
effect on dependabot's next scheduled run.