### PR TITLE
fix(timeline): finish the theme-switch recolour and destroy the flame chart on disconnect

### DIFF
--- a/log-viewer/src/features/timeline/components/TimelineFlameChart.ts
+++ b/log-viewer/src/features/timeline/components/TimelineFlameChart.ts
@@ -123,6 +123,9 @@ export class TimelineFlameChart extends LitElement {
   /** Unsubscribe for the appearance subscription; set while connected. */
   private themeUnsubscribe: (() => void) | null = null;
 
+  /** Bumped by every `cleanup()`, so an in-flight `init` can tell it was superseded. */
+  private initEpoch = 0;
+
   override connectedCallback(): void {
     super.connectedCallback();
     this.themeUnsubscribe ??= themeObserver.on(() => {
@@ -133,6 +136,9 @@ export class TimelineFlameChart extends LitElement {
   override disconnectedCallback(): void {
     this.themeUnsubscribe?.();
     this.themeUnsubscribe = null;
+    // A `lana.timeline.legacy` toggle swaps this element out while the panel is
+    // open, so the Pixi app has to go with it or its WebGL context leaks.
+    this.cleanup();
     super.disconnectedCallback();
   }
 
@@ -196,14 +202,24 @@ export class TimelineFlameChart extends LitElement {
         editorColors: this.extractEditorColors(),
       };
 
-      this.apexLogTimeline = new ApexLogTimeline();
-      await this.apexLogTimeline.init(this.containerRef, this.apexLog, optionsWithTheme);
+      const epoch = this.initEpoch;
+      const timeline = new ApexLogTimeline();
+      await timeline.init(this.containerRef, this.apexLog, optionsWithTheme);
+
+      // `init` is async, so a second re-init (or a disconnect) can land while it
+      // runs. The later one owns the container — drop this Pixi app instead of
+      // leaking it over the top.
+      if (epoch !== this.initEpoch) {
+        timeline.destroy();
+        return;
+      }
+      this.apexLogTimeline = timeline;
 
       // Navigate after initialization completes, preferring unique eventIndex.
       if (this.navigateToEventIndex !== undefined) {
-        this.apexLogTimeline.navigateToEventIndex(this.navigateToEventIndex);
+        timeline.navigateToEventIndex(this.navigateToEventIndex);
       } else if (this.navigateToTimestamp !== undefined) {
-        this.apexLogTimeline.navigateToTimestamp(this.navigateToTimestamp);
+        timeline.navigateToTimestamp(this.navigateToTimestamp);
       }
     } catch (error) {
       this.handleError(error);
@@ -271,6 +287,9 @@ export class TimelineFlameChart extends LitElement {
    * Clean up renderer and observers.
    */
   private cleanup(): void {
+    // Supersede any in-flight `initializeTimeline`.
+    this.initEpoch++;
+
     // Destroy renderer
     if (this.apexLogTimeline) {
       this.apexLogTimeline.destroy();

--- a/log-viewer/src/features/timeline/optimised/time-axis/MeshAxisRenderer.ts
+++ b/log-viewer/src/features/timeline/optimised/time-axis/MeshAxisRenderer.ts
@@ -103,7 +103,6 @@ export class MeshAxisRenderer {
   private labelsContainer: Container;
   private screenSpaceContainer: Container | null = null;
   private config: AxisConfig;
-  private labelCache: Map<string, Text> = new Map();
   /** Pool of reusable Text labels (index-based to support duplicate text) */
   private labelPool: Text[] = [];
   /** Number of active labels in current frame */
@@ -232,7 +231,7 @@ export class MeshAxisRenderer {
     }
 
     // Update existing labels with new color
-    for (const label of this.labelCache.values()) {
+    for (const label of this.labelPool) {
       label.style.fill = textColor;
     }
 

--- a/log-viewer/src/features/timeline/services/Timeline.ts
+++ b/log-viewer/src/features/timeline/services/Timeline.ts
@@ -539,14 +539,24 @@ export function refreshThemeColors(): void {
   }
 
   const computedStyle = getComputedStyle(canvas);
+  const previousFindMatchColor = findMatchColor;
+  // getPropertyValue returns '' for an unset property, never null.
   findMatchColor =
-    computedStyle.getPropertyValue('--vscode-editor-findMatchHighlightBackground') ?? '#ea5c0054';
+    computedStyle.getPropertyValue('--vscode-editor-findMatchHighlightBackground') || '#ea5c0054';
   currentFindMatchColor =
-    computedStyle.getPropertyValue('--vscode-editor-findMatchBackground') ?? '#9e6a03';
+    computedStyle.getPropertyValue('--vscode-editor-findMatchBackground') || '#9e6a03';
   borderSettings = new Map<string, number>([
     [strokeColor, 1],
     [findMatchColor, 2],
   ]);
+
+  // borderRenderQueue is keyed by color and only rebuilt on find, so re-key any live
+  // matches — otherwise they keep drawing in the outgoing theme's color.
+  const liveMatches = borderRenderQueue.get(previousFindMatchColor);
+  if (liveMatches && previousFindMatchColor !== findMatchColor) {
+    borderRenderQueue.delete(previousFindMatchColor);
+    borderRenderQueue.set(findMatchColor, liveMatches);
+  }
 
   state.requestRedraw();
 }


### PR DESCRIPTION
Follow-on to #898, which landed the theme-switch observer but deliberately deferred these three fixes.

### Axis labels kept the outgoing theme's colour

`MeshAxisRenderer.setColors` looped over `labelCache`, a field nothing ever writes to. Pooled labels get their `fill` only when first created, and the pool never shrinks, so every visible label kept the old colour permanently. Loops over `labelPool` and drops the dead field.

### Live find matches kept the outgoing theme's colour

`borderRenderQueue` is keyed by colour, filled once at init and rebuilt only when the search text changes. The stroke colour comes from the map key, so a theme switch during an open find left the matches drawn in the old colour until the search was retyped. Re-keys any live matches.

Also swaps `??` for `||` on the two `getPropertyValue` reads: it returns `''` for an unset property, never `null`, so the fallback could not fire.

### The flame chart leaked its WebGL context on a legacy toggle

`TimelineView` swaps `<timeline-flame-chart>` for `<timeline-legacy>` when `lana.timeline.legacy` changes. Lit removes the element, but nothing destroyed the Pixi app. `disconnectedCallback` now calls `cleanup()`, and an `initEpoch` guard lets a superseded in-flight `init` destroy its own app instead of layering it over the container.

### Verification

`tsc -b`, `eslint`, `jest` (100 suites / 1317 tests) and `prettier --check` all pass.

No CHANGELOG entry: all three defects are in unreleased 1.21.0 code paths.