### PR TITLE
feat(inspector): log-wide analysis diagnostics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Dock it left, right or bottom, drag to resize, and collapse the sections you don't need — the layout is remembered.
   - Right-click a row for **Show in Call Tree**, **Copy Name**, **Copy Details** or **Copy Call Stack**; `Cmd/Ctrl+C` copies the table.
   - **Log overview**: with nothing selected, the Inspector shows the whole log instead of sitting empty — the six governor metrics closest to their limit, each as `used / limit`. A metric is read from the namespace nearest its own limit, never from a sum across namespaces.
+  - With nothing selected the **Analysis** tab lists **Findings** — log-wide diagnostics built from what the log already holds: truncation, governor breaches, exceptions, query-plan verdicts, SOQL optimization tips grouped with a count, statements repeated from one line (the usual sign of a query or DML in a loop), debug-statement cost and the methods with the most self time. Click a finding to reveal the row behind it in the Analysis grid.
 - 🗄️ **Database Analysis**: governor-limit visibility and SOSL usage. ([#162])
   - 📏 **Governor-limit overview**: SOQL, SOSL, DML and query/DML rows shown as `used / limit`, colored as they approach the limit.
   - 🧮 **Found vs Counted**: each section reconciles statements found in the log against the governor-counted total, flagging queries that didn't consume the limit (e.g. custom metadata, which is free unless it selects a long text area field or runs in a Flow).

--- a/README.md
+++ b/README.md
@@ -134,6 +134,7 @@ Select anything — a timeline frame, a call tree or analysis row, a SOQL/DML/SO
 - **Call stack** – The frames that led to the selection, with total and self time.
 - **Call tree** – The selection's own subtree, in Time Order, Aggregated or Bottom-Up. Scoped to what you picked, which is what makes it different from the Call Tree tab.
 - **SOQL issues** – Optimization tips for the selected query.
+- **Nothing selected?** – It shows the whole log: the governor metrics closest to their limits, and on the Analysis tab a **Findings** list — what is slow or wrong in the log, each finding linking to the row behind it.
 - **Dock it where you want** – Left, right or bottom; drag to resize, collapse the sections you don't need. Your layout is remembered.
 - **Right-click a row** for **Show in Call Tree**, **Copy Name**, **Copy Details** or **Copy Call Stack**; `Cmd/Ctrl+C` copies the table.
 

--- a/lana-docs/docs/docs/features/inspector.md
+++ b/lana-docs/docs/docs/features/inspector.md
@@ -31,6 +31,14 @@ It docks to the **right**, **left** or **bottom**, resizes by dragging its edge,
 
 Collapse any section by clicking its header, or drag the divider between two to resize them. It's one panel, so your layout follows you from tab to tab, and is restored next time.
 
+### Nothing selected
+
+With no selection the inspector shows the whole log. Every tab starts with a **Log overview** — the six governor metrics closest to their limit, each as `used / limit`, read from the namespace nearest its own limit. The **Analysis** tab adds:
+
+- **Findings** – what is slow or wrong in the log, and what to do about it. One pass over the log reports truncation (which makes every figure below it an undercount), governor breaches, exceptions, query-plan verdicts, SOQL optimization tips, statements repeated from one line — the usual sign of a query or DML in a loop — debug-statement cost, and the methods with the most self time. Query-plan verdicts need a `FINEST` log; without one the pane says the verdicts are unknown rather than reading clean. Each finding shows the code the log named with its figures; click it to reveal the row behind it in the Analysis grid.
+
+Select a row and the sections re-scope to it; deselect and the whole-log view returns.
+
 ### Row actions
 
 Right-click a row in the **Call stack** or **Call tree** for:

--- a/log-viewer/src/__tests__/soql/SOQLLinter.test.ts
+++ b/log-viewer/src/__tests__/soql/SOQLLinter.test.ts
@@ -131,10 +131,9 @@ describe('Negative Filter Operator Rule tests', () => {
 
 describe('Order By Without Limit Rule tests', () => {
   const orderByWithoutLimit = {
-    summary:
-      'Avoid ORDER BY unless the result set needs to be ordered, it can increase query time.',
+    summary: 'ORDER BY without a LIMIT.',
     message:
-      "An ORDER BY clause doesn't have anything to do with selectivity. Selectivity is determined by available indexes that align with filter conditions (WHERE clause) and record visibility (sharing rules, etc.). Once the optimizer determines which rows to return, it applies the ORDER BY logic to sort the records in the return set. However an ORDER BY and LIMIT can sometimes be optimizable.",
+      'Sorting costs time and does nothing for selectivity, which comes from indexes on the WHERE clause. Drop the ORDER BY unless the caller needs the order, or add a LIMIT, since ORDER BY with a LIMIT can be optimised.',
     severity: 'Info',
   };
 

--- a/log-viewer/src/components/__tests__/detailSections.test.ts
+++ b/log-viewer/src/components/__tests__/detailSections.test.ts
@@ -60,10 +60,16 @@ describe('buildDetailSections', () => {
   });
 
   it('builds the whole-log overview when nothing is selected, for every source', async () => {
-    for (const source of ['timeline', 'calltree', 'analysis', 'database'] as const) {
+    for (const source of ['timeline', 'calltree', 'database'] as const) {
       const sections = await buildDetailSections(source, null);
       expect(sections.map((s) => s.id)).toEqual(['overview']);
       expect(sections[0]?.title).toBe('Log overview');
     }
+  });
+
+  it('adds the findings section on Analysis, which is that tab at log scope', async () => {
+    const sections = await buildDetailSections('analysis', null);
+    expect(sections.map((s) => s.id)).toEqual(['overview', 'findings']);
+    expect(sections[1]?.title).toBe('Findings');
   });
 });

--- a/log-viewer/src/components/detailSections.ts
+++ b/log-viewer/src/components/detailSections.ts
@@ -8,6 +8,7 @@ import { buildDatabaseSections } from '../features/database/components/databaseS
 import type { PaneSection } from './PaneView.js';
 
 // web components
+import '../features/analysis/components/LogDiagnosticsView.js';
 import './CallStackDetail.js';
 import './CallTreeDetail.js';
 import './EventVitals.js';
@@ -20,8 +21,8 @@ import './LogOverview.js';
  * {@link buildDatabaseSections}.
  *
  * With nothing selected every source gets the whole-log analogue of what its tab
- * does. Only the shared **Log overview** is built so far, so each source returns
- * the same single section.
+ * does: the shared **Log overview**, plus the sections that tab can answer at log
+ * scope. Analysis adds **Findings**; the other tabs have theirs still to come.
  *
  * Precedence rule, binding on future scoping inputs such as a timeline time
  * range: an explicit row/frame `selection` always wins. A range or other
@@ -36,7 +37,7 @@ export async function buildDetailSections(
   // per-source selection hint itself, since `DetailDock`'s empty state now only
   // shows before a tab id resolves.
   if (!selection) {
-    return [
+    const sections: PaneSection[] = [
       {
         id: 'overview',
         title: 'Log overview',
@@ -44,6 +45,15 @@ export async function buildDetailSections(
         content: html`<log-overview source=${source}></log-overview>`,
       },
     ];
+    if (source === 'analysis') {
+      sections.push({
+        id: 'findings',
+        title: 'Findings',
+        weight: 3,
+        content: html`<log-diagnostics></log-diagnostics>`,
+      });
+    }
+    return sections;
   }
 
   // The Database grids resolve statement-specific vitals and SOQL lint issues.

--- a/log-viewer/src/components/logOverviewMetrics.ts
+++ b/log-viewer/src/components/logOverviewMetrics.ts
@@ -11,11 +11,11 @@ import type { GaugeMetric } from '../features/database/components/GovernorSummar
 const MAX_GAUGES = 6;
 
 /**
- * Every governor-tracked metric, with the label its gauge shows. A local list
- * rather than the timeline adapter's `APEX_METRICS`, which is internal to that
- * feature.
+ * Every governor-tracked metric, with the label the inspector shows for it. Kept
+ * here rather than taken from the timeline adapter's `APEX_METRICS`, which is
+ * internal to that feature.
  */
-const METRICS: ReadonlyArray<{ key: keyof Limits; label: string }> = [
+export const METRICS: ReadonlyArray<{ key: keyof Limits; label: string }> = [
   { key: 'cpuTime', label: 'CPU Time' },
   { key: 'heapSize', label: 'Heap Size' },
   { key: 'soqlQueries', label: 'SOQL' },

--- a/log-viewer/src/features/analysis/components/AnalysisView.ts
+++ b/log-viewer/src/features/analysis/components/AnalysisView.ts
@@ -14,6 +14,7 @@ import type { ApexLog } from 'apex-log-parser';
 import '../../../components/ContextMenu.js';
 import type { ContextMenu } from '../../../components/ContextMenu.js';
 import { eventBus } from '../../../core/events/EventBus.js';
+import { SelectionEchoGuard } from '../../../core/events/SelectionEchoGuard.js';
 import { isVisible } from '../../../core/utility/Util.js';
 import { getSettings, updateSetting } from '../../settings/Settings.js';
 import { createBottomUpTable } from '../../call-tree/components/BottomUpTable.js';
@@ -139,9 +140,20 @@ export class AnalysisView extends LitElement {
   /** Releases the category-colouring settings subscription; set while connected. */
   private _categoryColoringOff: (() => void) | null = null;
 
+  /** Guards the programmatic select made on the inspector's behalf. */
+  private _echoGuard = new SelectionEchoGuard();
+  private _inspectorRevealUnsubscribe: (() => void) | null = null;
+
   constructor() {
     super();
 
+    // An inspector finding names one event; the grid holds it in the bucket for
+    // its method, so that bucket is what gets revealed.
+    this._inspectorRevealUnsubscribe = eventBus.on('inspector:reveal', (detail) => {
+      if (detail.source === 'analysis') {
+        void this._revealEventIndex(detail.eventIndex);
+      }
+    });
     document.addEventListener('lv-find', this._findEvt);
     document.addEventListener('lv-find-match', this._findEvt);
     document.addEventListener('lv-find-close', this._findEvt);
@@ -159,6 +171,43 @@ export class AnalysisView extends LitElement {
     document.removeEventListener('lv-find', this._findEvt);
     document.removeEventListener('lv-find-match', this._findEvt);
     document.removeEventListener('lv-find-close', this._findEvt);
+    this._inspectorRevealUnsubscribe?.();
+    this._inspectorRevealUnsubscribe = null;
+  }
+
+  /**
+   * Select the bucket holding `eventIndex` and scroll it into view. Guarded, so the
+   * inspector keeps the findings it was clicked in rather than being rebuilt around
+   * the row it just asked for.
+   */
+  private async _revealEventIndex(eventIndex: number): Promise<void> {
+    const table = this.analysisTable;
+    // `instances` is populated on root buckets only, which is what the grid lists.
+    const match = table
+      ?.getRows()
+      .find((row) =>
+        (row.getData() as BottomUpRow).instances?.some((event) => event.eventIndex === eventIndex),
+      );
+    if (!table || !match) {
+      return;
+    }
+
+    // Show Details keeps only rows with a duration, so the buckets for debug
+    // lines, thrown exceptions and query plans are filtered out — exactly the
+    // events a finding points at. Turn the filter off rather than reveal nothing.
+    const data = match.getData();
+    if (
+      !this.filterState.showDetails &&
+      !table.getRows('active').some((row) => row.getData() === data)
+    ) {
+      this._handleShowDetailsChange();
+      await this.updateComplete;
+    }
+
+    await this._echoGuard.runAsync(() =>
+      //@ts-expect-error This is a custom function added in by RowNavigation custom module
+      table.goToRow(match, { scrollIfVisible: false, focusRow: false }),
+    );
   }
 
   firstUpdated(): void {
@@ -565,10 +614,10 @@ export class AnalysisView extends LitElement {
 
     // Feed the inspector. Analysis rows merge many calls, so they
     // scope to every occurrence of the method.
-    // No `inspector:reveal` subscription here on purpose: analysis rows are
-    // aggregates keyed by type|namespace|text, so an eventIndex only resolves
-    // back to the whole bucket - which is already the selected row.
     this.analysisTable.on('rowSelectionChanged', (_data, rows) => {
+      if (this._echoGuard.suppressed) {
+        return;
+      }
       const data = rows[0]?.getData() as BottomUpRow | undefined;
       const event = data?.originalData;
       if (!event) {

--- a/log-viewer/src/features/analysis/components/LogDiagnosticsView.ts
+++ b/log-viewer/src/features/analysis/components/LogDiagnosticsView.ts
@@ -130,25 +130,40 @@ export class LogDiagnosticsView extends LitElement {
         color: var(--lana-fg-muted);
       }
 
-      /* What is behind the finding: the code the log named, then its figures, on
-         one line. The name and the figures carry the meaning, so the lead reads as
-         a quiet label beside them. */
+      /* What is behind the finding, as a figure row: a quiet label, the code the
+         log named, then its figures held to the right edge so the eye reads the
+         names down the pane and the numbers up the right of it. The label is the
+         one part that never wraps away from the name. */
       .cause {
+        display: flex;
+        flex-wrap: wrap;
+        align-items: baseline;
+        gap: var(--lana-space-2xs) var(--lana-space-sm);
         margin: var(--lana-space-xs) 0 0;
       }
 
       .cause__label {
+        flex: 0 0 auto;
         color: var(--lana-fg-muted);
+        font-size: var(--lana-text-sm);
       }
 
       .cause__name {
+        flex: 1 1 auto;
+        min-width: 0;
         font-family: var(--lana-font-mono);
+        font-size: var(--lana-text-sm);
         overflow-wrap: anywhere;
       }
 
       .cause__value {
+        flex: 0 0 auto;
+        margin-left: auto;
+        color: var(--vscode-foreground);
         font-family: var(--lana-font-mono);
+        font-size: var(--lana-text-sm);
         font-variant-numeric: tabular-nums;
+        font-weight: 600;
       }
 
       /* The line the finding points at: the statement it read, or the frame the
@@ -254,11 +269,11 @@ export class LogDiagnosticsView extends LitElement {
     if (!cause) {
       return '';
     }
-    return html`<p class="cause">
+    return html`<div class="cause">
       <span class="cause__label">${cause.label}</span>
       <span class="cause__name">${cause.name}</span>
       <span class="cause__value">${cause.value}</span>
-    </p>`;
+    </div>`;
   }
 
   /**

--- a/log-viewer/src/features/analysis/components/LogDiagnosticsView.ts
+++ b/log-viewer/src/features/analysis/components/LogDiagnosticsView.ts
@@ -1,0 +1,314 @@
+/*
+ * Copyright (c) 2026 Certinia Inc. All rights reserved.
+ */
+import '#vscode-elements/vscode-icon.js';
+import { LitElement, css, html } from 'lit';
+import { customElement, state } from 'lit/decorators.js';
+
+import { dispatchInspectorReveal } from '../../../components/inspectorReveal.js';
+import { eventBus } from '../../../core/events/EventBus.js';
+import { globalStyles } from '../../../styles/global.styles.js';
+import { severityIcon, severityStyles } from '../../../styles/severity.styles.js';
+import {
+  computeLogDiagnostics,
+  type Diagnostic,
+  type LogDiagnostics,
+} from '../services/LogDiagnostics.js';
+
+/**
+ * The Analysis tab's whole-log findings: what the log says is slow or wrong, and
+ * what to do about it. The list is the shape every comparable tool uses for this.
+ *
+ * Two absences are reported rather than hidden. A truncated log makes every
+ * figure below it an undercount, so it heads the pane; and without FINEST
+ * database logging there are no query plans, which says nothing about the
+ * queries — so the pane says the verdicts are unknown instead of leaving them
+ * looking clean.
+ */
+@customElement('log-diagnostics')
+export class LogDiagnosticsView extends LitElement {
+  @state()
+  private _result: LogDiagnostics | null = null;
+
+  private _offLogLoaded: (() => void) | null = null;
+
+  override connectedCallback() {
+    super.connectedCallback();
+    void this._analyse();
+    // The inspector paints before the first log is parsed, and it rebuilds only
+    // on a tab change or a selection.
+    this._offLogLoaded = eventBus.on('log:loaded', () => void this._analyse());
+  }
+
+  override disconnectedCallback() {
+    this._offLogLoaded?.();
+    this._offLogLoaded = null;
+    super.disconnectedCallback();
+  }
+
+  static styles = [
+    globalStyles,
+    severityStyles,
+    css`
+      :host {
+        display: block;
+        padding: 0 var(--lana-space-md) var(--lana-space-md) var(--lana-section-inset);
+        overflow-y: auto;
+      }
+
+      /* One finding is one row: a fixed-height line that never reflows the list,
+         with the detail behind a disclosure. */
+      summary {
+        display: flex;
+        align-items: center;
+        gap: var(--lana-space-2xs);
+        border-radius: var(--lana-radius-sm);
+        padding: var(--lana-space-3xs) var(--lana-space-2xs);
+        cursor: pointer;
+      }
+
+      summary:hover {
+        background-color: var(--lana-row-hover-bg);
+      }
+
+      /* The chevron replaces the native marker, so every row shows it can open. */
+      summary::marker,
+      summary::-webkit-details-marker {
+        content: '';
+        display: none;
+      }
+
+      summary vscode-icon {
+        flex: 0 0 auto;
+      }
+
+      .chevron {
+        color: var(--lana-fg-muted);
+        transition: transform 0.1s ease-out;
+      }
+
+      details[open] .chevron {
+        transform: rotate(90deg);
+      }
+
+      /* The summary states the problem; the figure behind it and the count are
+         metadata, so they sit right and do not push the title around. */
+      .title {
+        flex: 1 1 auto;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+      }
+
+      .meta {
+        flex: 0 0 auto;
+        color: var(--lana-fg-muted);
+        font-family: var(--lana-font-mono);
+        font-size: var(--lana-text-sm);
+        font-variant-numeric: tabular-nums;
+      }
+
+      /* How many events raised the finding, as a count badge. */
+      .count {
+        flex: 0 0 auto;
+        min-width: 1.4em;
+        border-radius: var(--lana-radius-md);
+        padding: 0 var(--lana-space-2xs);
+        background-color: var(--lana-badge-bg);
+        color: var(--lana-badge-fg);
+        font-size: var(--lana-text-sm);
+        font-variant-numeric: tabular-nums;
+        text-align: center;
+      }
+
+      .body {
+        margin: 0 0 var(--lana-space-sm) calc(var(--lana-space-lg) + var(--lana-space-2xs));
+      }
+
+      .detail {
+        margin: 0;
+        color: var(--lana-fg-muted);
+      }
+
+      /* What is behind the finding: the code the log named, then its figures, on
+         one line. The name and the figures carry the meaning, so the lead reads as
+         a quiet label beside them. */
+      .cause {
+        margin: var(--lana-space-xs) 0 0;
+      }
+
+      .cause__label {
+        color: var(--lana-fg-muted);
+      }
+
+      .cause__name {
+        font-family: var(--lana-font-mono);
+        overflow-wrap: anywhere;
+      }
+
+      .cause__value {
+        font-family: var(--lana-font-mono);
+        font-variant-numeric: tabular-nums;
+      }
+
+      /* The line the finding points at: the statement it read, or the frame the
+         transaction stopped on. A code surface, so it reads as the log's own words
+         and not as more of the prose above it. */
+      .evidence {
+        display: flex;
+        align-items: flex-start;
+        gap: var(--lana-space-xs);
+        width: 100%;
+        margin: var(--lana-space-xs) 0 0;
+        border: var(--lana-stroke) solid var(--lana-surface-border);
+        border-radius: var(--lana-radius-sm);
+        padding: var(--lana-space-2xs) var(--lana-space-xs);
+        background-color: var(--lana-code-bg);
+        color: var(--vscode-foreground);
+        font-family: var(--lana-font-mono);
+        font-size: var(--lana-text-sm);
+        text-align: left;
+      }
+
+      .evidence__text {
+        flex: 1 1 auto;
+        white-space: pre-wrap;
+        overflow-wrap: anywhere;
+      }
+
+      /* The evidence names one event, so it is the way back to that row. */
+      .evidence--link {
+        cursor: pointer;
+      }
+
+      .evidence--link:hover {
+        border-color: var(--vscode-focusBorder);
+        background-color: var(--lana-row-hover-bg);
+      }
+
+      .evidence--link:focus-visible {
+        outline: var(--lana-stroke) solid var(--vscode-focusBorder);
+        outline-offset: var(--lana-stroke);
+      }
+
+      .evidence__go {
+        flex: 0 0 auto;
+        color: var(--lana-fg-muted);
+      }
+
+      .evidence--link:hover .evidence__go {
+        color: var(--vscode-foreground);
+      }
+
+      .note {
+        padding: var(--lana-space-sm) var(--lana-space-2xs);
+        color: var(--lana-fg-muted);
+        font-size: var(--lana-text-sm);
+      }
+
+      .truncated {
+        color: var(--lana-severity-warning);
+      }
+    `,
+  ];
+
+  render() {
+    const result = this._result;
+    if (!result) {
+      return html`<p class="note">Analysing the log…</p>`;
+    }
+
+    return html`
+      ${result.truncation ? html`<p class="note truncated">${result.truncation}</p>` : ''}
+      ${
+        result.diagnostics.length
+          ? result.diagnostics.map((diagnostic) => {
+              const severity = diagnostic.severity.toLowerCase();
+              return html`<details>
+                <summary>
+                  <vscode-icon class="chevron" name="chevron-right"></vscode-icon>
+                  <vscode-icon
+                    class="sev-${severity}"
+                    name=${severityIcon(diagnostic.severity)}
+                  ></vscode-icon>
+                  <span class="title" title=${diagnostic.summary}>${diagnostic.summary}</span>
+                  ${diagnostic.meta ? html`<span class="meta">${diagnostic.meta}</span>` : ''}
+                  ${
+                    diagnostic.count > 1 ? html`<span class="count">${diagnostic.count}</span>` : ''
+                  }
+                </summary>
+                <div class="body">
+                  ${diagnostic.message ? html`<p class="detail">${diagnostic.message}</p>` : ''}
+                  ${this._cause(diagnostic.cause)} ${this._evidence(diagnostic)}
+                </div>
+              </details>`;
+            })
+          : html`<p class="note">No findings.</p>`
+      }
+      ${this._caveats(result).map((caveat) => html`<p class="note">${caveat}</p>`)}
+    `;
+  }
+
+  /** The one thing behind the finding, when the log named one. */
+  private _cause(cause: Diagnostic['cause']) {
+    if (!cause) {
+      return '';
+    }
+    return html`<p class="cause">
+      <span class="cause__label">${cause.label}</span>
+      <span class="cause__name">${cause.name}</span>
+      <span class="cause__value">${cause.value}</span>
+    </p>`;
+  }
+
+  /**
+   * The log line behind the finding. A log-wide finding names no single event, so
+   * that one is text only; every other one is the way back to its row in the grid.
+   */
+  private _evidence(diagnostic: Diagnostic) {
+    if (!diagnostic.evidence) {
+      return '';
+    }
+    const text = html`<span class="evidence__text">${diagnostic.evidence}</span>`;
+    if (diagnostic.eventIndex < 0) {
+      return html`<div class="evidence">${text}</div>`;
+    }
+    return html`<button
+      class="evidence evidence--link"
+      type="button"
+      title="Show this in the grid"
+      @click=${() => dispatchInspectorReveal(this, diagnostic.eventIndex)}
+    >
+      ${text}
+      <vscode-icon class="evidence__go" name="arrow-right"></vscode-icon>
+    </button>`;
+  }
+
+  /** What the log could not answer, so no absent data reads as a clean result. */
+  private _caveats(result: LogDiagnostics): string[] {
+    const caveats: string[] = [];
+    if (!result.queryPlansKnown) {
+      caveats.push(
+        'This log holds no query plans, so how selective the queries are is unknown. Re-run with the Database log level at FINEST to see them.',
+      );
+    }
+    const { linted, distinct } = result.lintedQueries;
+    if (linted < distinct) {
+      caveats.push(
+        `The SOQL rules cover the ${linted} most repeated of ${distinct} distinct queries.`,
+      );
+    }
+    return caveats;
+  }
+
+  private async _analyse(): Promise<void> {
+    this._result = null;
+    this._result = await computeLogDiagnostics();
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'log-diagnostics': LogDiagnosticsView;
+  }
+}

--- a/log-viewer/src/features/analysis/components/__tests__/LogDiagnosticsView.test.ts
+++ b/log-viewer/src/features/analysis/components/__tests__/LogDiagnosticsView.test.ts
@@ -1,0 +1,212 @@
+/*
+ * Copyright (c) 2026 Certinia Inc. All rights reserved.
+ *
+ * @jest-environment jsdom
+ */
+import { beforeEach, describe, expect, it } from '@jest/globals';
+
+import type { LogDiagnostics } from '../../services/LogDiagnostics.js';
+
+jest.mock('#vscode-elements/vscode-icon.js', () => ({}));
+
+let result: LogDiagnostics = {
+  diagnostics: [],
+  truncation: null,
+  queryPlansKnown: true,
+  lintedQueries: { linted: 0, distinct: 0 },
+};
+
+jest.mock('../../services/LogDiagnostics.js', () => ({
+  computeLogDiagnostics: () => Promise.resolve(result),
+}));
+
+import { eventBus } from '../../../../core/events/EventBus.js';
+import '../LogDiagnosticsView.js';
+
+const view = async () => {
+  const element = document.createElement('log-diagnostics');
+  document.body.append(element);
+  await element.updateComplete;
+  // One more turn: the findings arrive from an async call in connectedCallback.
+  await element.updateComplete;
+  return element;
+};
+
+const text = (element: HTMLElement, selector: string) =>
+  [...element.shadowRoot!.querySelectorAll(selector)].map((node) => node.textContent?.trim());
+
+describe('log-diagnostics', () => {
+  beforeEach(() => {
+    document.body.replaceChildren();
+    result = {
+      diagnostics: [],
+      truncation: null,
+      queryPlansKnown: true,
+      lintedQueries: { linted: 0, distinct: 0 },
+    };
+  });
+
+  it('says so when the log has no findings', async () => {
+    const element = await view();
+    expect(text(element, '.note')).toEqual(['No findings.']);
+  });
+
+  it('shows each finding, with a count only where it grouped', async () => {
+    result.diagnostics = [
+      {
+        id: 'a',
+        severity: 'Error',
+        summary: 'Not selective.',
+        message: 'why',
+        count: 3,
+        eventIndex: 1,
+      },
+      {
+        id: 'b',
+        severity: 'Info',
+        summary: '50 debug statements ran.',
+        message: 'why',
+        count: 1,
+        eventIndex: 2,
+      },
+    ];
+    const element = await view();
+
+    expect(text(element, '.title')).toEqual(['Not selective.', '50 debug statements ran.']);
+    expect(text(element, '.count')).toEqual(['3']);
+    expect(text(element, '.detail')).toEqual(['why', 'why']);
+  });
+
+  it('keeps the evidence in the expanded row, not in the summary', async () => {
+    result.diagnostics = [
+      {
+        id: 'a',
+        severity: 'Error',
+        summary: 'System.LimitException: Apex CPU time limit exceeded',
+        message: 'why',
+        count: 2,
+        eventIndex: 1,
+        evidence: 'Class.A.run: line 31, column 1',
+      },
+    ];
+    const element = await view();
+
+    expect(text(element, '.title')).toEqual([
+      'System.LimitException: Apex CPU time limit exceeded',
+    ]);
+    expect(text(element, '.evidence')).toEqual(['Class.A.run: line 31, column 1']);
+  });
+
+  it('states the cause as figures, not as prose', async () => {
+    result.diagnostics = [
+      {
+        id: 'a',
+        severity: 'Error',
+        summary: 'CPU limit exceeded.',
+        message: 'The governor stopped the transaction here.',
+        count: 1,
+        eventIndex: 1,
+        cause: { label: 'Most time in', name: 'Slow.run()', value: '11.3 s (46%)' },
+      },
+    ];
+    const element = await view();
+
+    expect(text(element, '.cause__label')).toEqual(['Most time in']);
+    expect(text(element, '.cause__name')).toEqual(['Slow.run()']);
+    expect(text(element, '.cause__value')).toEqual(['11.3 s (46%)']);
+  });
+
+  it('asks the inspector to reveal the event the evidence names', async () => {
+    result.diagnostics = [
+      {
+        id: 'a',
+        severity: 'Warning',
+        summary: 'SOQL is unbounded.',
+        message: 'why',
+        count: 1,
+        eventIndex: 7,
+        evidence: 'SELECT Id FROM Account',
+      },
+    ];
+    const element = await view();
+    const seen: number[] = [];
+    element.addEventListener('inspector-reveal', (e) => {
+      seen.push((e as CustomEvent<{ eventIndex: number }>).detail.eventIndex);
+    });
+
+    element.shadowRoot!.querySelector<HTMLButtonElement>('.evidence--link')?.click();
+
+    expect(seen).toEqual([7]);
+  });
+
+  it('leaves a log-wide finding unclickable, since it names no one event', async () => {
+    result.diagnostics = [
+      {
+        id: 'a',
+        severity: 'Info',
+        summary: '50 debug statements ran.',
+        message: 'why',
+        count: 1,
+        eventIndex: -1,
+        evidence: 'System.debug',
+      },
+    ];
+    const element = await view();
+
+    expect(element.shadowRoot!.querySelector('.evidence--link')).toBeNull();
+    expect(text(element, '.evidence')).toEqual(['System.debug']);
+  });
+
+  it('gives the truncated summary a hover of its own', async () => {
+    result.diagnostics = [
+      {
+        id: 'a',
+        severity: 'Info',
+        summary: 'A long finding.',
+        message: 'why',
+        count: 1,
+        eventIndex: 1,
+      },
+    ];
+    const element = await view();
+    expect(element.shadowRoot!.querySelector('.title')?.getAttribute('title')).toBe(
+      'A long finding.',
+    );
+  });
+
+  it('heads the pane with the truncation note', async () => {
+    result.truncation = 'The maximum log size has been reached.';
+    const element = await view();
+    expect(text(element, '.truncated')).toEqual(['The maximum log size has been reached.']);
+  });
+
+  it('reports absent query plans rather than leaving the queries looking clean', async () => {
+    result.queryPlansKnown = false;
+    const element = await view();
+    expect(text(element, '.note').join(' ')).toContain('no query plans');
+  });
+
+  it('reports how much of the log the SOQL rules covered when they were capped', async () => {
+    result.lintedQueries = { linted: 250, distinct: 900 };
+    const element = await view();
+    expect(text(element, '.note').join(' ')).toContain('250 most repeated of 900');
+  });
+
+  it('re-analyses when a log is loaded', async () => {
+    const element = await view();
+    result.diagnostics = [
+      {
+        id: 'a',
+        severity: 'Warning',
+        summary: 'Later finding.',
+        message: 'why',
+        count: 1,
+        eventIndex: 1,
+      },
+    ];
+    eventBus.emit('log:loaded', {});
+    await element.updateComplete;
+    await element.updateComplete;
+    expect(text(element, '.title')).toEqual(['Later finding.']);
+  });
+});

--- a/log-viewer/src/features/analysis/services/LogDiagnostics.ts
+++ b/log-viewer/src/features/analysis/services/LogDiagnostics.ts
@@ -1,0 +1,610 @@
+/*
+ * Copyright (c) 2026 Certinia Inc. All rights reserved.
+ */
+import type {
+  ApexLog,
+  GovernorLimits,
+  Limits,
+  LogEvent,
+  SOQLExecuteBeginLine,
+} from 'apex-log-parser';
+
+import { METRICS } from '../../../components/logOverviewMetrics.js';
+import { DEFAULT_NAMESPACE } from '../../../core/utility/CallerNamespace.js';
+import { formatByteSize, formatDuration, formatInteger } from '../../../core/utility/Util.js';
+import { getEventKey } from '../../call-tree/utils/Aggregation.js';
+import { DatabaseAccess } from '../../database/services/Database.js';
+import {
+  QueryPlanCostRule,
+  SEVERITY_TYPES,
+  SOQLLinter,
+  TableScanRule,
+  type Severity,
+} from '../../soql/services/SOQLLinter.js';
+
+/** How many times a statement has to repeat before it is worth reporting. */
+const REPEAT_THRESHOLD = 5;
+/** How many debug statements make the log's own cost worth reporting. */
+const DEBUG_THRESHOLD = 50;
+/** Share of a governor limit that counts as near it. */
+const NEAR_LIMIT_RATIO = 0.8;
+/** Share of the log's self time that makes one signature worth naming as the cause. */
+const HOT_SPOT_SHARE = 0.2;
+/**
+ * How many distinct queries the SOQL linter parses. Each parse is an antlr run,
+ * so a log with thousands of distinct queries would break the panel's budget.
+ * The most repeated queries are kept, and {@link LogDiagnostics.lintedQueries}
+ * reports what was covered so the cap is never silent.
+ */
+const MAX_LINTED_QUERIES = 250;
+
+/**
+ * What is behind a finding, when the log names one thing: what it is, and the
+ * figures for it. Structured rather than folded into the prose, so the figures
+ * read as figures.
+ */
+export interface DiagnosticCause {
+  /** What the named thing is to this finding, e.g. `Most time in`. */
+  label: string;
+  /** The code the log named. */
+  name: string;
+  /** Its figures, already formatted, e.g. `11.3 s (46%)`. */
+  value: string;
+}
+
+/**
+ * One finding about the log as a whole. `summary` and `message` follow
+ * {@link SOQLLinterRule}: a short statement of the problem, then the
+ * prescriptive detail.
+ */
+export interface Diagnostic {
+  /** Stable key. Identical findings share one, so they group with a count. */
+  id: string;
+  severity: Severity;
+  summary: string;
+  message: string;
+  /** The figure behind the finding, shown beside the summary. */
+  meta?: string;
+  /** How many events raised this finding. */
+  count: number;
+  /** The first event that raised it, or -1 when the finding is log-wide. */
+  eventIndex: number;
+  /**
+   * The line of the log the finding points at — the statement it read, or the
+   * frame the transaction stopped on. Without it a finding names a problem the
+   * reader cannot tie back to anything.
+   */
+  evidence?: string;
+  /** The one thing behind the finding, when the log names one. */
+  cause?: DiagnosticCause;
+}
+
+export interface LogDiagnostics {
+  /** Findings, highest severity first, then most frequent. */
+  diagnostics: Diagnostic[];
+  /**
+   * Set when the log is truncated. Every figure below it is an undercount, so
+   * this frames the whole pane rather than being one finding in it.
+   */
+  truncation: string | null;
+  /**
+   * False when the log holds no query plan lines. The plans need FINEST database
+   * logging, and their absence says nothing about the queries — so the pane must
+   * report it rather than leave the queries looking clean.
+   */
+  queryPlansKnown: boolean;
+  /** Distinct queries seen, and how many of them the linter parsed. */
+  lintedQueries: { linted: number; distinct: number };
+}
+
+const EMPTY: LogDiagnostics = {
+  diagnostics: [],
+  truncation: null,
+  queryPlansKnown: false,
+  lintedQueries: { linted: 0, distinct: 0 },
+};
+
+/** A grouped set of events, keyed by whatever makes two of them the same finding. */
+interface Group {
+  count: number;
+  eventIndex: number;
+  events: LogEvent[];
+}
+
+function groupBy(events: LogEvent[], key: (event: LogEvent) => string | null): Map<string, Group> {
+  const groups = new Map<string, Group>();
+  for (const event of events) {
+    const id = key(event);
+    if (id === null) {
+      continue;
+    }
+    const group = groups.get(id);
+    if (group) {
+      group.count++;
+      group.events.push(event);
+    } else {
+      groups.set(id, { count: 1, eventIndex: event.eventIndex, events: [event] });
+    }
+  }
+  return groups;
+}
+
+/** How each metric's figures read. Bytes and milliseconds are not bare counts. */
+const LIMIT_FORMATS: Partial<Record<keyof Limits, (value: number) => string>> = {
+  heapSize: formatByteSize,
+  cpuTime: (value) => `${formatInteger(value)} ms`,
+};
+
+/**
+ * The metric a `System.LimitException` names, in the platform's own wording. The
+ * exception and the cumulative total are the same fact, so the mapping lets the
+ * pane report it once.
+ */
+const LIMIT_EXCEPTION_METRICS: ReadonlyArray<{ key: keyof Limits; phrase: string }> = [
+  { key: 'cpuTime', phrase: 'apex cpu time' },
+  { key: 'heapSize', phrase: 'apex heap size' },
+  { key: 'soqlQueries', phrase: 'too many soql queries' },
+  { key: 'queryRows', phrase: 'too many query rows' },
+  { key: 'dmlStatements', phrase: 'too many dml statements' },
+  { key: 'dmlRows', phrase: 'too many dml rows' },
+  { key: 'soslQueries', phrase: 'too many sosl queries' },
+  { key: 'callouts', phrase: 'too many callouts' },
+  { key: 'emailInvocations', phrase: 'too many email invocations' },
+  { key: 'futureCalls', phrase: 'too many future calls' },
+  { key: 'queueableJobsAddedToQueue', phrase: 'too many queueable jobs' },
+];
+
+/** The heaviest event by self time, and its share of all the self time in the log. */
+interface HotSpot {
+  label: string;
+  selfNs: number;
+  share: number;
+}
+
+/**
+ * The one event signature that most of the log's own time went into.
+ *
+ * This answers the question a breach raises next — where the time went — without
+ * putting a second grid beside the one already on screen. Nothing is reported
+ * when no signature stands out, because then there is nothing to point at.
+ */
+function hotSpot(selfTime: Map<string, number>, totalSelf: number): HotSpot | null {
+  if (totalSelf <= 0) {
+    return null;
+  }
+  let label = '';
+  let selfNs = 0;
+  for (const [key, self] of selfTime) {
+    if (self > selfNs) {
+      label = key;
+      selfNs = self;
+    }
+  }
+  const share = selfNs / totalSelf;
+  if (share < HOT_SPOT_SHARE) {
+    return null;
+  }
+  // `getEventKey` is `type|namespace|text`; only the text names the code.
+  return { label: label.slice(label.lastIndexOf('|') + 1), selfNs, share };
+}
+
+/** A governor breach the log reported as an exception, with where it stopped. */
+interface Breach {
+  eventIndex: number;
+  frame?: string;
+}
+
+/**
+ * Governor metrics at or near a limit, and the breaches the log threw for them.
+ *
+ * A `LimitException` is not a defect of its own: the governor raised it because a
+ * metric ran out. It is therefore merged into that metric's finding, so one
+ * breach is one row.
+ *
+ * Only the default namespace is read. A log reports usage per namespace, but not
+ * whether a package is certified — and only a certified package gets a budget of
+ * its own. Some metrics, CPU time among them, are shared whatever the namespace.
+ * A per-namespace figure against a per-namespace limit would therefore be a
+ * guess, so this reports the one scope the log makes certain (#862).
+ */
+function limitDiagnostics(
+  limits: GovernorLimits,
+  limitExceptions: LogEvent[],
+  hotSpot: HotSpot | null,
+): Diagnostic[] {
+  const breaches = new Map<keyof Limits, Breach>();
+  const unmapped: LogEvent[] = [];
+  for (const event of limitExceptions) {
+    const { head, frame } = splitException(event.text);
+    const lower = head.toLowerCase();
+    const named = LIMIT_EXCEPTION_METRICS.find((entry) => lower.includes(entry.phrase));
+    if (!named) {
+      unmapped.push(event);
+      continue;
+    }
+    // The throw and the fatal error carry the same breach; only the fatal one
+    // carries a stack, so keep whichever frame the log gave us.
+    const seen = breaches.get(named.key);
+    breaches.set(named.key, {
+      eventIndex: seen?.eventIndex ?? event.eventIndex,
+      frame: seen?.frame || frame || undefined,
+    });
+  }
+
+  const forNamespace = limits.byNamespace.get(DEFAULT_NAMESPACE);
+  const found: Diagnostic[] = [];
+  for (const { key, label } of METRICS) {
+    const breach = breaches.get(key);
+    const metric = forNamespace?.[key];
+    const known = metric && metric.limit > 0 && metric.used > 0;
+    const ratio = known ? metric.used / metric.limit : 0;
+    if (!breach && (!known || ratio < NEAR_LIMIT_RATIO)) {
+      continue;
+    }
+
+    const format = LIMIT_FORMATS[key] ?? formatInteger;
+    const exceeded = breach !== undefined || ratio >= 1;
+    const cause: DiagnosticCause | undefined =
+      key === 'cpuTime' && hotSpot
+        ? {
+            label: 'Most time in',
+            name: hotSpot.label,
+            value: `${formatDuration(hotSpot.selfNs)} (${Math.round(hotSpot.share * 100)}%)`,
+          }
+        : undefined;
+    found.push({
+      id: `limit|${key}`,
+      severity: exceeded ? 'Error' : 'Warning',
+      summary: exceeded
+        ? `${label} limit exceeded.`
+        : `${label} is at ${Math.round(ratio * 100)}% of its limit.`,
+      meta: known ? `${format(metric.used)} / ${format(metric.limit)}` : undefined,
+      message: breach
+        ? 'The governor stopped the transaction here.'
+        : known
+          ? `${format(metric.used)} of ${format(metric.limit)} used.`
+          : '',
+      count: 1,
+      eventIndex: breach?.eventIndex ?? -1,
+      evidence: breach?.frame,
+      cause,
+    });
+  }
+
+  // A breach whose wording we do not map still has to be reported.
+  return [...found, ...exceptionDiagnostics(unmapped)];
+}
+
+/** Where the stack begins in an exception's text, when one follows it. */
+const STACK_FRAME = /(?:Class|Trigger|AnonymousBlock|External entry point)[.:]/;
+
+/**
+ * The exception, split from the stack some events carry after it. The stack is
+ * per throw, so grouping on the whole text would list the same problem once per
+ * call path — and a stack makes a poor summary.
+ *
+ * Only the innermost frame is kept. It is the line the transaction stopped on,
+ * which is what the reader needs; the rest of a deep or recursive stack fills the
+ * pane and says nothing more.
+ */
+function splitException(text: string): { head: string; frame: string } {
+  const match = STACK_FRAME.exec(text);
+  if (!match?.index) {
+    return { head: text.trim(), frame: '' };
+  }
+  const stack = text.slice(match.index).trim();
+  return { head: text.slice(0, match.index).trim(), frame: stack.split('\n')[0]?.trim() ?? '' };
+}
+
+/**
+ * Exceptions the log recorded, grouped by the exception rather than the throw.
+ *
+ * The parser pushes both the throw and the fatal error that followed it, so the
+ * count is of throws alone; a fatal error says the transaction did not recover.
+ */
+function exceptionDiagnostics(exceptions: LogEvent[]): Diagnostic[] {
+  const groups = groupBy(exceptions, (event) => splitException(event.text).head);
+  return [...groups].map(([head, group]) => {
+    const thrown = group.events.filter((event) => event.type === 'EXCEPTION_THROWN').length;
+    const fatal = group.events.some((event) => event.type === 'FATAL_ERROR');
+    const frame = group.events
+      .map((event) => splitException(event.text).frame)
+      .find((first) => first.length > 0);
+    return {
+      id: `exception|${head}`,
+      severity: 'Error' as Severity,
+      summary: head,
+      meta: fatal ? 'unhandled' : undefined,
+      message: fatal
+        ? 'Nothing caught this exception, so the transaction rolled back.'
+        : 'Even a caught exception costs CPU time, and a thrown-and-caught exception used as flow control is expensive.',
+      count: Math.max(thrown, 1),
+      eventIndex: group.eventIndex,
+      evidence: frame,
+    };
+  });
+}
+
+/**
+ * Anomalies the parser met in the log itself, such as an entry without its exit.
+ *
+ * Only these are read here. The parser also files an issue per exception and per
+ * fatal error, which are the same events {@link exceptionDiagnostics} and
+ * {@link limitDiagnostics} already report.
+ */
+function logIssueDiagnostics(log: ApexLog): Diagnostic[] {
+  return log.logIssues
+    .filter((issue) => issue.type === 'unexpected')
+    .map((issue) => ({
+      id: `issue|${issue.summary}`,
+      severity: 'Warning' as Severity,
+      summary: issue.summary,
+      message: issue.description,
+      count: 1,
+      eventIndex: issue.eventIndex ?? -1,
+    }));
+}
+
+/**
+ * Statements that ran many times. A log has no loop markers, so it cannot say
+ * "SOQL in a loop" — but "line 214 ran 340 queries" is the same signal and is
+ * what a developer acts on.
+ */
+function repetitionDiagnostics(statements: LogEvent[], label: string): Diagnostic[] {
+  const found: Diagnostic[] = [];
+
+  const perLine = groupBy(statements, (event) =>
+    typeof event.lineNumber === 'number' ? `${event.lineNumber}|${event.text}` : null,
+  );
+  for (const [key, group] of perLine) {
+    if (group.count < REPEAT_THRESHOLD) {
+      continue;
+    }
+    found.push({
+      id: `repeat-line|${label}|${key}`,
+      severity: 'Warning',
+      summary: `${group.count} ${label} statements from line ${group.events[0]?.lineNumber}.`,
+      message: `The same statement ran ${group.count} times from one line, which is the usual sign of ${label} inside a loop. Move it out of the loop and work on the whole collection at once.`,
+      count: group.count,
+      eventIndex: group.eventIndex,
+      evidence: group.events[0]?.text,
+    });
+  }
+
+  // The same statement from several lines: one call site cannot be pointed at,
+  // so the fix is to run it once and re-use the result.
+  const perText = groupBy(statements, (event) => event.text);
+  for (const [text, group] of perText) {
+    const lines = new Set(group.events.map((event) => event.lineNumber));
+    if (group.count < REPEAT_THRESHOLD || lines.size < 2) {
+      continue;
+    }
+    found.push({
+      id: `repeat-text|${label}|${text}`,
+      severity: 'Warning',
+      summary: `${group.count} identical ${label} statements, from ${lines.size} lines.`,
+      message: `The same statement ran ${group.count} times from ${lines.size} places. Run it once and pass the result around, or cache it for the transaction.`,
+      count: group.count,
+      eventIndex: group.eventIndex,
+      evidence: text,
+    });
+  }
+
+  return found;
+}
+
+/** Verdicts from the platform's own query optimiser, grouped by object. */
+function queryPlanDiagnostics(queries: SOQLExecuteBeginLine[]): {
+  diagnostics: Diagnostic[];
+  queryPlansKnown: boolean;
+} {
+  const costs = new Map<
+    string,
+    { count: number; eventIndex: number; worst: number; query: string }
+  >();
+  const scans = new Map<string, { count: number; eventIndex: number; query: string }>();
+  let explains = 0;
+
+  // The plan lines are children of the query they explain, so the walk keeps the
+  // query itself: a verdict on an object means nothing without the statement, and
+  // the query is the row the reader wants, not the plan line under it.
+  for (const query of queries) {
+    for (const explain of query.children) {
+      explains++;
+      const sObject = explain.sObjectType ?? 'the queried object';
+      if (explain.relativeCost !== null && explain.relativeCost > 1) {
+        const seen = costs.get(sObject);
+        if (seen) {
+          seen.count++;
+          if (explain.relativeCost > seen.worst) {
+            seen.worst = explain.relativeCost;
+            seen.query = query.text;
+            seen.eventIndex = query.eventIndex;
+          }
+        } else {
+          costs.set(sObject, {
+            count: 1,
+            eventIndex: query.eventIndex,
+            worst: explain.relativeCost,
+            query: query.text,
+          });
+        }
+      }
+      if (explain.leadingOperationType === 'TableScan') {
+        const seen = scans.get(sObject);
+        if (seen) {
+          seen.count++;
+        } else {
+          scans.set(sObject, { count: 1, eventIndex: query.eventIndex, query: query.text });
+        }
+      }
+    }
+  }
+
+  // The wording is the SOQL linter's, so a plan verdict reads the same here as it
+  // does beside the statement in the database grids. The object is metadata.
+  const diagnostics: Diagnostic[] = [
+    ...[...costs].map(([sObject, group]) => {
+      const rule = new QueryPlanCostRule(group.worst);
+      return {
+        id: `plan-cost|${sObject}`,
+        severity: rule.severity,
+        summary: rule.summary,
+        message: rule.message,
+        meta: sObject,
+        count: group.count,
+        eventIndex: group.eventIndex,
+        evidence: group.query,
+      };
+    }),
+    ...[...scans].map(([sObject, group]) => {
+      const rule = new TableScanRule();
+      return {
+        id: `plan-scan|${sObject}`,
+        severity: rule.severity,
+        summary: rule.summary,
+        message: rule.message,
+        meta: sObject,
+        count: group.count,
+        eventIndex: group.eventIndex,
+        evidence: group.query,
+      };
+    }),
+  ];
+
+  return { diagnostics, queryPlansKnown: explains > 0 };
+}
+
+/** Debug statements are not free: they cost CPU and heap even when nobody reads them. */
+function debugDiagnostics(debugLines: LogEvent[]): Diagnostic[] {
+  if (debugLines.length < DEBUG_THRESHOLD) {
+    return [];
+  }
+  return [
+    {
+      id: 'debug-statements',
+      severity: 'Info',
+      summary: `${debugLines.length} debug statements ran.`,
+      message:
+        'Each statement builds its message and writes it, whether or not anyone reads the log. Remove the ones that are no longer needed, and keep the rest behind a lower log level.',
+      count: debugLines.length,
+      eventIndex: debugLines[0]?.eventIndex ?? -1,
+    },
+  ];
+}
+
+/**
+ * The shipped SOQL rules, run over the whole log. Queries are grouped by text
+ * first, so each distinct query is parsed once and its findings carry the count.
+ * The stack of the first occurrence is what the stack-aware rules see.
+ */
+async function soqlLintDiagnostics(queries: SOQLExecuteBeginLine[]): Promise<{
+  diagnostics: Diagnostic[];
+  lintedQueries: { linted: number; distinct: number };
+}> {
+  const distinct = [...groupBy(queries, (event) => event.text)]
+    .sort(([, a], [, b]) => b.count - a.count)
+    .slice(0, MAX_LINTED_QUERIES);
+
+  const linter = new SOQLLinter();
+  const database = DatabaseAccess.instance();
+  const grouped = new Map<string, Diagnostic>();
+
+  for (const [text, group] of distinct) {
+    const stack = database?.getStackByEventIndex(group.eventIndex).reverse() ?? [];
+    for (const rule of await linter.lint(text, stack)) {
+      const id = `soql|${rule.summary}`;
+      const seen = grouped.get(id);
+      if (seen) {
+        seen.count += group.count;
+      } else {
+        grouped.set(id, {
+          id,
+          severity: rule.severity,
+          summary: rule.summary,
+          message: rule.message,
+          count: group.count,
+          eventIndex: group.eventIndex,
+          // The queries are in most-repeated order, so this is the query the rule
+          // fired on most — what the finding is about.
+          evidence: text,
+        });
+      }
+    }
+  }
+
+  return {
+    diagnostics: [...grouped.values()],
+    lintedQueries: { linted: distinct.length, distinct: new Set(queries.map((q) => q.text)).size },
+  };
+}
+
+/**
+ * Everything the log says about itself, as one ordered findings list.
+ *
+ * Every rule reads data the parser already produced, so the whole engine is one
+ * pass over `eventsById` plus one antlr parse per distinct query. Nothing here
+ * infers source-level structure — a log holds no loops and no source, so the
+ * findings are what ran, how often, and what the platform said about it.
+ */
+export async function computeLogDiagnostics(): Promise<LogDiagnostics> {
+  const log = DatabaseAccess.instance()?.getApexLog();
+  if (!log) {
+    return EMPTY;
+  }
+
+  const queries: SOQLExecuteBeginLine[] = [];
+  const dml: LogEvent[] = [];
+  const debugLines: LogEvent[] = [];
+  const selfTime = new Map<string, number>();
+  let totalSelf = 0;
+  for (const event of log.eventsById) {
+    switch (event.type) {
+      case 'SOQL_EXECUTE_BEGIN':
+        queries.push(event as SOQLExecuteBeginLine);
+        break;
+      case 'DML_BEGIN':
+        dml.push(event);
+        break;
+      case 'USER_DEBUG':
+        debugLines.push(event);
+        break;
+      default:
+        break;
+    }
+    const self = event.duration.self;
+    if (self > 0) {
+      const key = getEventKey(event);
+      selfTime.set(key, (selfTime.get(key) ?? 0) + self);
+      totalSelf += self;
+    }
+  }
+
+  const plans = queryPlanDiagnostics(queries);
+  const lint = await soqlLintDiagnostics(queries);
+  // A `LimitException` belongs to its governor metric, not to the exception list.
+  const isLimit = (event: LogEvent) => event.text.includes('System.LimitException');
+  const limitExceptions = log.exceptions.filter(isLimit);
+  const others = log.exceptions.filter((event) => !isLimit(event));
+  const diagnostics = [
+    ...limitDiagnostics(log.governorLimits, limitExceptions, hotSpot(selfTime, totalSelf)),
+    ...logIssueDiagnostics(log),
+    ...exceptionDiagnostics(others),
+    ...plans.diagnostics,
+    ...lint.diagnostics,
+    ...repetitionDiagnostics(queries, 'SOQL'),
+    ...repetitionDiagnostics(dml, 'DML'),
+    ...debugDiagnostics(debugLines),
+  ].sort(
+    (a, b) =>
+      SEVERITY_TYPES.indexOf(a.severity) - SEVERITY_TYPES.indexOf(b.severity) || b.count - a.count,
+  );
+
+  const truncation = log.logIssues.find((issue) => issue.type === 'skip');
+  return {
+    diagnostics,
+    truncation: truncation ? truncation.description : null,
+    queryPlansKnown: plans.queryPlansKnown,
+    lintedQueries: lint.lintedQueries,
+  };
+}

--- a/log-viewer/src/features/analysis/services/LogDiagnostics.ts
+++ b/log-viewer/src/features/analysis/services/LogDiagnostics.ts
@@ -188,6 +188,24 @@ function hotSpot(selfTime: Map<string, number>, totalSelf: number): HotSpot | nu
   return { label: label.slice(label.lastIndexOf('|') + 1), selfNs, share };
 }
 
+/**
+ * The method the log was running when the event happened.
+ *
+ * An exception and a breach are both raised inside code, and that code is the
+ * cause the reader wants: the exception row itself takes no time and says only
+ * that the transaction ended. The log root is skipped, since it is not code.
+ */
+function enclosingMethodIndex(event: LogEvent): number {
+  let node = event.parent;
+  while (node) {
+    if (node.isParent && node.parent) {
+      return node.eventIndex;
+    }
+    node = node.parent;
+  }
+  return event.eventIndex;
+}
+
 /** A governor breach the log reported as an exception, with where it stopped. */
 interface Breach {
   eventIndex: number;
@@ -226,7 +244,7 @@ function limitDiagnostics(
     // carries a stack, so keep whichever frame the log gave us.
     const seen = breaches.get(named.key);
     breaches.set(named.key, {
-      eventIndex: seen?.eventIndex ?? event.eventIndex,
+      eventIndex: seen?.eventIndex ?? enclosingMethodIndex(event),
       frame: seen?.frame || frame || undefined,
     });
   }
@@ -310,6 +328,7 @@ function exceptionDiagnostics(exceptions: LogEvent[]): Diagnostic[] {
     const frame = group.events
       .map((event) => splitException(event.text).frame)
       .find((first) => first.length > 0);
+    const thrownIn = group.events[0];
     return {
       id: `exception|${head}`,
       severity: 'Error' as Severity,
@@ -319,7 +338,7 @@ function exceptionDiagnostics(exceptions: LogEvent[]): Diagnostic[] {
         ? 'Nothing caught this exception, so the transaction rolled back.'
         : 'Even a caught exception costs CPU time, and a thrown-and-caught exception used as flow control is expensive.',
       count: Math.max(thrown, 1),
-      eventIndex: group.eventIndex,
+      eventIndex: thrownIn ? enclosingMethodIndex(thrownIn) : group.eventIndex,
       evidence: frame,
     };
   });

--- a/log-viewer/src/features/analysis/services/__tests__/LogDiagnostics.test.ts
+++ b/log-viewer/src/features/analysis/services/__tests__/LogDiagnostics.test.ts
@@ -309,6 +309,26 @@ describe('computeLogDiagnostics', () => {
     });
   });
 
+  it('points a breach at the method it stopped in, not at the exception row', async () => {
+    const method = event({ type: 'METHOD_ENTRY', eventIndex: 2, text: 'A.run()' });
+    // `isParent` marks a method; the log root is a parent too, so it is skipped.
+    const root = event({ eventIndex: 0, isParent: true });
+    Object.assign(method, { isParent: true, parent: root });
+    log = apexLog({
+      exceptions: [
+        event({
+          type: 'EXCEPTION_THROWN',
+          eventIndex: 4,
+          text: 'System.LimitException: Apex CPU time limit exceeded',
+          parent: method,
+        }),
+      ],
+    });
+
+    const { diagnostics } = await computeLogDiagnostics();
+    expect(diagnostics[0]?.eventIndex).toBe(2);
+  });
+
   it('counts debug statements once they are worth reporting', async () => {
     const debugLine = (index: number) =>
       event({ type: 'USER_DEBUG', eventIndex: index, text: 'DEBUG|hello' });

--- a/log-viewer/src/features/analysis/services/__tests__/LogDiagnostics.test.ts
+++ b/log-viewer/src/features/analysis/services/__tests__/LogDiagnostics.test.ts
@@ -1,0 +1,338 @@
+/*
+ * Copyright (c) 2026 Certinia Inc. All rights reserved.
+ */
+import type { ApexLog, GovernorLimits, LogEvent, Limits } from 'apex-log-parser';
+import { beforeEach, describe, expect, it } from '@jest/globals';
+
+import { emptyLimits } from '../../../../components/__tests__/limitsTestUtils.js';
+
+let log: ApexLog | null = null;
+
+jest.mock('../../../database/services/Database.js', () => ({
+  DatabaseAccess: {
+    instance: () => (log ? { getApexLog: () => log, getStackByEventIndex: () => [] } : null),
+  },
+}));
+
+import { computeLogDiagnostics } from '../LogDiagnostics.js';
+
+/** A parsed event, with only the fields the diagnostics read. */
+function event(fields: Partial<LogEvent>): LogEvent {
+  // The engine reads a handful of fields; a real parser event needs a parser.
+  return {
+    eventIndex: 0,
+    text: '',
+    lineNumber: null,
+    children: [],
+    duration: { self: 0, total: 0 },
+    ...fields,
+  } as LogEvent;
+}
+
+function apexLog(fields: Partial<ApexLog> & { namespaceLimits?: Limits }): ApexLog {
+  const { namespaceLimits, ...rest } = fields;
+  const governorLimits = {
+    ...emptyLimits(),
+    byNamespace: new Map(namespaceLimits ? [['default', namespaceLimits]] : []),
+    snapshots: [],
+  } as GovernorLimits;
+  // Same reason as `event`: only the fields the engine reads are supplied.
+  return {
+    eventsById: [],
+    exceptions: [],
+    logIssues: [],
+    governorLimits,
+    ...rest,
+  } as ApexLog;
+}
+
+const soql = (fields: Partial<LogEvent>) => event({ type: 'SOQL_EXECUTE_BEGIN', ...fields });
+
+describe('computeLogDiagnostics', () => {
+  beforeEach(() => {
+    log = null;
+  });
+
+  it('returns nothing while no log is parsed', async () => {
+    const result = await computeLogDiagnostics();
+    expect(result.diagnostics).toEqual([]);
+    expect(result.queryPlansKnown).toBe(false);
+  });
+
+  it('reports a governor limit that is reached, and one that is near', async () => {
+    const namespaceLimits = emptyLimits();
+    namespaceLimits.cpuTime = { used: 10_000, limit: 10_000 };
+    namespaceLimits.soqlQueries = { used: 85, limit: 100 };
+    log = apexLog({ namespaceLimits });
+
+    const { diagnostics } = await computeLogDiagnostics();
+    expect(diagnostics.map((d) => [d.severity, d.summary, d.meta])).toEqual([
+      ['Error', 'CPU Time limit exceeded.', '10,000 ms / 10,000 ms'],
+      ['Warning', 'SOQL is at 85% of its limit.', '85 / 100'],
+    ]);
+  });
+
+  it('leaves a metric below the near-limit share out', async () => {
+    const namespaceLimits = emptyLimits();
+    namespaceLimits.soqlQueries = { used: 40, limit: 100 };
+    log = apexLog({ namespaceLimits });
+
+    expect((await computeLogDiagnostics()).diagnostics).toEqual([]);
+  });
+
+  it('leaves another namespace alone, because the log cannot say it has its own budget', async () => {
+    const namespaceLimits = emptyLimits();
+    namespaceLimits.cpuTime = { used: 9_000, limit: 10_000 };
+    log = apexLog({});
+    log.governorLimits.byNamespace = new Map([['pkg', namespaceLimits]]);
+
+    expect((await computeLogDiagnostics()).diagnostics).toEqual([]);
+  });
+
+  it('groups a statement repeated from one line', async () => {
+    const text = 'SELECT Id FROM Account WHERE Id = :id LIMIT 1';
+    log = apexLog({
+      eventsById: Array.from({ length: 6 }, (_, index) =>
+        soql({ eventIndex: index, lineNumber: 214, text }),
+      ),
+    });
+
+    const { diagnostics } = await computeLogDiagnostics();
+    const repeat = diagnostics.find((d) => d.id.startsWith('repeat-line|'));
+    expect(repeat?.summary).toBe('6 SOQL statements from line 214.');
+    expect(repeat?.count).toBe(6);
+    expect(repeat?.eventIndex).toBe(0);
+  });
+
+  it('keeps a statement below the repeat threshold quiet', async () => {
+    log = apexLog({
+      eventsById: Array.from({ length: 4 }, (_, index) =>
+        soql({ eventIndex: index, lineNumber: 12, text: 'SELECT Id FROM Account LIMIT 1' }),
+      ),
+    });
+
+    expect((await computeLogDiagnostics()).diagnostics).toEqual([]);
+  });
+
+  it('reports an identical statement that runs from several lines', async () => {
+    const text = 'SELECT Id FROM Account LIMIT 1';
+    log = apexLog({
+      eventsById: Array.from({ length: 6 }, (_, index) =>
+        soql({ eventIndex: index, lineNumber: 10 + index, text }),
+      ),
+    });
+
+    const { diagnostics } = await computeLogDiagnostics();
+    const repeat = diagnostics.find((d) => d.id.startsWith('repeat-text|'));
+    expect(repeat?.summary).toBe('6 identical SOQL statements, from 6 lines.');
+    // Three from each of two lines would be under the per-line threshold, so the
+    // per-line rule must stay quiet here.
+    expect(diagnostics.some((d) => d.id.startsWith('repeat-line|'))).toBe(false);
+  });
+
+  it('runs the SOQL rules once per distinct query and carries the count', async () => {
+    log = apexLog({
+      eventsById: Array.from({ length: 3 }, (_, index) =>
+        soql({ eventIndex: index, text: 'SELECT Id FROM Account' }),
+      ),
+    });
+
+    const { diagnostics, lintedQueries } = await computeLogDiagnostics();
+    const unbounded = diagnostics.find((d) => d.summary.startsWith('SOQL is unbounded'));
+    expect(unbounded?.count).toBe(3);
+    // The rule names a problem; the query it read is what ties it to the grid.
+    expect(unbounded?.evidence).toBe('SELECT Id FROM Account');
+    expect(lintedQueries).toEqual({ linted: 1, distinct: 1 });
+  });
+
+  it('reads the query plan verdicts, and knows when there are none', async () => {
+    const explain = event({
+      type: 'SOQL_EXECUTE_EXPLAIN',
+      eventIndex: 1,
+      relativeCost: 2.5,
+      leadingOperationType: 'TableScan',
+      sObjectType: 'Account',
+    } as Partial<LogEvent>);
+    log = apexLog({
+      eventsById: [soql({ text: 'SELECT Id FROM Account LIMIT 1', children: [explain] })],
+    });
+
+    const { diagnostics, queryPlansKnown } = await computeLogDiagnostics();
+    expect(queryPlansKnown).toBe(true);
+    expect(diagnostics.map((d) => [d.summary, d.meta])).toEqual([
+      ['Query is not selective.', 'Account'],
+      ['Full table scan.', 'Account'],
+    ]);
+    expect(diagnostics.map((d) => d.evidence)).toEqual([
+      'SELECT Id FROM Account LIMIT 1',
+      'SELECT Id FROM Account LIMIT 1',
+    ]);
+    // The query is the row to reveal, not the plan line under it (eventIndex 1).
+    expect(diagnostics.map((d) => d.eventIndex)).toEqual([0, 0]);
+  });
+
+  it('says the plans are unknown when the log holds none', async () => {
+    log = apexLog({ eventsById: [soql({ text: 'SELECT Id FROM Account LIMIT 1' })] });
+    expect((await computeLogDiagnostics()).queryPlansKnown).toBe(false);
+  });
+
+  it('frames a truncated log rather than listing it as a finding', async () => {
+    log = apexLog({
+      logIssues: [
+        {
+          summary: 'Max-Size-reached',
+          description: 'The maximum log size has been reached. Part of the log has been truncated.',
+          type: 'skip',
+        },
+        {
+          summary: 'Unexpected-End',
+          description: 'An entry event was found without a corresponding exit event',
+          type: 'unexpected',
+        },
+      ],
+    });
+
+    const { diagnostics, truncation } = await computeLogDiagnostics();
+    expect(truncation).toContain('maximum log size');
+    expect(diagnostics.map((d) => d.summary)).toEqual(['Unexpected-End']);
+  });
+
+  it('groups exceptions by their text, counting the throws', async () => {
+    const text = 'System.NullPointerException: Attempt to de-reference a null object';
+    const thrown = (eventIndex: number) => event({ type: 'EXCEPTION_THROWN', eventIndex, text });
+    log = apexLog({ exceptions: [thrown(4), thrown(9)] });
+
+    const { diagnostics } = await computeLogDiagnostics();
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0]?.count).toBe(2);
+    expect(diagnostics[0]?.eventIndex).toBe(4);
+    expect(diagnostics[0]?.evidence).toBeUndefined();
+  });
+
+  it('groups the same exception thrown from different places, and keeps the frame', async () => {
+    const message = 'System.NullPointerException: Attempt to de-reference a null object';
+    log = apexLog({
+      exceptions: [
+        event({
+          type: 'EXCEPTION_THROWN',
+          eventIndex: 4,
+          text: `${message}\nClass.A.run: line 31, column 1`,
+        }),
+        event({
+          type: 'EXCEPTION_THROWN',
+          eventIndex: 9,
+          text: `${message}\nClass.B.run: line 7, column 1`,
+        }),
+      ],
+    });
+
+    const { diagnostics } = await computeLogDiagnostics();
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0]?.summary).toBe(message);
+    expect(diagnostics[0]?.count).toBe(2);
+    expect(diagnostics[0]?.evidence).toBe('Class.A.run: line 31, column 1');
+  });
+
+  it('marks an exception nothing caught', async () => {
+    const message = 'System.NullPointerException: Attempt to de-reference a null object';
+    log = apexLog({
+      exceptions: [
+        event({ type: 'EXCEPTION_THROWN', eventIndex: 4, text: message }),
+        event({ type: 'FATAL_ERROR', eventIndex: 5, text: message }),
+      ],
+    });
+
+    const { diagnostics } = await computeLogDiagnostics();
+    expect(diagnostics).toHaveLength(1);
+    // One throw, reported once: the fatal error is that same throw escaping.
+    expect(diagnostics[0]?.count).toBe(1);
+    expect(diagnostics[0]?.meta).toBe('unhandled');
+  });
+
+  it('reports a limit exception as the governor breach it is, not as an exception', async () => {
+    const message = 'System.LimitException: Apex CPU time limit exceeded';
+    const namespaceLimits = emptyLimits();
+    namespaceLimits.cpuTime = { used: 15_163, limit: 10_000 };
+    log = apexLog({
+      namespaceLimits,
+      exceptions: [
+        event({ type: 'EXCEPTION_THROWN', eventIndex: 4, text: message }),
+        event({
+          type: 'FATAL_ERROR',
+          eventIndex: 5,
+          text: `${message}\nClass.A.run: line 31, column 1`,
+        }),
+      ],
+    });
+
+    const { diagnostics } = await computeLogDiagnostics();
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0]?.summary).toBe('CPU Time limit exceeded.');
+    expect(diagnostics[0]?.meta).toBe('15,163 ms / 10,000 ms');
+    expect(diagnostics[0]?.eventIndex).toBe(4);
+    expect(diagnostics[0]?.evidence).toBe('Class.A.run: line 31, column 1');
+  });
+
+  it('still reports a limit exception when the log holds no cumulative totals', async () => {
+    log = apexLog({
+      exceptions: [
+        event({
+          type: 'EXCEPTION_THROWN',
+          eventIndex: 4,
+          text: 'System.LimitException: Too many SOQL queries: 101',
+        }),
+      ],
+    });
+
+    const { diagnostics } = await computeLogDiagnostics();
+    expect(diagnostics.map((d) => [d.summary, d.meta])).toEqual([
+      ['SOQL limit exceeded.', undefined],
+    ]);
+  });
+
+  it('names the method most of the self time went into, beside the CPU breach', async () => {
+    const namespaceLimits = emptyLimits();
+    namespaceLimits.cpuTime = { used: 15_163, limit: 10_000 };
+    log = apexLog({
+      namespaceLimits,
+      eventsById: [
+        event({ type: 'METHOD_ENTRY', text: 'Slow.run()', duration: { self: 9e9, total: 9e9 } }),
+        event({ type: 'METHOD_ENTRY', text: 'Fast.run()', duration: { self: 1e9, total: 1e9 } }),
+      ],
+    });
+
+    const { diagnostics } = await computeLogDiagnostics();
+    expect(diagnostics[0]?.cause).toEqual({
+      label: 'Most time in',
+      name: 'Slow.run()',
+      value: '9 s (90%)',
+    });
+  });
+
+  it('counts debug statements once they are worth reporting', async () => {
+    const debugLine = (index: number) =>
+      event({ type: 'USER_DEBUG', eventIndex: index, text: 'DEBUG|hello' });
+    log = apexLog({ eventsById: Array.from({ length: 49 }, (_, i) => debugLine(i)) });
+    expect((await computeLogDiagnostics()).diagnostics).toEqual([]);
+
+    log = apexLog({ eventsById: Array.from({ length: 50 }, (_, i) => debugLine(i)) });
+    const { diagnostics } = await computeLogDiagnostics();
+    expect(diagnostics[0]?.summary).toBe('50 debug statements ran.');
+    expect(diagnostics[0]?.severity).toBe('Info');
+  });
+
+  it('orders findings by severity, then by how often they happened', async () => {
+    const namespaceLimits = emptyLimits();
+    namespaceLimits.cpuTime = { used: 9_000, limit: 10_000 };
+    log = apexLog({
+      namespaceLimits,
+      exceptions: [event({ text: 'System.QueryException: List has no rows' })],
+      eventsById: Array.from({ length: 50 }, (_, index) =>
+        event({ type: 'USER_DEBUG', eventIndex: index, text: 'DEBUG|hello' }),
+      ),
+    });
+
+    const { diagnostics } = await computeLogDiagnostics();
+    expect(diagnostics.map((d) => d.severity)).toEqual(['Error', 'Warning', 'Info']);
+  });
+});

--- a/log-viewer/src/features/database/components/GovernorSummary.ts
+++ b/log-viewer/src/features/database/components/GovernorSummary.ts
@@ -62,7 +62,10 @@ export class GovernorSummary extends LitElement {
         display: flex;
         flex-direction: column;
         gap: 4px;
-        min-width: 6.5rem;
+        /* The label and the value never wrap, so a gauge must not shrink below
+           the wider of the two: at a 6.5rem floor a long value overflowed its
+           box and ran over the next gauge. min-content wraps the row instead. */
+        min-width: min-content;
         flex: 1 1 6.5rem;
         max-width: 12rem;
       }

--- a/log-viewer/src/features/soql/components/SOQLLinterIssues.ts
+++ b/log-viewer/src/features/soql/components/SOQLLinterIssues.ts
@@ -8,34 +8,21 @@ import { customElement, property, state } from 'lit/decorators.js';
 import type { SOQLExecuteBeginLine } from 'apex-log-parser';
 import { DatabaseAccess } from '../../database/services/Database.js';
 import {
+  QueryPlanCostRule,
   SEVERITY_TYPES,
   SOQLLinter,
   type SOQLLinterRule,
-  type Severity,
 } from '../services/SOQLLinter.js';
 
 // styles
 import { globalStyles } from '../../../styles/global.styles.js';
-
-const severityToIcon = new Map<string, string>(
-  Object.entries({ error: 'error', warning: 'warning', info: 'info' }),
-);
-
-/** Selectivity issue derived directly from the query-plan explain line. */
-class ExplainLineSelectivityRule implements SOQLLinterRule {
-  message = '';
-  severity: Severity = 'Error';
-  summary = 'Query is not selective.';
-  constructor(relativeCost: number) {
-    this.message = `The relative cost of the query is ${relativeCost}.`;
-  }
-}
+import { severityIcon, severityStyles } from '../../../styles/severity.styles.js';
 
 function getIssuesFromSOQLLine(soqlLine: SOQLExecuteBeginLine | null): SOQLLinterRule[] {
   const soqlIssues: SOQLLinterRule[] = [];
   const explain = soqlLine?.children[0];
   if (explain?.relativeCost && explain.relativeCost > 1) {
-    soqlIssues.push(new ExplainLineSelectivityRule(explain.relativeCost));
+    soqlIssues.push(new QueryPlanCostRule(explain.relativeCost));
   }
   return soqlIssues;
 }
@@ -79,6 +66,7 @@ export class SOQLLinterIssues extends LitElement {
 
   static styles = [
     globalStyles,
+    severityStyles,
     css`
       :host {
         flex: 1;
@@ -103,15 +91,6 @@ export class SOQLLinterIssues extends LitElement {
       }
       summary vscode-icon {
         flex: 0 0 auto;
-      }
-      .sev-error {
-        color: var(--vscode-problemsErrorIcon-foreground, var(--vscode-errorForeground));
-      }
-      .sev-warning {
-        color: var(--vscode-problemsWarningIcon-foreground, var(--vscode-editorWarning-foreground));
-      }
-      .sev-info {
-        color: var(--vscode-problemsInfoIcon-foreground, var(--vscode-editorInfo-foreground));
       }
       p {
         margin: 2px 0 4px 20px;
@@ -143,7 +122,7 @@ export class SOQLLinterIssues extends LitElement {
       const sev = issue.severity.toLowerCase();
       return html`<details>
         <summary title=${issue.summary}>
-          <vscode-icon class="sev-${sev}" name=${severityToIcon.get(sev) ?? 'info'}></vscode-icon>
+          <vscode-icon class="sev-${sev}" name=${severityIcon(issue.severity)}></vscode-icon>
           <span>${issue.summary}</span>
         </summary>
         <p>${issue.message}</p>

--- a/log-viewer/src/features/soql/services/SOQLLinter.ts
+++ b/log-viewer/src/features/soql/services/SOQLLinter.ts
@@ -42,6 +42,28 @@ export interface SOQLLinterRule {
   test?(soqlTree: SOQLTree, stack: Stack): boolean;
 }
 
+/**
+ * The platform optimiser's verdict on a query, from a plan line rather than from
+ * a parse — so these are constructed, not registered with {@link SOQLLinter}.
+ * They live here so one wording serves every view that reports a plan.
+ */
+export class QueryPlanCostRule implements SOQLLinterRule {
+  summary = 'Query is not selective.';
+  severity: Severity = 'Error';
+  message: string;
+
+  constructor(relativeCost: number) {
+    this.message = `The query optimiser gave the query a relative cost of ${relativeCost}. A cost above 1 means no index could be used. Filter on an indexed field, and keep the filter selective enough for the index to be worth using.`;
+  }
+}
+
+export class TableScanRule implements SOQLLinterRule {
+  summary = 'Full table scan.';
+  severity: Severity = 'Warning';
+  message =
+    'The optimiser read every record of the object because no filter matched an index. Add a filter on an indexed field.';
+}
+
 class UnboundedSOQLRule implements SOQLLinterRule {
   summary = 'SOQL is unbounded. Add a WHERE or LIMIT clause or both.';
   severity: Severity = 'Warning';
@@ -122,9 +144,9 @@ class NegativeFilterOperatorRule implements SOQLLinterRule {
 }
 
 class OrderByWithoutLimitRule implements SOQLLinterRule {
-  summary = 'Avoid ORDER BY unless the result set needs to be ordered, it can increase query time.';
+  summary = 'ORDER BY without a LIMIT.';
   message =
-    "An ORDER BY clause doesn't have anything to do with selectivity. Selectivity is determined by available indexes that align with filter conditions (WHERE clause) and record visibility (sharing rules, etc.). Once the optimizer determines which rows to return, it applies the ORDER BY logic to sort the records in the return set. However an ORDER BY and LIMIT can sometimes be optimizable.";
+    'Sorting costs time and does nothing for selectivity, which comes from indexes on the WHERE clause. Drop the ORDER BY unless the caller needs the order, or add a LIMIT, since ORDER BY with a LIMIT can be optimised.';
   severity: Severity = 'Info';
 
   test(soqlTree: SOQLTree, _stack: Stack): boolean {

--- a/log-viewer/src/styles/severity.styles.ts
+++ b/log-viewer/src/styles/severity.styles.ts
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2026 Certinia Inc. All rights reserved.
+ */
+import { css } from 'lit';
+
+import type { Severity } from '../features/soql/services/SOQLLinter.js';
+
+/** The codicon VS Code marks a Problems row of this severity with. */
+export function severityIcon(severity: Severity): string {
+  switch (severity.toLowerCase()) {
+    case 'error':
+      return 'error';
+    case 'warning':
+      return 'warning';
+    default:
+      return 'info';
+  }
+}
+
+/** Colours for `class="sev-<severity>"`, where the severity is lower case. */
+export const severityStyles = css`
+  .sev-error {
+    color: var(--lana-severity-error);
+  }
+  .sev-warning {
+    color: var(--lana-severity-warning);
+  }
+  .sev-info {
+    color: var(--lana-severity-info);
+  }
+`;

--- a/log-viewer/src/styles/tokens.css
+++ b/log-viewer/src/styles/tokens.css
@@ -48,6 +48,9 @@
      rather than states. */
   --lana-text-sm: calc(var(--vscode-font-size, 13px) * 0.85);
 
+  /* Monospace, for text whose alignment carries meaning: stacks, code. */
+  --lana-font-mono: var(--vscode-editor-font-family, monospace);
+
   /* Surfaces — the same registered colors VS Code's own chrome is built from.
      `surface-border` is absent before the size-token registry (stable 1.128 ships
      none of the `--vscode-surface-*` set), so its fallback chain is load-bearing. */
@@ -60,6 +63,9 @@
     var(--vscode-editor-background, transparent)
   );
 
+  /* Code surface — the fill VS Code gives inline code blocks in its own markdown. */
+  --lana-code-bg: var(--vscode-textCodeBlock-background, rgba(128, 128, 128, 0.12));
+
   /* Skeleton fill — a tint of the foreground, so it stays visible on the themes
      that set `editorWidget.background` to the editor background. */
   --lana-skeleton-bg: color-mix(in srgb, var(--vscode-foreground, #cccccc) 12%, transparent);
@@ -70,6 +76,23 @@
   /* Badges — small count/kind pills, matching VS Code's own badge chrome. */
   --lana-badge-bg: var(--vscode-badge-background, #616161);
   --lana-badge-fg: var(--vscode-badge-foreground, #f8f8f8);
+
+  /* Severity — the same colours VS Code's Problems panel marks its rows with. */
+  --lana-severity-error: var(
+    --vscode-problemsErrorIcon-foreground,
+    var(--vscode-errorForeground, #f14c4c)
+  );
+  --lana-severity-warning: var(
+    --vscode-problemsWarningIcon-foreground,
+    var(--vscode-editorWarning-foreground, #cca700)
+  );
+  --lana-severity-info: var(
+    --vscode-problemsInfoIcon-foreground,
+    var(--vscode-editorInfo-foreground, #3794ff)
+  );
+
+  /* Row hover, for lists whose rows can be opened or picked. */
+  --lana-row-hover-bg: var(--vscode-list-hoverBackground, rgba(128, 128, 128, 0.12));
 
   /* Secondary text — metadata that must not compete with the content it annotates. */
   --lana-fg-muted: var(--vscode-descriptionForeground, rgba(204, 204, 204, 0.7));


### PR DESCRIPTION
# 📝 PR Overview

Gives the Inspector's **Analysis** tab a log-wide diagnostics engine. With no row selected the tab
now answers "what is slow or wrong in this log, and what do I do about it" as a findings list, and
each finding links back to the row behind it in the Analysis grid.

Builds on #912 (the section seam).

## 🛠️ Changes made

- New `features/analysis/services/LogDiagnostics.ts`: one whole-log pass that produces findings
  from data the parser already holds.
  - SOQL rules, log-wide, delegated to `SOQLLinter` and grouped with a count.
  - Query plan verdicts (relative cost, table scan). When the log holds no plans the pane says the
    verdicts are unknown, so absent FINEST data never reads as a clean result.
  - Repeated statements at one line: the N+1 signal.
  - Governor breaches, exceptions and debug-statement cost. A CPU breach is presented as the
    governor stopping the transaction, not as a thrown exception.
  - Truncation heads the pane, since it makes every figure below it an undercount.
  - Hot spots from the bottom-up tree, so which method to optimise is measured.
- New `features/analysis/components/LogDiagnosticsView.ts`: the findings list. A finding shows its
  cause as a figure row (label, the code the log named, its figures) and its evidence as the way
  back to the grid.
- Clicking the evidence reveals that row in the Analysis grid, in the same tab. A breach or an
  exception reveals the **method it was raised in**, not the exception row, which holds no time.
- `fix(soql)`: tightened the rule wording and moved the query-plan verdicts into `SOQLLinter` so
  the Database tab and the Inspector say the same thing.
- `fix(database)`: the governor gauges no longer overlap as the panel narrows.

## 🧩 Type of change (check all applicable)

- [x] 🐛 Bug fix - something not working as expected
- [x] ✨ New feature – adds new functionality
- [ ] ♻️ Refactor - internal changes with no user impact
- [ ] ⚡ Performance Improvement
- [ ] 📝 Documentation - README or documentation site changes
- [ ] 🔧 Chore - dev tooling, CI, config
- [ ] 💥 Breaking change

## 📷 Screenshots / gifs / video [optional]
Same panel on every tab at this stage

<img width="1917" height="466" alt="image" src="https://github.com/user-attachments/assets/a7b0dd21-0616-459d-a6fd-41c4463e11de" />

## 🔗 Related Issues

related #875

## ✅ Tests added?

- [x] 👍 yes

`LogDiagnostics.test.ts` covers each rule family, the grouping and the reveal target.
`LogDiagnosticsView.test.ts` covers the list, the cause row, the caveats and the reveal event.

## 📚 Docs updated?

- [ ] 🔖 README.md
- [ ] 🔖 CHANGELOG.md
- [ ] 📖 help site
- [ ] 🧪 Marked any pre-release-only features
- [x] 🙅 not needed

README and CHANGELOG land with the release.

## Anything else we need to know? [optional]

Verified with `tsc -b log-viewer`, `eslint log-viewer/src`, jest (111 suites / 1459 tests),
prettier and a production build, then checked in the dev host in a light and a dark theme.
