### PR TITLE
feat(inspector): show a whole-log overview when nothing is selected

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Click a row and the matching frame or row is highlighted in the tab you're on, without switching tab: the Timeline selects the frame and centers it when it's off screen, the Call Tree scrolls to it in **Time Order**, and the Database tab selects the statement.
   - Dock it left, right or bottom, drag to resize, and collapse the sections you don't need — the layout is remembered.
   - Right-click a row for **Show in Call Tree**, **Copy Name**, **Copy Details** or **Copy Call Stack**; `Cmd/Ctrl+C` copies the table.
+  - **Log overview**: with nothing selected, the Inspector shows the whole log instead of sitting empty — the six governor metrics closest to their limit, each as `used / limit`. A metric is read from the namespace nearest its own limit, never from a sum across namespaces.
 - 🗄️ **Database Analysis**: governor-limit visibility and SOSL usage. ([#162])
   - 📏 **Governor-limit overview**: SOQL, SOSL, DML and query/DML rows shown as `used / limit`, colored as they approach the limit.
   - 🧮 **Found vs Counted**: each section reconciles statements found in the log against the governor-counted total, flagging queries that didn't consume the limit (e.g. custom metadata, which is free unless it selects a long text area field or runs in a Flow).
@@ -59,6 +60,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - 🎨 **Timeline theme switch**: parts of the Timeline did not update on theme switch until the log view was reopened; they now do.
 - 📊 **Database usage bars** (Row Count, Time Taken): the usage bar was hidden whenever the rounded percentage was 0% (the common case for small row counts against large governor limits), so it rarely appeared; it now fills relative to the grid's own column total rather than a governor limit, shows on grouped summary rows, and Time Taken (ms) now shows a bar too. ([#873])
 - 🎨 **Theme colours**: some colours did not update on theme switch; they now do.
+- 🧭 **Inspector call stack**: cumulative limit and profiling frames appeared in the stack, so the path to a selection read wrong; the stack now excludes them, like the call tree already did.
 
 ## [1.20.1] 2026-07-23
 

--- a/log-viewer/src/components/LogOverview.ts
+++ b/log-viewer/src/components/LogOverview.ts
@@ -1,0 +1,94 @@
+/*
+ * Copyright (c) 2026 Certinia Inc. All rights reserved.
+ */
+import { LitElement, css, html } from 'lit';
+import { customElement, property } from 'lit/decorators.js';
+
+import type { DetailSource } from '../core/events/EventBus.js';
+import { eventBus } from '../core/events/EventBus.js';
+import type { GaugeMetric } from '../features/database/components/GovernorSummary.js';
+import { DatabaseAccess } from '../features/database/services/Database.js';
+import { globalStyles } from '../styles/global.styles.js';
+import { emptyTextFor } from './detailEmptyText.js';
+import { tightestGauges } from './logOverviewMetrics.js';
+
+// web components
+import '../features/database/components/GovernorSummary.js';
+
+/**
+ * The inspector's whole-log section, shown while nothing is selected: the
+ * governor metrics nearest a limit, plus the hint that names what to select for
+ * a scoped read. The hint lives here because every source now returns a section,
+ * so `DetailDock`'s own empty text only shows before a tab id resolves.
+ *
+ * Log size and duration are deliberately absent — `LogMeta` heads the app with
+ * both.
+ */
+@customElement('log-overview')
+export class LogOverview extends LitElement {
+  /** The tab the inspector follows, which decides the selection hint. */
+  @property({ type: String })
+  source: DetailSource | undefined;
+
+  private _offLogLoaded: (() => void) | null = null;
+
+  override connectedCallback() {
+    super.connectedCallback();
+    // The inspector paints before the first log is parsed, and it rebuilds only
+    // on a tab change or a selection — so the gauges have to follow the log
+    // themselves.
+    this._offLogLoaded = eventBus.on('log:loaded', () => this.requestUpdate());
+  }
+
+  override disconnectedCallback() {
+    this._offLogLoaded?.();
+    this._offLogLoaded = null;
+    super.disconnectedCallback();
+  }
+
+  static styles = [
+    globalStyles,
+    css`
+      :host {
+        display: block;
+      }
+
+      .note,
+      .hint {
+        /* Left inset lines the text up with the gauge strip's labels. */
+        padding: var(--lana-space-sm) var(--lana-space-md) 0 var(--lana-section-inset);
+        color: var(--lana-fg-muted);
+        font-size: var(--lana-text-sm);
+      }
+
+      .hint {
+        padding-bottom: var(--lana-space-md);
+      }
+    `,
+  ];
+
+  render() {
+    const gauges = this._gauges();
+    return html`
+      ${
+        gauges.length
+          ? html`<governor-summary .metrics=${gauges}></governor-summary>`
+          : html`<p class="note">
+              This log has no cumulative limit usage, so governor totals are unknown.
+            </p>`
+      }
+      <p class="hint">${emptyTextFor(this.source)}</p>
+    `;
+  }
+
+  private _gauges(): GaugeMetric[] {
+    const limits = DatabaseAccess.instance()?.getApexLog()?.governorLimits;
+    return limits ? tightestGauges(limits) : [];
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'log-overview': LogOverview;
+  }
+}

--- a/log-viewer/src/components/__tests__/LogOverview.test.ts
+++ b/log-viewer/src/components/__tests__/LogOverview.test.ts
@@ -3,24 +3,10 @@
  *
  * @jest-environment jsdom
  */
-import type { GovernorLimits, Limits } from 'apex-log-parser';
+import type { GovernorLimits } from 'apex-log-parser';
 import { beforeEach, describe, expect, it } from '@jest/globals';
 
-const emptyLimits = (): Limits => ({
-  soqlQueries: { used: 0, limit: 0 },
-  soslQueries: { used: 0, limit: 0 },
-  queryRows: { used: 0, limit: 0 },
-  dmlStatements: { used: 0, limit: 0 },
-  publishImmediateDml: { used: 0, limit: 0 },
-  dmlRows: { used: 0, limit: 0 },
-  cpuTime: { used: 0, limit: 0 },
-  heapSize: { used: 0, limit: 0 },
-  callouts: { used: 0, limit: 0 },
-  emailInvocations: { used: 0, limit: 0 },
-  futureCalls: { used: 0, limit: 0 },
-  queueableJobsAddedToQueue: { used: 0, limit: 0 },
-  mobileApexPushCalls: { used: 0, limit: 0 },
-});
+import { emptyLimits } from './limitsTestUtils.js';
 
 // The log arrives after the first paint, which is the case this covers.
 let governorLimits: GovernorLimits | null = null;

--- a/log-viewer/src/components/__tests__/LogOverview.test.ts
+++ b/log-viewer/src/components/__tests__/LogOverview.test.ts
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 2026 Certinia Inc. All rights reserved.
+ *
+ * @jest-environment jsdom
+ */
+import type { GovernorLimits, Limits } from 'apex-log-parser';
+import { beforeEach, describe, expect, it } from '@jest/globals';
+
+const emptyLimits = (): Limits => ({
+  soqlQueries: { used: 0, limit: 0 },
+  soslQueries: { used: 0, limit: 0 },
+  queryRows: { used: 0, limit: 0 },
+  dmlStatements: { used: 0, limit: 0 },
+  publishImmediateDml: { used: 0, limit: 0 },
+  dmlRows: { used: 0, limit: 0 },
+  cpuTime: { used: 0, limit: 0 },
+  heapSize: { used: 0, limit: 0 },
+  callouts: { used: 0, limit: 0 },
+  emailInvocations: { used: 0, limit: 0 },
+  futureCalls: { used: 0, limit: 0 },
+  queueableJobsAddedToQueue: { used: 0, limit: 0 },
+  mobileApexPushCalls: { used: 0, limit: 0 },
+});
+
+// The log arrives after the first paint, which is the case this covers.
+let governorLimits: GovernorLimits | null = null;
+jest.mock('../../features/database/services/Database.js', () => ({
+  DatabaseAccess: {
+    instance: () => (governorLimits ? { getApexLog: () => ({ governorLimits }) } : null),
+  },
+}));
+
+import { eventBus } from '../../core/events/EventBus.js';
+import '../LogOverview.js';
+
+const overview = async () => {
+  const element = document.createElement('log-overview');
+  element.source = 'timeline';
+  document.body.append(element);
+  await element.updateComplete;
+  return element;
+};
+
+describe('log-overview', () => {
+  beforeEach(() => {
+    document.body.replaceChildren();
+    governorLimits = null;
+  });
+
+  it('says the totals are unknown while no log holds cumulative limits', async () => {
+    const element = await overview();
+    expect(element.shadowRoot?.querySelector('.note')?.textContent).toContain(
+      'no cumulative limit usage',
+    );
+    expect(element.shadowRoot?.querySelector('governor-summary')).toBeNull();
+  });
+
+  it('shows the gauges once the log is parsed, without a selection', async () => {
+    const element = await overview();
+
+    const namespace = emptyLimits();
+    namespace.soqlQueries = { used: 40, limit: 100 };
+    governorLimits = {
+      ...emptyLimits(),
+      byNamespace: new Map([['default', namespace]]),
+      snapshots: [],
+    } as GovernorLimits;
+    eventBus.emit('log:loaded', {});
+    await element.updateComplete;
+
+    expect(element.shadowRoot?.querySelector('governor-summary')).not.toBeNull();
+    expect(element.shadowRoot?.querySelector('.note')).toBeNull();
+  });
+
+  it('names what to select for the source it follows', async () => {
+    const element = await overview();
+    expect(element.shadowRoot?.querySelector('.hint')?.textContent).toContain('timeline');
+  });
+});

--- a/log-viewer/src/components/__tests__/callStackData.test.ts
+++ b/log-viewer/src/components/__tests__/callStackData.test.ts
@@ -54,7 +54,7 @@ describe('buildCallStackData', () => {
     expect(rootTotal).toBe(0);
   });
 
-  it('drops detail frames, as the Call Tree tab does', () => {
+  it('drops detail frames, keeping call frames only', () => {
     currentStack = [
       {
         eventIndex: 7,

--- a/log-viewer/src/components/__tests__/callStackData.test.ts
+++ b/log-viewer/src/components/__tests__/callStackData.test.ts
@@ -54,6 +54,22 @@ describe('buildCallStackData', () => {
     expect(rootTotal).toBe(0);
   });
 
+  it('drops detail frames, as the Call Tree tab does', () => {
+    currentStack = [
+      {
+        eventIndex: 7,
+        type: 'CUMULATIVE_LIMIT_USAGE',
+        text: 'LIMIT_USAGE_FOR_NS',
+        duration: { total: 900_000, self: 0 },
+      },
+      ...stack,
+    ];
+    const { rows, rootTotal } = buildCallStackData(3);
+    expect(rows.map((r) => r.eventIndex)).toEqual([1, 2, 3]);
+    // The denominator follows the outermost frame still shown.
+    expect(rootTotal).toBe(41_200_000);
+  });
+
   it('handles an empty stack', () => {
     currentStack = [];
     const { rows, rootTotal } = buildCallStackData(3);

--- a/log-viewer/src/components/__tests__/detailSections.test.ts
+++ b/log-viewer/src/components/__tests__/detailSections.test.ts
@@ -10,6 +10,7 @@ import { describe, expect, it } from '@jest/globals';
 jest.mock('../CallStackDetail.js', () => ({}));
 jest.mock('../CallTreeDetail.js', () => ({}));
 jest.mock('../EventVitals.js', () => ({}));
+jest.mock('../LogOverview.js', () => ({}));
 
 const databaseCalls: { eventIndex: number; type: string }[] = [];
 jest.mock('../../features/database/components/databaseSections.js', () => ({
@@ -58,9 +59,11 @@ describe('buildDetailSections', () => {
     expect(sections.map((s) => s.id)).toEqual(['vitals', 'callstack', 'calltree']);
   });
 
-  it('builds no sections when nothing is selected, for every source', async () => {
+  it('builds the whole-log overview when nothing is selected, for every source', async () => {
     for (const source of ['timeline', 'calltree', 'analysis', 'database'] as const) {
-      expect(await buildDetailSections(source, null)).toEqual([]);
+      const sections = await buildDetailSections(source, null);
+      expect(sections.map((s) => s.id)).toEqual(['overview']);
+      expect(sections[0]?.title).toBe('Log overview');
     }
   });
 });

--- a/log-viewer/src/components/__tests__/limitsTestUtils.ts
+++ b/log-viewer/src/components/__tests__/limitsTestUtils.ts
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) 2026 Certinia Inc. All rights reserved.
+ */
+import type { Limits } from 'apex-log-parser';
+
+/** Every governor metric at zero, for a test to set only the ones it cares about. */
+export const emptyLimits = (): Limits => ({
+  soqlQueries: { used: 0, limit: 0 },
+  soslQueries: { used: 0, limit: 0 },
+  queryRows: { used: 0, limit: 0 },
+  dmlStatements: { used: 0, limit: 0 },
+  publishImmediateDml: { used: 0, limit: 0 },
+  dmlRows: { used: 0, limit: 0 },
+  cpuTime: { used: 0, limit: 0 },
+  heapSize: { used: 0, limit: 0 },
+  callouts: { used: 0, limit: 0 },
+  emailInvocations: { used: 0, limit: 0 },
+  futureCalls: { used: 0, limit: 0 },
+  queueableJobsAddedToQueue: { used: 0, limit: 0 },
+  mobileApexPushCalls: { used: 0, limit: 0 },
+});

--- a/log-viewer/src/components/__tests__/logOverviewMetrics.test.ts
+++ b/log-viewer/src/components/__tests__/logOverviewMetrics.test.ts
@@ -1,0 +1,106 @@
+/*
+ * Copyright (c) 2026 Certinia Inc. All rights reserved.
+ */
+import type { GovernorLimits, Limits } from 'apex-log-parser';
+import { describe, expect, it } from '@jest/globals';
+
+import { formatByteSize } from '../../core/utility/Util.js';
+import { tightestGauges } from '../logOverviewMetrics.js';
+
+const emptyLimits = (): Limits => ({
+  soqlQueries: { used: 0, limit: 0 },
+  soslQueries: { used: 0, limit: 0 },
+  queryRows: { used: 0, limit: 0 },
+  dmlStatements: { used: 0, limit: 0 },
+  publishImmediateDml: { used: 0, limit: 0 },
+  dmlRows: { used: 0, limit: 0 },
+  cpuTime: { used: 0, limit: 0 },
+  heapSize: { used: 0, limit: 0 },
+  callouts: { used: 0, limit: 0 },
+  emailInvocations: { used: 0, limit: 0 },
+  futureCalls: { used: 0, limit: 0 },
+  queueableJobsAddedToQueue: { used: 0, limit: 0 },
+  mobileApexPushCalls: { used: 0, limit: 0 },
+});
+
+const governorLimits = (byNamespace: Map<string, Limits>, rollUp?: Partial<Limits>) =>
+  ({ ...emptyLimits(), ...rollUp, byNamespace, snapshots: [] }) as GovernorLimits;
+
+describe('tightestGauges', () => {
+  it('ranks by percentage of the limit, tightest first', () => {
+    const ns = emptyLimits();
+    ns.soqlQueries = { used: 20, limit: 100 };
+    ns.dmlStatements = { used: 120, limit: 150 };
+    ns.cpuTime = { used: 500, limit: 10_000 };
+
+    const gauges = tightestGauges(governorLimits(new Map([['default', ns]])));
+
+    expect(gauges.map((g) => g.label)).toEqual(['DML', 'SOQL', 'CPU Time']);
+    expect(gauges[0]).toEqual({ label: 'DML', found: 120, used: 120, limit: 150 });
+  });
+
+  it('takes the tightest namespace per metric, never the sum (#862)', () => {
+    const first = emptyLimits();
+    first.soqlQueries = { used: 60, limit: 100 };
+    const second = emptyLimits();
+    second.soqlQueries = { used: 90, limit: 100 };
+
+    const gauges = tightestGauges(
+      governorLimits(
+        new Map([
+          ['default', first],
+          ['MyPackage', second],
+        ]),
+      ),
+    );
+
+    // 90/100, not 150/100 — and the namespace is named because it isn't default.
+    expect(gauges).toEqual([{ label: 'SOQL (MyPackage)', found: 90, used: 90, limit: 100 }]);
+  });
+
+  it('reads heap from the roll-up, where the parser stores the peak', () => {
+    const ns = emptyLimits();
+    ns.heapSize = { used: 1_000_000, limit: 6_000_000 };
+
+    const gauges = tightestGauges(
+      governorLimits(new Map([['default', ns]]), {
+        heapSize: { used: 5_400_000, limit: 6_000_000 },
+      }),
+    );
+
+    expect(gauges).toEqual([
+      {
+        label: 'Heap Size',
+        found: 5_400_000,
+        used: 5_400_000,
+        limit: 6_000_000,
+        // Bytes are written compactly; the raw figures do not fit a gauge.
+        format: formatByteSize,
+      },
+    ]);
+    expect(gauges[0]?.format?.(5_400_000)).toBe('5.4 MB');
+  });
+
+  it('drops metrics with no limit or no usage, and caps the strip at six', () => {
+    const ns = emptyLimits();
+    ns.soqlQueries = { used: 10, limit: 0 };
+    ns.dmlStatements = { used: 0, limit: 150 };
+    ns.cpuTime = { used: 1, limit: 10_000 };
+    ns.queryRows = { used: 2, limit: 50_000 };
+    ns.dmlRows = { used: 3, limit: 10_000 };
+    ns.soslQueries = { used: 4, limit: 20 };
+    ns.callouts = { used: 5, limit: 100 };
+    ns.futureCalls = { used: 6, limit: 50 };
+    ns.emailInvocations = { used: 7, limit: 10 };
+
+    const gauges = tightestGauges(governorLimits(new Map([['default', ns]])));
+
+    expect(gauges).toHaveLength(6);
+    expect(gauges.map((g) => g.label)).not.toContain('SOQL');
+    expect(gauges.map((g) => g.label)).not.toContain('DML');
+  });
+
+  it('returns nothing when no namespace reported any limits', () => {
+    expect(tightestGauges(governorLimits(new Map()))).toEqual([]);
+  });
+});

--- a/log-viewer/src/components/__tests__/logOverviewMetrics.test.ts
+++ b/log-viewer/src/components/__tests__/logOverviewMetrics.test.ts
@@ -6,22 +6,7 @@ import { describe, expect, it } from '@jest/globals';
 
 import { formatByteSize } from '../../core/utility/Util.js';
 import { tightestGauges } from '../logOverviewMetrics.js';
-
-const emptyLimits = (): Limits => ({
-  soqlQueries: { used: 0, limit: 0 },
-  soslQueries: { used: 0, limit: 0 },
-  queryRows: { used: 0, limit: 0 },
-  dmlStatements: { used: 0, limit: 0 },
-  publishImmediateDml: { used: 0, limit: 0 },
-  dmlRows: { used: 0, limit: 0 },
-  cpuTime: { used: 0, limit: 0 },
-  heapSize: { used: 0, limit: 0 },
-  callouts: { used: 0, limit: 0 },
-  emailInvocations: { used: 0, limit: 0 },
-  futureCalls: { used: 0, limit: 0 },
-  queueableJobsAddedToQueue: { used: 0, limit: 0 },
-  mobileApexPushCalls: { used: 0, limit: 0 },
-});
+import { emptyLimits } from './limitsTestUtils.js';
 
 const governorLimits = (byNamespace: Map<string, Limits>, rollUp?: Partial<Limits>) =>
   ({ ...emptyLimits(), ...rollUp, byNamespace, snapshots: [] }) as GovernorLimits;

--- a/log-viewer/src/components/callStackData.ts
+++ b/log-viewer/src/components/callStackData.ts
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2025 Certinia Inc. All rights reserved.
  */
+import { EXCLUDED_DETAIL_TYPES } from '../features/call-tree/utils/DetailsFilter.js';
 import { DatabaseAccess } from '../features/database/services/Database.js';
 
 export interface CallStackRow {
@@ -15,6 +16,10 @@ export interface CallStackRow {
  * frames that led to `eventIndex`, outermost first (as `getStackByEventIndex`
  * returns them). `rootTotal` (the outermost frame's total, in ns) is the
  * denominator for the Total/Self percentage bars.
+ *
+ * Detail frames are dropped, so the inspector never shows what the Call Tree tab
+ * hides: a `CUMULATIVE_LIMIT_USAGE` or `CUMULATIVE_PROFILING_BEGIN` block is a
+ * parent, so it can be an ancestor of a selected detail row.
  */
 export function buildCallStackData(eventIndex: number): {
   rows: CallStackRow[];
@@ -22,11 +27,14 @@ export function buildCallStackData(eventIndex: number): {
 } {
   const stack =
     eventIndex >= 0 ? (DatabaseAccess.instance()?.getStackByEventIndex(eventIndex) ?? []) : [];
-  const rows = stack.map((entry) => ({
-    eventIndex: entry.eventIndex,
-    type: entry.type ?? '',
-    text: entry.text,
-    duration: { total: entry.duration.total, self: entry.duration.self },
-  }));
-  return { rows, rootTotal: stack[0]?.duration.total ?? 0 };
+  const rows = stack
+    .filter((entry) => !EXCLUDED_DETAIL_TYPES.has(entry.type ?? ''))
+    .map((entry) => ({
+      eventIndex: entry.eventIndex,
+      type: entry.type ?? '',
+      text: entry.text,
+      duration: { total: entry.duration.total, self: entry.duration.self },
+    }));
+  // Taken after the filter, so the bars are a share of the outermost frame shown.
+  return { rows, rootTotal: rows[0]?.duration.total ?? 0 };
 }

--- a/log-viewer/src/components/callStackData.ts
+++ b/log-viewer/src/components/callStackData.ts
@@ -17,9 +17,10 @@ export interface CallStackRow {
  * returns them). `rootTotal` (the outermost frame's total, in ns) is the
  * denominator for the Total/Self percentage bars.
  *
- * Detail frames are dropped, so the inspector never shows what the Call Tree tab
- * hides: a `CUMULATIVE_LIMIT_USAGE` or `CUMULATIVE_PROFILING_BEGIN` block is a
- * parent, so it can be an ancestor of a selected detail row.
+ * Detail frames are dropped: the inspector's stack holds call frames only. A
+ * `CUMULATIVE_LIMIT_USAGE` or `CUMULATIVE_PROFILING_BEGIN` block is a parent, so
+ * it can be an ancestor of a selected row. `EXCLUDED_DETAIL_TYPES` names them
+ * for the Call Tree tab, which keeps them visible; here they are the exclusion.
  */
 export function buildCallStackData(eventIndex: number): {
   rows: CallStackRow[];

--- a/log-viewer/src/components/detailSections.ts
+++ b/log-viewer/src/components/detailSections.ts
@@ -11,12 +11,17 @@ import type { PaneSection } from './PaneView.js';
 import './CallStackDetail.js';
 import './CallTreeDetail.js';
 import './EventVitals.js';
+import './LogOverview.js';
 
 /**
  * Build the inspector's sections for a selection from any tab. Every source gets
  * the same shared trio — Details, Call stack, Call tree — scoped to the
  * selection; the Database view keeps its richer set (Vitals + SOQL issues) via
  * {@link buildDatabaseSections}.
+ *
+ * With nothing selected every source gets the whole-log analogue of what its tab
+ * does. Only the shared **Log overview** is built so far, so each source returns
+ * the same single section.
  *
  * Precedence rule, binding on future scoping inputs such as a timeline time
  * range: an explicit row/frame `selection` always wins. A range or other
@@ -27,9 +32,18 @@ export async function buildDetailSections(
   source: DetailSource,
   selection: DetailSelection | null,
 ): Promise<PaneSection[]> {
-  // Nothing selected: no sections, so the inspector shows `emptyTextFor(source)`.
+  // Nothing selected: the whole log is the scope. The overview carries the
+  // per-source selection hint itself, since `DetailDock`'s empty state now only
+  // shows before a tab id resolves.
   if (!selection) {
-    return [];
+    return [
+      {
+        id: 'overview',
+        title: 'Log overview',
+        weight: 1,
+        content: html`<log-overview source=${source}></log-overview>`,
+      },
+    ];
   }
 
   // The Database grids resolve statement-specific vitals and SOQL lint issues.

--- a/log-viewer/src/components/logOverviewMetrics.ts
+++ b/log-viewer/src/components/logOverviewMetrics.ts
@@ -1,0 +1,99 @@
+/*
+ * Copyright (c) 2026 Certinia Inc. All rights reserved.
+ */
+import type { GovernorLimits, Limits } from 'apex-log-parser';
+
+import { DEFAULT_NAMESPACE } from '../core/utility/CallerNamespace.js';
+import { formatByteSize } from '../core/utility/Util.js';
+import type { GaugeMetric } from '../features/database/components/GovernorSummary.js';
+
+/** How many gauges the strip shows before it stops being at-a-glance. */
+const MAX_GAUGES = 6;
+
+/**
+ * Every governor-tracked metric, with the label its gauge shows. A local list
+ * rather than the timeline adapter's `APEX_METRICS`, which is internal to that
+ * feature.
+ */
+const METRICS: ReadonlyArray<{ key: keyof Limits; label: string }> = [
+  { key: 'cpuTime', label: 'CPU Time' },
+  { key: 'heapSize', label: 'Heap Size' },
+  { key: 'soqlQueries', label: 'SOQL' },
+  { key: 'queryRows', label: 'Query Rows' },
+  { key: 'dmlStatements', label: 'DML' },
+  { key: 'dmlRows', label: 'DML Rows' },
+  { key: 'soslQueries', label: 'SOSL' },
+  { key: 'publishImmediateDml', label: 'Publish Immediate DML' },
+  { key: 'callouts', label: 'Callouts' },
+  { key: 'emailInvocations', label: 'Email Invocations' },
+  { key: 'futureCalls', label: 'Future Calls' },
+  { key: 'queueableJobsAddedToQueue', label: 'Queueable Jobs' },
+  { key: 'mobileApexPushCalls', label: 'Mobile Push Calls' },
+];
+
+interface RankedGauge {
+  gauge: GaugeMetric;
+  /** Fraction of the limit consumed; ranks the strip and is then dropped. */
+  ratio: number;
+}
+
+/**
+ * The whole-log gauges closest to a limit, tightest first, capped at
+ * {@link MAX_GAUGES}. A metric with no limit or no usage is left out.
+ *
+ * Read per namespace, never from the rolled-up totals: the roll-up sums `used`
+ * across namespaces and so overstates every metric (#862). Each namespace has
+ * its own budget, so the transaction's real risk is the tightest single
+ * percentage — not a sum over a sum. The namespace is named in the label unless
+ * it is the default one.
+ *
+ * Heap is the one exception: the parser stores a transaction-wide peak in the
+ * roll-up, and each namespace on its own undercounts it.
+ */
+export function tightestGauges(limits: GovernorLimits): GaugeMetric[] {
+  const ranked = METRICS.flatMap<RankedGauge>(({ key, label }) => {
+    if (key === 'heapSize') {
+      const heap = limits.heapSize;
+      return heap.limit > 0 && heap.used > 0
+        ? [
+            {
+              gauge: {
+                label,
+                found: heap.used,
+                used: heap.used,
+                limit: heap.limit,
+                format: formatByteSize,
+              },
+              ratio: heap.used / heap.limit,
+            },
+          ]
+        : [];
+    }
+
+    let tightest: RankedGauge | null = null;
+    for (const [namespace, forNamespace] of limits.byNamespace) {
+      const metric = forNamespace[key];
+      if (metric.limit <= 0 || metric.used <= 0) {
+        continue;
+      }
+      const ratio = metric.used / metric.limit;
+      if (!tightest || ratio > tightest.ratio) {
+        tightest = {
+          gauge: {
+            label: namespace === DEFAULT_NAMESPACE ? label : `${label} (${namespace})`,
+            found: metric.used,
+            used: metric.used,
+            limit: metric.limit,
+          },
+          ratio,
+        };
+      }
+    }
+    return tightest ? [tightest] : [];
+  });
+
+  return ranked
+    .sort((a, b) => b.ratio - a.ratio)
+    .slice(0, MAX_GAUGES)
+    .map((entry) => entry.gauge);
+}

--- a/log-viewer/src/components/logOverviewMetrics.ts
+++ b/log-viewer/src/components/logOverviewMetrics.ts
@@ -37,6 +37,11 @@ interface RankedGauge {
   ratio: number;
 }
 
+const rank = (gauge: GaugeMetric & { used: number }): RankedGauge => ({
+  gauge,
+  ratio: gauge.used / gauge.limit,
+});
+
 /**
  * The whole-log gauges closest to a limit, tightest first, capped at
  * {@link MAX_GAUGES}. A metric with no limit or no usage is left out.
@@ -56,16 +61,13 @@ export function tightestGauges(limits: GovernorLimits): GaugeMetric[] {
       const heap = limits.heapSize;
       return heap.limit > 0 && heap.used > 0
         ? [
-            {
-              gauge: {
-                label,
-                found: heap.used,
-                used: heap.used,
-                limit: heap.limit,
-                format: formatByteSize,
-              },
-              ratio: heap.used / heap.limit,
-            },
+            rank({
+              label,
+              found: heap.used,
+              used: heap.used,
+              limit: heap.limit,
+              format: formatByteSize,
+            }),
           ]
         : [];
     }
@@ -76,17 +78,14 @@ export function tightestGauges(limits: GovernorLimits): GaugeMetric[] {
       if (metric.limit <= 0 || metric.used <= 0) {
         continue;
       }
-      const ratio = metric.used / metric.limit;
-      if (!tightest || ratio > tightest.ratio) {
-        tightest = {
-          gauge: {
-            label: namespace === DEFAULT_NAMESPACE ? label : `${label} (${namespace})`,
-            found: metric.used,
-            used: metric.used,
-            limit: metric.limit,
-          },
-          ratio,
-        };
+      const candidate = rank({
+        label: namespace === DEFAULT_NAMESPACE ? label : `${label} (${namespace})`,
+        found: metric.used,
+        used: metric.used,
+        limit: metric.limit,
+      });
+      if (!tightest || candidate.ratio > tightest.ratio) {
+        tightest = candidate;
       }
     }
     return tightest ? [tightest] : [];

--- a/log-viewer/src/core/events/EventBus.ts
+++ b/log-viewer/src/core/events/EventBus.ts
@@ -24,6 +24,12 @@ export type DetailSelection =
   | { kind: 'aggregate'; instances: number[]; label: string };
 
 interface EventMap {
+  // A log finished parsing and the event-lookup service holds it. Whole-log
+  // content reads that service directly, so it needs telling once the data is
+  // there; the first paint happens before any log exists. No payload: a listener
+  // that needs the log asks the service for it, keeping one source of truth.
+  'log:loaded': Record<string, never>;
+
   // Supply eventIndex (preferred — unique) OR timestamp (fallback for raw-log entry where eventIndex isn't known).
 
   'timeline:navigate-to':

--- a/log-viewer/src/core/utility/Util.ts
+++ b/log-viewer/src/core/utility/Util.ts
@@ -96,6 +96,22 @@ export function formatInteger(value: number): string {
 }
 
 /**
+ * Byte count → compact string (e.g. 5400000 → "5.4 MB"), for places too narrow
+ * for the full figure. Decimal units, because the platform states the heap limit
+ * as 6 MB for 6,000,000 bytes.
+ */
+export function formatByteSize(bytes: number): string {
+  const magnitude = Math.abs(bytes);
+  if (magnitude >= 1_000_000) {
+    return `${(bytes / 1_000_000).toLocaleString(undefined, { maximumFractionDigits: 1 })} MB`;
+  }
+  if (magnitude >= 1_000) {
+    return `${(bytes / 1_000).toLocaleString(undefined, { maximumFractionDigits: 1 })} KB`;
+  }
+  return `${formatInteger(bytes)} bytes`;
+}
+
+/**
  * Formats milliseconds-since-midnight to `HH:MM:SS.mmm` wall-clock time string.
  *
  * @param ms - Milliseconds since midnight (0–86,400,000)

--- a/log-viewer/src/core/utility/__tests__/Util.test.ts
+++ b/log-viewer/src/core/utility/__tests__/Util.test.ts
@@ -3,7 +3,7 @@
  */
 import { describe, expect, it } from '@jest/globals';
 
-import { computeWallClockMs, formatWallClockTime } from '../Util.js';
+import { computeWallClockMs, formatByteSize, formatWallClockTime } from '../Util.js';
 
 describe('formatWallClockTime', () => {
   it('should format midnight as 00:00:00.000', () => {
@@ -58,5 +58,25 @@ describe('computeWallClockMs', () => {
     // 500,000 ns = 0.5 ms
     const result = computeWallClockMs(0, 0, 500000);
     expect(result).toBe(0.5);
+  });
+});
+
+describe('formatByteSize', () => {
+  it('writes megabytes with one decimal at most', () => {
+    expect(formatByteSize(5_400_000)).toBe('5.4 MB');
+    expect(formatByteSize(6_000_000)).toBe('6 MB');
+    expect(formatByteSize(12_345_678)).toBe('12.3 MB');
+  });
+
+  it('writes kilobytes below a megabyte', () => {
+    expect(formatByteSize(2_048)).toBe('2 KB');
+    expect(formatByteSize(999_900)).toBe('999.9 KB');
+  });
+
+  it('writes small and negative counts as bytes', () => {
+    expect(formatByteSize(0)).toBe('0 bytes');
+    expect(formatByteSize(940)).toBe('940 bytes');
+    // A net heap figure can be negative; the sign survives.
+    expect(formatByteSize(-1_500_000)).toBe('-1.5 MB');
   });
 });

--- a/log-viewer/src/features/app/LogViewer.ts
+++ b/log-viewer/src/features/app/LogViewer.ts
@@ -243,6 +243,9 @@ export class LogViewer extends LitElement {
     // The event-lookup service backs the inspector on every tab, so it is
     // created with the parsed log rather than by whichever tab loads first.
     await DatabaseAccess.create(apexLog);
+    // After the service holds the log, never before: whole-log content reads it
+    // straight from there.
+    eventBus.emit('log:loaded', {});
 
     this.logSize = apexLog.size;
     this.timelineRoot = apexLog;

--- a/log-viewer/src/features/database/components/GovernorSummary.ts
+++ b/log-viewer/src/features/database/components/GovernorSummary.ts
@@ -138,7 +138,7 @@ export class GovernorSummary extends LitElement {
 
   private _renderGauge(metric: GaugeMetric) {
     const muted = metric.found === 0 && (metric.used ?? 0) === 0;
-    const format = metric.format ?? ((value: number) => integer.format(value));
+    const format = metric.format ?? integer.format;
 
     if (metric.used === null || metric.limit <= 0) {
       return html`<div class="gauge ${muted ? 'muted' : ''}">

--- a/log-viewer/src/features/database/components/GovernorSummary.ts
+++ b/log-viewer/src/features/database/components/GovernorSummary.ts
@@ -17,6 +17,12 @@ export interface GaugeMetric {
   used: number | null;
   /** Governor limit (0 when none applies). */
   limit: number;
+  /**
+   * How to write the numbers. Defaults to a thousand-separated integer; a byte
+   * metric passes a compact one, since `5,400,000 / 6,000,000` is wider than a
+   * gauge.
+   */
+  format?: (value: number) => string;
 }
 
 function tier(percent: number): 'safe' | 'warn' | 'danger' {
@@ -132,12 +138,13 @@ export class GovernorSummary extends LitElement {
 
   private _renderGauge(metric: GaugeMetric) {
     const muted = metric.found === 0 && (metric.used ?? 0) === 0;
+    const format = metric.format ?? ((value: number) => integer.format(value));
 
     if (metric.used === null || metric.limit <= 0) {
       return html`<div class="gauge ${muted ? 'muted' : ''}">
         <span class="gauge__label">${metric.label}</span>
         <span class="gauge__value"
-          >${integer.format(metric.found)} <span class="gauge__na">seen</span></span
+          >${format(metric.found)} <span class="gauge__na">seen</span></span
         >
       </div>`;
     }
@@ -152,8 +159,7 @@ export class GovernorSummary extends LitElement {
     >
       <span class="gauge__label">${metric.label}</span>
       <span class="gauge__value"
-        >${integer.format(metric.used)}
-        <span class="gauge__limit">/ ${integer.format(metric.limit)}</span></span
+        >${format(metric.used)} <span class="gauge__limit">/ ${format(metric.limit)}</span></span
       >
       <div class="gauge__track">
         <div

--- a/log-viewer/src/styles/tokens.css
+++ b/log-viewer/src/styles/tokens.css
@@ -46,7 +46,7 @@
 
   /* Type — one step down from the host's body size, for text that annotates
      rather than states. */
-  --lana-text-sm: 0.85rem;
+  --lana-text-sm: calc(var(--vscode-font-size, 13px) * 0.85);
 
   /* Surfaces — the same registered colors VS Code's own chrome is built from.
      `surface-border` is absent before the size-token registry (stable 1.128 ships

--- a/log-viewer/src/styles/tokens.css
+++ b/log-viewer/src/styles/tokens.css
@@ -40,6 +40,14 @@
 
   --lana-stroke: var(--vscode-strokeThickness, 1px);
 
+  /* Left inset for content that lines up past a section's accent bar: the
+     gutter, plus the bar itself (`DatabaseSection`). */
+  --lana-section-inset: calc(var(--lana-space-md) + 3px);
+
+  /* Type — one step down from the host's body size, for text that annotates
+     rather than states. */
+  --lana-text-sm: 0.85rem;
+
   /* Surfaces — the same registered colors VS Code's own chrome is built from.
      `surface-border` is absent before the size-token registry (stable 1.128 ships
      none of the `--vscode-surface-*` set), so its fallback chain is load-bearing. */


### PR DESCRIPTION
# 📝 PR Overview

The Inspector showed nothing but a line of guidance text when no row was selected — every tab wasted its whole panel until you clicked something. This adds the seam that lets each tab answer at log level, and lands the shared **Log overview** section on it.

The rule: **a tab's no-selection state is the log-level analogue of what that tab already does.** An explicit selection always wins over the ambient log scope, so the new branch sits inside `!selection` in `buildDetailSections`.

Chrome DevTools' Summary tab and Firefox Profiler's sidebar work the same way — the same analysis, re-scoped, not a different feature. Perfetto's area-selection aggregation is the same machinery with bounds, so this is also the groundwork for range-scoped stats (#875).

## 🛠️ Changes made

**Log overview section** (`components/LogOverview.ts`, `logOverviewMetrics.ts`)

- The six governor metrics closest to their limit, ranked by percentage, through the existing `<governor-summary>`.
- **Per namespace, never summed** (#862): the parser sums `used` across namespaces while overwriting `limit`, which can report 119/100. Each metric is taken from the single namespace nearest its own limit. Heap is the exception — the parser stores a peak on the roll-up, so heap is read from there.
- No log size or duration: `LogMeta` already heads the app with both.

**A gauge formats its own numbers** (`GovernorSummary.ts`, `core/utility/Util.ts`)

- `GaugeMetric.format` lets a byte metric print `5.4 MB / 6 MB`. `5,400,000 / 6,000,000` overflowed the gauge, which is fixed-width by design.
- New `formatByteSize` helper, decimal units to match the platform stating a 6,000,000-byte heap limit as 6 MB.

**Whole-log content follows the log** (`core/events/EventBus.ts`, `features/app/LogViewer.ts`)

- New `log:loaded` event, emitted after the lookup service holds the parsed log. The Inspector rebuilds only on a tab change or a selection, so the gauges read an empty service on first paint and corrected only after a select-then-deselect. No payload: a listener asks the service, keeping one source of truth.

**Fix: detail frames in the call stack** (`components/callStackData.ts`)

- `CumulativeLimitUsageLine` and `CumulativeProfilingBeginLine` extend `DurationLogEvent`, so they satisfied `isParent` and leaked into the stack. Both now go through the same `EXCLUDED_DETAIL_TYPES` filter the call tree uses, and the root total is taken after the filter.

**Tokens** (`styles/tokens.css`)

- `--lana-section-inset` (lines text up past a section's accent bar) and `--lana-text-sm`, so the new code carries no literals.

## 🧩 Type of change (check all applicable)

- [x] 🐛 Bug fix - something not working as expected
- [x] ✨ New feature – adds new functionality
- [ ] ♻️ Refactor - internal changes with no user impact
- [ ] ⚡ Performance Improvement
- [ ] 📝 Documentation - README or documentation site changes
- [ ] 🔧 Chore - dev tooling, CI, config
- [ ] 💥 Breaking change

## 📷 Screenshots / gifs / video [optional]

_Checked in the dev host on every tab, in a light and a dark theme._

## 🔗 Related Issues

related #113
related #862
related #875

## ✅ Tests added?

- [x] 👍 yes
- [ ] 🙅 no, not needed
- [ ] 🙋 no, I need help

`LogOverview.test.ts` (the note before a log arrives, the gauges after `log:loaded`, the per-source hint), `logOverviewMetrics.test.ts` (ranking, tightest-namespace, heap from the roll-up, the six-gauge cap), `formatByteSize` cases, and the `callStackData` exclusion. `detailSections.test.ts` no longer asserts the empty array.

## 📚 Docs updated?

- [ ] 🔖 README.md
- [x] 🔖 CHANGELOG.md
- [ ] 📖 help site
- [ ] 🧪 Marked any pre-release-only features
- [ ] 🙅 not needed

## Anything else we need to know? [optional]

This is item 1 of six. It lands the seam alone so it is reviewable on its own; the per-tab content (Analysis diagnostics, Timeline charts, Call Tree shape, Database totals) follows in separate PRs that import it.
