### PR TITLE
perf(log-viewer): let the inspector paint before building the scoped call tree

### DIFF
--- a/log-viewer/src/components/CallTreeDetail.ts
+++ b/log-viewer/src/components/CallTreeDetail.ts
@@ -27,6 +27,7 @@ import { soqlInlineElement } from '../features/soql/format/inlineCell.js';
 import { soqlSyntaxStyles } from '../features/soql/styles/soql-syntax.css.js';
 import { globalStyles } from '../styles/global.styles.js';
 import { progressColumnWidth } from '../tabulator/format/measureWidth.js';
+import type { ProgressParams } from '../tabulator/format/ProgressMS.js';
 import dataGridStyles from '../tabulator/style/DataGrid.scss';
 import './ContextMenu.js';
 import type { ContextMenu } from './ContextMenu.js';
@@ -113,6 +114,23 @@ export class CallTreeDetail extends LitElement {
     'bottom-up': null,
   };
 
+  /** Modes whose table holds a previous selection's rows, so it needs re-filling
+   *  before it is shown again. */
+  private _stale = new Set<ViewMode>();
+
+  /**
+   * The bar/percentage params, shared by every column of every mode table and
+   * mutated in place per selection. Tabulator reads `formatterParams` by
+   * reference at render time, so this keeps the column definitions
+   * selection-independent — which is what lets a new selection re-fill a table
+   * with `setData` instead of rebuilding it.
+   */
+  private readonly _barParams: ProgressParams = {
+    precision: 2,
+    totalValue: 0,
+    showPercentageText: true,
+  };
+
   // The scoped tree (all three representations) for the current eventIndex,
   // computed once per selection and shared across the mode tables.
   private _scoped: ScopedCallTree | null = null;
