### PR TITLE
fix(log-viewer): clear the inspector when a database grid is deselected

### DIFF
--- a/log-viewer/src/core/events/EventBus.ts
+++ b/log-viewer/src/core/events/EventBus.ts
@@ -11,13 +11,16 @@
  *  active tab, keyed by source. */
 export type DetailSource = 'timeline' | 'calltree' | 'analysis' | 'database';
 
+/** Which of the database grids a selection came from. */
+export type StatementType = 'dml' | 'soql' | 'sosl';
+
 /**
  * A selection to inspect in the inspector. A single frame maps to one `eventIndex`;
  * an aggregate row (Call Tree Aggregated/Bottom-Up, Analysis) scopes to all its
  * occurrences (`instances` = their eventIndexes), aggregated.
  */
 export type DetailSelection =
-  | { kind: 'event'; eventIndex: number; type?: 'dml' | 'soql' | 'sosl' }
+  | { kind: 'event'; eventIndex: number; type?: StatementType }
   | { kind: 'aggregate'; instances: number[]; label: string };
 
 interface EventMap {

--- a/log-viewer/src/core/events/SelectionEchoGuard.ts
+++ b/log-viewer/src/core/events/SelectionEchoGuard.ts
@@ -3,9 +3,11 @@
  */
 
 /**
- * Marks the window in which a view selects a row on the inspector's behalf, so
- * the view can skip the `detail:select` it would otherwise emit and send the
- * inspector back the very selection it asked for.
+ * Marks the window in which a view changes its selection for a reason the
+ * inspector must not hear about, so the view can skip the `detail:select` it
+ * would otherwise emit: a row selected on the inspector's own behalf, which
+ * would send back the very selection it asked for, or a grid cleared because a
+ * sibling grid was picked, whose null would arrive after the pick and undo it.
  *
  * Needed because neither consumer offers a silent select: tabulator fires
  * `rowSelectionChanged` for a programmatic `row.select()`, and the flame chart

--- a/log-viewer/src/features/database/__tests__/gridSelection.test.ts
+++ b/log-viewer/src/features/database/__tests__/gridSelection.test.ts
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2026 Certinia Inc. All rights reserved.
+ */
+import { afterEach, beforeEach, describe, expect, it } from '@jest/globals';
+
+import type { RowComponent } from 'tabulator-tables';
+
+import {
+  eventBus,
+  type DetailSelection,
+  type DetailSource,
+} from '../../../core/events/EventBus.js';
+import { SelectionEchoGuard } from '../../../core/events/SelectionEchoGuard.js';
+import { emitGridSelection } from '../components/gridSelection.js';
+
+interface StatementRow {
+  eventIndex?: number;
+  soql?: string;
+}
+
+/** Only `getData` is read, so the rest of the row component is not built. */
+function row(data: StatementRow): RowComponent {
+  return { getData: () => data } as unknown as RowComponent;
+}
+
+const soqlEventIndex = (data: StatementRow) => (data.soql ? data.eventIndex : undefined);
+
+describe('emitGridSelection', () => {
+  let seen: Array<{ source: DetailSource; selection: DetailSelection | null }>;
+  let off: () => void;
+
+  beforeEach(() => {
+    seen = [];
+    off = eventBus.on('detail:select', (d) => seen.push(d));
+  });
+
+  afterEach(() => off());
+
+  it('reports the picked row', () => {
+    emitGridSelection(
+      new SelectionEchoGuard(),
+      'soql',
+      [row({ eventIndex: 7, soql: 'SELECT' })],
+      soqlEventIndex,
+    );
+
+    expect(seen).toEqual([
+      { source: 'database', selection: { kind: 'event', eventIndex: 7, type: 'soql' } },
+    ]);
+  });
+
+  it('clears the inspector when the grid is cleared', () => {
+    emitGridSelection(new SelectionEchoGuard(), 'soql', [], soqlEventIndex);
+
+    expect(seen).toEqual([{ source: 'database', selection: null }]);
+  });
+
+  it('says nothing while a select on the inspector behalf is in flight', () => {
+    const guard = new SelectionEchoGuard();
+
+    guard.run(() => emitGridSelection(guard, 'soql', [], soqlEventIndex));
+
+    expect(seen).toEqual([]);
+  });
+
+  it('leaves the inspector alone for a row that holds no statement', () => {
+    emitGridSelection(new SelectionEchoGuard(), 'soql', [row({ eventIndex: 7 })], soqlEventIndex);
+
+    expect(seen).toEqual([]);
+  });
+});

--- a/log-viewer/src/features/database/components/DMLView.ts
+++ b/log-viewer/src/features/database/components/DMLView.ts
@@ -9,13 +9,13 @@ import { customElement, property, state } from 'lit/decorators.js';
 import { Tabulator, type GroupComponent, type RowComponent } from 'tabulator-tables';
 
 import type { ApexLog, DMLBeginLine } from 'apex-log-parser';
-import { eventBus } from '../../../core/events/EventBus.js';
 import { SelectionEchoGuard } from '../../../core/events/SelectionEchoGuard.js';
 import { vscodeMessenger } from '../../../core/messaging/VSCodeExtensionMessenger.js';
 import { getCallerNamespace } from '../../../core/utility/CallerNamespace.js';
 import { goToRow } from '../../call-tree/navigation.js';
 import { isVisible } from '../../../core/utility/Util.js';
 import { getSettings, updateSetting } from '../../settings/Settings.js';
+import { emitGridSelection } from './gridSelection.js';
 import { selectRowByEventIndex } from './revealRow.js';
 import {
   applyColumnView,
@@ -435,8 +435,9 @@ export class DMLView extends LitElement {
     this.dmlTable?.copyToClipboard('all');
   }
 
+  /** Clears this grid because another one was picked, so it emits nothing. */
   deselectRows() {
-    this.dmlTable?.deselectRow();
+    this._echoGuard.run(() => this.dmlTable?.deselectRow());
   }
 
   /**
@@ -699,18 +700,9 @@ export class DMLView extends LitElement {
     // navigation updates it too. RowKeyboardNavigation keeps a single row
     // selected across mouse and arrow-key navigation.
     this.dmlTable.on('rowSelectionChanged', (_data, rows) => {
-      if (this._echoGuard.suppressed) {
-        return;
-      }
-      const data = rows[0]?.getData() as DMLRow | undefined;
-      if (!data || data.eventIndex === undefined || !data.dml) {
-        return;
-      }
-
-      eventBus.emit('detail:select', {
-        source: 'database',
-        selection: { kind: 'event', eventIndex: data.eventIndex, type: 'dml' },
-      });
+      emitGridSelection(this._echoGuard, 'dml', rows, (data: DMLRow) =>
+        data.dml ? data.eventIndex : undefined,
+      );
     });
 
     this.dmlTable.on('rowContext', (e, row) => {

--- a/log-viewer/src/features/database/components/SOQLView.ts
+++ b/log-viewer/src/features/database/components/SOQLView.ts
@@ -14,7 +14,6 @@ import {
 } from 'tabulator-tables';
 
 import type { ApexLog, SOQLExecuteBeginLine } from 'apex-log-parser';
-import { eventBus } from '../../../core/events/EventBus.js';
 import { SelectionEchoGuard } from '../../../core/events/SelectionEchoGuard.js';
 import { vscodeMessenger } from '../../../core/messaging/VSCodeExtensionMessenger.js';
 import { isVisible } from '../../../core/utility/Util.js';
@@ -25,6 +24,7 @@ import { soqlGroupHeader } from '../../soql/format/groupHeader.js';
 import { soqlInlineElement } from '../../soql/format/inlineCell.js';
 import { soqlSyntaxStyles } from '../../soql/styles/soql-syntax.css.js';
 import { getSettings, updateSetting } from '../../settings/Settings.js';
+import { emitGridSelection } from './gridSelection.js';
 import { selectRowByEventIndex } from './revealRow.js';
 import {
   applyColumnView,
@@ -453,8 +453,9 @@ export class SOQLView extends LitElement {
     this.soqlTable?.copyToClipboard('all');
   }
 
+  /** Clears this grid because another one was picked, so it emits nothing. */
   deselectRows() {
-    this.soqlTable?.deselectRow();
+    this._echoGuard.run(() => this.soqlTable?.deselectRow());
   }
 
   /**
@@ -850,18 +851,9 @@ export class SOQLView extends LitElement {
     // navigation updates it too. RowKeyboardNavigation keeps a single row
     // selected across mouse and arrow-key navigation.
     this.soqlTable.on('rowSelectionChanged', (_data, rows) => {
-      if (this._echoGuard.suppressed) {
-        return;
-      }
-      const data = rows[0]?.getData() as GridSOQLData | undefined;
-      if (!data || data.eventIndex === undefined || !data.soql) {
-        return;
-      }
-
-      eventBus.emit('detail:select', {
-        source: 'database',
-        selection: { kind: 'event', eventIndex: data.eventIndex, type: 'soql' },
-      });
+      emitGridSelection(this._echoGuard, 'soql', rows, (data: GridSOQLData) =>
+        data.soql ? data.eventIndex : undefined,
+      );
     });
 
     this.soqlTable.on('rowContext', (e, row) => {

--- a/log-viewer/src/features/database/components/SOSLView.ts
+++ b/log-viewer/src/features/database/components/SOSLView.ts
@@ -9,13 +9,13 @@ import { customElement, property, state } from 'lit/decorators.js';
 import { Tabulator, type GroupComponent, type RowComponent } from 'tabulator-tables';
 
 import type { ApexLog, SOSLExecuteBeginLine } from 'apex-log-parser';
-import { eventBus } from '../../../core/events/EventBus.js';
 import { SelectionEchoGuard } from '../../../core/events/SelectionEchoGuard.js';
 import { vscodeMessenger } from '../../../core/messaging/VSCodeExtensionMessenger.js';
 import { getCallerNamespace } from '../../../core/utility/CallerNamespace.js';
 import { goToRow } from '../../call-tree/navigation.js';
 import { isVisible } from '../../../core/utility/Util.js';
 import { getSettings, updateSetting } from '../../settings/Settings.js';
+import { emitGridSelection } from './gridSelection.js';
 import { selectRowByEventIndex } from './revealRow.js';
 import { soqlInlineElement } from '../../soql/format/inlineCell.js';
 import { soqlSyntaxStyles } from '../../soql/styles/soql-syntax.css.js';
@@ -655,17 +655,9 @@ export class SOSLView extends LitElement {
     // Drive the detail panel off selection (not click) so keyboard row
     // navigation updates it too, matching the SOQL/DML grids.
     this.soslTable.on('rowSelectionChanged', (_data, rows) => {
-      if (this._echoGuard.suppressed) {
-        return;
-      }
-      const data = rows[0]?.getData() as SOSLRow | undefined;
-      if (!data || data.eventIndex === undefined || !data.sosl) {
-        return;
-      }
-      eventBus.emit('detail:select', {
-        source: 'database',
-        selection: { kind: 'event', eventIndex: data.eventIndex, type: 'sosl' },
-      });
+      emitGridSelection(this._echoGuard, 'sosl', rows, (data: SOSLRow) =>
+        data.sosl ? data.eventIndex : undefined,
+      );
     });
 
     this.soslTable.on('rowContext', (e, row) => {
@@ -746,8 +738,9 @@ export class SOSLView extends LitElement {
     return this.holder;
   }
 
+  /** Clears this grid because another one was picked, so it emits nothing. */
   deselectRows() {
-    this.soslTable?.deselectRow();
+    this._echoGuard.run(() => this.soslTable?.deselectRow());
   }
 
   /**

--- a/log-viewer/src/features/database/components/gridSelection.ts
+++ b/log-viewer/src/features/database/components/gridSelection.ts
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2026 Certinia Inc. All rights reserved.
+ */
+import type { RowComponent } from 'tabulator-tables';
+
+import { eventBus, type StatementType } from '../../../core/events/EventBus.js';
+import type { SelectionEchoGuard } from '../../../core/events/SelectionEchoGuard.js';
+
+/**
+ * Reports a database grid's selection to the inspector: the picked row, or
+ * null once the grid is cleared, so the inspector stops showing the row the
+ * user just deselected.
+ *
+ * Emits nothing while `guard` suppresses - that clear came from the inspector,
+ * or from `DatabaseView` clearing the two grids the pick did not land in, and
+ * its null would arrive after the pick and undo it.
+ *
+ * `eventIndexOf` returns undefined for a row that holds no statement, which is
+ * reported as no change rather than as a clear.
+ */
+export function emitGridSelection<T>(
+  guard: SelectionEchoGuard,
+  type: StatementType,
+  rows: RowComponent[],
+  eventIndexOf: (data: T) => number | undefined,
+): void {
+  if (guard.suppressed) {
+    return;
+  }
+
+  const data = rows[0]?.getData() as T | undefined;
+  if (!data) {
+    eventBus.emit('detail:select', { source: 'database', selection: null });
+    return;
+  }
+
+  const eventIndex = eventIndexOf(data);
+  if (eventIndex === undefined) {
+    return;
+  }
+
+  eventBus.emit('detail:select', {
+    source: 'database',
+    selection: { kind: 'event', eventIndex, type },
+  });
+}


### PR DESCRIPTION
The DML, SOQL and SOSL grids returned early when their selection emptied, so the
Inspector kept showing the row the user had just deselected and the database
empty state could never appear. `CalltreeView` and `AnalysisView` already emit
`selection: null`; the database grids now match them.

All three handlers share one `emitGridSelection` helper, which stays quiet while
the echo guard is set. That matters because `DatabaseView` clears the two grids a
pick did not land in, and their nulls would otherwise arrive after the pick and
undo it — so `deselectRows()` now runs inside the guard.

A row that holds no statement is reported as no change rather than as a clear.

Also folded in: `'dml' | 'soql' | 'sosl'` is now one named `StatementType` in
`EventBus.ts` instead of being restated, and `SelectionEchoGuard`'s doc covers
the second reason a view suppresses its echo.

## Testing

New `gridSelection.test.ts` covers the four branches: the picked row, the clear,
the suppressed clear, and a row with no statement.

`tsc -b`, `eslint`, `jest` (97 suites / 1302 tests) and `prettier --check` all pass.
