### PR TITLE
docs: document the inspector's click-to-reveal in the active tab

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - **Details**: type, timing, and every governor metric the selection consumed as `used / limit`.
   - **Call stack**: the frames that led to the selection, with total and self time.
   - **Call tree**: the selected frame's own subtree, switchable between **Time Order**, **Aggregated** and **Bottom-Up**. Times are relative to the selection, and zero-duration rows (heap allocations, statements, variable assignments) are left out — read those on the Call Tree tab.
+  - Click a row and the matching frame or row is highlighted in the tab you're on, without switching tab: the Timeline selects the frame and centers it when it's off screen, the Call Tree scrolls to it in **Time Order**, and the Database tab selects the statement.
   - Dock it left, right or bottom, drag to resize, and collapse the sections you don't need — the layout is remembered.
   - Right-click a row for **Show in Call Tree**, **Copy Name**, **Copy Details** or **Copy Call Stack**; `Cmd/Ctrl+C` copies the table.
 - 🗄️ **Database Analysis**: governor-limit visibility and SOSL usage. ([#162])

--- a/lana-docs/docs/docs/features/inspector.md
+++ b/lana-docs/docs/docs/features/inspector.md
@@ -42,4 +42,4 @@ Right-click a row in the **Call stack** or **Call tree** for:
 | **Copy Details**      | Name, type, duration and governor metrics                       |
 | **Copy Call Stack**   | The whole parent chain, one frame per line                      |
 
-Clicking a row on its own never navigates away — in the Call stack it selects the frame, and in the Call tree it expands or collapses its subtree. Arrow keys move between rows, and `CMD / CTRL + c` copies the table.
+Clicking a row highlights the matching frame or row in the tab you're on, and never switches tab: the Timeline selects the frame and centers it when it's off screen, the Call Tree scrolls to it in **Time Order**, and the Database tab selects the statement. Rows in the Call tree's **Aggregated** and **Bottom-Up** views merge several occurrences, so there is no single frame to highlight. Arrow keys move between rows, and `CMD / CTRL + c` copies the table.


### PR DESCRIPTION
Documents the click-to-reveal behaviour that shipped in #895.

- `CHANGELOG.md` — a sub-bullet under the existing 🧭 Inspector entry.
- `lana-docs/docs/docs/features/inspector.md` — replaces the now-stale closing line of **Row actions**, and states why the Call tree's **Aggregated** and **Bottom-Up** rows have no single frame to highlight.

Docs only, no code changes.