### PR TITLE
feat(inspector): reveal the selected row in the active tab's view

### DIFF
--- a/log-viewer/src/components/CallStackDetail.ts
+++ b/log-viewer/src/components/CallStackDetail.ts
@@ -20,6 +20,7 @@ import dataGridStyles from '../tabulator/style/DataGrid.scss';
 import { buildCallStackData, type CallStackRow } from './callStackData.js';
 import './ContextMenu.js';
 import type { ContextMenu } from './ContextMenu.js';
+import { dispatchInspectorReveal } from './inspectorReveal.js';
 import { PANEL_ROW_MENU_ITEMS, runPanelRowAction } from './panelRowMenu.js';
 
 /**
@@ -149,6 +150,14 @@ export class CallStackDetail extends LitElement {
     // right-click action. The call stack is flat, so there is nothing to toggle.
     this._table.on('rowContext', (e, row) => {
       this._showRowMenu(e as MouseEvent, row);
+    });
+    // Selecting a frame reveals it in the tab on screen; the inspector adds the
+    // source, since only it knows which tab that is.
+    this._table.on('rowSelectionChanged', (_data, rows) => {
+      const eventIndex = (rows[0]?.getData() as CallStackRow | undefined)?.eventIndex;
+      if (eventIndex !== undefined) {
+        dispatchInspectorReveal(this, eventIndex);
+      }
     });
   }
 

--- a/log-viewer/src/components/CallTreeDetail.ts
+++ b/log-viewer/src/components/CallTreeDetail.ts
@@ -30,8 +30,14 @@ import { progressColumnWidth } from '../tabulator/format/measureWidth.js';
 import dataGridStyles from '../tabulator/style/DataGrid.scss';
 import './ContextMenu.js';
 import type { ContextMenu } from './ContextMenu.js';
+import { dispatchInspectorReveal } from './inspectorReveal.js';
 import { PANEL_ROW_MENU_ITEMS, runPanelRowAction } from './panelRowMenu.js';
-import { buildScopedCallTree, type ScopedCallTree } from './scopedCallTree.js';
+import {
+  buildScopedCallTree,
+  revealableEventIndex,
+  type ScopedCallTree,
+  type ScopedRow,
+} from './scopedCallTree.js';
 import './ViewModeSwitch.js';
 import type { ViewModeOption } from './ViewModeSwitch.js';
 
@@ -300,6 +306,15 @@ export class CallTreeDetail extends LitElement {
     });
     table.on('rowContext', (e, row) => {
       this._showRowMenu(e as MouseEvent, row, table);
+    });
+    // Selecting a real frame reveals it in the tab on screen. Aggregated and
+    // bottom-up rows merge occurrences behind a synthetic negative id, so
+    // revealing one would misname which occurrence was clicked.
+    table.on('rowSelectionChanged', (_data, rows) => {
+      const eventIndex = revealableEventIndex(rows[0]?.getData() as Partial<ScopedRow> | undefined);
+      if (eventIndex !== null) {
+        dispatchInspectorReveal(this, eventIndex);
+      }
     });
     this._tables[mode] = table;
   }

--- a/log-viewer/src/components/LogInspector.ts
+++ b/log-viewer/src/components/LogInspector.ts
@@ -5,6 +5,7 @@ import { LitElement, css, html, type PropertyValues } from 'lit';
 import { customElement, property, state } from 'lit/decorators.js';
 
 import { type DetailSelection, type DetailSource, eventBus } from '../core/events/EventBus.js';
+import type { InspectorRevealEvent } from './inspectorReveal.js';
 import { debounce } from '../core/utility/Util.js';
 import { getSettings, updateSetting } from '../features/settings/Settings.js';
 import { buildDetailSections } from './detailSections.js';
@@ -142,6 +143,7 @@ export class LogInspector extends LitElement {
         @dock-collapse=${this._hidePanel}
         @pane-toggle=${this._onPaneToggle}
         @pane-resize=${this._onPaneResize}
+        @inspector-reveal=${this._onReveal}
       >
         <slot slot="main" name="main"></slot>
       </dock-layout>
@@ -166,6 +168,18 @@ export class LogInspector extends LitElement {
       this._scheduleRebuild();
     }
   }
+
+  /**
+   * An inspector row asks to be revealed. Only the active tab's own view acts on
+   * it, so the source is stamped here - a call-tree selection must never move
+   * the timeline.
+   */
+  private _onReveal = (e: InspectorRevealEvent): void => {
+    const source = this._activeSource;
+    if (source) {
+      eventBus.emit('inspector:reveal', { source, eventIndex: e.detail.eventIndex });
+    }
+  };
 
   private _onToggle(detail: { visible?: boolean }): void {
     this._setVisible(detail.visible ?? !this._visible);

--- a/log-viewer/src/components/__tests__/CallStackDetail.test.ts
+++ b/log-viewer/src/components/__tests__/CallStackDetail.test.ts
@@ -12,13 +12,17 @@ jest.mock('../../tabulator/format/Progress.css', () => ({}));
 // Capture the options the component hands to Tabulator. The real ESM build (and
 // its module registrations) doesn't load under jest.
 const built: Record<string, unknown>[] = [];
+type TableHandler = (...args: unknown[]) => void;
+const handlers: Record<string, TableHandler> = {};
 jest.mock('tabulator-tables', () => ({
   Tabulator: class {
     static registerModule() {}
     constructor(_el: HTMLElement, options: Record<string, unknown>) {
       built.push(options);
     }
-    on() {}
+    on(event: string, handler: TableHandler) {
+      handlers[event] = handler;
+    }
     destroy() {}
     getSelectedRows() {
       return [];
@@ -35,6 +39,7 @@ jest.mock('../callStackData.js', () => ({
 
 import type { CallStackDetail } from '../CallStackDetail.js';
 import '../CallStackDetail.js';
+import { INSPECTOR_REVEAL_EVENT, type InspectorRevealEvent } from '../inspectorReveal.js';
 
 async function mount(eventIndex: number): Promise<CallStackDetail> {
   const el = document.createElement('call-stack-detail') as CallStackDetail;
@@ -69,5 +74,18 @@ describe('CallStackDetail', () => {
     const options = built.at(-1);
     expect(options?.selectableRows).toBe('highlight');
     expect(options?.rowKeyboardNavigation).toBe(true);
+  });
+
+  it('asks the inspector to reveal the frame the selection landed on', async () => {
+    const el = await mount(4);
+
+    const seen: number[] = [];
+    document.addEventListener(INSPECTOR_REVEAL_EVENT, (e) => {
+      seen.push((e as InspectorRevealEvent).detail.eventIndex);
+    });
+    handlers.rowSelectionChanged?.([], [{ getData: () => ({ eventIndex: 11 }) }]);
+
+    expect(seen).toEqual([11]);
+    el.remove();
   });
 });

--- a/log-viewer/src/components/__tests__/LogInspector.test.ts
+++ b/log-viewer/src/components/__tests__/LogInspector.test.ts
@@ -46,6 +46,7 @@ import { eventBus } from '../../core/events/EventBus.js';
 import type { LogInspector } from '../LogInspector.js';
 import type { PaneView } from '../PaneView.js';
 import '../LogInspector.js';
+import { dispatchInspectorReveal } from '../inspectorReveal.js';
 
 /**
  * Settles the rAF-debounced rebuild, the async section build and the render.
@@ -74,6 +75,15 @@ function paneView(el: LogInspector): PaneView {
     ?.shadowRoot?.querySelector<PaneView>('pane-view');
   if (!found) {
     throw new Error('pane-view not rendered');
+  }
+  return found;
+}
+
+/** The reveal listener sits on `dock-layout`, which renders whether or not a row is selected. */
+function dockLayout(el: LogInspector): HTMLElement {
+  const found = el.shadowRoot?.querySelector<HTMLElement>('dock-layout');
+  if (!found) {
+    throw new Error('dock-layout not rendered');
   }
   return found;
 }
@@ -192,5 +202,27 @@ describe('LogInspector', () => {
     // The stored `visible: false` and `collapsed` don't undo either action.
     expect(visible(el)).toBe(true);
     expect(paneView(el).collapsed).toEqual({ vitals: true });
+  });
+
+  it('stamps the active tab on a reveal, so only that tab acts on it', async () => {
+    const el = await mount('tree-tab');
+
+    const seen: Array<{ source: string; eventIndex: number }> = [];
+    const off = eventBus.on('inspector:reveal', (d) => seen.push(d));
+    dispatchInspectorReveal(dockLayout(el), 5);
+    off();
+
+    expect(seen).toEqual([{ source: 'calltree', eventIndex: 5 }]);
+  });
+
+  it('drops a reveal from a tab with no inspectable view', async () => {
+    const el = await mount('unknown-tab');
+
+    const seen: unknown[] = [];
+    const off = eventBus.on('inspector:reveal', (d) => seen.push(d));
+    dispatchInspectorReveal(dockLayout(el), 5);
+    off();
+
+    expect(seen).toEqual([]);
   });
 });

--- a/log-viewer/src/components/__tests__/inspectorReveal.test.ts
+++ b/log-viewer/src/components/__tests__/inspectorReveal.test.ts
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2026 Certinia Inc. All rights reserved.
+ *
+ * @jest-environment jsdom
+ */
+import { describe, expect, it } from '@jest/globals';
+
+import type { LogEvent } from 'apex-log-parser';
+
+import {
+  dispatchInspectorReveal,
+  INSPECTOR_REVEAL_EVENT,
+  type InspectorRevealEvent,
+} from '../inspectorReveal.js';
+import { revealableEventIndex, type ScopedRow } from '../scopedCallTree.js';
+
+function scopedRow(id: number, eventIndex: number): Partial<ScopedRow> {
+  return { id, originalData: { eventIndex } as LogEvent };
+}
+
+describe('dispatchInspectorReveal', () => {
+  it('raises a composed event that escapes the section shadow root', () => {
+    const host = document.createElement('div');
+    const shadow = host.attachShadow({ mode: 'open' });
+    const section = document.createElement('div');
+    shadow.appendChild(section);
+    document.body.appendChild(host);
+
+    const seen: number[] = [];
+    document.addEventListener(INSPECTOR_REVEAL_EVENT, (e) => {
+      seen.push((e as InspectorRevealEvent).detail.eventIndex);
+    });
+
+    dispatchInspectorReveal(section, 42);
+
+    expect(seen).toEqual([42]);
+  });
+});
+
+describe('revealableEventIndex', () => {
+  it('reveals a real row by its own event', () => {
+    expect(revealableEventIndex(scopedRow(3, 17))).toBe(17);
+  });
+
+  it('reveals nothing for a merged row, whose id is synthetic and negative', () => {
+    expect(revealableEventIndex(scopedRow(-1, 17))).toBeNull();
+  });
+
+  it('reveals nothing when there is no row', () => {
+    expect(revealableEventIndex(undefined)).toBeNull();
+  });
+});

--- a/log-viewer/src/components/inspectorReveal.ts
+++ b/log-viewer/src/components/inspectorReveal.ts
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2026 Certinia Inc. All rights reserved.
+ */
+
+/** Name of the DOM event an inspector section raises to reveal one of its rows. */
+export const INSPECTOR_REVEAL_EVENT = 'inspector-reveal';
+
+export type InspectorRevealEvent = CustomEvent<{ eventIndex: number }>;
+
+/**
+ * Ask the inspector to reveal `eventIndex` in the tab on screen. A composed DOM
+ * event rather than an `eventBus` emit: only {@link LogInspector} knows which
+ * tab is active, so it is the one that puts the source on the bus event.
+ */
+export function dispatchInspectorReveal(source: HTMLElement, eventIndex: number): void {
+  source.dispatchEvent(
+    new CustomEvent(INSPECTOR_REVEAL_EVENT, {
+      detail: { eventIndex },
+      bubbles: true,
+      composed: true,
+    }),
+  );
+}

--- a/log-viewer/src/components/scopedCallTree.ts
+++ b/log-viewer/src/components/scopedCallTree.ts
@@ -26,6 +26,16 @@ export interface ScopedRow {
   _children: ScopedRow[] | null;
 }
 
+/**
+ * The event a scoped row reveals, or null when it merges occurrences. Aggregated
+ * and bottom-up rows carry a synthetic negative id and keep only the first
+ * occurrence, so revealing one would misname which occurrence was clicked.
+ */
+export function revealableEventIndex(row: Partial<ScopedRow> | undefined): number | null {
+  const { id, originalData } = row ?? {};
+  return id !== undefined && id >= 0 && originalData ? originalData.eventIndex : null;
+}
+
 export interface ScopedCallTree {
   /** The selected node's total time (ns) — the % denominator for the bars. */
   rootTotal: number;

--- a/log-viewer/src/core/events/EventBus.ts
+++ b/log-viewer/src/core/events/EventBus.ts
@@ -32,6 +32,12 @@ interface EventMap {
 
   // App-level request to show/hide (or force a state on) the inspector.
   'detail:toggle': { visible?: boolean };
+
+  // A row was picked inside the inspector — reveal that event in the tab the
+  // inspector is currently showing, never in another tab: `source` is the active
+  // tab and only that view acts. Strictly outbound from the inspector, as
+  // `detail:select` is strictly inbound to it; separate events stop an echo loop.
+  'inspector:reveal': { source: DetailSource; eventIndex: number };
 }
 
 type EventCallback<K extends keyof EventMap> = (detail: EventMap[K]) => void;

--- a/log-viewer/src/core/events/SelectionEchoGuard.ts
+++ b/log-viewer/src/core/events/SelectionEchoGuard.ts
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2026 Certinia Inc. All rights reserved.
+ */
+
+/**
+ * Marks the window in which a view selects a row on the inspector's behalf, so
+ * the view can skip the `detail:select` it would otherwise emit and send the
+ * inspector back the very selection it asked for.
+ *
+ * Needed because neither consumer offers a silent select: tabulator fires
+ * `rowSelectionChanged` for a programmatic `row.select()`, and the flame chart
+ * re-emits through `SelectionOrchestrator.selectFrame`.
+ */
+export class SelectionEchoGuard {
+  private _active = false;
+
+  /** True while a programmatic select is in flight - do not emit `detail:select`. */
+  get suppressed(): boolean {
+    return this._active;
+  }
+
+  /** Runs a synchronous select with echoes suppressed. */
+  run<T>(select: () => T): T {
+    this._active = true;
+    try {
+      return select();
+    } finally {
+      this._active = false;
+    }
+  }
+
+  /** Runs an asynchronous select with echoes suppressed until it settles. */
+  async runAsync<T>(select: () => Promise<T>): Promise<T> {
+    this._active = true;
+    try {
+      return await select();
+    } finally {
+      this._active = false;
+    }
+  }
+}

--- a/log-viewer/src/core/events/__tests__/SelectionEchoGuard.test.ts
+++ b/log-viewer/src/core/events/__tests__/SelectionEchoGuard.test.ts
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2026 Certinia Inc. All rights reserved.
+ */
+import { describe, expect, it } from '@jest/globals';
+
+import { SelectionEchoGuard } from '../SelectionEchoGuard.js';
+
+describe('SelectionEchoGuard', () => {
+  it('suppresses only while the select runs', () => {
+    const guard = new SelectionEchoGuard();
+    const during: boolean[] = [];
+
+    expect(guard.suppressed).toBe(false);
+    const result = guard.run(() => {
+      during.push(guard.suppressed);
+      return 'selected';
+    });
+
+    expect(during).toEqual([true]);
+    expect(result).toBe('selected');
+    expect(guard.suppressed).toBe(false);
+  });
+
+  it('suppresses until an async select settles', async () => {
+    const guard = new SelectionEchoGuard();
+    let settle: (() => void) | null = null;
+
+    const pending = guard.runAsync(() => new Promise<void>((resolve) => (settle = resolve)));
+    expect(guard.suppressed).toBe(true);
+
+    settle!(); // set synchronously by the promise executor above
+    await pending;
+    expect(guard.suppressed).toBe(false);
+  });
+
+  it('stops suppressing when the select throws', () => {
+    const guard = new SelectionEchoGuard();
+
+    expect(() =>
+      guard.run(() => {
+        throw new Error('no such row');
+      }),
+    ).toThrow('no such row');
+    expect(guard.suppressed).toBe(false);
+  });
+});

--- a/log-viewer/src/features/analysis/components/AnalysisView.ts
+++ b/log-viewer/src/features/analysis/components/AnalysisView.ts
@@ -560,6 +560,9 @@ export class AnalysisView extends LitElement {
 
     // Feed the inspector. Analysis rows merge many calls, so they
     // scope to every occurrence of the method.
+    // No `inspector:reveal` subscription here on purpose: analysis rows are
+    // aggregates keyed by type|namespace|text, so an eventIndex only resolves
+    // back to the whole bucket - which is already the selected row.
     this.analysisTable.on('rowSelectionChanged', (_data, rows) => {
       const data = rows[0]?.getData() as BottomUpRow | undefined;
       const event = data?.originalData;

--- a/log-viewer/src/features/call-tree/components/CalltreeView.ts
+++ b/log-viewer/src/features/call-tree/components/CalltreeView.ts
@@ -12,6 +12,7 @@ import type { RowComponent, Tabulator } from 'tabulator-tables';
 
 import type { ApexLog, LogEvent } from 'apex-log-parser';
 import { eventBus, type DetailSource } from '../../../core/events/EventBus.js';
+import { SelectionEchoGuard } from '../../../core/events/SelectionEchoGuard.js';
 import { vscodeMessenger } from '../../../core/messaging/VSCodeExtensionMessenger.js';
 import { findEventByEventIndex } from '../../../core/utility/EventSearch.js';
 import { isVisible } from '../../../core/utility/Util.js';
@@ -149,9 +150,20 @@ export class CalltreeView extends LitElement {
     this._goToRow(e.detail.eventIndex);
   }) as EventListener;
 
+  /** Guards the programmatic select made on the inspector's behalf. */
+  private _echoGuard = new SelectionEchoGuard();
+  private _inspectorRevealUnsubscribe: (() => void) | null = null;
+
   constructor() {
     super();
 
+    // Reveal an inspector row here, but only while the Call Tree is the tab the
+    // inspector is showing.
+    this._inspectorRevealUnsubscribe = eventBus.on('inspector:reveal', (detail) => {
+      if (detail.source === 'calltree') {
+        void this._revealEventIndex(detail.eventIndex);
+      }
+    });
     document.addEventListener(CALLTREE_GO_TO_ROW, this._goToRowEvt);
     document.addEventListener('lv-find', this._findEvt);
     document.addEventListener('lv-find-match', this._findEvt);
@@ -169,6 +181,8 @@ export class CalltreeView extends LitElement {
     document.removeEventListener('lv-find', this._findEvt);
     document.removeEventListener('lv-find-match', this._findEvt);
     document.removeEventListener('lv-find-close', this._findEvt);
+    this._inspectorRevealUnsubscribe?.();
+    this._inspectorRevealUnsubscribe = null;
     this._destroyCurrentTable();
   }
 
@@ -829,6 +843,27 @@ export class CalltreeView extends LitElement {
     await this.calltreeTable.goToRow(treeRow, { scrollIfVisible: true, focusRow: true });
   }
 
+  /**
+   * Select the row for `eventIndex` in place: no tab switch, no view-mode change
+   * and no focus steal, unlike {@link _goToRow}. Only Time Order has a row per
+   * event, so the grouped modes are left alone.
+   */
+  private async _revealEventIndex(eventIndex: number): Promise<void> {
+    if (this.viewMode !== 'time-order' || !this.calltreeTable) {
+      return;
+    }
+
+    const treeRow = await this._findByEventIndex(this.calltreeTable.getRows(), eventIndex);
+    if (!treeRow) {
+      return;
+    }
+
+    await this._echoGuard.runAsync(() =>
+      //@ts-expect-error This is a custom function added in by RowNavigation custom module
+      this.calltreeTable.goToRow(treeRow, { scrollIfVisible: false, focusRow: false }),
+    );
+  }
+
   async _find(e: CustomEvent<{ text: string; count: number; options: { matchCase: boolean } }>) {
     const activeTable = this._getActiveTable();
     const isTableVisible = !!activeTable?.element?.clientHeight;
@@ -1037,6 +1072,9 @@ export class CalltreeView extends LitElement {
    */
   private _emitDetailSelection(table: Tabulator, source: DetailSource = 'calltree'): void {
     table.on('rowSelectionChanged', (_data, rows) => {
+      if (this._echoGuard.suppressed) {
+        return;
+      }
       const data = rows[0]?.getData() as
         { originalData?: LogEvent; instances?: LogEvent[]; text?: string } | undefined;
       const event = data?.originalData;

--- a/log-viewer/src/features/database/__tests__/revealRow.test.ts
+++ b/log-viewer/src/features/database/__tests__/revealRow.test.ts
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2026 Certinia Inc. All rights reserved.
+ */
+import { describe, expect, it } from '@jest/globals';
+
+import type { Tabulator } from 'tabulator-tables';
+
+import { SelectionEchoGuard } from '../../../core/events/SelectionEchoGuard.js';
+import { selectRowByEventIndex } from '../components/revealRow.js';
+
+/** The slice of tabulator the helper touches: rows to scan, and a select on the match. */
+function fakeTable(eventIndexes: number[]): {
+  table: Tabulator;
+  selected: number[];
+  deselects: number;
+} {
+  const selected: number[] = [];
+  const state = { deselects: 0 };
+  const rows = eventIndexes.map((eventIndex) => ({
+    getData: () => ({ eventIndex }),
+    select: () => selected.push(eventIndex),
+  }));
+  const table = {
+    getRows: () => rows,
+    deselectRow: () => (state.deselects += 1),
+  } as unknown as Tabulator;
+
+  return {
+    table,
+    selected,
+    get deselects() {
+      return state.deselects;
+    },
+  };
+}
+
+describe('selectRowByEventIndex', () => {
+  it('selects the row that owns the event, clearing the previous one', () => {
+    const grid = fakeTable([4, 9]);
+    const guard = new SelectionEchoGuard();
+
+    expect(selectRowByEventIndex(grid.table, guard, 9)).toBe(true);
+    expect(grid.selected).toEqual([9]);
+    expect(grid.deselects).toBe(1);
+  });
+
+  it('leaves a grid that does not own the event untouched', () => {
+    const grid = fakeTable([4, 9]);
+    const guard = new SelectionEchoGuard();
+
+    expect(selectRowByEventIndex(grid.table, guard, 7)).toBe(false);
+    expect(grid.selected).toEqual([]);
+    expect(grid.deselects).toBe(0);
+  });
+
+  it('suppresses the echo while it selects, so the inspector is not sent its own selection', () => {
+    const guard = new SelectionEchoGuard();
+    const during: boolean[] = [];
+    const table = {
+      getRows: () => [{ getData: () => ({ eventIndex: 1 }), select: () => {} }],
+      deselectRow: () => during.push(guard.suppressed),
+    } as unknown as Tabulator;
+
+    selectRowByEventIndex(table, guard, 1);
+
+    expect(during).toEqual([true]);
+    expect(guard.suppressed).toBe(false);
+  });
+
+  it('reveals nothing when the grid has no table yet', () => {
+    expect(selectRowByEventIndex(null, new SelectionEchoGuard(), 1)).toBe(false);
+  });
+});

--- a/log-viewer/src/features/database/components/DMLView.ts
+++ b/log-viewer/src/features/database/components/DMLView.ts
@@ -16,6 +16,7 @@ import { getCallerNamespace } from '../../../core/utility/CallerNamespace.js';
 import { goToRow } from '../../call-tree/navigation.js';
 import { isVisible } from '../../../core/utility/Util.js';
 import { getSettings, updateSetting } from '../../settings/Settings.js';
+import { selectRowByEventIndex } from './revealRow.js';
 import {
   applyColumnView,
   buildColumnMenuItems,
@@ -443,19 +444,7 @@ export class DMLView extends LitElement {
    * inspector that asked for it. Returns false when this grid has no such row.
    */
   selectByEventIndex(eventIndex: number): boolean {
-    // The tabulator index is a synthetic row id, so the eventIndex is scanned for.
-    const match = this.dmlTable
-      ?.getRows()
-      .find((candidate) => (candidate.getData() as DMLRow).eventIndex === eventIndex);
-    if (!match) {
-      return false;
-    }
-
-    this._echoGuard.run(() => {
-      this.dmlTable?.deselectRow();
-      match.select();
-    });
-    return true;
+    return selectRowByEventIndex(this.dmlTable, this._echoGuard, eventIndex);
   }
 
   _exportToCSV() {

--- a/log-viewer/src/features/database/components/DMLView.ts
+++ b/log-viewer/src/features/database/components/DMLView.ts
@@ -10,6 +10,7 @@ import { Tabulator, type GroupComponent, type RowComponent } from 'tabulator-tab
 
 import type { ApexLog, DMLBeginLine } from 'apex-log-parser';
 import { eventBus } from '../../../core/events/EventBus.js';
+import { SelectionEchoGuard } from '../../../core/events/SelectionEchoGuard.js';
 import { vscodeMessenger } from '../../../core/messaging/VSCodeExtensionMessenger.js';
 import { getCallerNamespace } from '../../../core/utility/CallerNamespace.js';
 import { goToRow } from '../../call-tree/navigation.js';
@@ -86,6 +87,8 @@ export class DMLView extends LitElement {
 
   dmlTable: Tabulator | null = null;
   holder: HTMLElement | null = null;
+  /** Guards the programmatic select made on the inspector's behalf. */
+  private _echoGuard = new SelectionEchoGuard();
   table: HTMLElement | null = null;
   findArgs: { text: string; count: number; options: { matchCase: boolean } } = {
     text: '',
@@ -435,6 +438,26 @@ export class DMLView extends LitElement {
     this.dmlTable?.deselectRow();
   }
 
+  /**
+   * Select the row for `eventIndex`, without echoing `detail:select` back at the
+   * inspector that asked for it. Returns false when this grid has no such row.
+   */
+  selectByEventIndex(eventIndex: number): boolean {
+    // The tabulator index is a synthetic row id, so the eventIndex is scanned for.
+    const match = this.dmlTable
+      ?.getRows()
+      .find((candidate) => (candidate.getData() as DMLRow).eventIndex === eventIndex);
+    if (!match) {
+      return false;
+    }
+
+    this._echoGuard.run(() => {
+      this.dmlTable?.deselectRow();
+      match.select();
+    });
+    return true;
+  }
+
   _exportToCSV() {
     this.dmlTable?.download('csv', 'dml.csv', { bom: true, delimiter: ',' });
   }
@@ -687,6 +710,9 @@ export class DMLView extends LitElement {
     // navigation updates it too. RowKeyboardNavigation keeps a single row
     // selected across mouse and arrow-key navigation.
     this.dmlTable.on('rowSelectionChanged', (_data, rows) => {
+      if (this._echoGuard.suppressed) {
+        return;
+      }
       const data = rows[0]?.getData() as DMLRow | undefined;
       if (!data || data.eventIndex === undefined || !data.dml) {
         return;

--- a/log-viewer/src/features/database/components/DatabaseView.ts
+++ b/log-viewer/src/features/database/components/DatabaseView.ts
@@ -75,6 +75,7 @@ export class DatabaseView extends LitElement {
   findMap = {};
 
   private _offDetailSelect: (() => void) | null = null;
+  private _offInspectorReveal: (() => void) | null = null;
 
   constructor() {
     super();
@@ -101,6 +102,24 @@ export class DatabaseView extends LitElement {
         }
       }
     });
+
+    // Reveal an inspector row here, but only while the Database tab is the tab
+    // the inspector is showing. The eventIndex belongs to exactly one grid, so
+    // each is offered it in turn until one owns it.
+    this._offInspectorReveal = eventBus.on('inspector:reveal', (d) => {
+      if (d.source !== 'database') {
+        return;
+      }
+      const views = [this._dmlView, this._soqlView, this._soslView];
+      const owner = views.find((view) => view?.selectByEventIndex(d.eventIndex));
+      if (owner) {
+        for (const view of views) {
+          if (view !== owner) {
+            view?.deselectRows();
+          }
+        }
+      }
+    });
   }
 
   disconnectedCallback(): void {
@@ -110,6 +129,8 @@ export class DatabaseView extends LitElement {
     document.removeEventListener('lv-find', this._findHandler as EventListener);
     this._offDetailSelect?.();
     this._offDetailSelect = null;
+    this._offInspectorReveal?.();
+    this._offInspectorReveal = null;
   }
 
   updated(changed: PropertyValues): void {

--- a/log-viewer/src/features/database/components/DatabaseView.ts
+++ b/log-viewer/src/features/database/components/DatabaseView.ts
@@ -113,11 +113,7 @@ export class DatabaseView extends LitElement {
       const views = [this._dmlView, this._soqlView, this._soslView];
       const owner = views.find((view) => view?.selectByEventIndex(d.eventIndex));
       if (owner) {
-        for (const view of views) {
-          if (view !== owner) {
-            view?.deselectRows();
-          }
-        }
+        views.filter((view) => view !== owner).forEach((view) => view?.deselectRows());
       }
     });
   }

--- a/log-viewer/src/features/database/components/SOQLView.ts
+++ b/log-viewer/src/features/database/components/SOQLView.ts
@@ -15,6 +15,7 @@ import {
 
 import type { ApexLog, SOQLExecuteBeginLine } from 'apex-log-parser';
 import { eventBus } from '../../../core/events/EventBus.js';
+import { SelectionEchoGuard } from '../../../core/events/SelectionEchoGuard.js';
 import { vscodeMessenger } from '../../../core/messaging/VSCodeExtensionMessenger.js';
 import { isVisible } from '../../../core/utility/Util.js';
 import { getCallerNamespace } from '../../../core/utility/CallerNamespace.js';
@@ -101,6 +102,8 @@ export class SOQLView extends LitElement {
 
   soqlTable: Tabulator | null = null;
   holder: HTMLElement | null = null;
+  /** Guards the programmatic select made on the inspector's behalf. */
+  private _echoGuard = new SelectionEchoGuard();
   table: HTMLElement | null = null;
 
   @state()
@@ -451,6 +454,26 @@ export class SOQLView extends LitElement {
 
   deselectRows() {
     this.soqlTable?.deselectRow();
+  }
+
+  /**
+   * Select the row for `eventIndex`, without echoing `detail:select` back at the
+   * inspector that asked for it. Returns false when this grid has no such row.
+   */
+  selectByEventIndex(eventIndex: number): boolean {
+    // The tabulator index is a synthetic row id, so the eventIndex is scanned for.
+    const match = this.soqlTable
+      ?.getRows()
+      .find((candidate) => (candidate.getData() as GridSOQLData).eventIndex === eventIndex);
+    if (!match) {
+      return false;
+    }
+
+    this._echoGuard.run(() => {
+      this.soqlTable?.deselectRow();
+      match.select();
+    });
+    return true;
   }
 
   _exportToCSV() {
@@ -838,6 +861,9 @@ export class SOQLView extends LitElement {
     // navigation updates it too. RowKeyboardNavigation keeps a single row
     // selected across mouse and arrow-key navigation.
     this.soqlTable.on('rowSelectionChanged', (_data, rows) => {
+      if (this._echoGuard.suppressed) {
+        return;
+      }
       const data = rows[0]?.getData() as GridSOQLData | undefined;
       if (!data || data.eventIndex === undefined || !data.soql) {
         return;

--- a/log-viewer/src/features/database/components/SOQLView.ts
+++ b/log-viewer/src/features/database/components/SOQLView.ts
@@ -25,6 +25,7 @@ import { soqlGroupHeader } from '../../soql/format/groupHeader.js';
 import { soqlInlineElement } from '../../soql/format/inlineCell.js';
 import { soqlSyntaxStyles } from '../../soql/styles/soql-syntax.css.js';
 import { getSettings, updateSetting } from '../../settings/Settings.js';
+import { selectRowByEventIndex } from './revealRow.js';
 import {
   applyColumnView,
   buildColumnMenuItems,
@@ -461,19 +462,7 @@ export class SOQLView extends LitElement {
    * inspector that asked for it. Returns false when this grid has no such row.
    */
   selectByEventIndex(eventIndex: number): boolean {
-    // The tabulator index is a synthetic row id, so the eventIndex is scanned for.
-    const match = this.soqlTable
-      ?.getRows()
-      .find((candidate) => (candidate.getData() as GridSOQLData).eventIndex === eventIndex);
-    if (!match) {
-      return false;
-    }
-
-    this._echoGuard.run(() => {
-      this.soqlTable?.deselectRow();
-      match.select();
-    });
-    return true;
+    return selectRowByEventIndex(this.soqlTable, this._echoGuard, eventIndex);
   }
 
   _exportToCSV() {

--- a/log-viewer/src/features/database/components/SOSLView.ts
+++ b/log-viewer/src/features/database/components/SOSLView.ts
@@ -16,6 +16,7 @@ import { getCallerNamespace } from '../../../core/utility/CallerNamespace.js';
 import { goToRow } from '../../call-tree/navigation.js';
 import { isVisible } from '../../../core/utility/Util.js';
 import { getSettings, updateSetting } from '../../settings/Settings.js';
+import { selectRowByEventIndex } from './revealRow.js';
 import { soqlInlineElement } from '../../soql/format/inlineCell.js';
 import { soqlSyntaxStyles } from '../../soql/styles/soql-syntax.css.js';
 import {
@@ -754,19 +755,7 @@ export class SOSLView extends LitElement {
    * inspector that asked for it. Returns false when this grid has no such row.
    */
   selectByEventIndex(eventIndex: number): boolean {
-    // The tabulator index is a synthetic row id, so the eventIndex is scanned for.
-    const match = this.soslTable
-      ?.getRows()
-      .find((candidate) => (candidate.getData() as SOSLRow).eventIndex === eventIndex);
-    if (!match) {
-      return false;
-    }
-
-    this._echoGuard.run(() => {
-      this.soslTable?.deselectRow();
-      match.select();
-    });
-    return true;
+    return selectRowByEventIndex(this.soslTable, this._echoGuard, eventIndex);
   }
 
   downlodEncoder(defaultFileName: string) {

--- a/log-viewer/src/features/database/components/SOSLView.ts
+++ b/log-viewer/src/features/database/components/SOSLView.ts
@@ -10,6 +10,7 @@ import { Tabulator, type GroupComponent, type RowComponent } from 'tabulator-tab
 
 import type { ApexLog, SOSLExecuteBeginLine } from 'apex-log-parser';
 import { eventBus } from '../../../core/events/EventBus.js';
+import { SelectionEchoGuard } from '../../../core/events/SelectionEchoGuard.js';
 import { vscodeMessenger } from '../../../core/messaging/VSCodeExtensionMessenger.js';
 import { getCallerNamespace } from '../../../core/utility/CallerNamespace.js';
 import { goToRow } from '../../call-tree/navigation.js';
@@ -87,6 +88,8 @@ export class SOSLView extends LitElement {
 
   soslTable: Tabulator | null = null;
   holder: HTMLElement | null = null;
+  /** Guards the programmatic select made on the inspector's behalf. */
+  private _echoGuard = new SelectionEchoGuard();
   table: HTMLElement | null = null;
   findArgs: { text: string; count: number; options: { matchCase: boolean } } = {
     text: '',
@@ -651,6 +654,9 @@ export class SOSLView extends LitElement {
     // Drive the detail panel off selection (not click) so keyboard row
     // navigation updates it too, matching the SOQL/DML grids.
     this.soslTable.on('rowSelectionChanged', (_data, rows) => {
+      if (this._echoGuard.suppressed) {
+        return;
+      }
       const data = rows[0]?.getData() as SOSLRow | undefined;
       if (!data || data.eventIndex === undefined || !data.sosl) {
         return;
@@ -741,6 +747,26 @@ export class SOSLView extends LitElement {
 
   deselectRows() {
     this.soslTable?.deselectRow();
+  }
+
+  /**
+   * Select the row for `eventIndex`, without echoing `detail:select` back at the
+   * inspector that asked for it. Returns false when this grid has no such row.
+   */
+  selectByEventIndex(eventIndex: number): boolean {
+    // The tabulator index is a synthetic row id, so the eventIndex is scanned for.
+    const match = this.soslTable
+      ?.getRows()
+      .find((candidate) => (candidate.getData() as SOSLRow).eventIndex === eventIndex);
+    if (!match) {
+      return false;
+    }
+
+    this._echoGuard.run(() => {
+      this.soslTable?.deselectRow();
+      match.select();
+    });
+    return true;
   }
 
   downlodEncoder(defaultFileName: string) {

--- a/log-viewer/src/features/database/components/revealRow.ts
+++ b/log-viewer/src/features/database/components/revealRow.ts
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2026 Certinia Inc. All rights reserved.
+ */
+import type { Tabulator } from 'tabulator-tables';
+
+import type { SelectionEchoGuard } from '../../../core/events/SelectionEchoGuard.js';
+
+/** The part of a database grid row that traces back to the log event it was built from. */
+interface EventRow {
+  eventIndex?: number;
+}
+
+/**
+ * Select the row for `eventIndex`, without echoing `detail:select` back at the
+ * inspector that asked for it. Returns false when the grid has no such row.
+ *
+ * Shared by the DML, SOQL and SOSL grids: the inspector offers an eventIndex to
+ * each in turn, and only the grid that owns it selects.
+ */
+export function selectRowByEventIndex(
+  table: Tabulator | null,
+  guard: SelectionEchoGuard,
+  eventIndex: number,
+): boolean {
+  // The tabulator index is a synthetic row id, so the eventIndex is scanned for.
+  const match = table
+    ?.getRows()
+    .find((candidate) => (candidate.getData() as EventRow).eventIndex === eventIndex);
+  if (!table || !match) {
+    return false;
+  }
+
+  guard.run(() => {
+    table.deselectRow();
+    match.select();
+  });
+  return true;
+}

--- a/log-viewer/src/features/timeline/__tests__/detail-selection-sync.test.ts
+++ b/log-viewer/src/features/timeline/__tests__/detail-selection-sync.test.ts
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2026 Certinia Inc. All rights reserved.
+ */
+import { describe, expect, it } from '@jest/globals';
+
+import { TimelineViewport } from '../optimised/TimelineViewport.js';
+import { isFrameOffscreen, toDetailSelection } from '../utils/detail-selection-sync.js';
+
+describe('toDetailSelection', () => {
+  it('builds an event selection from an eventIndex', () => {
+    expect(toDetailSelection(7)).toEqual({ kind: 'event', eventIndex: 7 });
+  });
+
+  it('keeps index 0, which is a real event and not "missing"', () => {
+    expect(toDetailSelection(0)).toEqual({ kind: 'event', eventIndex: 0 });
+  });
+
+  it('returns null when there is no eventIndex to select', () => {
+    expect(toDetailSelection(undefined)).toBeNull();
+  });
+});
+
+describe('isFrameOffscreen', () => {
+  const viewport = new TimelineViewport(1000, 600, 1_000_000, 10);
+  const bounds = viewport.getBounds();
+
+  it('reports a frame inside both ranges as on screen', () => {
+    expect(isFrameOffscreen(bounds, bounds.timeStart, 1_000, bounds.depthStart)).toBe(false);
+  });
+
+  it('reports a frame after the visible time range as off screen', () => {
+    expect(isFrameOffscreen(bounds, bounds.timeEnd + 1_000, 1_000, bounds.depthStart)).toBe(true);
+  });
+
+  it('reports a frame before the visible time range as off screen', () => {
+    expect(isFrameOffscreen(bounds, bounds.timeStart - 5_000, 1_000, bounds.depthStart)).toBe(true);
+  });
+
+  it('reports a frame below the visible depth range as off screen', () => {
+    expect(isFrameOffscreen(bounds, bounds.timeStart, 1_000, bounds.depthEnd + 1)).toBe(true);
+  });
+});

--- a/log-viewer/src/features/timeline/optimised/ApexLogTimeline.ts
+++ b/log-viewer/src/features/timeline/optimised/ApexLogTimeline.ts
@@ -21,6 +21,7 @@ import type { ApexLog, LogEvent } from 'apex-log-parser';
 import { ContextMenu } from '../../../components/ContextMenu.js';
 import { ContextMenuBuilder } from '../../../components/ContextMenuBuilder.js';
 import { eventBus } from '../../../core/events/EventBus.js';
+import { SelectionEchoGuard } from '../../../core/events/SelectionEchoGuard.js';
 import { copyToClipboard } from '../../../core/utility/Clipboard.js';
 import { vscodeMessenger } from '../../../core/messaging/VSCodeExtensionMessenger.js';
 import { findEventByEventIndex, findEventByTimestamp } from '../../../core/utility/EventSearch.js';
@@ -38,6 +39,7 @@ import {
   type ViewportState,
 } from '../types/flamechart.types.js';
 import type { SearchCursor } from '../types/search.types.js';
+import { isFrameOffscreen, toDetailSelection } from '../utils/detail-selection-sync.js';
 import { extractExceptionMarkers, extractMarkers } from '../utils/marker-utils.js';
 import { logEventToTreeAndRects } from '../utils/tree-converter.js';
 import { FlameChart } from './FlameChart.js';
@@ -60,6 +62,9 @@ export class ApexLogTimeline {
   private selectedEventForContextMenu: EventNode | null = null;
   private selectedMarkerForContextMenu: TimelineMarker | null = null;
   private eventBusUnsubscribe: (() => void) | null = null;
+  private inspectorRevealUnsubscribe: (() => void) | null = null;
+  /** Guards the programmatic select made on the inspector's behalf. */
+  private echoGuard = new SelectionEchoGuard();
 
   constructor() {
     this.flamechart = new FlameChart();
@@ -197,6 +202,44 @@ export class ApexLogTimeline {
         this.navigateToTimestamp(detail.timestamp);
       }
     });
+
+    // Reveal an inspector row in the flame chart, but only while the timeline is
+    // the tab the inspector is showing.
+    this.inspectorRevealUnsubscribe = eventBus.on('inspector:reveal', (detail) => {
+      if (detail.source === 'timeline') {
+        this.selectFrameByEventIndex(detail.eventIndex);
+      }
+    });
+  }
+
+  /**
+   * Select the frame for `eventIndex` and pan to it when it is off-screen.
+   * Passive sync, so it never zooms - a full focus would be too disruptive.
+   */
+  private selectFrameByEventIndex(eventIndex: number): void {
+    if (!this.apexLog) {
+      return;
+    }
+
+    const result = findEventByEventIndex(this.apexLog, eventIndex);
+    if (!result) {
+      return;
+    }
+
+    const selected = this.echoGuard.run(() =>
+      this.flamechart.selectByEventNode(this.toEventNode(result)),
+    );
+    if (!selected) {
+      return;
+    }
+
+    const bounds = this.flamechart.getViewportManager()?.getBounds();
+    if (
+      bounds &&
+      isFrameOffscreen(bounds, result.event.timestamp, result.event.duration.total, result.depth)
+    ) {
+      this.flamechart.centerOnSelectedFrame();
+    }
   }
 
   /**
@@ -231,7 +274,14 @@ export class ApexLogTimeline {
       return;
     }
 
-    const eventNode: EventNode = {
+    this.flamechart.selectByEventNode(this.toEventNode(result));
+    const viewport = this.flamechart.getViewportManager();
+    viewport?.focusOnEvent(result.event.timestamp, result.event.duration.total, result.depth);
+    this.flamechart.requestRender();
+  }
+
+  private toEventNode(result: { event: LogEvent; depth: number }): EventNode {
+    return {
       id: `${result.event.eventIndex}-${result.depth}`,
       timestamp: result.event.timestamp,
       duration: result.event.duration.total,
@@ -239,11 +289,6 @@ export class ApexLogTimeline {
       text: result.event.text,
       original: result.event,
     };
-
-    this.flamechart.selectByEventNode(eventNode);
-    const viewport = this.flamechart.getViewportManager();
-    viewport?.focusOnEvent(result.event.timestamp, result.event.duration.total, result.depth);
-    this.flamechart.requestRender();
   }
 
   /**
@@ -273,6 +318,10 @@ export class ApexLogTimeline {
     if (this.eventBusUnsubscribe) {
       this.eventBusUnsubscribe();
       this.eventBusUnsubscribe = null;
+    }
+    if (this.inspectorRevealUnsubscribe) {
+      this.inspectorRevealUnsubscribe();
+      this.inspectorRevealUnsubscribe = null;
     }
 
     this.flamechart.destroy();
@@ -426,6 +475,10 @@ export class ApexLogTimeline {
    * Use J key for explicit "jump to call tree" action.
    */
   private handleSelect(eventNode: EventNode | null): void {
+    if (this.echoGuard.suppressed) {
+      return;
+    }
+
     if (!eventNode) {
       // Selection cleared - hide tooltip
       if (this.tooltipRenderer) {
@@ -439,11 +492,9 @@ export class ApexLogTimeline {
     // User can press J to explicitly jump to call tree
     // The inspector shows the selected frame's detail.
     const originalEvent = (eventNode as EventNode & { original?: LogEvent }).original;
-    if (originalEvent?.eventIndex !== undefined) {
-      eventBus.emit('detail:select', {
-        source: 'timeline',
-        selection: { kind: 'event', eventIndex: originalEvent.eventIndex },
-      });
+    const selection = toDetailSelection(originalEvent?.eventIndex);
+    if (selection) {
+      eventBus.emit('detail:select', { source: 'timeline', selection });
     }
   }
 
@@ -484,11 +535,9 @@ export class ApexLogTimeline {
     // Marker selection only - no auto-navigation to call tree
     // User can press J to explicitly jump to call tree
     // Markers only carry an eventIndex when they map to a log event.
-    if (marker.eventIndex !== undefined) {
-      eventBus.emit('detail:select', {
-        source: 'timeline',
-        selection: { kind: 'event', eventIndex: marker.eventIndex },
-      });
+    const selection = toDetailSelection(marker.eventIndex);
+    if (selection) {
+      eventBus.emit('detail:select', { source: 'timeline', selection });
     }
   }
 

--- a/log-viewer/src/features/timeline/optimised/FlameChart.ts
+++ b/log-viewer/src/features/timeline/optimised/FlameChart.ts
@@ -1874,16 +1874,30 @@ export class FlameChart<E extends EventNode = EventNode> {
 
   /**
    * Select a frame by its EventNode reference.
-   * Used when navigating from external sources (e.g., calltree "Show in Timeline").
+   * Used when navigating from external sources (e.g., calltree "Show in Timeline"),
+   * or on a passive selection sync from the inspector.
    *
    * @param eventNode - The EventNode containing an original reference to find and select
+   * @returns true when the frame was found and selected
    */
-  public selectByEventNode(eventNode: EventNode): void {
+  public selectByEventNode(eventNode: EventNode): boolean {
     const treeNode = this.selectionOrchestrator?.findByOriginal(eventNode);
-    if (treeNode) {
-      this.selectionOrchestrator?.selectFrame(treeNode);
-      this.requestRender();
+    if (!treeNode) {
+      return false;
     }
+
+    this.selectionOrchestrator?.selectFrame(treeNode);
+    this.requestRender();
+    return true;
+  }
+
+  /**
+   * Pan (without changing zoom) so the currently selected frame is visible.
+   * Animated, and a no-op if the frame is already in view - use this for the
+   * passive selection sync, where a full zoom-to-fit would be too disruptive.
+   */
+  public centerOnSelectedFrame(): void {
+    this.selectionOrchestrator?.centerOnSelectedFrame();
   }
 
   /**

--- a/log-viewer/src/features/timeline/utils/detail-selection-sync.ts
+++ b/log-viewer/src/features/timeline/utils/detail-selection-sync.ts
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2026 Certinia Inc. All rights reserved.
+ */
+
+/**
+ * Pure helpers for the timeline's half of the inspector selection sync. Kept
+ * side-effect free so both directions can be unit tested without a PixiJS
+ * flame chart instance.
+ */
+import type { DetailSelection } from '../../../core/events/EventBus.js';
+import type { ViewportBounds } from '../types/flamechart.types.js';
+
+/** The `detail:select` payload for a frame, or null when it carries no eventIndex. */
+export function toDetailSelection(eventIndex: number | undefined): DetailSelection | null {
+  return eventIndex === undefined ? null : { kind: 'event', eventIndex };
+}
+
+/** True when the frame falls outside the viewport in time or in depth. */
+export function isFrameOffscreen(
+  bounds: ViewportBounds,
+  timestamp: number,
+  duration: number,
+  depth: number,
+): boolean {
+  const frameEnd = timestamp + duration;
+  const inTimeRange = frameEnd >= bounds.timeStart && timestamp <= bounds.timeEnd;
+  const inDepthRange = depth >= bounds.depthStart && depth <= bounds.depthEnd;
+  return !(inTimeRange && inDepthRange);
+}


### PR DESCRIPTION
Closes the missing direction of the Inspector selection sync: until now every main view pushed its selection *into* the Inspector, and nothing came back out.

Picking a row in the Inspector's **Call stack** or **Call tree** section now selects the matching frame in the tab that is already on screen:

- **Timeline** — selects the frame, and pans to it (no zoom change) only when it is off view.
- **Call Tree** — selects the row in place in Time Order: no tab switch, no view-mode change, no focus steal. The grouped modes have no per-event row, so they are left alone.
- **Database** — selects the DML/SOQL/SOSL statement that owns the event, and clears the other two grids.
- **Analysis** — deliberately out. Its rows are aggregates keyed by `type|namespace|text`, so an eventIndex only resolves back to the whole bucket, which is already the selected row. A comment says so.

### Never cross-tab

A new outbound `inspector:reveal` bus event carries the active `DetailSource`, stamped by `LogInspector` — the only component that knows which tab is showing. Each consumer acts only on its own source, so a Call Tree row click can never move the timeline off-screen.

Keeping `inspector:reveal` distinct from `detail:select` (strictly inbound to the Inspector) is what stops an echo loop. Neither consumer offers a silent select — tabulator fires `rowSelectionChanged` for a programmatic `row.select()`, and the flame chart re-emits through `SelectionOrchestrator.selectFrame` — so a shared `SelectionEchoGuard` marks the window in which a view is selecting on the Inspector's behalf.

Merged Inspector rows (Aggregated and Bottom-Up) reveal nothing: they keep a single occurrence behind a synthetic negative id, so revealing it would name the wrong call.

### Tests

`SelectionEchoGuard`, `toDetailSelection`/`isFrameOffscreen`, the composed reveal dispatch, the merged-row rule, and that `LogInspector` stamps the active tab (and drops a reveal from a tab with no inspectable view). 93 suites / 1281 tests.