### PR TITLE
fix(timeline): fill the container height instead of 90 percent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - 🎨 **Timeline theme switch**: parts of the Timeline did not update on theme switch until the log view was reopened; they now do.
 - 📊 **Database usage bars** (Row Count, Time Taken): the usage bar was hidden whenever the rounded percentage was 0% (the common case for small row counts against large governor limits), so it rarely appeared; it now fills relative to the grid's own column total rather than a governor limit, shows on grouped summary rows, and Time Taken (ms) now shows a bar too. ([#873])
 - 🎨 **Theme colours**: some colours did not update on theme switch; they now do.
+- 📐 **Timeline height**: the Flame Chart stopped short of the bottom of its panel, leaving a strip of empty space; it now fills the panel and follows the Inspector as you resize or re-dock it.
 
 ## [1.20.1] 2026-07-23
 

--- a/log-viewer/src/features/timeline/components/TimelineView.ts
+++ b/log-viewer/src/features/timeline/components/TimelineView.ts
@@ -136,7 +136,7 @@ export class TimelineView extends LitElement {
         flex: 1;
         position: relative;
         width: 100%;
-        height: 90%;
+        height: 100%;
         /* inset previously provided by the tab panel's padding */
         padding: 10px 6px;
         box-sizing: border-box;
@@ -147,6 +147,21 @@ export class TimelineView extends LitElement {
         align-items: center;
         justify-content: flex-end;
         gap: 4px;
+        flex: 0 0 auto;
+      }
+
+      /* The chart takes every row the container gives it, and the renderer scrolls
+         when the call depth needs more; the key and the toolbar keep their own
+         height. The zero min-height lets the chart shrink below its content, which
+         a flex item does not do by default. */
+      timeline-flame-chart,
+      timeline-legacy,
+      timeline-skeleton {
+        flex: 1 1 0;
+        min-height: 0;
+      }
+
+      timeline-key {
         flex: 0 0 auto;
       }
     `,


### PR DESCRIPTION
# 📝 PR Overview

The Timeline's Flame Chart pinned itself to 90% of its tab panel, so the bottom tenth of the panel stayed empty. This is most visible now the Inspector can dock at the bottom: the chart stopped short of the sash. The chart now fills the panel and follows it on resize and re-dock.

The panel element is a block box, so the host's `flex: 1` never applied and the percentage was a guess to leave room for the colour key.

The container drives the size and the content scrolls — the model Chrome DevTools Performance, Firefox Profiler and Perfetto all use. Height is deliberately not derived from call depth: that would make the pane jump between logs, fight the dock sash, and still fail once depth passes what the screen holds. The renderer already scrolls vertically to the full depth (`TimelineViewport.clampOffsetY`), anchored at the bottom.

## 🛠️ Changes made

- `TimelineView` host height 90% → 100%.
- The chart is the growing flex item (`flex: 1 1 0; min-height: 0`); the toolbar and the colour key keep their own height.
- Same rule covers the loading skeleton and the legacy chart, which held the same guess (80%).

## 🧩 Type of change (check all applicable)

- [x] 🐛 Bug fix - something not working as expected
- [ ] ✨ New feature – adds new functionality
- [ ] ♻️ Refactor - internal changes with no user impact
- [ ] ⚡ Performance Improvement
- [ ] 📝 Documentation - README or documentation site changes
- [ ] 🔧 Chore - dev tooling, CI, config
- [ ] 💥 Breaking change

## 📷 Screenshots / gifs / video [optional]

_Checked in the dev host, Inspector docked bottom and right, in a light and a dark theme._

## 🔗 Related Issues

None — found while testing the Inspector's bottom dock.

## ✅ Tests added?

- [ ] 👍 yes
- [x] 🙅 no, not needed
- [ ] 🙋 no, I need help

A three-line stylesheet change with no logic to assert; jsdom does not lay out flexbox, so a unit test could only re-state the CSS.

## 📚 Docs updated?

- [ ] 🔖 README.md
- [x] 🔖 CHANGELOG.md
- [ ] 📖 help site
- [ ] 🧪 Marked any pre-release-only features
- [ ] 🙅 not needed
