### PR TITLE
build(deps): require VS Code 1.102 and update salesforce packages to v9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- ⬆️ **Requires VS Code 1.102 or newer**.
 - 📊 **Timeline**
   - **Governor limits strip**: tooltip rows keep a stable order and always show the `used / limit` value, so figures no longer jump around as you move the pointer. ([#827])
   - **Timeline zooming**: consistent, smooth zoom across platforms and input devices — a Windows mouse wheel no longer over-zooms in large jumps, fast scrolls stay bounded, and zooming in then back out returns to the same level.

--- a/lana/package.json
+++ b/lana/package.json
@@ -47,7 +47,7 @@
     "url": "https://github.com/certinia/debug-log-analyzer.git"
   },
   "engines": {
-    "vscode": "^1.100.0"
+    "vscode": "^1.102.0"
   },
   "categories": [
     "Other"
@@ -376,13 +376,13 @@
   "dependencies": {
     "@apexdevtools/apex-ls": "^6.0.2",
     "@apexdevtools/apex-parser": "5.1.0",
-    "@salesforce/apex-node": "^8.4.39",
-    "@salesforce/core": "^8.32.6"
+    "@salesforce/apex-node": "^9.0.0",
+    "@salesforce/core": "^9.1.0"
   },
   "devDependencies": {
     "@types/jest": "^30.0.0",
     "@types/node": "~22.16.5",
-    "@types/vscode": "~1.100.0",
+    "@types/vscode": "~1.102.0",
     "typescript": "npm:@typescript/typescript6@^6.0.2"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -119,11 +119,11 @@ importers:
         specifier: 5.1.0
         version: 5.1.0
       '@salesforce/apex-node':
-        specifier: ^8.4.39
-        version: 8.4.39
+        specifier: ^9.0.0
+        version: 9.0.2
       '@salesforce/core':
-        specifier: ^8.32.6
-        version: 8.32.6
+        specifier: ^9.1.0
+        version: 9.1.0
     devDependencies:
       '@types/jest':
         specifier: ^30.0.0
@@ -132,8 +132,8 @@ importers:
         specifier: ~22.16.5
         version: 22.16.5
       '@types/vscode':
-        specifier: ~1.100.0
-        version: 1.100.0
+        specifier: ~1.102.0
+        version: 1.102.0
       typescript:
         specifier: npm:@typescript/typescript6@^6.0.2
         version: '@typescript/typescript6@6.0.2'
@@ -2710,20 +2710,21 @@ packages:
   '@rspack/lite-tapable@1.1.0':
     resolution: {integrity: sha512-E2B0JhYFmVAwdDiG14+DW0Di4Ze4Jg10Pc4/lILUrd5DRCaklduz2OvJ5HYQ6G+hd+WTzqQb3QnDNfK4yvAFYw==}
 
-  '@salesforce/apex-node@8.4.39':
-    resolution: {integrity: sha512-zmE6FyBJsskUpVeZxJwFmyCxwDv6Ab3ApJ2FRyWBwX8QBlMnvyV4KqCxPoOxCW6zgl5Af9fw/3aVKNhnrMC+mA==}
-    engines: {node: '>=18.18.2'}
+  '@salesforce/apex-node@9.0.2':
+    resolution: {integrity: sha512-TD7REX5rTf60pH2DzY5DgbFOsonmwqAQLmfw6mTHTGTbx8jCEcPgaa1F2mvQn7Vg2i7r+ifbJ9YPkwn7aqXF5w==}
+    engines: {node: '>=22.0.0'}
 
-  '@salesforce/core@8.32.6':
-    resolution: {integrity: sha512-ZR973WoqCgi6cR58WhgokbHVZOaADNKHiuM1FAwS5pTLQnC91xYi04i2e/gpAX2AUf7Ya6zjbusYtZNpSyKKAQ==}
-    engines: {node: '>=18.0.0'}
+  '@salesforce/core@9.1.0':
+    resolution: {integrity: sha512-ID9g4YH0yZBeWI0eKJv2IJRRN6ZuNjwpIOjEZm9a79Gzxa3IITsV4PCvD8q7JA3PKqiln57p8yJE458Kn5KW1g==}
+    engines: {node: '>=22.0.0'}
 
-  '@salesforce/kit@3.2.6':
-    resolution: {integrity: sha512-O8S4LWerHa9Zosqh+IoQjgLtpxMOfObRxaRnUdRV4MLtFUi+bQxQiyFvve6eEaBaMP1b1xVDQpvSvQ+PXEDGFQ==}
+  '@salesforce/kit@4.0.0':
+    resolution: {integrity: sha512-VwxhSH/8PQ5YmPAdhmLaJGCgR0n/pOm8T2y+/odMFthd5SA0xsO/kTdaRLFnFQAxxNj1nYtNHRb+BoMuAatzew==}
+    engines: {node: '>=22.0.0'}
 
-  '@salesforce/ts-types@2.0.12':
-    resolution: {integrity: sha512-BIJyduJC18Kc8z+arUm5AZ9VkPRyw1KKAm+Tk+9LT99eOzhNilyfKzhZ4t+tG2lIGgnJpmytZfVDZ0e2kFul8g==}
-    engines: {node: '>=18.0.0'}
+  '@salesforce/ts-types@3.0.1':
+    resolution: {integrity: sha512-NWkveMYT2I3O7EAYwWHi6/ba2YUwp9MFi/zJzA+czK5MVqJfdD6FZbiQrTbALZNvFzgFSdq9BvHm6ygRmtROzw==}
+    engines: {node: '>=22.0.0'}
 
   '@sideway/address@4.1.5':
     resolution: {integrity: sha512-IqO/DUQHUkPeixNQ8n0JA6102hT9CmaljNTPmQ1u8MEhBo/R4Q8eKLN/vGZxuebwOroDB4cbpjheD4+/sKFK4Q==}
@@ -3201,8 +3202,8 @@ packages:
   '@types/unist@3.0.3':
     resolution: {integrity: sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==}
 
-  '@types/vscode@1.100.0':
-    resolution: {integrity: sha512-4uNyvzHoraXEeCamR3+fzcBlh7Afs4Ifjs4epINyUX/jvdk0uzLnwiDY35UKDKnkCHP5Nu3dljl2H8lR6s+rQw==}
+  '@types/vscode@1.102.0':
+    resolution: {integrity: sha512-V9sFXmcXz03FtYTSUsYsu5K0Q9wH9w9V25slddcxrh5JgORD14LpnOA7ov0L9ALi+6HrTjskLJ/tY5zeRF3TFA==}
 
   '@types/ws@8.18.1':
     resolution: {integrity: sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==}
@@ -7356,10 +7357,6 @@ packages:
     engines: {node: '>=20.19.0'}
     hasBin: true
 
-  sax@1.6.0:
-    resolution: {integrity: sha512-6R3J5M4AcbtLUdZmRv2SygeVaM7IhrLXu9BmnOGmmACak8fiUtOsYNWUS4uK7upbmHIBbLBeFeI//477BKLBzA==}
-    engines: {node: '>=11.0.0'}
-
   sax@1.6.1:
     resolution: {integrity: sha512-42tBVwLWnaQvW5zc4HbZrTuWccECCZfBi92FDuwtqxasH+JbPB3/FOKb1m222K42R4WxuxzzMsTswfzgtSu64Q==}
     engines: {node: '>=11.0.0'}
@@ -7406,11 +7403,6 @@ packages:
 
   semver@7.8.1:
     resolution: {integrity: sha512-rkVq3IXh+4FDGch+KwzX3aV9W3kO54GyEgpvBzSyctDA6Xtd7RJQV1xmXbeQp5v7+VzLOfVqiutSE6GICgPFvg==}
-    engines: {node: '>=10'}
-    hasBin: true
-
-  semver@7.8.4:
-    resolution: {integrity: sha512-rUCObTnP32Q08R2uuIrt7r9PlEonuTmtuXYcW6s5kjdlj3xbnwe+21yXptAUYcMAABLkYYTtnmzb3w3EDZfueA==}
     engines: {node: '>=10'}
     hasBin: true
 
@@ -7762,12 +7754,6 @@ packages:
     peerDependencies:
       tslib: ^2
 
-  thingies@2.6.0:
-    resolution: {integrity: sha512-rMHRjmlFLM1R96UYPvpmnc3LYtdFrT33JIB7L9hetGue1qAPfn1N2LJeEjxUSidu1Iku+haLZXDuEXUHNGO/lg==}
-    engines: {node: '>=10.18'}
-    peerDependencies:
-      tslib: ^2
-
   thingies@2.6.1:
     resolution: {integrity: sha512-cV/CMGTK3M4MlnJ/0At6ismOw/A0EEniDNScajjz/Br3c1sqE72YD01rGpPTKwd27wAxI5Pr+6+0w8yofzFRYw==}
     engines: {node: '>=10.18'}
@@ -7934,10 +7920,6 @@ packages:
 
   undici-types@8.3.0:
     resolution: {integrity: sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==}
-
-  undici@8.5.0:
-    resolution: {integrity: sha512-xamtWoB1EshgjpmlXd7GGm2VfdDtw1+rD8uhry8pSNW3If6S8E0m2T2+orSKeZXEn/aPJMviCpDBA65WJt8zhg==}
-    engines: {node: '>=22.19.0'}
 
   undici@8.9.0:
     resolution: {integrity: sha512-aWZpUj7XoGonMClx4gdDRfgBjqeA+F473aDmROQQbM9n6PRfK/u1q/a0X4wMTgcHfT8H6fpbt98PFuDUwFg2YA==}
@@ -11130,7 +11112,7 @@ snapshots:
       faye: 1.4.1
       form-data: 4.0.6
       multistream: 3.1.0
-      undici: 8.5.0
+      undici: 8.9.0
       xml2js: 0.6.2
 
   '@jsonjoy.com/base64@1.1.2(tslib@2.8.1)':
@@ -11925,10 +11907,10 @@ snapshots:
 
   '@rspack/lite-tapable@1.1.0': {}
 
-  '@salesforce/apex-node@8.4.39':
+  '@salesforce/apex-node@9.0.2':
     dependencies:
-      '@salesforce/core': 8.32.6
-      '@salesforce/kit': 3.2.6
+      '@salesforce/core': 9.1.0
+      '@salesforce/kit': 4.0.0
       '@types/istanbul-reports': 3.0.4
       fast-glob: 3.3.3
       faye: 1.4.1
@@ -11937,11 +11919,11 @@ snapshots:
       istanbul-reports: 3.2.0
       json-stream-stringify: 3.1.7
 
-  '@salesforce/core@8.32.6':
+  '@salesforce/core@9.1.0':
     dependencies:
       '@jsforce/jsforce-node': 3.10.19
-      '@salesforce/kit': 3.2.6
-      '@salesforce/ts-types': 2.0.12
+      '@salesforce/kit': 4.0.0
+      '@salesforce/ts-types': 3.0.1
       ajv: 8.20.0
       change-case: 4.1.2
       fast-levenshtein: 3.0.0
@@ -11955,15 +11937,15 @@ snapshots:
       pino-abstract-transport: 1.2.0
       pino-pretty: 11.3.0
       proper-lockfile: 4.1.2
-      semver: 7.8.4
+      semver: 7.8.5
       ts-retry-promise: 0.8.1
       zod: 4.4.3
 
-  '@salesforce/kit@3.2.6':
+  '@salesforce/kit@4.0.0':
     dependencies:
-      '@salesforce/ts-types': 2.0.12
+      '@salesforce/ts-types': 3.0.1
 
-  '@salesforce/ts-types@2.0.12': {}
+  '@salesforce/ts-types@3.0.1': {}
 
   '@sideway/address@4.1.5':
     dependencies:
@@ -12434,7 +12416,7 @@ snapshots:
 
   '@types/unist@3.0.3': {}
 
-  '@types/vscode@1.100.0': {}
+  '@types/vscode@1.102.0': {}
 
   '@types/ws@8.18.1':
     dependencies:
@@ -15255,7 +15237,7 @@ snapshots:
       lodash.isstring: 4.0.1
       lodash.once: 4.1.1
       ms: 2.1.3
-      semver: 7.8.4
+      semver: 7.8.5
 
   jszip@3.10.1:
     dependencies:
@@ -15665,7 +15647,7 @@ snapshots:
       '@jsonjoy.com/json-pack': 1.21.0(tslib@2.8.1)
       '@jsonjoy.com/util': 1.9.0(tslib@2.8.1)
       glob-to-regex.js: 1.2.0(tslib@2.8.1)
-      thingies: 2.6.0(tslib@2.8.1)
+      thingies: 2.6.1(tslib@2.8.1)
       tree-dump: 1.1.0(tslib@2.8.1)
       tslib: 2.8.1
 
@@ -17404,8 +17386,6 @@ snapshots:
     optionalDependencies:
       '@parcel/watcher': 2.5.6
 
-  sax@1.6.0: {}
-
   sax@1.6.1: {}
 
   saxes@6.0.0:
@@ -17450,8 +17430,6 @@ snapshots:
   semver@6.3.1: {}
 
   semver@7.8.1: {}
-
-  semver@7.8.4: {}
 
   semver@7.8.5: {}
 
@@ -17795,10 +17773,6 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
-  thingies@2.6.0(tslib@2.8.1):
-    dependencies:
-      tslib: 2.8.1
-
   thingies@2.6.1(tslib@2.8.1):
     dependencies:
       tslib: 2.8.1
@@ -17949,8 +17923,6 @@ snapshots:
   undici-types@7.24.6: {}
 
   undici-types@8.3.0: {}
-
-  undici@8.5.0: {}
 
   undici@8.9.0: {}
 
@@ -18418,7 +18390,7 @@ snapshots:
 
   xml2js@0.6.2:
     dependencies:
-      sax: 1.6.0
+      sax: 1.6.1
       xmlbuilder: 11.0.1
 
   xmlbuilder@11.0.1: {}


### PR DESCRIPTION
Takes the `@salesforce/core` 9 / `@salesforce/apex-node` 9 majors (supersedes #905 and #902, which are individually unmergeable because `apex-node@9` requires `core@^9`).

The v9 majors' only breaking change is requiring Node >=22. The desktop extension host already runs Node 22 at our current floor (VS Code 1.100 = Electron 34.5), but the *remote* extension host at 1.100 is Node 20.19 — VS Code 1.101 is the first release whose remote host runs Node 22. This bumps `engines.vscode` to `^1.102.0` (June 2025 release) so Node >=22 holds on desktop and remote, and moves `@types/vscode` to match.

- `engines.vscode` / `@types/vscode` → 1.102
- `@salesforce/core` → ^9.1.0, `@salesforce/apex-node` → ^9.0.0 (lockfile resolves 9.1.0 / 9.0.2)
- CHANGELOG: requires VS Code 1.102 or newer

Verified: typecheck, lint, all 1324 tests, production build, and `vsce package --no-dependencies` all pass.