### PR TITLE
feat(log-issues): structured issue kind with meta line, drop FATAL ERROR prefix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - 🎨 **Header bar**
   - **Log problems** icon now shows the most severe problem found, with a count.
   - **Log problems** and **Notifications** redesigned cards, show two lines of summary and message (click the message for the rest), and go to the Call Tree when clicked. An **Unsupported log event** card opens a prefilled bug report.
+  - **Log problems** cards say what kind of problem they are: a `Fatal error` / `Exception` pill and the time in the log sit on a line under the summary. Fatal errors drop the `FATAL ERROR! cause=` prefix, exception summaries are no longer cut at 99 characters, and both popovers are wider.
   - **Help & documentation** and **Report an issue** move into a `•••` menu, which also holds the controls the header drops as the window narrows.
 - ♻️ Replace `webview-ui-toolkit` with [vscode-elements](https://github.com/vscode-elements/elements) for all UI controls. ([#576]).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,9 +48,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - 🧱 **Data grids**: a crisper header/content separator and tidied grid styling across all tables. ([#873])
 - 📐 **Column widths**: sized to fit their header and values, so nothing clips.
 - 🎨 **Header bar**
-  - **Log problems** icon now shows the most severe problem found, with a count.
   - **Log problems** and **Notifications** redesigned cards, show two lines of summary and message (click the message for the rest), and go to the Call Tree when clicked. An **Unsupported log event** card opens a prefilled bug report.
-  - **Log problems** cards say what kind of problem they are: a `Fatal error` / `Exception` pill and the time in the log sit on a line under the summary. Fatal errors drop the `FATAL ERROR! cause=` prefix, exception summaries are no longer cut at 99 characters, and both popovers are wider.
+  - **Log problems** icon shows the most severe problem found, with a count, the card shows the issue kind (a `Fatal error` / `Exception` pill) and the time in the log under the summary .
+  - **Log problems** card say what kind of problem they are: a `Fatal error` / `Exception` pill and the time in the log sit under the summary.
   - **Help & documentation** and **Report an issue** move into a `•••` menu, which also holds the controls the header drops as the window narrows.
 - ♻️ Replace `webview-ui-toolkit` with [vscode-elements](https://github.com/vscode-elements/elements) for all UI controls. ([#576]).
 

--- a/apex-log-parser/__tests__/ApexLogParser.test.ts
+++ b/apex-log-parser/__tests__/ApexLogParser.test.ts
@@ -309,6 +309,7 @@ describe('parseLog tests', () => {
     expect(apexLog.logIssues[0]?.summary).toBe(
       'System.LimitException: c2g:Too many SOQL queries: 101',
     );
+    expect(apexLog.logIssues[0]?.type).toBe('error');
   });
   it('Should detect fatal errors', async () => {
     const log =
@@ -321,8 +322,57 @@ describe('parseLog tests', () => {
 
     expect(apexLog.children.length).toBe(1);
     expect(apexLog.logIssues[0]?.summary).toBe(
-      'FATAL ERROR! cause=System.LimitException: c2g:Too many SOQL queries: 101',
+      'System.LimitException: c2g:Too many SOQL queries: 101',
     );
+    expect(apexLog.logIssues[0]?.type).toBe('fatal');
+    expect(apexLog.logIssues[0]?.description).toBe('');
+  });
+
+  it('Fatal error summary is the first line; description is the stack trace only', async () => {
+    const log =
+      '09:18:22.6 (100)|EXECUTION_STARTED\n\n' +
+      '16:16:04.97 (1000)|FATAL_ERROR|System.LimitException: Apex CPU time limit exceeded\n\n' +
+      'Class.pse.JSONUtils.removeNamespaceFromKeys: line 32, column 1\n' +
+      'Class.pse.ExtendedSObject.marshall: line 186, column 1\n' +
+      '09:19:13.82 (2000)|EXECUTION_FINISHED\n';
+
+    const apexLog = parse(log);
+
+    const fatal = apexLog.logIssues.find((issue) => issue.type === 'fatal');
+    expect(fatal?.summary).toBe('System.LimitException: Apex CPU time limit exceeded');
+    expect(fatal?.description).toBe(
+      'Class.pse.JSONUtils.removeNamespaceFromKeys: line 32, column 1\n' +
+        'Class.pse.ExtendedSObject.marshall: line 186, column 1',
+    );
+  });
+
+  it('Keeps a fatal error and a thrown exception with the same message as separate issues', async () => {
+    const log =
+      '09:18:22.6 (100)|EXECUTION_STARTED\n\n' +
+      '16:16:04.97 (500)|EXCEPTION_THROWN|[60]|System.LimitException: Apex CPU time limit exceeded\n' +
+      '16:16:04.97 (1000)|FATAL_ERROR|System.LimitException: Apex CPU time limit exceeded\n' +
+      '09:19:13.82 (2000)|EXECUTION_FINISHED\n';
+
+    const apexLog = parse(log);
+
+    const types = apexLog.logIssues.map((issue) => issue.type);
+    expect(types).toEqual(['error', 'fatal']);
+    expect(apexLog.logIssues[0]?.summary).toBe(apexLog.logIssues[1]?.summary);
+  });
+
+  it('Exception summary keeps the full first line without truncation', async () => {
+    const message =
+      'System.LimitException: Update failed. First exception on row 0 with id aCC3Y000000TNpbWAG; ' +
+      'first error: CANNOT_EXECUTE_FLOW_TRIGGER, this message runs well past the old 99 character cap';
+    const log =
+      '09:18:22.6 (100)|EXECUTION_STARTED\n\n' +
+      `16:16:04.97 (1000)|EXCEPTION_THROWN|[60]|${message}\n` +
+      '09:19:13.82 (2000)|EXECUTION_FINISHED\n';
+
+    const apexLog = parse(log);
+
+    expect(apexLog.logIssues[0]?.summary).toBe(message);
+    expect(apexLog.logIssues[0]?.description).toBe('');
   });
   it('Skipped-Lines endTime resolves to the next entry event, ignoring detail lines', async () => {
     const log =

--- a/apex-log-parser/src/ApexLogParser.ts
+++ b/apex-log-parser/src/ApexLogParser.ts
@@ -572,8 +572,11 @@ export class ApexLogParser {
     description: string,
     type: IssueType,
   ) {
-    if (!this.reasons.has(summary)) {
-      this.reasons.add(summary);
+    // Key on type + summary so a FATAL_ERROR and an EXCEPTION_THROWN with the
+    // same first line both survive.
+    const reason = type + ':' + summary;
+    if (!this.reasons.has(reason)) {
+      this.reasons.add(reason);
       this.logIssues.push({
         startTime: startTime,
         eventIndex: eventIndex,
@@ -594,12 +597,12 @@ export class ApexLogParser {
     type: IssueType,
   ) {
     const elem = this.logIssues.findIndex((item) => {
-      return item.summary === summary;
+      return item.summary === summary && item.type === type;
     });
     if (elem > -1) {
       this.logIssues.splice(elem, 1);
     }
-    this.reasons.delete(summary);
+    this.reasons.delete(type + ':' + summary);
 
     this.addLogIssue(startTime, eventIndex, summary, description, type);
   }

--- a/apex-log-parser/src/ApexLogParser.ts
+++ b/apex-log-parser/src/ApexLogParser.ts
@@ -10,6 +10,14 @@ const typePattern = /^[A-Z_]*$/,
   settingsPattern = /^\d+\.\d+\sAPEX_CODE,\w+;APEX_PROFILING,.+$/m;
 
 /**
+ * Identity of a log issue for dedupe. Keyed on type + summary so a FATAL_ERROR and an
+ * EXCEPTION_THROWN with the same first line both survive.
+ */
+function issueKey(type: IssueType, summary: string): string {
+  return type + ':' + summary;
+}
+
+/**
  * Takes string input of a log and returns the ApexLog class, which represents a log tree
  * @param {string} logData
  * @returns {ApexLog}
@@ -572,11 +580,9 @@ export class ApexLogParser {
     description: string,
     type: IssueType,
   ) {
-    // Key on type + summary so a FATAL_ERROR and an EXCEPTION_THROWN with the
-    // same first line both survive.
-    const reason = type + ':' + summary;
-    if (!this.reasons.has(reason)) {
-      this.reasons.add(reason);
+    const key = issueKey(type, summary);
+    if (!this.reasons.has(key)) {
+      this.reasons.add(key);
       this.logIssues.push({
         startTime: startTime,
         eventIndex: eventIndex,
@@ -596,13 +602,12 @@ export class ApexLogParser {
     description: string,
     type: IssueType,
   ) {
-    const elem = this.logIssues.findIndex((item) => {
-      return item.summary === summary && item.type === type;
-    });
+    const key = issueKey(type, summary);
+    const elem = this.logIssues.findIndex((item) => issueKey(item.type, item.summary) === key);
     if (elem > -1) {
       this.logIssues.splice(elem, 1);
     }
-    this.reasons.delete(type + ':' + summary);
+    this.reasons.delete(key);
 
     this.addLogIssue(startTime, eventIndex, summary, description, type);
   }

--- a/apex-log-parser/src/LogEvents.ts
+++ b/apex-log-parser/src/LogEvents.ts
@@ -2382,6 +2382,21 @@ export class WFSpoolActionBeginLine extends LogEvent {
   }
 }
 
+/**
+ * Splits issue text into a summary (the full first line — presentation truncation
+ * is the consumer's job) and a description (the remainder, e.g. a stack trace).
+ */
+function splitIssueText(text: string): { summary: string; description: string } {
+  const newLineIndex = text.indexOf('\n');
+  if (newLineIndex === -1) {
+    return { summary: text.trim(), description: '' };
+  }
+  return {
+    summary: text.slice(0, newLineIndex).trim(),
+    description: text.slice(newLineIndex + 1).trim(),
+  };
+}
+
 export class ExceptionThrownLine extends LogEvent {
   debugLevel = LOG_LEVEL.Info;
   debugCategory = DEBUG_CATEGORY.ApexCode;
@@ -2398,12 +2413,8 @@ export class ExceptionThrownLine extends LogEvent {
 
   onAfter(parser: ApexLogParser, _next?: LogEvent): void {
     if (this.text.indexOf('System.LimitException') >= 0) {
-      const isMultiLine = this.text.indexOf('\n');
-      const len = isMultiLine < 0 ? 99 : isMultiLine;
-      const truncateText = this.text.length > len;
-      const summary = this.text.slice(0, len + 1) + (truncateText ? '…' : '');
-      const message = truncateText ? this.text : '';
-      parser.addLogIssue(this.timestamp, this.eventIndex, summary, message, 'error');
+      const { summary, description } = splitIssueText(this.text);
+      parser.addLogIssue(this.timestamp, this.eventIndex, summary, description, 'error');
     }
   }
 }
@@ -2421,16 +2432,8 @@ export class FatalErrorLine extends LogEvent {
   }
 
   onAfter(parser: ApexLogParser, _next?: LogEvent): void {
-    const newLineIndex = this.text.indexOf('\n');
-    const summary = newLineIndex > -1 ? this.text.slice(0, newLineIndex + 1) : this.text;
-    const detailText = summary.length !== this.text.length ? this.text : '';
-    parser.addLogIssue(
-      this.timestamp,
-      this.eventIndex,
-      'FATAL ERROR! cause=' + summary,
-      detailText,
-      'error',
-    );
+    const { summary, description } = splitIssueText(this.text);
+    parser.addLogIssue(this.timestamp, this.eventIndex, summary, description, 'fatal');
   }
 }
 

--- a/apex-log-parser/src/types.ts
+++ b/apex-log-parser/src/types.ts
@@ -16,7 +16,7 @@ export const LOG_LEVEL = {
 
 export type LogLevel = (typeof LOG_LEVEL)[keyof typeof LOG_LEVEL] | '';
 
-export type IssueType = 'unexpected' | 'error' | 'skip';
+export type IssueType = 'unexpected' | 'error' | 'skip' | 'fatal';
 
 export type LineNumber = number | 'EXTERNAL' | null; // an actual line-number or 'EXTERNAL'
 

--- a/lana-docs/docs/docs/features/features.mdx
+++ b/lana-docs/docs/docs/features/features.mdx
@@ -27,7 +27,7 @@ Explore the Apex Log Analyzer for Salesforce debug logs features including inter
 
 **Log problems** are problems found in the log itself — governor limit exceptions, fatal errors, skipped lines. A chip shows the worst severity's icon with a count badge, and a tick when the log is clean. **Notifications** are messages about the tool rather than the log — today, parser diagnostics for log lines it couldn't understand. The two are kept apart so they don't read as one severity count.
 
-Each opens as a list of cards: a severity icon, a summary that expands on click if it runs past two lines, and — for problems that point at a spot in the log — an arrow action that jumps to it in the Call Tree.
+Each opens as a list of cards: a severity icon, a summary, a dimmed line with the kind and the time in the log (e.g. `Fatal error · 24.6 s`), a message that expands on click if it runs past two lines, and — for problems that point at a spot in the log — an arrow action that jumps to it in the Call Tree.
 
 If the parser meets a log event it doesn't recognize, a notification card carries a **Report unsupported log event** action, opening a pre-filled GitHub issue.
 

--- a/log-viewer/src/components/AnchoredPopover.ts
+++ b/log-viewer/src/components/AnchoredPopover.ts
@@ -80,8 +80,9 @@ export class AnchoredPopover extends LitElement {
         inset: auto;
         margin: 6px 0 0 0;
         box-sizing: border-box;
-        width: 320px;
-        max-width: min(92vw, 320px);
+        /* Consumers widen via --anchored-popover-width; menus keep the compact default. */
+        width: var(--anchored-popover-width, 320px);
+        max-width: min(92vw, var(--anchored-popover-width, 320px));
         max-height: 540px;
         overflow-y: auto;
         padding: 6px;

--- a/log-viewer/src/components/AnchoredPopover.ts
+++ b/log-viewer/src/components/AnchoredPopover.ts
@@ -40,6 +40,14 @@ export class AnchoredPopover extends LitElement {
   @property({ attribute: 'empty-message' })
   emptyMessage = '';
 
+  /**
+   * Widen the panel for content-bearing popovers — issue cards carry whole exception
+   * messages, and 400px lets the two-line clamp hold a readable measure (~60 chars/line).
+   * Off for menus, which keep the compact default.
+   */
+  @property({ type: Boolean })
+  wide = false;
+
   /** Queried live rather than cached: the slot's content changes without a re-render. */
   private get _panelContent(): readonly Element[] {
     const slot = this.shadowRoot?.querySelector<HTMLSlotElement>('slot[name="panel"]');
@@ -80,7 +88,6 @@ export class AnchoredPopover extends LitElement {
         inset: auto;
         margin: 6px 0 0 0;
         box-sizing: border-box;
-        /* Consumers widen via --anchored-popover-width; menus keep the compact default. */
         width: var(--anchored-popover-width, 320px);
         max-width: min(92vw, var(--anchored-popover-width, 320px));
         max-height: 540px;
@@ -96,6 +103,10 @@ export class AnchoredPopover extends LitElement {
 
       :host([align='start']) .panel {
         position-area: bottom span-right;
+      }
+
+      :host([wide]) {
+        --anchored-popover-width: 400px;
       }
 
       .panel__head {

--- a/log-viewer/src/components/LogProblemsChip.ts
+++ b/log-viewer/src/components/LogProblemsChip.ts
@@ -60,12 +60,6 @@ export class LogProblemsChip extends LitElement {
         width: 16px;
         height: 16px;
       }
-
-      /* Issue cards carry whole exception messages: widen past the menu default so the
-         two-line clamp holds a readable measure (~60 chars/line). */
-      anchored-popover {
-        --anchored-popover-width: 400px;
-      }
     `,
   ];
 
@@ -82,6 +76,7 @@ export class LogProblemsChip extends LitElement {
       align="start"
       heading="Log problems"
       show-heading
+      wide
       empty-message="No problems found in this log"
     >
       <span

--- a/log-viewer/src/components/LogProblemsChip.ts
+++ b/log-viewer/src/components/LogProblemsChip.ts
@@ -60,6 +60,12 @@ export class LogProblemsChip extends LitElement {
         width: 16px;
         height: 16px;
       }
+
+      /* Issue cards carry whole exception messages: widen past the menu default so the
+         two-line clamp holds a readable measure (~60 chars/line). */
+      anchored-popover {
+        --anchored-popover-width: 400px;
+      }
     `,
   ];
 

--- a/log-viewer/src/components/__tests__/LogProblemsChip.test.ts
+++ b/log-viewer/src/components/__tests__/LogProblemsChip.test.ts
@@ -19,6 +19,7 @@ function issue(severity: IssueSeverity): LogIssue {
     summary: severity,
     message: '',
     severity,
+    label: null,
     action: null,
     category: null,
     timestamp: null,

--- a/log-viewer/src/components/__tests__/NavBar.test.ts
+++ b/log-viewer/src/components/__tests__/NavBar.test.ts
@@ -90,6 +90,7 @@ function issue(severity: IssueSeverity): LogIssue {
     summary: severity,
     message: '',
     severity,
+    label: null,
     action: null,
     category: null,
     timestamp: null,

--- a/log-viewer/src/features/app/LogViewer.ts
+++ b/log-viewer/src/features/app/LogViewer.ts
@@ -298,6 +298,7 @@ export class LogViewer extends LitElement {
         summary: 'Could not read log',
         message: msg,
         severity: 'error',
+        label: null,
         action: null,
         category: null,
         timestamp: null,

--- a/log-viewer/src/features/app/__tests__/logIssues.test.ts
+++ b/log-viewer/src/features/app/__tests__/logIssues.test.ts
@@ -19,6 +19,29 @@ describe('toLogIssue', () => {
     expect(issue.category).toBe('skip');
     expect(issue.timestamp).toBe(120);
     expect(issue.action?.label).toBe('Go to call tree');
+    expect(issue.label).toBeNull();
+  });
+
+  it('labels fatal errors and thrown exceptions with their kind', () => {
+    const fatal = toLogIssue({
+      summary: 'System.LimitException: Apex CPU time limit exceeded',
+      description: '',
+      type: 'fatal',
+      startTime: 100,
+    });
+    const thrown = toLogIssue({
+      summary: 'System.LimitException: Apex CPU time limit exceeded',
+      description: '',
+      type: 'error',
+      startTime: 50,
+    });
+
+    expect(fatal.severity).toBe('error');
+    expect(fatal.category).toBe('exception');
+    expect(fatal.label).toBe('Fatal error');
+    expect(thrown.severity).toBe('error');
+    expect(thrown.category).toBe('exception');
+    expect(thrown.label).toBe('Exception');
   });
 
   it('leaves an issue with no event unactivatable', () => {
@@ -27,5 +50,12 @@ describe('toLogIssue', () => {
     expect(issue.action).toBeNull();
     expect(issue.category).toBe('unexpected');
     expect(issue.severity).toBe('warning');
+    expect(issue.timestamp).toBeNull();
+  });
+
+  it('keeps a timestamp of 0 — the log can fail on its first line', () => {
+    const issue = toLogIssue({ summary: 'boom', description: '', type: 'error', startTime: 0 });
+
+    expect(issue.timestamp).toBe(0);
   });
 });

--- a/log-viewer/src/features/app/logIssues.ts
+++ b/log-viewer/src/features/app/logIssues.ts
@@ -8,9 +8,19 @@ import type { IssueSeverity, LogIssue } from '../notifications/types.js';
 import { markerTypeForIssue } from '../timeline/types/flamechart.types.js';
 
 const SEVERITY_BY_ISSUE_TYPE: ReadonlyMap<string, IssueSeverity> = new Map([
+  ['fatal', 'error'],
   ['error', 'error'],
   ['unexpected', 'warning'],
   ['skip', 'info'],
+]);
+
+/**
+ * Kind badge for the two exception-shaped issues: a fatal error killed the transaction,
+ * a thrown exception may have been caught. Other types self-describe in their summary.
+ */
+const LABEL_BY_ISSUE_TYPE: ReadonlyMap<string, string> = new Map([
+  ['fatal', 'Fatal error'],
+  ['error', 'Exception'],
 ]);
 
 /** A parsed log issue as a card: severity, rail colour, head, and where activating it goes. */
@@ -19,10 +29,11 @@ export function toLogIssue(issue: ParsedLogIssue): LogIssue {
     summary: issue.summary,
     message: issue.description,
     severity: toSeverity(issue.type),
+    label: LABEL_BY_ISSUE_TYPE.get(issue.type) || null,
     action: issue.eventIndex !== undefined ? goToCallTreeAction(issue.eventIndex) : null,
     // The card's rail is the colour the timeline draws for the same issue.
     category: markerTypeForIssue(issue.type),
-    timestamp: issue.startTime || null,
+    timestamp: issue.startTime ?? null,
   };
 }
 

--- a/log-viewer/src/features/app/parserNotifications.ts
+++ b/log-viewer/src/features/app/parserNotifications.ts
@@ -24,6 +24,7 @@ export function parserIssuesToNotifications(parsingErrors: readonly string[]): L
       // A parse gap means some of the log wasn't understood, which can silently skew
       // every view built from it — a warning, not the untinted 'None' it used to be.
       severity: 'warning',
+      label: null,
       // Only an unsupported event name is safe to report: `Invalid log line: …` echoes log
       // text that can carry customer data, so that card stays static.
       action: eventName ? reportUnsupportedTypeAction(eventName) : null,

--- a/log-viewer/src/features/notifications/__tests__/IssueList.test.ts
+++ b/log-viewer/src/features/notifications/__tests__/IssueList.test.ts
@@ -98,6 +98,33 @@ describe('IssueList', () => {
     expect(issues.map((i) => i.summary)).toEqual(['skipped', 'limit exception']);
   });
 
+  it('renders a meta line with the kind pill and the moment in the log', async () => {
+    const el = await mount([
+      { ...issue('error', 'cpu limit'), label: 'Fatal error', timestamp: 100_000_000 },
+      issue('info', 'skipped'),
+    ]);
+
+    const meta = cards(el)[0]?.querySelector('.issue__meta');
+    expect(meta?.querySelector('.issue__label')?.textContent).toBe('Fatal error');
+    expect(meta?.textContent?.replace(/\s+/g, ' ')).toContain('· 100 ms');
+    // The meta line lives under the head, so the summary's clamp keeps the full width.
+    expect(cards(el)[0]?.querySelector('.issue__head .issue__label')).toBeNull();
+    // Meta is part of the card's accessible name, since the row is presentation.
+    expect(cards(el)[0]?.getAttribute('aria-label')).toBe('cpu limit (Fatal error, 100 ms)');
+    // No label and no timestamp — no meta row at all.
+    expect(cards(el)[1]?.querySelector('.issue__meta')).toBeNull();
+  });
+
+  it('shows a time-only meta line, including for a timestamp of 0', async () => {
+    const el = await mount([{ ...issue('warning', 'truncated'), timestamp: 0 }]);
+
+    const meta = cards(el)[0]?.querySelector('.issue__meta');
+    expect(meta?.querySelector('.issue__label')).toBeNull();
+    expect(meta?.textContent).not.toContain('·');
+    expect(meta?.textContent?.replace(/\s+/g, ' ')).toContain('0 ms');
+    expect(cards(el)[0]?.getAttribute('aria-label')).toBe('truncated (0 ms)');
+  });
+
   it('activates by clicking the card and by the keyboard-reachable action button', async () => {
     const run = jest.fn();
     const el = await mount([issue('error', 'has action', { label: 'Go somewhere', run })]);

--- a/log-viewer/src/features/notifications/__tests__/IssueList.test.ts
+++ b/log-viewer/src/features/notifications/__tests__/IssueList.test.ts
@@ -19,7 +19,15 @@ function issue(
   action: IssueAction | null = null,
   category: LogIssue['category'] = null,
 ): LogIssue {
-  return { summary, message: `${summary} detail`, severity, action, category, timestamp: null };
+  return {
+    summary,
+    message: `${summary} detail`,
+    severity,
+    label: null,
+    action,
+    category,
+    timestamp: null,
+  };
 }
 
 async function mount(issues: readonly LogIssue[]): Promise<IssueList> {

--- a/log-viewer/src/features/notifications/__tests__/NotificationCentre.test.ts
+++ b/log-viewer/src/features/notifications/__tests__/NotificationCentre.test.ts
@@ -19,6 +19,7 @@ function issue(severity: IssueSeverity): LogIssue {
     summary: severity,
     message: '',
     severity,
+    label: null,
     action: null,
     category: null,
     timestamp: null,

--- a/log-viewer/src/features/notifications/__tests__/types.test.ts
+++ b/log-viewer/src/features/notifications/__tests__/types.test.ts
@@ -13,7 +13,15 @@ import {
 } from '../types.js';
 
 function issue(severity: IssueSeverity, summary: string = severity): LogIssue {
-  return { summary, message: '', severity, action: null, category: null, timestamp: null };
+  return {
+    summary,
+    message: '',
+    severity,
+    label: null,
+    action: null,
+    category: null,
+    timestamp: null,
+  };
 }
 
 describe('worstSeverity', () => {

--- a/log-viewer/src/features/notifications/components/IssueList.ts
+++ b/log-viewer/src/features/notifications/components/IssueList.ts
@@ -102,7 +102,8 @@ export class IssueList extends LitElement {
       /* The meta line under the summary: kind pill, then the moment in the log. Its own
          row rather than a trailing decoration so the summary's clamp keeps the full width,
          and so fatal/thrown pairs with identical summaries stay distinguishable at a
-         glance. line-height matches the pill's box, so a pill-less row is the same height. */
+         glance. The 16px line-height sizes the pill's box too, so a pill-less row is the
+         same height. */
       .issue__meta {
         display: flex;
         align-items: center;
@@ -119,7 +120,6 @@ export class IssueList extends LitElement {
         flex: 0 0 auto;
         font-size: 10px;
         font-weight: 600;
-        line-height: 1.6;
         padding: 0 var(--lana-space-xs);
         border-radius: var(--lana-radius-sm);
         color: var(--lana-badge-fg);

--- a/log-viewer/src/features/notifications/components/IssueList.ts
+++ b/log-viewer/src/features/notifications/components/IssueList.ts
@@ -5,6 +5,7 @@ import '#vscode-elements/vscode-icon.js';
 import { LitElement, css, html, type PropertyValues, type TemplateResult } from 'lit';
 import { customElement, property, state } from 'lit/decorators.js';
 
+import { formatDuration } from '../../../core/utility/Util.js';
 import { markerColorCss } from '../../timeline/types/flamechart.types.js';
 import { SEVERITY_META, sortBySeverity, type LogIssue } from '../types.js';
 
@@ -96,6 +97,34 @@ export class IssueList extends LitElement {
         font-size: 12px;
         flex: 1 1 auto;
         min-width: 0;
+      }
+
+      /* The meta line under the summary: kind pill, then the moment in the log. Its own
+         row rather than a trailing decoration so the summary's clamp keeps the full width,
+         and so fatal/thrown pairs with identical summaries stay distinguishable at a
+         glance. line-height matches the pill's box, so a pill-less row is the same height. */
+      .issue__meta {
+        display: flex;
+        align-items: center;
+        flex-wrap: wrap;
+        gap: var(--lana-space-xs);
+        font-size: 11px;
+        line-height: 16px;
+        color: var(--lana-fg-muted);
+      }
+
+      /* Kind pill (e.g. "Fatal error" vs "Exception") — the severity glyph says how bad,
+         the pill says what kind, so the summary can stay the raw message. */
+      .issue__label {
+        flex: 0 0 auto;
+        font-size: 10px;
+        font-weight: 600;
+        line-height: 1.6;
+        padding: 0 var(--lana-space-xs);
+        border-radius: var(--lana-radius-sm);
+        color: var(--lana-badge-fg);
+        background-color: var(--lana-badge-bg);
+        white-space: nowrap;
       }
 
       /* Most summaries are a short label, but a FATAL ERROR carries the whole exception:
@@ -219,7 +248,11 @@ export class IssueList extends LitElement {
 
   private _card(issue: LogIssue, index: number): TemplateResult {
     const action = issue.action;
-    const label = action ? `${issue.summary} — ${action.label}` : issue.summary;
+    // One composition for meta, title and aria, so the three can never drift apart.
+    const time = issue.timestamp !== null ? formatDuration(issue.timestamp) : null;
+    const meta = [issue.label, time].filter(Boolean);
+    const head = meta.length ? `${issue.summary} (${meta.join(', ')})` : issue.summary;
+    const label = action ? `${head} — ${action.label}` : head;
 
     // The card is a group, not a button: its message can itself be a button, and a control
     // inside a control is neither valid ARIA nor navigable. Pointer clicks still activate the
@@ -258,6 +291,16 @@ export class IssueList extends LitElement {
               : ''
           }
         </div>
+        ${
+          meta.length
+            ? // No issue__clamp/data-index here: _measure() must only ever see messages.
+              html`<div class="issue__meta">
+                ${issue.label ? html`<span class="issue__label">${issue.label}</span>` : ''}
+                ${issue.label && time ? html`<span>·</span>` : ''}
+                ${time ? html`<span>${time}</span>` : ''}
+              </div>`
+            : ''
+        }
         ${this._message(issue, index)}
       </div>
     </div>`;

--- a/log-viewer/src/features/notifications/components/NotificationCentre.ts
+++ b/log-viewer/src/features/notifications/components/NotificationCentre.ts
@@ -37,6 +37,12 @@ export class NotificationCentre extends LitElement {
         display: inline-flex;
         flex: 0 0 auto;
       }
+
+      /* Issue cards carry whole exception messages: widen past the menu default so the
+         two-line clamp holds a readable measure (~60 chars/line). */
+      anchored-popover {
+        --anchored-popover-width: 400px;
+      }
     `,
   ];
 

--- a/log-viewer/src/features/notifications/components/NotificationCentre.ts
+++ b/log-viewer/src/features/notifications/components/NotificationCentre.ts
@@ -37,12 +37,6 @@ export class NotificationCentre extends LitElement {
         display: inline-flex;
         flex: 0 0 auto;
       }
-
-      /* Issue cards carry whole exception messages: widen past the menu default so the
-         two-line clamp holds a readable measure (~60 chars/line). */
-      anchored-popover {
-        --anchored-popover-width: 400px;
-      }
     `,
   ];
 
@@ -55,6 +49,7 @@ export class NotificationCentre extends LitElement {
       align="end"
       heading="Notifications"
       show-heading
+      wide
       empty-message="Log parsed with no issues"
     >
       <span slot="trigger" class="header-control" title=${label} aria-label=${label}>

--- a/log-viewer/src/features/notifications/types.ts
+++ b/log-viewer/src/features/notifications/types.ts
@@ -34,8 +34,8 @@ export interface LogIssue {
   readonly summary: string;
   readonly message: string | TemplateResult<1>;
   readonly severity: IssueSeverity;
-  /** Short kind badge next to the summary (e.g. `Fatal error`), or absent for none. */
-  readonly label?: string | null;
+  /** Short kind badge on the meta line (e.g. `Fatal error`), or `null` for none. */
+  readonly label: string | null;
   /** What clicking the card does, or `null` for a card that isn't actionable. */
   readonly action: IssueAction | null;
   /**

--- a/log-viewer/src/features/notifications/types.ts
+++ b/log-viewer/src/features/notifications/types.ts
@@ -34,6 +34,8 @@ export interface LogIssue {
   readonly summary: string;
   readonly message: string | TemplateResult<1>;
   readonly severity: IssueSeverity;
+  /** Short kind badge next to the summary (e.g. `Fatal error`), or absent for none. */
+  readonly label?: string | null;
   /** What clicking the card does, or `null` for a card that isn't actionable. */
   readonly action: IssueAction | null;
   /**

--- a/log-viewer/src/features/timeline/__tests__/marker-utils.test.ts
+++ b/log-viewer/src/features/timeline/__tests__/marker-utils.test.ts
@@ -45,9 +45,10 @@ describe('extractMarkers', () => {
     expect(markers[0]!.endTime).toBeUndefined();
   });
 
-  it('drops error issues (exceptions cover them)', () => {
+  it('drops error and fatal issues (exceptions cover them)', () => {
     const issues: LogIssue[] = [
-      { startTime: 100, summary: 'FATAL ERROR! cause=boom', description: '', type: 'error' },
+      { startTime: 100, summary: 'System.LimitException: cpu', description: '', type: 'fatal' },
+      { startTime: 150, summary: 'System.LimitException: soql', description: '', type: 'error' },
       { startTime: 200, summary: 'Skipped-Lines', description: '', type: 'skip' },
     ];
 

--- a/log-viewer/src/features/timeline/services/Timeline.ts
+++ b/log-viewer/src/features/timeline/services/Timeline.ts
@@ -25,6 +25,7 @@ interface TimelineColors {
 const truncationColors: Map<string, string> = new Map([
   ['exception', 'rgba(229, 72, 77, 0.9)'],
   ['error', 'rgba(255, 128, 128, 0.2)'],
+  ['fatal', 'rgba(255, 128, 128, 0.2)'],
   ['skip', 'rgb(30, 128, 255, 0.2)'],
   ['unexpected', 'rgba(128, 128, 255, 0.2)'],
 ]);

--- a/log-viewer/src/features/timeline/types/flamechart.types.ts
+++ b/log-viewer/src/features/timeline/types/flamechart.types.ts
@@ -637,11 +637,11 @@ export function markerColorCss(type: MarkerType): string {
 /**
  * The marker a parsed log issue is drawn as, so a DOM renderer can match its band.
  *
- * `'error'` maps to `'exception'`: `extractMarkers` drops `'error'` logIssues and the same
+ * `'error'` and `'fatal'` map to `'exception'`: `extractMarkers` drops both and the same
  * failure is drawn from `log.exceptions`, so the exception hue is what's actually on screen.
  */
 export function markerTypeForIssue(issueType: LogIssue['type']): MarkerType {
-  return issueType === 'error' ? 'exception' : issueType;
+  return issueType === 'error' || issueType === 'fatal' ? 'exception' : issueType;
 }
 
 /**

--- a/log-viewer/src/features/timeline/utils/marker-utils.ts
+++ b/log-viewer/src/features/timeline/utils/marker-utils.ts
@@ -42,7 +42,8 @@ export function extractMarkers(log: ApexLog): TimelineMarker[] {
     }
 
     // Exceptions are drawn from the exception events (see extractExceptionMarkers),
-    // so skip 'error' issues here to avoid a duplicated red channel.
+    // so skip 'error' issues here to avoid a duplicated red channel. 'fatal' issues
+    // are excluded for the same reason, by the isMarkerType guard above.
     if (issue.type === 'error') {
       continue;
     }

--- a/log-viewer/src/features/timeline/utils/marker-utils.ts
+++ b/log-viewer/src/features/timeline/utils/marker-utils.ts
@@ -10,7 +10,7 @@
 
 import type { ApexLog } from 'apex-log-parser';
 import type { TimelineMarker } from '../types/flamechart.types.js';
-import { isMarkerType } from '../types/flamechart.types.js';
+import { isMarkerType, markerTypeForIssue } from '../types/flamechart.types.js';
 
 /**
  * Extracts markers from ApexLog.logIssues array.
@@ -21,7 +21,7 @@ import { isMarkerType } from '../types/flamechart.types.js';
  * Mapping rules:
  * - 'skip' → skip (skipped lines)
  * - 'unexpected' → unexpected (incomplete entries)
- * - 'error' issues are dropped here: exceptions are surfaced instead via
+ * - 'error' and 'fatal' issues are dropped here: exceptions are surfaced instead via
  *   {@link extractExceptionMarkers}, which covers LimitException/FATAL_ERROR.
  *
  * @param log - Parsed Apex log containing logIssues array
@@ -36,15 +36,14 @@ export function extractMarkers(log: ApexLog): TimelineMarker[] {
 
   let markerIndex = 0;
   for (const issue of log.logIssues) {
-    // Validate type using type guard
-    if (!isMarkerType(issue.type)) {
+    // Exceptions are drawn from the exception events (see extractExceptionMarkers), so
+    // skip any issue on the exception channel here to avoid a duplicated red channel.
+    if (markerTypeForIssue(issue.type) === 'exception') {
       continue;
     }
 
-    // Exceptions are drawn from the exception events (see extractExceptionMarkers),
-    // so skip 'error' issues here to avoid a duplicated red channel. 'fatal' issues
-    // are excluded for the same reason, by the isMarkerType guard above.
-    if (issue.type === 'error') {
+    // Validate type using type guard
+    if (!isMarkerType(issue.type)) {
       continue;
     }
 

--- a/log-viewer/src/styles/tokens.css
+++ b/log-viewer/src/styles/tokens.css
@@ -59,6 +59,13 @@
   --lana-shadow-popover: 0 4px 16px var(--vscode-widget-shadow, rgba(0, 0, 0, 0.36));
   --lana-shadow-overlay: 0 8px 24px var(--vscode-widget-shadow, rgba(0, 0, 0, 0.5));
 
+  /* Badges — small count/kind pills, matching VS Code's own badge chrome. */
+  --lana-badge-bg: var(--vscode-badge-background, #616161);
+  --lana-badge-fg: var(--vscode-badge-foreground, #f8f8f8);
+
+  /* Secondary text — metadata that must not compete with the content it annotates. */
+  --lana-fg-muted: var(--vscode-descriptionForeground, rgba(204, 204, 204, 0.7));
+
   /* The hairline between panes, and around a docked one. */
   --lana-panel-divider: var(--vscode-sideBar-border, transparent);
 


### PR DESCRIPTION
## What

Improves how the parser reports log issues and how the issue cards present them.

**Parser (`apex-log-parser`)**
- New `'fatal'` `IssueType` for FATAL_ERROR issues; the `FATAL ERROR! cause=` text prefix is gone — kind is data, not text.
- Issue summaries are the full untruncated first line (the 99-char + `…` cap on exception summaries is removed; the UI clamps for presentation).
- Descriptions carry only the stack trace, no duplicated first line and no trailing newline.
- Fatal/thrown pairs with identical messages both survive dedupe (key is now `type + summary`) — cause and effect are distinct issues at distinct timestamps.

**Log viewer**
- Issue cards get a meta line under the summary: a kind pill plus the time in the log, e.g. `Fatal error · 24.6 s`. Duplicate-looking fatal/thrown pairs are now distinguishable at a glance, and the summary keeps its full width for the two-line clamp.
- The Log problems and Notifications popovers widen to 400px (~60 chars/line readable measure); menus keep the compact 320px default via a new `--anchored-popover-width` knob on `anchored-popover`.
- New `--lana-fg-muted` token for secondary text; timeline markers treat `'fatal'` like `'error'` (drawn from `log.exceptions`, not double-drawn).

<img width="578" height="333" alt="image" src="https://github.com/user-attachments/assets/58659701-c993-47df-be4b-4b62e8e5713c" />


## Why

`FATAL ERROR! cause=` reads badly in the panel and severity/kind is better conveyed as UI data (icon, rail, pill) than as shouty text. A survey of ~146 real logs showed the prefix adds no information — the payloads are already self-describing exceptions.

## Testing

- Full suite green (1324 tests), typecheck and lint clean.
- Manually verified in the extension dev host with fatal logs, light and dark themes: pill + time meta line, full-width summary clamp, stack-only descriptions, timeline markers unchanged.