### PR TITLE
ci(dependabot): encode platform constraints, group salesforce, add cooldown

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,15 +5,32 @@ updates:
     schedule:
       interval: 'daily'
     versioning-strategy: auto
-    # majors are deliberately left out of the groups so each one still arrives
-    # as its own PR - they need reading and are reverted individually
+    # let freshly published versions age before proposing them (supply-chain hygiene)
+    cooldown:
+      default-days: 7
+      semver-major-days: 14
+    # majors are deliberately left out of the minor/patch groups so each one still
+    # arrives as its own PR - they need reading and are reverted individually
     groups:
+      # exception: @salesforce/apex-node majors require the matching
+      # @salesforce/core major, so these move in lockstep incl. majors
+      salesforce:
+        patterns: ['@salesforce/*']
       production-dependencies:
         dependency-type: 'production'
         update-types: ['minor', 'patch']
       development-dependencies:
         dependency-type: 'development'
         update-types: ['minor', 'patch']
+    ignore:
+      # engines.vscode sets the API floor; types must not exceed it (vsce rejects
+      # the package otherwise). Bump by hand when engines.vscode is raised.
+      - dependency-name: '@types/vscode'
+        update-types: ['version-update:semver-major', 'version-update:semver-minor']
+      # types track the extension-host Node runtime of the minimum supported
+      # VS Code version, not the latest Node release
+      - dependency-name: '@types/node'
+        update-types: ['version-update:semver-major']
   - package-ecosystem: 'github-actions'
     directory: '/'
     schedule:


### PR DESCRIPTION
Dependabot keeps proposing updates the project cannot take, and manually closed PRs come back with each new release. This encodes the platform constraints in the config so only mergeable PRs are raised:

- **Ignore `@types/vscode` minor/major updates** — `engines.vscode` sets the API floor; `vsce` rejects a package whose types exceed it. Minor bumps were landing inside the grouped dev-dependencies PR and blocking the whole group (see #906). Patch updates still flow; bump by hand when the engine floor is raised.
- **Ignore `@types/node` major updates** — types track the extension-host Node runtime of the minimum supported VS Code version, not the latest Node release (see #885 and its closed predecessors).
- **Group `@salesforce/*` including majors** — `@salesforce/apex-node` majors require the matching `@salesforce/core` major, so they must arrive as one PR instead of two unmergeable halves (see #905 / #902).
- **Add a cooldown** (7 days, 14 for majors) so freshly published versions age before being proposed — npm supply-chain hygiene.

After this merges, `@dependabot recreate` on #906 regenerates it without `@types/vscode`, leaving only the lint-staged bump, which passes CI. Dependabot closes #885 on its next run.