@@ -187,11 +205,16 @@ export class CallTreeDetail extends LitElement {
   updated(changed: PropertyValues) {
     const scopeChanged = changed.has('eventIndex') || changed.has('instances');
     if (scopeChanged) {
-      // The scoped root changed — drop every table so each rebuilds on demand.
+      // The scoped root changed — mark every built table stale so each is
+      // re-filled on demand, rather than destroyed and rebuilt.
       // `_scoped` is only invalidated here and only rebuilt in `_showActive`,
       // past its paint yield — never before it.
-      this._destroyTables();
       this._scoped = null;
+      for (const mode of Object.keys(this._tables) as ViewMode[]) {
+        if (this._tables[mode]) {
+          this._stale.add(mode);
+        }
+      }
     }
     if (scopeChanged || changed.has('viewMode')) {
       void this._showActive();
@@ -208,6 +231,7 @@ export class CallTreeDetail extends LitElement {
       this._tables[mode]?.destroy();
       this._tables[mode] = null;
     }
+    this._stale.clear();
   }
 
   private async _showActive(): Promise<void> {
@@ -226,7 +250,7 @@ export class CallTreeDetail extends LitElement {
 
     const mode = this.viewMode;
     const existing = this._tables[mode];
-    if (existing) {
+    if (existing && !this._stale.has(mode)) {
       existing.redraw(); // re-fit the layout for the now-visible host
       return;
     }
@@ -235,6 +259,22 @@ export class CallTreeDetail extends LitElement {
     // the rest of the panel paint before this potentially expensive walk runs.
     this._scoped ??= buildScopedCallTree(this.eventIndex, this.instances);
     const scoped = this._scoped;
+    // Percentages are relative to the selection, so retarget the shared params
+    // the formatters read rather than rebuilding the columns around a new total.
+    this._barParams.totalValue = scoped?.rootTotal ?? 0;
+    const data = !scoped
+      ? []
+      : mode === 'time-order'
+        ? scoped.timeOrder
+        : mode === 'aggregated'
+          ? scoped.aggregated
+          : scoped.bottomUp;
+
+    if (existing) {
+      this._stale.delete(mode);
+      void existing.setData(data);
+      return;
+    }
     if (!scoped) {
       return;
     }
@@ -242,13 +282,6 @@ export class CallTreeDetail extends LitElement {
     if (!container) {
       return;
     }
-
-    const data =
-      mode === 'time-order'
-        ? scoped.timeOrder
-        : mode === 'aggregated'
-          ? scoped.aggregated
-          : scoped.bottomUp;
 
     registerTableModules();
     const table = new Tabulator(container, {
@@ -273,7 +306,7 @@ export class CallTreeDetail extends LitElement {
       ...clipboardCopyOptions,
       headerSortElement,
       columnDefaults: commonColumnDefaults,
-      columns: this._columns(mode, scoped.rootTotal),
+      columns: this._columns(mode, progressColumnWidth(scoped.logTotal)),
       // Time Order stays chronological — that's what the mode is for. The
       // grouped modes lead with their ranking metric, as the Call Tree tab's
       // Bottom-Up does; either way the headers stay sortable.
@@ -330,10 +363,14 @@ export class CallTreeDetail extends LitElement {
     this._contextMenu.show(PANEL_ROW_MENU_ITEMS, event.clientX, event.clientY);
   }
 
-  private _columns(mode: ViewMode, rootTotal: number): ColumnDefinition[] {
+  /**
+   * `barWidth` is sized from the whole log rather than the selection, so the bar
+   * columns keep one width as the selection changes — and never have to grow for
+   * a wider total.
+   */
+  private _columns(mode: ViewMode, barWidth: number): ColumnDefinition[] {
     const isTimeOrder = mode === 'time-order';
-    const barParams = { precision: 2, totalValue: rootTotal, showPercentageText: true };
-    const barWidth = progressColumnWidth(rootTotal);
+    const barParams = this._barParams;
 
     const columns: ColumnDefinition[] = [
       {

--- a/log-viewer/src/components/CallTreeDetail.ts
+++ b/log-viewer/src/components/CallTreeDetail.ts
@@ -32,7 +32,12 @@ import dataGridStyles from '../tabulator/style/DataGrid.scss';
 import './ContextMenu.js';
 import type { ContextMenu } from './ContextMenu.js';
 import { PANEL_ROW_MENU_ITEMS, runPanelRowAction } from './panelRowMenu.js';
-import { buildScopedCallTree, type ScopedCallTree } from './scopedCallTree.js';
+import {
+  buildScopedCallTree,
+  type ScopedBuildOptions,
+  type ScopedCallTree,
+  type ScopedRow,
+} from './scopedCallTree.js';
 import './ViewModeSwitch.js';
 import type { ViewModeOption } from './ViewModeSwitch.js';
 
@@ -136,6 +141,10 @@ export class CallTreeDetail extends LitElement {
   // Guards against a slow view-switch resolving after a newer one.
   private _switchEpoch = 0;
 
+  /** True while a scoped build is in flight. Read by the tables' placeholder,
+   *  which Tabulator re-evaluates every time it shows one. */
+  private _pending = false;
+
   private _contextMenu: ContextMenu | null = null;
   /** eventIndex of the row whose context menu is open. */
   private _menuEventIndex = -1;
@@ -231,6 +240,35 @@ export class CallTreeDetail extends LitElement {
     }
   }
 
+  /**
+   * The rows for `mode`, building (and caching) the scoped tree first if this is
+   * the selection's first view. Returns an empty array when nothing is in scope,
+   * and null when the build was abandoned because a newer selection arrived.
+   */
+  private async _rows(mode: ViewMode, options: ScopedBuildOptions): Promise<ScopedRow[] | null> {
+    if (!this._scoped) {
+      const scoped = await buildScopedCallTree(this.eventIndex, this.instances, options);
+      if (options.cancelled?.()) {
+        // Abandoned rather than empty — don't cache the null over a scope that
+        // was never walked.
+        return null;
+      }
+      this._scoped = scoped;
+    }
+    const scoped = this._scoped;
+    if (!scoped) {
+      return [];
+    }
+    switch (mode) {
+      case 'time-order':
+        return scoped.timeOrder(options);
+      case 'aggregated':
+        return scoped.aggregated(options);
+      case 'bottom-up':
+        return scoped.bottomUp(options);
+    }
+  }
+
   private async _showActive(): Promise<void> {
     const epoch = ++this._switchEpoch;
     // Wait for the now-visible host to lay out before Tabulator measures column
@@ -246,38 +284,43 @@ export class CallTreeDetail extends LitElement {
     }
 
     const mode = this.viewMode;
-    const slot = this._tables[mode];
-    if (slot && !slot.stale) {
-      slot.table.redraw(); // re-fit the layout for the now-visible host
+    const built = this._tables[mode];
+    if (built && !built.stale) {
+      built.table.redraw(); // re-fit the layout for the now-visible host
       return;
     }
 
-    // Built lazily here, after the yield above, so the selection highlight and
-    // the rest of the panel paint before this potentially expensive walk runs.
-    this._scoped ??= buildScopedCallTree(this.eventIndex, this.instances);
-    const scoped = this._scoped;
+    // Started here, after the yield above, so the selection highlight and the
+    // rest of the panel paint before the walk does anything; the walk then
+    // slices itself, so it never blocks a frame either.
+    this._pending = true;
+    if (built) {
+      // Those rows belong to the previous selection and the build below spans
+      // several frames — clear them rather than leave them standing under a
+      // selection they don't describe.
+      void built.table.setData([]);
+    }
+    const data = await this._rows(mode, {
+      yieldFrame: waitForNextFrame,
+      cancelled: () => epoch !== this._switchEpoch || !this.isConnected,
+    });
+    if (!data || epoch !== this._switchEpoch || !this.isConnected) {
+      return; // superseded, or the pane went away mid-build
+    }
+    this._pending = false;
     // Percentages are relative to the selection, so retarget the shared params
     // the formatters read rather than rebuilding the columns around a new total.
+    const scoped = this._scoped;
     this._barParams.totalValue = scoped?.rootTotal ?? 0;
-    if (!scoped) {
-      // Nothing in scope: empty a built table, and there is nothing to size a
-      // new one against.
-      if (slot) {
-        slot.stale = false;
-        void slot.table.setData([]);
-      }
-      return;
-    }
 
-    const data =
-      mode === 'time-order'
-        ? scoped.timeOrder
-        : mode === 'aggregated'
-          ? scoped.aggregated
-          : scoped.bottomUp;
+    const slot = this._tables[mode];
     if (slot) {
       slot.stale = false;
       void slot.table.setData(data);
+      return;
+    }
+    if (!scoped) {
+      // Nothing in scope, so there is nothing to size a new table against.
       return;
     }
 
@@ -293,7 +336,9 @@ export class CallTreeDetail extends LitElement {
       layout: 'fitColumns',
       height: '100%',
       maxHeight: '100%',
-      placeholder: 'No call tree available',
+      // Re-evaluated every time Tabulator shows the placeholder, so the pending
+      // text tracks the build without a second empty-state element.
+      placeholder: () => (this._pending ? 'Building the call tree…' : 'No call tree available'),
       // A scoped subtree is unbounded, so only the visible rows are rendered —
       // the same deal the Call Tree tab's tables get. The build in
       // `scopedCallTree` is still eager; this bounds the paint, not the walk.

--- a/log-viewer/src/components/CallTreeDetail.ts
+++ b/log-viewer/src/components/CallTreeDetail.ts
@@ -188,9 +188,8 @@ export class CallTreeDetail extends LitElement {
     const scopeChanged = changed.has('eventIndex') || changed.has('instances');
     if (scopeChanged) {
       // The scoped root changed — drop every table so each rebuilds on demand.
-      // The walk itself (`buildScopedCallTree`) is deferred to `_showActive`,
-      // past its paint yield: for a wide aggregate it's occurrences × subtree,
-      // and running it here would block the selection highlight from painting.
+      // `_scoped` is only invalidated here and only rebuilt in `_showActive`,
+      // past its paint yield — never before it.
       this._destroyTables();
       this._scoped = null;
     }

--- a/log-viewer/src/components/CallTreeDetail.ts
+++ b/log-viewer/src/components/CallTreeDetail.ts
@@ -269,17 +269,23 @@ export class CallTreeDetail extends LitElement {
     }
   }
 
+  /**
+   * True once `epoch`'s work should be thrown away: a newer switch replaced it,
+   * or the component was disconnected mid-wait (e.g. the pane collapsed) —
+   * building into detached DOM that disconnectedCallback already ran past would
+   * leak the Tabulator.
+   */
+  private _superseded(epoch: number): boolean {
+    return epoch !== this._switchEpoch || !this.isConnected;
+  }
+
   private async _showActive(): Promise<void> {
     const epoch = ++this._switchEpoch;
     // Wait for the now-visible host to lay out before Tabulator measures column
     // widths — building against a hidden/zero-width host makes columns overlap.
     await this.updateComplete;
     await waitForNextFrame();
-    // Bail if a newer switch superseded this one, or the component was
-    // disconnected mid-wait (e.g. the pane collapsed) — otherwise we'd build a
-    // Tabulator into detached DOM that disconnectedCallback already ran past,
-    // leaking it.
-    if (epoch !== this._switchEpoch || !this.isConnected) {
+    if (this._superseded(epoch)) {
       return;
     }
 
@@ -302,10 +308,10 @@ export class CallTreeDetail extends LitElement {
     }
     const data = await this._rows(mode, {
       yieldFrame: waitForNextFrame,
-      cancelled: () => epoch !== this._switchEpoch || !this.isConnected,
+      cancelled: () => this._superseded(epoch),
     });
-    if (!data || epoch !== this._switchEpoch || !this.isConnected) {
-      return; // superseded, or the pane went away mid-build
+    if (!data || this._superseded(epoch)) {
+      return;
     }
     this._pending = false;
     // Percentages are relative to the selection, so retarget the shared params

--- a/log-viewer/src/components/CallTreeDetail.ts
+++ b/log-viewer/src/components/CallTreeDetail.ts
@@ -108,15 +108,13 @@ export class CallTreeDetail extends LitElement {
   @state()
   private viewMode: ViewMode = 'time-order';
 
-  private _tables: Record<ViewMode, Tabulator | null> = {
+  /** A built table. `stale` means it holds a previous selection's rows, so it
+   *  needs re-filling before it is shown again. */
+  private _tables: Record<ViewMode, { table: Tabulator; stale: boolean } | null> = {
     'time-order': null,
     aggregated: null,
     'bottom-up': null,
   };
-
-  /** Modes whose table holds a previous selection's rows, so it needs re-filling
-   *  before it is shown again. */
-  private _stale = new Set<ViewMode>();
 
   /**
    * The bar/percentage params, shared by every column of every mode table and
@@ -210,9 +208,9 @@ export class CallTreeDetail extends LitElement {
       // `_scoped` is only invalidated here and only rebuilt in `_showActive`,
       // past its paint yield — never before it.
       this._scoped = null;
-      for (const mode of Object.keys(this._tables) as ViewMode[]) {
-        if (this._tables[mode]) {
-          this._stale.add(mode);
+      for (const slot of Object.values(this._tables)) {
+        if (slot) {
+          slot.stale = true;
         }
       }
     }
@@ -228,10 +226,9 @@ export class CallTreeDetail extends LitElement {
 
   private _destroyTables() {
     for (const mode of Object.keys(this._tables) as ViewMode[]) {
-      this._tables[mode]?.destroy();
+      this._tables[mode]?.table.destroy();
       this._tables[mode] = null;
     }
-    this._stale.clear();
   }
 
   private async _showActive(): Promise<void> {
@@ -249,9 +246,9 @@ export class CallTreeDetail extends LitElement {
     }
 
     const mode = this.viewMode;
-    const existing = this._tables[mode];
-    if (existing && !this._stale.has(mode)) {
-      existing.redraw(); // re-fit the layout for the now-visible host
+    const slot = this._tables[mode];
+    if (slot && !slot.stale) {
+      slot.table.redraw(); // re-fit the layout for the now-visible host
       return;
     }
 
@@ -262,22 +259,28 @@ export class CallTreeDetail extends LitElement {
     // Percentages are relative to the selection, so retarget the shared params
     // the formatters read rather than rebuilding the columns around a new total.
     this._barParams.totalValue = scoped?.rootTotal ?? 0;
-    const data = !scoped
-      ? []
-      : mode === 'time-order'
+    if (!scoped) {
+      // Nothing in scope: empty a built table, and there is nothing to size a
+      // new one against.
+      if (slot) {
+        slot.stale = false;
+        void slot.table.setData([]);
+      }
+      return;
+    }
+
+    const data =
+      mode === 'time-order'
         ? scoped.timeOrder
         : mode === 'aggregated'
           ? scoped.aggregated
           : scoped.bottomUp;
+    if (slot) {
+      slot.stale = false;
+      void slot.table.setData(data);
+      return;
+    }
 
-    if (existing) {
-      this._stale.delete(mode);
-      void existing.setData(data);
-      return;
-    }
-    if (!scoped) {
-      return;
-    }
     const container = this.renderRoot?.querySelector<HTMLDivElement>(`#${mode}-tree`);
     if (!container) {
       return;
@@ -338,7 +341,7 @@ export class CallTreeDetail extends LitElement {
     table.on('rowContext', (e, row) => {
       this._showRowMenu(e as MouseEvent, row, table);
     });
-    this._tables[mode] = table;
+    this._tables[mode] = { table, stale: false };
   }
 
   /** Row right-click menu: reveal in the Call Tree tab, or copy the frame. */
@@ -400,7 +403,7 @@ export class CallTreeDetail extends LitElement {
         field: 'duration.self',
         barWidth,
         barParams,
-        bottomCalc: makeSumSelfTimeAllVisible(() => this._tables[mode] ?? undefined),
+        bottomCalc: makeSumSelfTimeAllVisible(() => this._tables[mode]?.table),
       }),
     ];
 

--- a/log-viewer/src/components/CallTreeDetail.ts
+++ b/log-viewer/src/components/CallTreeDetail.ts
@@ -187,10 +187,12 @@ export class CallTreeDetail extends LitElement {
   updated(changed: PropertyValues) {
     const scopeChanged = changed.has('eventIndex') || changed.has('instances');
     if (scopeChanged) {
-      // The scoped root changed — drop every table so each rebuilds on demand,
-      // and recompute the scoped tree once (all three modes share it).
+      // The scoped root changed — drop every table so each rebuilds on demand.
+      // The walk itself (`buildScopedCallTree`) is deferred to `_showActive`,
+      // past its paint yield: for a wide aggregate it's occurrences × subtree,
+      // and running it here would block the selection highlight from painting.
       this._destroyTables();
-      this._scoped = buildScopedCallTree(this.eventIndex, this.instances);
+      this._scoped = null;
     }
     if (scopeChanged || changed.has('viewMode')) {
       void this._showActive();
@@ -230,6 +232,9 @@ export class CallTreeDetail extends LitElement {
       return;
     }
 
+    // Built lazily here, after the yield above, so the selection highlight and
+    // the rest of the panel paint before this potentially expensive walk runs.
+    this._scoped ??= buildScopedCallTree(this.eventIndex, this.instances);
     const scoped = this._scoped;
     if (!scoped) {
       return;

--- a/log-viewer/src/components/__tests__/CallTreeDetailScopedBuild.test.ts
+++ b/log-viewer/src/components/__tests__/CallTreeDetailScopedBuild.test.ts
@@ -9,26 +9,61 @@ import { beforeEach, describe, expect, it } from '@jest/globals';
 jest.mock('../../tabulator/style/DataGrid.scss', () => ({ default: '' }));
 jest.mock('../../tabulator/format/Progress.css', () => ({}));
 // The tabulator ESM build (+ its module registrations) doesn't load under jest;
-// the mocked walk returns null so no table is ever built here.
-jest.mock('tabulator-tables', () => ({
-  Tabulator: class {
+// this stub records what the component does to a table instead.
+jest.mock('tabulator-tables', () => {
+  class Tabulator {
     static registerModule() {}
-  },
-  Module: class {},
-  Renderer: class {},
-}));
+    static instances: Tabulator[] = [];
+    setData = jest.fn(() => Promise.resolve());
+    redraw = jest.fn();
+    destroy = jest.fn();
+    on = jest.fn();
+    options: Record<string, unknown>;
+    constructor(_element: HTMLElement, options: Record<string, unknown>) {
+      this.options = options;
+      Tabulator.instances.push(this);
+    }
+  }
+  return { Tabulator, Module: class {}, Renderer: class {} };
+});
 // vscode-button needs ElementInternals.setFormValue (absent in jsdom).
 jest.mock('#vscode-elements/vscode-button.js', () => ({}));
 
-// The walk is what this suite times, so it's stubbed; null keeps the build from
-// reaching Tabulator.
+// The walk is what this suite is about, so it's stubbed; each test says whether
+// it yields a tree or nothing.
 jest.mock('../scopedCallTree.js', () => ({ buildScopedCallTree: jest.fn(() => null) }));
+
+import { Tabulator } from 'tabulator-tables';
 
 import type { CallTreeDetail } from '../CallTreeDetail.js';
 import '../CallTreeDetail.js';
-import { buildScopedCallTree } from '../scopedCallTree.js';
+import { buildScopedCallTree, type ScopedCallTree } from '../scopedCallTree.js';
+import type { ProgressParams } from '../../tabulator/format/ProgressMS.js';
 
 const build = jest.mocked(buildScopedCallTree);
+
+interface StubTable {
+  options: { columns: Array<{ field: string; formatterParams: ProgressParams; width: number }> };
+  setData: jest.Mock;
+  redraw: jest.Mock;
+  destroy: jest.Mock;
+}
+
+/** The stub tables built so far, oldest first. */
+const tables = Tabulator as unknown as { instances: StubTable[] };
+
+/** A scoped tree with no rows — only its totals matter to these tests. */
+function tree(rootTotal: number): ScopedCallTree {
+  return { rootTotal, logTotal: 5_000_000, timeOrder: [], aggregated: [], bottomUp: [] };
+}
+
+function totalColumn(table: StubTable) {
+  const column = table.options.columns.find((c) => c.field === 'duration.total');
+  if (!column) {
+    throw new Error('Total column not built');
+  }
+  return column;
+}
 
 /** Lets the rAF the build waits behind fire, then settles the render. */
 async function frame(el: CallTreeDetail): Promise<void> {
@@ -46,8 +81,10 @@ async function mount(eventIndex: number): Promise<CallTreeDetail> {
 
 describe('CallTreeDetail scoped build', () => {
   beforeEach(() => {
-    build.mockClear();
     document.body.replaceChildren();
+    build.mockReset();
+    build.mockReturnValue(null);
+    tables.instances.length = 0;
   });
 
   it('defers the walk past the paint yield', async () => {
@@ -69,5 +106,41 @@ describe('CallTreeDetail scoped build', () => {
     // superseded one before it can pay for a walk nobody is waiting on.
     await frame(el);
     expect(build.mock.calls).toEqual([[6, null]]);
+  });
+
+  it('re-fills the built table for a new selection instead of rebuilding it', async () => {
+    build.mockImplementation((eventIndex) => tree(eventIndex * 1000));
+    const el = await mount(5);
+    await frame(el);
+    expect(tables.instances).toHaveLength(1);
+    const table = tables.instances[0]!;
+
+    el.eventIndex = 6;
+    await el.updateComplete;
+    await frame(el);
+
+    // Same table, re-filled — a Tabulator is expensive to construct, and its
+    // construction is what used to land on the selection's critical path.
+    expect(tables.instances).toHaveLength(1);
+    expect(table.destroy).not.toHaveBeenCalled();
+    expect(table.setData).toHaveBeenCalledTimes(1);
+  });
+
+  it('retargets the percentage denominator without touching the bar width', async () => {
+    build.mockImplementation((eventIndex) => tree(eventIndex * 1000));
+    const el = await mount(5);
+    await frame(el);
+    const column = totalColumn(tables.instances[0]!);
+    const widthAtBuild = column.width;
+    expect(column.formatterParams.totalValue).toBe(5000);
+
+    el.eventIndex = 6;
+    await el.updateComplete;
+    await frame(el);
+
+    // The formatters read these params by reference at render time, so the new
+    // selection's total reaches the bars with the columns left as they were.
+    expect(column.formatterParams.totalValue).toBe(6000);
+    expect(column.width).toBe(widthAtBuild);
   });
 });

--- a/log-viewer/src/components/__tests__/CallTreeDetailScopedBuild.test.ts
+++ b/log-viewer/src/components/__tests__/CallTreeDetailScopedBuild.test.ts
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2026 Certinia Inc. All rights reserved.
+ *
+ * @jest-environment jsdom
+ */
+import { beforeEach, describe, expect, it } from '@jest/globals';
+
+// The swc transform can't parse `.scss`/`.css`; stub the stylesheet assets.
+jest.mock('../../tabulator/style/DataGrid.scss', () => ({ default: '' }));
+jest.mock('../../tabulator/format/Progress.css', () => ({}));
+// The tabulator ESM build (+ its module registrations) doesn't load under jest;
+// the mocked walk returns null so no table is ever built here.
+jest.mock('tabulator-tables', () => ({
+  Tabulator: class {
+    static registerModule() {}
+  },
+  Module: class {},
+  Renderer: class {},
+}));
+// vscode-button needs ElementInternals.setFormValue (absent in jsdom).
+jest.mock('#vscode-elements/vscode-button.js', () => ({}));
+
+// The walk is what this suite times, so it's stubbed; null keeps the build from
+// reaching Tabulator.
+jest.mock('../scopedCallTree.js', () => ({ buildScopedCallTree: jest.fn(() => null) }));
+
+import type { CallTreeDetail } from '../CallTreeDetail.js';
+import '../CallTreeDetail.js';
+import { buildScopedCallTree } from '../scopedCallTree.js';
+
+const build = jest.mocked(buildScopedCallTree);
+
+/** Lets the rAF the build waits behind fire, then settles the render. */
+async function frame(el: CallTreeDetail): Promise<void> {
+  await new Promise((resolve) => requestAnimationFrame(resolve));
+  await el.updateComplete;
+}
+
+async function mount(eventIndex: number): Promise<CallTreeDetail> {
+  const el = document.createElement('call-tree-detail') as CallTreeDetail;
+  el.eventIndex = eventIndex;
+  document.body.appendChild(el);
+  await el.updateComplete;
+  return el;
+}
+
+describe('CallTreeDetail scoped build', () => {
+  beforeEach(() => {
+    build.mockClear();
+    document.body.replaceChildren();
+  });
+
+  it('defers the walk past the paint yield', async () => {
+    const el = await mount(5);
+
+    // The selection has been applied and rendered; the walk has not run yet.
+    expect(build).not.toHaveBeenCalled();
+
+    await frame(el);
+    expect(build.mock.calls).toEqual([[5, null]]);
+  });
+
+  it('walks only the latest scope when selections arrive back to back', async () => {
+    const el = await mount(5);
+    el.eventIndex = 6;
+    await el.updateComplete;
+
+    // Both switches are still behind the same yield; the epoch guard drops the
+    // superseded one before it can pay for a walk nobody is waiting on.
+    await frame(el);
+    expect(build.mock.calls).toEqual([[6, null]]);
+  });
+});

--- a/log-viewer/src/components/__tests__/CallTreeDetailScopedBuild.test.ts
+++ b/log-viewer/src/components/__tests__/CallTreeDetailScopedBuild.test.ts
@@ -30,8 +30,10 @@ jest.mock('tabulator-tables', () => {
 jest.mock('#vscode-elements/vscode-button.js', () => ({}));
 
 // The walk is what this suite is about, so it's stubbed; each test says whether
-// it yields a tree or nothing.
-jest.mock('../scopedCallTree.js', () => ({ buildScopedCallTree: jest.fn(() => null) }));
+// it yields a tree or nothing, and when.
+jest.mock('../scopedCallTree.js', () => ({
+  buildScopedCallTree: jest.fn(() => Promise.resolve(null)),
+}));
 
 import { Tabulator } from 'tabulator-tables';
 
@@ -43,7 +45,10 @@ import type { ProgressParams } from '../../tabulator/format/ProgressMS.js';
 const build = jest.mocked(buildScopedCallTree);
 
 interface StubTable {
-  options: { columns: Array<{ field: string; formatterParams: ProgressParams; width: number }> };
+  options: {
+    columns: Array<{ field: string; formatterParams: ProgressParams; width: number }>;
+    placeholder: () => string;
+  };
   setData: jest.Mock;
   redraw: jest.Mock;
   destroy: jest.Mock;
@@ -54,7 +59,21 @@ const tables = Tabulator as unknown as { instances: StubTable[] };
 
 /** A scoped tree with no rows — only its totals matter to these tests. */
 function tree(rootTotal: number): ScopedCallTree {
-  return { rootTotal, logTotal: 5_000_000, timeOrder: [], aggregated: [], bottomUp: [] };
+  return {
+    rootTotal,
+    logTotal: 5_000_000,
+    timeOrder: () => Promise.resolve([]),
+    aggregated: () => Promise.resolve([]),
+    bottomUp: () => Promise.resolve([]),
+  };
+}
+
+/** Holds every build open, so a test decides when — and in which order — the
+ *  walks finish. Returns the resolvers, one per build, in start order. */
+function deferBuilds(): Array<(scoped: ScopedCallTree | null) => void> {
+  const resolvers: Array<(scoped: ScopedCallTree | null) => void> = [];
+  build.mockImplementation(() => new Promise((resolve) => resolvers.push(resolve)));
+  return resolvers;
 }
 
 function totalColumn(table: StubTable) {
@@ -65,10 +84,18 @@ function totalColumn(table: StubTable) {
   return column;
 }
 
+/** The build chain awaits more than once, so keep re-awaiting the render rather
+ *  than counting microtasks. */
+async function settle(el: CallTreeDetail): Promise<void> {
+  for (let i = 0; i < 5; i++) {
+    await el.updateComplete;
+  }
+}
+
 /** Lets the rAF the build waits behind fire, then settles the render. */
 async function frame(el: CallTreeDetail): Promise<void> {
   await new Promise((resolve) => requestAnimationFrame(resolve));
-  await el.updateComplete;
+  await settle(el);
 }
 
 async function mount(eventIndex: number): Promise<CallTreeDetail> {
@@ -83,7 +110,7 @@ describe('CallTreeDetail scoped build', () => {
   beforeEach(() => {
     document.body.replaceChildren();
     build.mockReset();
-    build.mockReturnValue(null);
+    build.mockResolvedValue(null);
     tables.instances.length = 0;
   });
 
@@ -94,7 +121,7 @@ describe('CallTreeDetail scoped build', () => {
     expect(build).not.toHaveBeenCalled();
 
     await frame(el);
-    expect(build.mock.calls).toEqual([[5, null]]);
+    expect(build.mock.calls).toEqual([[5, null, expect.anything()]]);
   });
 
   it('walks only the latest scope when selections arrive back to back', async () => {
@@ -105,11 +132,11 @@ describe('CallTreeDetail scoped build', () => {
     // Both switches are still behind the same yield; the epoch guard drops the
     // superseded one before it can pay for a walk nobody is waiting on.
     await frame(el);
-    expect(build.mock.calls).toEqual([[6, null]]);
+    expect(build.mock.calls).toEqual([[6, null, expect.anything()]]);
   });
 
   it('re-fills the built table for a new selection instead of rebuilding it', async () => {
-    build.mockImplementation((eventIndex) => tree(eventIndex * 1000));
+    build.mockImplementation((eventIndex) => Promise.resolve(tree(eventIndex * 1000)));
     const el = await mount(5);
     await frame(el);
     expect(tables.instances).toHaveLength(1);
@@ -120,14 +147,16 @@ describe('CallTreeDetail scoped build', () => {
     await frame(el);
 
     // Same table, re-filled — a Tabulator is expensive to construct, and its
-    // construction is what used to land on the selection's critical path.
+    // construction is what used to land on the selection's critical path. Two
+    // fills: the previous selection's rows are cleared before the walk, then
+    // the new ones land.
     expect(tables.instances).toHaveLength(1);
     expect(table.destroy).not.toHaveBeenCalled();
-    expect(table.setData).toHaveBeenCalledTimes(1);
+    expect(table.setData).toHaveBeenCalledTimes(2);
   });
 
   it('retargets the percentage denominator without touching the bar width', async () => {
-    build.mockImplementation((eventIndex) => tree(eventIndex * 1000));
+    build.mockImplementation((eventIndex) => Promise.resolve(tree(eventIndex * 1000)));
     const el = await mount(5);
     await frame(el);
     const column = totalColumn(tables.instances[0]!);
@@ -142,5 +171,50 @@ describe('CallTreeDetail scoped build', () => {
     // selection's total reaches the bars with the columns left as they were.
     expect(column.formatterParams.totalValue).toBe(6000);
     expect(column.width).toBe(widthAtBuild);
+  });
+
+  it('clears the stale rows and says the walk is running', async () => {
+    const resolvers = deferBuilds();
+    const el = await mount(5);
+    await frame(el);
+    resolvers[0]!(tree(5000));
+    await settle(el);
+    const table = tables.instances[0]!;
+    expect(table.options.placeholder()).toBe('No call tree available');
+
+    el.eventIndex = 6;
+    await el.updateComplete;
+    await frame(el);
+
+    // The rows on screen describe the previous selection, so they go before the
+    // walk starts; Tabulator re-reads the placeholder each time it shows one.
+    expect(table.setData).toHaveBeenLastCalledWith([]);
+    expect(table.options.placeholder()).toBe('Building the call tree…');
+
+    resolvers[1]!(tree(6000));
+    await settle(el);
+    expect(table.options.placeholder()).toBe('No call tree available');
+  });
+
+  it('drops a superseded walk that finishes after the newer one', async () => {
+    const resolvers = deferBuilds();
+    const el = await mount(5);
+    await frame(el);
+    el.eventIndex = 6;
+    await el.updateComplete;
+    await frame(el);
+    expect(resolvers).toHaveLength(2);
+
+    // The newer walk finishes first; the stale one lands afterwards, as it would
+    // if its own scope were simply wider.
+    resolvers[1]!(tree(6000));
+    await settle(el);
+    expect(totalColumn(tables.instances[0]!).formatterParams.totalValue).toBe(6000);
+
+    resolvers[0]!(tree(5000));
+    await settle(el);
+    // The epoch guard drops it — the denominator still describes what's shown.
+    expect(tables.instances).toHaveLength(1);
+    expect(totalColumn(tables.instances[0]!).formatterParams.totalValue).toBe(6000);
   });
 });

--- a/log-viewer/src/components/__tests__/LogInspector.test.ts
+++ b/log-viewer/src/components/__tests__/LogInspector.test.ts
@@ -30,16 +30,32 @@ jest.mock('../../features/settings/Settings.js', () => ({
 }));
 
 // The real builders mount Tabulator tables; only the section ids matter here.
+// `deferSections` lets a test hold a build's resolution open so it can
+// interleave a second, faster selection ahead of it (see the epoch test below);
+// every other test leaves it false and gets an immediately-resolved build.
+let deferSections = false;
+const pendingSections: Array<() => void> = [];
 jest.mock('../detailSections.js', () => ({
-  buildDetailSections: (_source: string, selection: unknown) =>
-    Promise.resolve(
-      selection
-        ? [
-            { id: 'vitals', title: 'Details', content: html`<div>v</div>` },
-            { id: 'callstack', title: 'Call stack', content: html`<div>c</div>` },
-          ]
-        : [],
-    ),
+  buildDetailSections: (_source: string, selection: { eventIndex?: number } | null) => {
+    // The marker carries the selection through to the rendered content, so a
+    // stale build resolving late is distinguishable from the one that supersedes it.
+    const sections = selection
+      ? [
+          {
+            id: 'vitals',
+            title: 'Details',
+            content: html`<div class="marker">${selection.eventIndex}</div>`,
+          },
+          { id: 'callstack', title: 'Call stack', content: html`<div>c</div>` },
+        ]
+      : [];
+    if (!deferSections) {
+      return Promise.resolve(sections);
+    }
+    return new Promise<typeof sections>((resolve) => {
+      pendingSections.push(() => resolve(sections));
+    });
+  },
 }));
 
 import { eventBus } from '../../core/events/EventBus.js';
@@ -54,6 +70,15 @@ import '../LogInspector.js';
  */
 async function flush(el: LogInspector): Promise<void> {
   await new Promise((resolve) => requestAnimationFrame(resolve));
+  for (let i = 0; i < 5; i++) {
+    await el.updateComplete;
+  }
+}
+
+/** Settles the render chain through the nested shadow DOMs, without the rAF
+ *  wait `flush` adds — a test that drives `_rebuild()` directly doesn't want
+ *  another debounced rebuild sneaking in. */
+async function settle(el: LogInspector): Promise<void> {
   for (let i = 0; i < 5; i++) {
     await el.updateComplete;
   }
@@ -86,12 +111,18 @@ function select(source: 'timeline' | 'database', eventIndex: number): void {
   eventBus.emit('detail:select', { source, selection: { kind: 'event', eventIndex } });
 }
 
+function marker(el: LogInspector): string | null {
+  return paneView(el).shadowRoot?.querySelector('.marker')?.textContent ?? null;
+}
+
 describe('LogInspector', () => {
   beforeEach(() => {
     written.length = 0;
     delete settings.inspector;
     deferSettings = false;
     releaseSettings = null;
+    deferSections = false;
+    pendingSections.length = 0;
     document.body.replaceChildren();
   });
 
@@ -192,5 +223,33 @@ describe('LogInspector', () => {
     // The stored `visible: false` and `collapsed` don't undo either action.
     expect(visible(el)).toBe(true);
     expect(paneView(el).collapsed).toEqual({ vitals: true });
+  });
+
+  it('drops a superseded rebuild: a stale build resolving late does not overwrite a newer one', async () => {
+    deferSections = true;
+    const el = await mount('timeline-tab');
+    // Mounting with an activeTab already triggers its own (empty-selection)
+    // rebuild; drain it before driving the two we care about.
+    pendingSections.pop()?.();
+    await settle(el);
+    pendingSections.length = 0;
+
+    select('timeline', 1);
+    await new Promise((resolve) => requestAnimationFrame(resolve)); // debounce fires -> _rebuild() epoch 1 starts, awaiting buildDetailSections
+    select('timeline', 2);
+    await new Promise((resolve) => requestAnimationFrame(resolve)); // debounce fires -> _rebuild() epoch 2 starts, awaiting buildDetailSections
+    expect(pendingSections).toHaveLength(2);
+
+    // The newer selection's build resolves first (it's the one the user is
+    // waiting on); the stale epoch-1 build resolves afterwards, as it would if
+    // its underlying walk was simply slower.
+    pendingSections[1]!();
+    await settle(el);
+    expect(marker(el)).toBe('2');
+
+    pendingSections[0]!();
+    await settle(el);
+    // The epoch guard drops the stale result — it must not clobber the newer one.
+    expect(marker(el)).toBe('2');
   });
 });

--- a/log-viewer/src/components/__tests__/LogInspector.test.ts
+++ b/log-viewer/src/components/__tests__/LogInspector.test.ts
@@ -64,24 +64,20 @@ import type { PaneView } from '../PaneView.js';
 import '../LogInspector.js';
 
 /**
- * Settles the rAF-debounced rebuild, the async section build and the render.
- * The build chain awaits more than once, so keep re-awaiting the render rather
- * than counting microtasks.
+ * Settles the async section build and the render chain through the nested
+ * shadow DOMs. The build chain awaits more than once, so keep re-awaiting the
+ * render rather than counting microtasks.
  */
-async function flush(el: LogInspector): Promise<void> {
-  await new Promise((resolve) => requestAnimationFrame(resolve));
+async function settle(el: LogInspector): Promise<void> {
   for (let i = 0; i < 5; i++) {
     await el.updateComplete;
   }
 }
 
-/** Settles the render chain through the nested shadow DOMs, without the rAF
- *  wait `flush` adds — a test that drives `_rebuild()` directly doesn't want
- *  another debounced rebuild sneaking in. */
-async function settle(el: LogInspector): Promise<void> {
-  for (let i = 0; i < 5; i++) {
-    await el.updateComplete;
-  }
+/** `settle`, plus the rAF wait that lets the debounced rebuild fire first. */
+async function flush(el: LogInspector): Promise<void> {
+  await new Promise((resolve) => requestAnimationFrame(resolve));
+  await settle(el);
 }
 
 async function mount(activeTab: string): Promise<LogInspector> {
@@ -226,13 +222,10 @@ describe('LogInspector', () => {
   });
 
   it('drops a superseded rebuild: a stale build resolving late does not overwrite a newer one', async () => {
-    deferSections = true;
+    // Mount undeferred so its own (empty-selection) rebuild resolves, then defer
+    // only the two builds this test drives.
     const el = await mount('timeline-tab');
-    // Mounting with an activeTab already triggers its own (empty-selection)
-    // rebuild; drain it before driving the two we care about.
-    pendingSections.pop()?.();
-    await settle(el);
-    pendingSections.length = 0;
+    deferSections = true;
 
     select('timeline', 1);
     await new Promise((resolve) => requestAnimationFrame(resolve)); // debounce fires -> _rebuild() epoch 1 starts, awaiting buildDetailSections

--- a/log-viewer/src/components/__tests__/scopedCallTree.test.ts
+++ b/log-viewer/src/components/__tests__/scopedCallTree.test.ts
@@ -155,6 +155,43 @@ describe('buildScopedCallTree', () => {
     expect(tree.timeOrder).toBe(tree.timeOrder);
   });
 
+  it('a wide aggregate merges every occurrence, uncapped', () => {
+    // A statement called from a loop: many occurrences of the same frame, each
+    // with its own small subtree — the "occurrences × subtree" shape a NODE_BUDGET
+    // cap used to bound (see PR #877's removal note). No cap exists any more, so
+    // every occurrence must still be represented.
+    const OCCURRENCES = 500;
+    const loop = ev(300, 'METHOD_ENTRY', 'loop', { total: OCCURRENCES, self: 0 });
+    loop.parent = root;
+    byId.set(loop.eventIndex, loop);
+
+    const instances: number[] = [];
+    let nextId = 301;
+    for (let i = 0; i < OCCURRENCES; i++) {
+      const call = ev(nextId++, 'SOQL_EXECUTE_BEGIN', 'SELECT Id FROM Account', {
+        total: 1,
+        self: 1,
+      });
+      call.parent = loop;
+      loop.children.push(call);
+      byId.set(call.eventIndex, call);
+      instances.push(call.eventIndex);
+    }
+
+    const tree = buildScopedCallTree(instances[0]!, instances)!;
+    expect(tree.rootTotal).toBe(OCCURRENCES);
+
+    // Every occurrence merges into a single aggregated row, counting every call.
+    const [aggregated] = tree.aggregated;
+    expect(aggregated?.callCount).toBe(OCCURRENCES);
+    expect(aggregated?.duration.total).toBe(OCCURRENCES);
+
+    // Same for bottom-up: the seed frame's self time sums across every occurrence.
+    const [bottomUp] = tree.bottomUp;
+    expect(bottomUp?.callCount).toBe(OCCURRENCES);
+    expect(bottomUp?.duration.self).toBe(OCCURRENCES);
+  });
+
   it('materialises every child rather than capping the subtree', () => {
     const big = ev(100, 'METHOD_ENTRY', 'big', { total: 100, self: 0 });
     big.parent = root;

--- a/log-viewer/src/components/__tests__/scopedCallTree.test.ts
+++ b/log-viewer/src/components/__tests__/scopedCallTree.test.ts
@@ -49,21 +49,51 @@ jest.mock('../../features/database/services/Database.js', () => ({
   },
 }));
 
-import { buildScopedCallTree, type ScopedRow } from '../scopedCallTree.js';
+import { buildScopedCallTree, type ScopedBuildOptions, type ScopedRow } from '../scopedCallTree.js';
+
+/** These fixtures are small enough to never hit a slice deadline, so `yieldFrame`
+ *  is only there to satisfy the contract. */
+const options: ScopedBuildOptions = { yieldFrame: () => Promise.resolve() };
+
+function build(eventIndex: number, instances?: number[]) {
+  return buildScopedCallTree(eventIndex, instances ?? null, options);
+}
+
+/** A statement called from a loop: `count` occurrences of the same frame, each
+ *  with its own small subtree. Returns their eventIndexes. */
+function loopOccurrences(count: number): number[] {
+  const loop = ev(300, 'METHOD_ENTRY', 'loop', { total: count, self: 0 });
+  loop.parent = root;
+  byId.set(loop.eventIndex, loop);
+
+  const instances: number[] = [];
+  let nextId = 301;
+  for (let i = 0; i < count; i++) {
+    const call = ev(nextId++, 'SOQL_EXECUTE_BEGIN', 'SELECT Id FROM Account', {
+      total: 1,
+      self: 1,
+    });
+    call.parent = loop;
+    loop.children.push(call);
+    byId.set(call.eventIndex, call);
+    instances.push(call.eventIndex);
+  }
+  return instances;
+}
 
 describe('buildScopedCallTree', () => {
-  it('returns null when nothing is selected', () => {
-    expect(buildScopedCallTree(-1)).toBeNull();
+  it('returns null when nothing is selected', async () => {
+    expect(await build(-1)).toBeNull();
   });
 
-  it('time-order: ancestors attributed to the selection, leaf keeps its real duration', () => {
+  it('time-order: ancestors attributed to the selection, leaf keeps its real duration', async () => {
     selectedIndex = 4;
-    const tree = buildScopedCallTree(selectedIndex)!;
+    const tree = (await build(selectedIndex))!;
     expect(tree.rootTotal).toBe(200);
 
     // Single chain root→leaf: exec → m1 → m2 → soql.
     const chain: ScopedRow[] = [];
-    let node: ScopedRow | undefined = tree.timeOrder[0];
+    let node: ScopedRow | undefined = (await tree.timeOrder(options))![0];
     while (node) {
       chain.push(node);
       node = node._children?.[0];
@@ -77,10 +107,11 @@ describe('buildScopedCallTree', () => {
     expect(chain[3]?.duration).toEqual({ total: 200, self: 200 });
   });
 
-  it('bottom-up: the selected leaf is the top row with callers nested in reverse', () => {
-    const tree = buildScopedCallTree(4)!;
-    expect(tree.bottomUp.map((r) => r.text)).toEqual(['SELECT Id FROM Account']);
-    const top = tree.bottomUp[0]!;
+  it('bottom-up: the selected leaf is the top row with callers nested in reverse', async () => {
+    const tree = (await build(4))!;
+    const rows = (await tree.bottomUp(options))!;
+    expect(rows.map((r) => r.text)).toEqual(['SELECT Id FROM Account']);
+    const top = rows[0]!;
     expect(top.duration.self).toBe(200);
 
     // Callers unwind back up to the root: soql → m2 → m1 → exec.
@@ -93,10 +124,10 @@ describe('buildScopedCallTree', () => {
     expect(callers).toEqual(['m2', 'm1', 'exec']);
   });
 
-  it('bottom-up: every caller counts the call it contributed, never zero', () => {
-    const tree = buildScopedCallTree(4)!;
+  it('bottom-up: every caller counts the call it contributed, never zero', async () => {
+    const tree = (await build(4))!;
     const counts: number[] = [];
-    let node: ScopedRow | undefined = tree.bottomUp[0];
+    let node: ScopedRow | undefined = (await tree.bottomUp(options))![0];
     while (node) {
       counts.push(node.callCount);
       node = node._children?.[0];
@@ -105,7 +136,7 @@ describe('buildScopedCallTree', () => {
     expect(counts).toEqual([1, 1, 1, 1]);
   });
 
-  it('drops zero-duration bookkeeping rows, keeping those with timed descendants', () => {
+  it('drops zero-duration bookkeeping rows, keeping those with timed descendants', async () => {
     const scope = ev(200, 'METHOD_ENTRY', 'scope', { total: 50, self: 0 });
     const heap = ev(201, 'HEAP_ALLOCATE', 'Bytes:8', { total: 0, self: 0 });
     const statement = ev(202, 'STATEMENT_EXECUTE', '[12]', { total: 0, self: 0 });
@@ -118,27 +149,27 @@ describe('buildScopedCallTree', () => {
     timed.parent = statement;
     byId.set(scope.eventIndex, scope);
 
-    const tree = buildScopedCallTree(scope.eventIndex)!;
-    const selected = tree.timeOrder[0]!;
+    const tree = (await build(scope.eventIndex))!;
+    const selected = (await tree.timeOrder(options))![0]!;
     // The bare heap allocation is gone; the statement stays because it is the
     // only way to reach `timed`.
     expect(selected._children!.map((row) => row.text)).toEqual(['[12]']);
     expect(selected._children![0]!._children!.map((row) => row.text)).toEqual(['timed']);
   });
 
-  it('keeps the selection itself even when it has no duration', () => {
+  it('keeps the selection itself even when it has no duration', async () => {
     const scope = ev(210, 'VARIABLE_SCOPE_BEGIN', 'scope', { total: 0, self: 0 });
     scope.parent = root;
     byId.set(scope.eventIndex, scope);
 
-    const tree = buildScopedCallTree(scope.eventIndex)!;
-    expect(tree.timeOrder.map((row) => row.text)).toEqual(['scope']);
+    const tree = (await build(scope.eventIndex))!;
+    expect((await tree.timeOrder(options))!.map((row) => row.text)).toEqual(['scope']);
   });
 
-  it('aggregated: linear path stays one node per frame', () => {
-    const tree = buildScopedCallTree(4)!;
+  it('aggregated: linear path stays one node per frame', async () => {
+    const tree = (await build(4))!;
     const texts: string[] = [];
-    let node: ScopedRow | undefined = tree.aggregated[0];
+    let node: ScopedRow | undefined = (await tree.aggregated(options))![0];
     while (node) {
       texts.push(node.text);
       expect(node.callCount).toBe(1);
@@ -147,52 +178,81 @@ describe('buildScopedCallTree', () => {
     expect(texts).toEqual(['exec', 'm1', 'm2', 'SELECT Id FROM Account']);
   });
 
-  it('builds each view only on first read, then caches it', () => {
-    const tree = buildScopedCallTree(4)!;
-    // Same object back on a second read — the walk is not repeated.
-    expect(tree.aggregated).toBe(tree.aggregated);
-    expect(tree.bottomUp).toBe(tree.bottomUp);
-    expect(tree.timeOrder).toBe(tree.timeOrder);
+  it('builds each view only on first read, then caches it', async () => {
+    const tree = (await build(4))!;
+    // Same array back on a second read — the walk is not repeated.
+    expect(await tree.aggregated(options)).toBe(await tree.aggregated(options));
+    expect(await tree.bottomUp(options)).toBe(await tree.bottomUp(options));
+    expect(await tree.timeOrder(options)).toBe(await tree.timeOrder(options));
   });
 
-  it('a wide aggregate merges every occurrence, uncapped', () => {
-    // A statement called from a loop: many occurrences of the same frame, each
-    // with its own small subtree — the "occurrences × subtree" shape a NODE_BUDGET
-    // cap used to bound (see PR #877's removal note). No cap exists any more, so
-    // every occurrence must still be represented.
+  it('a wide aggregate merges every occurrence, uncapped', async () => {
+    // The "occurrences × subtree" shape a NODE_BUDGET cap used to bound (see PR
+    // #877's removal note). No cap exists any more, so every occurrence must
+    // still be represented.
     const OCCURRENCES = 500;
-    const loop = ev(300, 'METHOD_ENTRY', 'loop', { total: OCCURRENCES, self: 0 });
-    loop.parent = root;
-    byId.set(loop.eventIndex, loop);
+    const instances = loopOccurrences(OCCURRENCES);
 
-    const instances: number[] = [];
-    let nextId = 301;
-    for (let i = 0; i < OCCURRENCES; i++) {
-      const call = ev(nextId++, 'SOQL_EXECUTE_BEGIN', 'SELECT Id FROM Account', {
-        total: 1,
-        self: 1,
-      });
-      call.parent = loop;
-      loop.children.push(call);
-      byId.set(call.eventIndex, call);
-      instances.push(call.eventIndex);
-    }
-
-    const tree = buildScopedCallTree(instances[0]!, instances)!;
+    const tree = (await build(instances[0]!, instances))!;
     expect(tree.rootTotal).toBe(OCCURRENCES);
 
     // Every occurrence merges into a single aggregated row, counting every call.
-    const [aggregated] = tree.aggregated;
+    const [aggregated] = (await tree.aggregated(options))!;
     expect(aggregated?.callCount).toBe(OCCURRENCES);
     expect(aggregated?.duration.total).toBe(OCCURRENCES);
 
     // Same for bottom-up: the seed frame's self time sums across every occurrence.
-    const [bottomUp] = tree.bottomUp;
+    const [bottomUp] = (await tree.bottomUp(options))!;
     expect(bottomUp?.callCount).toBe(OCCURRENCES);
     expect(bottomUp?.duration.self).toBe(OCCURRENCES);
   });
 
-  it('materialises every child rather than capping the subtree', () => {
+  it('counts every occurrence even when the walk is sliced across frames', async () => {
+    const OCCURRENCES = 500;
+    const instances = loopOccurrences(OCCURRENCES);
+    let yields = 0;
+    const sliced: ScopedBuildOptions = {
+      yieldFrame: () => {
+        yields += 1;
+        return Promise.resolve();
+      },
+      cancelled: () => false,
+    };
+
+    // Every clock read lands past the slice deadline, so each check yields —
+    // the totals must come out the same as an unsliced build.
+    const clock = jest.spyOn(performance, 'now');
+    let time = 0;
+    clock.mockImplementation(() => (time += 100));
+    try {
+      const tree = (await buildScopedCallTree(instances[0]!, instances, sliced))!;
+      const [aggregated] = (await tree.aggregated(sliced))!;
+      expect(aggregated?.callCount).toBe(OCCURRENCES);
+      expect(aggregated?.duration.total).toBe(OCCURRENCES);
+    } finally {
+      clock.mockRestore();
+    }
+    expect(yields).toBeGreaterThan(0);
+  });
+
+  it('abandons a superseded walk instead of finishing it', async () => {
+    const instances = loopOccurrences(500);
+    const clock = jest.spyOn(performance, 'now');
+    let time = 0;
+    clock.mockImplementation(() => (time += 100));
+    try {
+      // The first yield is the first chance to notice; nothing is returned after it.
+      const tree = await buildScopedCallTree(instances[0]!, instances, {
+        yieldFrame: () => Promise.resolve(),
+        cancelled: () => true,
+      });
+      expect(tree).toBeNull();
+    } finally {
+      clock.mockRestore();
+    }
+  });
+
+  it('materialises every child rather than capping the subtree', async () => {
     const big = ev(100, 'METHOD_ENTRY', 'big', { total: 100, self: 0 });
     big.parent = root;
     big.children = Array.from({ length: 5 }, (_unused, i) =>
@@ -203,9 +263,10 @@ describe('buildScopedCallTree', () => {
     }
     byId.set(big.eventIndex, big);
 
-    const tree = buildScopedCallTree(big.eventIndex)!;
-    expect(tree.timeOrder[0]!.text).toBe('big');
+    const tree = (await build(big.eventIndex))!;
+    const rows = (await tree.timeOrder(options))!;
+    expect(rows[0]!.text).toBe('big');
     // Every child is present — expansion is the renderer's job, not a build-time cap.
-    expect(tree.timeOrder[0]!._children!.length).toBe(5);
+    expect(rows[0]!._children!.length).toBe(5);
   });
 });

--- a/log-viewer/src/components/scopedCallTree.ts
+++ b/log-viewer/src/components/scopedCallTree.ts
@@ -59,9 +59,10 @@ export interface ScopedRow {
 export interface ScopedCallTree {
   /** The selected node's total time (ns) — the % denominator for the bars. */
   rootTotal: number;
-  /** The whole log's total time (ns). Every selection's `rootTotal` fits inside
-   *  it, so it sizes the bar columns once for the log instead of per selection —
-   *  the widths then stay put as the selection changes. */
+  /** The whole log's total time (ns). It sizes the bar columns once for the log
+   *  instead of per selection, so the widths stay put as the selection changes.
+   *  An aggregate `rootTotal` sums nested occurrences, so it can read wider than
+   *  this; the column carries enough padding to absorb that. */
   logTotal: number;
   /** The three views, built on first call and cached (only one is on screen).
    *  Each hands the frame back as it works, and returns null when abandoned. */

--- a/log-viewer/src/components/scopedCallTree.ts
+++ b/log-viewer/src/components/scopedCallTree.ts
@@ -29,6 +29,10 @@ export interface ScopedRow {
 export interface ScopedCallTree {
   /** The selected node's total time (ns) — the % denominator for the bars. */
   rootTotal: number;
+  /** The whole log's total time (ns). Every selection's `rootTotal` fits inside
+   *  it, so it sizes the bar columns once for the log instead of per selection —
+   *  the widths then stay put as the selection changes. */
+  logTotal: number;
   /** The three views are built on first read and cached (only one is visible). */
   readonly timeOrder: ScopedRow[];
   readonly aggregated: ScopedRow[];
@@ -130,6 +134,7 @@ export function buildScopedCallTree(
   let bottomUp: ScopedRow[] | null = null;
   return {
     rootTotal,
+    logTotal: apexLog.duration.total,
     get timeOrder(): ScopedRow[] {
       // Many occurrences usually share ancestors, so merge the paths for a
       // readable tree; a single occurrence keeps its exact chain.

--- a/log-viewer/src/components/scopedCallTree.ts
+++ b/log-viewer/src/components/scopedCallTree.ts
@@ -290,6 +290,13 @@ interface BottomUpNode extends ScopedRow {
   _map: Map<string, BottomUpNode>;
 }
 
+/** A row's ancestors, innermost first. Siblings share the whole tail, so the
+ *  walk carries a link per node instead of a copy of the path. */
+interface CallerChain {
+  row: ScopedRow;
+  caller: CallerChain | null;
+}
+
 /**
  * Bottom-up: each frame with self time seeds a top-level row (ranked by self),
  * and its callers nest beneath it up to the root — the reverse of the call
@@ -329,39 +336,40 @@ async function buildBottomUp(
 
   // Iterative pre-order over every occurrence's subtree: both the occurrence
   // count and the subtree size grow, so one flat sliceable loop covers both.
-  const stack: Array<{ row: ScopedRow; path: ScopedRow[] }> = [];
+  const stack: Array<{ row: ScopedRow; callers: CallerChain | null }> = [];
   for (let i = rows.length - 1; i >= 0; i--) {
-    stack.push({ row: rows[i]!, path: [] });
+    stack.push({ row: rows[i]!, callers: null });
   }
   let steps = 0;
   while (stack.length) {
     if (steps++ % CHECK_EVERY === 0 && !(await tick())) {
       return null;
     }
-    const { row, path } = stack.pop()!;
+    const { row, callers } = stack.pop()!;
     if (row.duration.self > 0) {
-      // Callee first, then its callers up to the root.
-      const chain = [row, ...path.slice().reverse()];
-      let map = topMap;
-      let order: BottomUpNode[] | null = topOrder;
-      for (let i = 0; i < chain.length; i++) {
-        const node = ensure(map, order, chain[i]!);
+      // The seed row, then its callers up to the root. The chain is already in
+      // that order, so it is walked in place rather than copied and reversed.
+      const seed = ensure(topMap, topOrder, row);
+      seed.duration.total += row.duration.self;
+      seed.duration.self += row.duration.self;
+      seed.callCount += 1;
+      let map = seed._map;
+      for (let link = callers; link; link = link.caller) {
+        const node = ensure(map, null, link.row);
         node.duration.total += row.duration.self;
         // Callers count the call they contributed too, matching the Call Tree
         // tab's bottom-up (every bucket in the chain accumulates); counting
         // only the seed left every caller row reading "Calls 0".
         node.callCount += 1;
-        if (i === 0) {
-          node.duration.self += row.duration.self;
-        }
         map = node._map;
-        order = null;
       }
     }
     if (row._children) {
-      const childPath = [...path, row];
+      // Shared by every child, so the ancestor path costs one link per node
+      // rather than a copy of the whole path.
+      const childCallers: CallerChain = { row, caller: callers };
       for (let i = row._children.length - 1; i >= 0; i--) {
-        stack.push({ row: row._children[i]!, path: childPath });
+        stack.push({ row: row._children[i]!, callers: childCallers });
       }
     }
   }
@@ -374,6 +382,7 @@ async function buildBottomUp(
     }
     const node = everyNode[i]!;
     node._children = node._map.size ? [...node._map.values()] : null;
+    node._map.clear(); // its entries live in `_children` now
   }
   return topOrder.sort((a, b) => b.duration.self - a.duration.self);
 }

--- a/log-viewer/src/components/scopedCallTree.ts
+++ b/log-viewer/src/components/scopedCallTree.ts
@@ -11,6 +11,36 @@ function frameKey(event: LogEvent): string {
   return `${event.type ?? ''}|${event.namespace}|${event.text}`;
 }
 
+/** Work slice before the frame is handed back (ms) — half a 60fps frame, so a
+ *  build never takes more than half of any frame it runs in. */
+const SLICE_MS = 8;
+/** Items between deadline checks. Reading the clock per item costs more than
+ *  the odd overrun it saves. */
+const CHECK_EVERY = 256;
+
+export interface ScopedBuildOptions {
+  /** Hands the frame back between work slices. */
+  yieldFrame: () => Promise<void>;
+  /** Polled after each yield; true abandons the build, which then returns null. */
+  cancelled?: () => boolean;
+}
+
+/** Returns false once the build has been abandoned. */
+type Tick = () => Promise<boolean>;
+
+/** A slice timer: cheap while the slice has time left, yields once it doesn't. */
+function frameBudget(options: ScopedBuildOptions): Tick {
+  let deadline = performance.now() + SLICE_MS;
+  return async () => {
+    if (performance.now() < deadline) {
+      return true;
+    }
+    await options.yieldFrame();
+    deadline = performance.now() + SLICE_MS;
+    return !options.cancelled?.();
+  };
+}
+
 /**
  * A row in the scoped call tree. `duration` is attributed to the selection (see
  * {@link buildScopedCallTree}); `originalData` is the real event (used by the
@@ -33,43 +63,70 @@ export interface ScopedCallTree {
    *  it, so it sizes the bar columns once for the log instead of per selection —
    *  the widths then stay put as the selection changes. */
   logTotal: number;
-  /** The three views are built on first read and cached (only one is visible). */
-  readonly timeOrder: ScopedRow[];
-  readonly aggregated: ScopedRow[];
-  readonly bottomUp: ScopedRow[];
+  /** The three views, built on first call and cached (only one is on screen).
+   *  Each hands the frame back as it works, and returns null when abandoned. */
+  timeOrder(options: ScopedBuildOptions): Promise<ScopedRow[] | null>;
+  aggregated(options: ScopedBuildOptions): Promise<ScopedRow[] | null>;
+  bottomUp(options: ScopedBuildOptions): Promise<ScopedRow[] | null>;
 }
 
 /**
  * The selected node + its real subtree, with real durations. Zero-duration
  * bookkeeping rows (heap allocations, statements, assignments) are dropped —
  * the Inspector is a summary, and the Call Tree tab is where those details are
- * read. Returns null when the row is one of them; `keep` forces the selection
- * itself through, whatever its duration.
+ * read. The selection itself is kept whatever its duration, so null means the
+ * build was abandoned rather than "nothing worth showing".
+ *
+ * Iterative rather than recursive: subtree size is the second unbounded
+ * dimension (the occurrence count is the first), and both have to be sliceable.
  */
-function realSubtree(event: LogEvent, keep = false): ScopedRow | null {
-  const row: ScopedRow = {
-    id: event.eventIndex,
-    originalData: event,
-    text: event.text,
-    type: event.type ?? '',
-    duration: { total: event.duration.total, self: event.duration.self },
-    callCount: 1,
-    _children: null,
-  };
-
-  const children: ScopedRow[] = [];
-  for (const kid of event.children) {
-    const child = realSubtree(kid);
-    if (child) {
-      children.push(child);
+async function realSubtree(event: LogEvent, tick: Tick): Promise<ScopedRow | null> {
+  // Pre-order, so a node always precedes its descendants and the prune below
+  // can walk it backwards to reach every child before its parent.
+  const rows: ScopedRow[] = [];
+  const parents: Array<ScopedRow | null> = [];
+  const stack: Array<{ event: LogEvent; parent: ScopedRow | null }> = [{ event, parent: null }];
+  let steps = 0;
+  while (stack.length) {
+    if (steps++ % CHECK_EVERY === 0 && !(await tick())) {
+      return null;
+    }
+    const { event: current, parent } = stack.pop()!;
+    const row: ScopedRow = {
+      id: current.eventIndex,
+      originalData: current,
+      text: current.text,
+      type: current.type ?? '',
+      duration: { total: current.duration.total, self: current.duration.self },
+      callCount: 1,
+      _children: null,
+    };
+    rows.push(row);
+    parents.push(parent);
+    for (let i = current.children.length - 1; i >= 0; i--) {
+      stack.push({ event: current.children[i]!, parent: row });
     }
   }
-  row._children = children.length ? children : null;
-  // Post-order: a zero-duration frame stays only as the path to a kept
-  // descendant, or because its type reports limits rather than time.
-  const significant =
-    keep || row.duration.total > 0 || children.length > 0 || EXCLUDED_DETAIL_TYPES.has(row.type);
-  return significant ? row : null;
+
+  for (let i = rows.length - 1; i >= 0; i--) {
+    if (i % CHECK_EVERY === 0 && !(await tick())) {
+      return null;
+    }
+    const row = rows[i]!;
+    // Deepest first, so every child has attached itself by now — appended in
+    // reverse, hence the flip.
+    row._children?.reverse();
+    if (i === 0) {
+      break; // the selection stays whatever its duration
+    }
+    // A zero-duration frame stays only as the path to a kept descendant, or
+    // because its type reports limits rather than time.
+    if (row.duration.total > 0 || row._children || EXCLUDED_DETAIL_TYPES.has(row.type)) {
+      const parent = parents[i]!;
+      (parent._children ??= []).push(row);
+    }
+  }
+  return rows[0]!;
 }
 
 /**
@@ -79,11 +136,18 @@ function realSubtree(event: LogEvent, keep = false): ScopedRow | null {
  * `self = 0`) so the selection's cost reads "all the way down"; the selected
  * node and its descendants keep their real durations. Returns the three views
  * (time-order / aggregated / bottom-up) or null when nothing is selected.
+ *
+ * An aggregate selection scopes to every occurrence, and a frame can occur tens
+ * of thousands of times, so the walk is sliced: it hands the frame back through
+ * `options.yieldFrame` rather than blocking on the whole selection at once.
+ * Nothing is capped or sampled — every occurrence is counted, just not all in
+ * one frame.
  */
-export function buildScopedCallTree(
+export async function buildScopedCallTree(
   eventIndex: number,
-  instances?: number[] | null,
-): ScopedCallTree | null {
+  instances: number[] | null | undefined,
+  options: ScopedBuildOptions,
+): Promise<ScopedCallTree | null> {
   const db = DatabaseAccess.instance();
   const apexLog = db?.getApexLog();
   if (!db || !apexLog) {
@@ -106,11 +170,18 @@ export function buildScopedCallTree(
   // Wrap each occurrence in its ancestor chain, innermost first, attributing that
   // occurrence's total up its path with no self time. Aggregation then merges
   // paths that share frames.
-  const roots = selectedEvents.map((selected) => {
-    // The selection and the path to it are the point of the view, so they show
-    // even when the selection itself has no duration (e.g. a variable scope) —
-    // `keep` is what makes this non-null.
-    let node = realSubtree(selected, true)!;
+  const tick = frameBudget(options);
+  const roots: ScopedRow[] = [];
+  for (let i = 0; i < selectedEvents.length; i++) {
+    if (i % CHECK_EVERY === 0 && !(await tick())) {
+      return null;
+    }
+    const selected = selectedEvents[i]!;
+    const subtree = await realSubtree(selected, tick);
+    if (!subtree) {
+      return null;
+    }
+    let node = subtree;
     let parent = selected.parent;
     while (parent && parent !== apexLog) {
       node = {
@@ -124,43 +195,53 @@ export function buildScopedCallTree(
       };
       parent = parent.parent;
     }
-    return node;
-  });
+    roots.push(node);
+  }
 
   // Only one view is on screen, so build each on first read and cache it —
   // aggregate()/buildBottomUp() are full walks of every retained subtree.
-  let timeOrder: ScopedRow[] | null = null;
-  let aggregated: ScopedRow[] | null = null;
-  let bottomUp: ScopedRow[] | null = null;
+  let timeOrderRows: ScopedRow[] | null = null;
+  let aggregatedRows: ScopedRow[] | null = null;
+  let bottomUpRows: ScopedRow[] | null = null;
   return {
     rootTotal,
     logTotal: apexLog.duration.total,
-    get timeOrder(): ScopedRow[] {
+    async timeOrder(viewOptions) {
       // Many occurrences usually share ancestors, so merge the paths for a
       // readable tree; a single occurrence keeps its exact chain.
-      timeOrder ??= roots.length > 1 ? aggregate(roots) : roots;
-      return timeOrder;
+      timeOrderRows ??= roots.length > 1 ? await aggregate(roots, viewOptions) : roots;
+      return timeOrderRows;
     },
-    get aggregated(): ScopedRow[] {
-      aggregated ??= aggregate(roots);
-      return aggregated;
+    async aggregated(viewOptions) {
+      aggregatedRows ??= await aggregate(roots, viewOptions);
+      return aggregatedRows;
     },
-    get bottomUp(): ScopedRow[] {
-      bottomUp ??= buildBottomUp(roots);
-      return bottomUp;
+    async bottomUp(viewOptions) {
+      bottomUpRows ??= await buildBottomUp(roots, viewOptions);
+      return bottomUpRows;
     },
   };
 }
 
 /** Top-down aggregation: merge sibling frames sharing a key, summing metrics. */
-function aggregate(rows: ScopedRow[]): ScopedRow[] {
+async function aggregate(
+  rows: ScopedRow[],
+  options: ScopedBuildOptions,
+): Promise<ScopedRow[] | null> {
+  const tick = frameBudget(options);
   let idSeq = 0;
   const nextId = () => (idSeq -= 1);
 
-  function merge(input: ScopedRow[]): ScopedRow[] {
+  // The recursion follows the call depth, which is shallow; each level's input
+  // is the wide dimension, so that is where the slicing goes.
+  async function merge(input: ScopedRow[]): Promise<ScopedRow[] | null> {
     const groups = new Map<string, ScopedRow>();
     const order: string[] = [];
-    for (const row of input) {
+    for (let i = 0; i < input.length; i++) {
+      if (i % CHECK_EVERY === 0 && !(await tick())) {
+        return null;
+      }
+      const row = input[i]!;
       const key = frameKey(row.originalData);
       let group = groups.get(key);
       if (!group) {
@@ -183,12 +264,23 @@ function aggregate(rows: ScopedRow[]): ScopedRow[] {
         (group._children as ScopedRow[]).push(...row._children);
       }
     }
-    return order.map((key) => {
+
+    const merged: ScopedRow[] = [];
+    for (const key of order) {
       const group = groups.get(key)!;
       const kids = group._children as ScopedRow[];
-      group._children = kids.length ? merge(kids) : null;
-      return group;
-    });
+      if (kids.length) {
+        const mergedKids = await merge(kids);
+        if (!mergedKids) {
+          return null;
+        }
+        group._children = mergedKids;
+      } else {
+        group._children = null;
+      }
+      merged.push(group);
+    }
+    return merged;
   }
 
   return merge(rows);
@@ -203,11 +295,16 @@ interface BottomUpNode extends ScopedRow {
  * and its callers nest beneath it up to the root — the reverse of the call
  * path, with the seed's self time attributed to every caller as `total`.
  */
-function buildBottomUp(rows: ScopedRow[]): ScopedRow[] {
+async function buildBottomUp(
+  rows: ScopedRow[],
+  options: ScopedBuildOptions,
+): Promise<ScopedRow[] | null> {
+  const tick = frameBudget(options);
   let idSeq = 0;
   const nextId = () => (idSeq -= 1);
   const topMap = new Map<string, BottomUpNode>();
   const topOrder: BottomUpNode[] = [];
+  const everyNode: BottomUpNode[] = [];
 
   const ensure = (map: Map<string, BottomUpNode>, order: BottomUpNode[] | null, src: ScopedRow) => {
     const key = frameKey(src.originalData);
@@ -225,50 +322,58 @@ function buildBottomUp(rows: ScopedRow[]): ScopedRow[] {
       };
       map.set(key, node);
       order?.push(node);
+      everyNode.push(node);
     }
     return node;
   };
 
-  function walk(list: ScopedRow[], path: ScopedRow[]) {
-    for (const row of list) {
-      if (row.duration.self > 0) {
-        // Callee first, then its callers up to the root.
-        const chain = [row, ...path.slice().reverse()];
-        let map = topMap;
-        let order: BottomUpNode[] | null = topOrder;
-        for (let i = 0; i < chain.length; i++) {
-          const node = ensure(map, order, chain[i]!);
-          node.duration.total += row.duration.self;
-          // Callers count the call they contributed too, matching the Call Tree
-          // tab's bottom-up (every bucket in the chain accumulates); counting
-          // only the seed left every caller row reading "Calls 0".
-          node.callCount += 1;
-          if (i === 0) {
-            node.duration.self += row.duration.self;
-          }
-          map = node._map;
-          order = null;
+  // Iterative pre-order over every occurrence's subtree: both the occurrence
+  // count and the subtree size grow, so one flat sliceable loop covers both.
+  const stack: Array<{ row: ScopedRow; path: ScopedRow[] }> = [];
+  for (let i = rows.length - 1; i >= 0; i--) {
+    stack.push({ row: rows[i]!, path: [] });
+  }
+  let steps = 0;
+  while (stack.length) {
+    if (steps++ % CHECK_EVERY === 0 && !(await tick())) {
+      return null;
+    }
+    const { row, path } = stack.pop()!;
+    if (row.duration.self > 0) {
+      // Callee first, then its callers up to the root.
+      const chain = [row, ...path.slice().reverse()];
+      let map = topMap;
+      let order: BottomUpNode[] | null = topOrder;
+      for (let i = 0; i < chain.length; i++) {
+        const node = ensure(map, order, chain[i]!);
+        node.duration.total += row.duration.self;
+        // Callers count the call they contributed too, matching the Call Tree
+        // tab's bottom-up (every bucket in the chain accumulates); counting
+        // only the seed left every caller row reading "Calls 0".
+        node.callCount += 1;
+        if (i === 0) {
+          node.duration.self += row.duration.self;
         }
+        map = node._map;
+        order = null;
       }
-      if (row._children) {
-        walk(row._children, [...path, row]);
+    }
+    if (row._children) {
+      const childPath = [...path, row];
+      for (let i = row._children.length - 1; i >= 0; i--) {
+        stack.push({ row: row._children[i]!, path: childPath });
       }
     }
   }
-  walk(rows, []);
 
-  const finalize = (node: BottomUpNode): ScopedRow => {
-    const children = [...node._map.values()].map(finalize);
-    return {
-      id: node.id,
-      originalData: node.originalData,
-      text: node.text,
-      type: node.type,
-      duration: node.duration,
-      callCount: node.callCount,
-      _children: children.length ? children : null,
-    };
-  };
-
-  return topOrder.map(finalize).sort((a, b) => b.duration.self - a.duration.self);
+  // The nodes are already ScopedRows; publishing each caller map as `_children`
+  // in place saves a second tree's worth of allocation.
+  for (let i = 0; i < everyNode.length; i++) {
+    if (i % CHECK_EVERY === 0 && !(await tick())) {
+      return null;
+    }
+    const node = everyNode[i]!;
+    node._children = node._map.size ? [...node._map.values()] : null;
+  }
+  return topOrder.sort((a, b) => b.duration.self - a.duration.self);
 }


### PR DESCRIPTION
Part of #34.

Selecting a row with many occurrences made the Inspector feel stuck: `buildScopedCallTree()` ran
synchronously inside `CallTreeDetail.updated()`, before the panel had painted, so the first frame
after the click waited on the whole build.

`_showActive()` already yields a frame (`updateComplete` + `waitForNextFrame()`) and guards against
superseded switches with `_switchEpoch`. This moves the tree build to after that yield — `updated()`
now only tears the tables down and clears the cached tree, and `_showActive()` builds it lazily once
it knows it is still the current selection.

### Measured

19.7MB FINEST log, worst aggregate row (`System.currentTimeMillis()`, 34,857 occurrences), rAF
frame-gap sampling, 3 trials:

| | first frame after click | Σ frame gaps >33ms | longest frame |
| --- | --- | --- | --- |
| before | 133 / 9 / 6 ms | 216 / 184 / 183 ms | 134 / 100 / 100 ms |
| after | 4 / 15 / 8 ms | 201 / 183 / 183 ms | 134 / 116 / 117 ms |

To be clear about what this does and does not do: it fixes the cold-path paint (133ms → 4ms) and
lets superseded selections skip the build entirely. **Total main-thread work is unchanged** — a
~120ms frame still lands after the paint, so #34 stays open. The follow-up is updating the tables
in place instead of rebuilding them, then taking the build itself off the blocking frame; no
occurrence capping or sampling, the figures need to stay truthful.

### Tests

- `scopedCallTree.test.ts` — a 500-occurrence aggregate fixture.
- `LogInspector.test.ts` — a stale-epoch selection does not apply its build.