### PR TITLE
feat(log-viewer): show entry point, user and start time in the header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,7 +35,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Filter by **Namespace**, **Object** or **Caller Namespace**, or by a **Row Count** / **Time Taken** min–max range; active filters are highlighted.
   - Collapse behind a **Filter** button on narrow window. ([#873])
 - 🔴 **Timeline exception markers**: exceptions show as red lines, with a **Throws** count in method tooltips. ([#828])
-- 🪪 **Header identity**: the header now says what ran, who ran it, and when — entry point, user, and start time after the log size and duration. Hover for the full values (raw entry point, email, start time with timezone). Items shed one at a time as the window narrows; their values stay in the log-name tooltip.
+- 🪪 **Header**: the header now includes entry point, user, and start time with hover for more details.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Filter by **Namespace**, **Object** or **Caller Namespace**, or by a **Row Count** / **Time Taken** min–max range; active filters are highlighted.
   - Collapse behind a **Filter** button on narrow window. ([#873])
 - 🔴 **Timeline exception markers**: exceptions show as red lines, with a **Throws** count in method tooltips. ([#828])
+- 🪪 **Header identity**: the header now says what ran, who ran it, and when — entry point, user, and start time after the log size and duration. Hover for the full values (raw entry point, email, start time with timezone). Items shed one at a time as the window narrows; their values stay in the log-name tooltip.
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ The bar above the tabs summarizes the log at a glance:
 
 - **Log problems** – A chip for problems found in the log itself (governor limit exceptions, fatal errors, skipped lines), with a count badge; click it for the full breakdown.
 - **Notifications** – A separate bell for messages about the tool rather than the log, kept apart from log problems so the two don't read as one severity count.
-- **Transaction identity** – What ran, who ran it, and when: entry point, user, and start time after the size and duration. Hover for the full values (raw entry point, email, start time with timezone).
+- **Log info** – Entry point, user, and start time; hover for full details.
 - **Debug levels** – Chips showing the debug levels the log was captured with, one per category. Read-only display, not a filter.
 - **`•••` menu** – Help, report an issue, and whatever the header sheds as the window narrows.
 

--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ The bar above the tabs summarizes the log at a glance:
 
 - **Log problems** – A chip for problems found in the log itself (governor limit exceptions, fatal errors, skipped lines), with a count badge; click it for the full breakdown.
 - **Notifications** – A separate bell for messages about the tool rather than the log, kept apart from log problems so the two don't read as one severity count.
+- **Transaction identity** – What ran, who ran it, and when: entry point, user, and start time after the size and duration. Hover for the full values (raw entry point, email, start time with timezone).
 - **Debug levels** – Chips showing the debug levels the log was captured with, one per category. Read-only display, not a filter.
 - **`•••` menu** – Help, report an issue, and whatever the header sheds as the window narrows.
 

--- a/lana-docs/docs/docs/features/features.mdx
+++ b/lana-docs/docs/docs/features/features.mdx
@@ -23,10 +23,6 @@ import DocCardList from '@theme/DocCardList';
 
 Explore the Apex Log Analyzer for Salesforce debug logs features including interactive timelines, detailed Time Order, Aggregated, and Bottom-Up call trees, in-depth analysis, database insights, and powerful search capabilities to streamline your debugging and performance tuning.
 
-## 🪪 Transaction identity
-
-The header says what ran, who ran it, and when — the entry point (e.g. `Anonymous Apex`, `Trigger MyTrigger`, a VF page), the user, and the wall-clock start time, shown after the log size and duration. Hover an item for its full value: the raw entry point, the user's email, or the start time with its timezone. As the window narrows the items shed one at a time, and their values stay in the log-name tooltip. A log that lacks the data (for example a cropped log with no `USER_INFO` line) omits that item.
-
 ## 🚦 Log problems and notifications
 
 **Log problems** are problems found in the log itself — governor limit exceptions, fatal errors, skipped lines. A chip shows the worst severity's icon with a count badge, and a tick when the log is clean. **Notifications** are messages about the tool rather than the log — today, parser diagnostics for log lines it couldn't understand. The two are kept apart so they don't read as one severity count.

--- a/lana-docs/docs/docs/features/features.mdx
+++ b/lana-docs/docs/docs/features/features.mdx
@@ -23,6 +23,10 @@ import DocCardList from '@theme/DocCardList';
 
 Explore the Apex Log Analyzer for Salesforce debug logs features including interactive timelines, detailed Time Order, Aggregated, and Bottom-Up call trees, in-depth analysis, database insights, and powerful search capabilities to streamline your debugging and performance tuning.
 
+## 🪪 Transaction identity
+
+The header says what ran, who ran it, and when — the entry point (e.g. `Anonymous Apex`, `Trigger MyTrigger`, a VF page), the user, and the wall-clock start time, shown after the log size and duration. Hover an item for its full value: the raw entry point, the user's email, or the start time with its timezone. As the window narrows the items shed one at a time, and their values stay in the log-name tooltip. A log that lacks the data (for example a cropped log with no `USER_INFO` line) omits that item.
+
 ## 🚦 Log problems and notifications
 
 **Log problems** are problems found in the log itself — governor limit exceptions, fatal errors, skipped lines. A chip shows the worst severity's icon with a count badge, and a tick when the log is clean. **Notifications** are messages about the tool rather than the log — today, parser diagnostics for log lines it couldn't understand. The two are kept apart so they don't read as one severity count.

--- a/log-viewer/src/components/LogIdentity.ts
+++ b/log-viewer/src/components/LogIdentity.ts
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2026 Certinia Inc. All rights reserved.
+ */
+import { LitElement, css, html } from 'lit';
+import { customElement, property } from 'lit/decorators.js';
+
+import type { LogIdentityItem } from '../features/app/logIdentity.js';
+import { globalStyles } from '../styles/global.styles.js';
+import { headerItemStyles } from '../styles/headerItem.styles.js';
+import { skeletonStyles } from '../styles/skeleton.styles.js';
+
+/**
+ * One header identity item (entry point, user, or start time). Same muted idiom
+ * as `log-meta`; the compact label is capped via `cap`, with the full value in
+ * the tooltip. Renders a skeleton while `item` is null; the host decides whether
+ * to render the element at all when the item is known to be absent.
+ */
+@customElement('log-identity')
+export class LogIdentity extends LitElement {
+  @property({ attribute: false })
+  item: LogIdentityItem | null = null;
+
+  /** Cap on the compact label as a CSS length, e.g. '24ch'. Empty means uncapped. */
+  @property()
+  cap = '';
+
+  /** Skeleton width while loading, e.g. '12ch'. */
+  @property()
+  skeletonWidth = '8ch';
+
+  static styles = [
+    globalStyles,
+    skeletonStyles,
+    headerItemStyles,
+    css`
+      /* The host's cap bounds the label; the tooltip carries the full value. */
+      .item {
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+      }
+
+      .item.skeleton {
+        height: 80%;
+      }
+    `,
+  ];
+
+  render() {
+    if (this.item === null) {
+      return html`<span class="item skeleton" style="width: ${this.skeletonWidth};"></span>`;
+    }
+    return html`<span
+      class="item"
+      style="${this.cap ? `max-width: ${this.cap};` : ''}"
+      title="${this.item.detail}"
+      >${this.item.label}</span
+    >`;
+  }
+}

--- a/log-viewer/src/components/LogMeta.ts
+++ b/log-viewer/src/components/LogMeta.ts
@@ -4,26 +4,23 @@
 import { LitElement, css, html } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
 
+import { headerItemStyles } from '../styles/headerItem.styles.js';
 import { skeletonStyles } from '../styles/skeleton.styles.js';
+import { tokenStyles } from '../styles/tokens.styles.js';
 
 import './DotSeparator.js';
 
 @customElement('log-meta')
 export class LogMeta extends LitElement {
   static styles = [
+    tokenStyles,
     skeletonStyles,
+    headerItemStyles,
     css`
-      :host {
-        display: inline-flex;
-        flex: 0 0 auto;
-      }
-
       .log__metadata {
         display: inline-flex;
         gap: 8px;
         align-items: center;
-        font-size: 0.9rem;
-        color: var(--vscode-descriptionForeground, #999);
       }
 
       .metadata__item {

--- a/log-viewer/src/components/NavBar.ts
+++ b/log-viewer/src/components/NavBar.ts
@@ -7,6 +7,7 @@ import { customElement, property, state } from 'lit/decorators.js';
 
 import { eventBus } from '../core/events/EventBus.js';
 import { formatDuration } from '../core/utility/Util.js';
+import type { LogIdentityData } from '../features/app/logIdentity.js';
 import type { LogIssue } from '../features/notifications/types.js';
 import { computeVisibleCount } from './overflowFit.js';
 
@@ -20,18 +21,45 @@ import '../features/notifications/components/NotificationCentre.js';
 import './Divider.js';
 import './DotSeparator.js';
 import './HeaderMenu.js';
+import './LogIdentity.js';
 import './LogMeta.js';
 import './LogProblemsChip.js';
 import './LogTitle.js';
 
 /**
- * What the header sheds as it narrows, in the order it *keeps* them: log meta goes
- * first (passive info, and its values survive in the title's tooltip), then the bell
- * (tool-level, usually empty), then the Inspector toggle (also on the command palette,
- * and the docked panel is visible either way), and log problems last — the only signal
- * that can invalidate the whole analysis. Everything shed reappears inside `•••`.
+ * The identity chunks in keep order (the last row sheds first), tying each chunk to
+ * its `LogIdentityData` field and its compact-label widths. `CHUNKS`, the render
+ * loop, `_chunkActive`, and the title tooltip all derive from this, so adding an
+ * item is one row here.
  */
-const CHUNKS = ['problems', 'inspector', 'bell', 'meta'] as const;
+const IDENTITY_CHUNKS = [
+  { chunk: 'entry', field: 'entryPoint', cap: '24ch', skeletonWidth: '12ch' },
+  { chunk: 'user', field: 'user', cap: '16ch', skeletonWidth: '8ch' },
+  { chunk: 'time', field: 'startTime', cap: '', skeletonWidth: '8ch' },
+] as const satisfies readonly {
+  chunk: string;
+  field: keyof LogIdentityData;
+  cap: string;
+  skeletonWidth: string;
+}[];
+
+/**
+ * What the header sheds as it narrows, in the order it *keeps* them: the transaction
+ * identity goes first, one item at a time from the right — time, then user, then entry
+ * point (losing "when" before "who" before "what") — then log meta (all passive info
+ * whose values survive in the title's tooltip), then the bell (tool-level, usually
+ * empty), then the Inspector toggle (also on the command palette, and the docked panel
+ * is visible either way), and log problems last — the only signal that can invalidate
+ * the whole analysis. Shed controls reappear inside `•••`; shed values survive in the
+ * title's tooltip.
+ */
+const CHUNKS = [
+  'problems',
+  'inspector',
+  'bell',
+  'meta',
+  ...IDENTITY_CHUNKS.map(({ chunk }) => chunk),
+] as const;
 type Chunk = (typeof CHUNKS)[number];
 
 /**
@@ -68,6 +96,10 @@ export class NavBar extends LitElement {
   /** Notifications about the tool — today, parser diagnostics. */
   @property({ attribute: false })
   notifications: readonly LogIssue[] = [];
+
+  /** Transaction identity (entry point · user · start time). `null` while parsing. */
+  @property({ attribute: false })
+  logIdentity: LogIdentityData | null = null;
 
   /** How many leading `CHUNKS` stay in the header; the rest are in the `•••` menu. */
   @state()
@@ -189,7 +221,8 @@ export class NavBar extends LitElement {
       changed.has('logSize') ||
       changed.has('logDuration') ||
       changed.has('logProblems') ||
-      changed.has('notifications')
+      changed.has('notifications') ||
+      changed.has('logIdentity')
     ) {
       this._widths.clear();
       this._visible = CHUNKS.length;
@@ -217,7 +250,13 @@ export class NavBar extends LitElement {
           <log-title
             logName="${this.logName}"
             logPath="${this.logPath}"
-            details="${[sizeText, elapsedText].filter(Boolean).join(' • ')}"
+            details="${[
+              sizeText,
+              elapsedText,
+              ...IDENTITY_CHUNKS.map(({ field }) => this.logIdentity?.[field]?.detail),
+            ]
+              .filter(Boolean)
+              .join(' • ')}"
           ></log-title>
           ${
             show.meta
@@ -227,6 +266,18 @@ export class NavBar extends LitElement {
                 </div>`
               : ''
           }
+          ${IDENTITY_CHUNKS.map(({ chunk, field, cap, skeletonWidth }) =>
+            show[chunk] && this._chunkActive(chunk)
+              ? html`<div class="chunk chunk--${chunk}">
+                  <dot-separator></dot-separator>
+                  <log-identity
+                    .item=${this.logIdentity?.[field] ?? null}
+                    cap=${cap}
+                    skeletonWidth=${skeletonWidth}
+                  ></log-identity>
+                </div>`
+              : '',
+          )}
           ${
             show.problems
               ? html`<div class="chunk chunk--problems">
@@ -285,9 +336,12 @@ export class NavBar extends LitElement {
     }
 
     this._measure();
-    const widths = CHUNKS.map((chunk) => this._widths.get(chunk) ?? 0);
+    // An inactive chunk renders nothing: it costs the ladder no width, and its zero
+    // width is legitimate rather than "not measured yet".
+    const active = CHUNKS.map((chunk) => this._chunkActive(chunk));
+    const widths = CHUNKS.map((chunk, i) => (active[i] ? (this._widths.get(chunk) ?? 0) : 0));
     // Nothing measured yet (first paint, or the webview is hidden) — leave the layout be.
-    if (widths.some((width) => width === 0)) {
+    if (widths.some((width, i) => width === 0 && active[i])) {
       return;
     }
 
@@ -295,6 +349,16 @@ export class NavBar extends LitElement {
     // `_fit` also runs from `updated`, so this must settle: an unchanged stage is not a
     // change, so lit schedules nothing and the loop stops.
     this._visible = computeVisibleCount(widths, avail, 0, 0);
+  }
+
+  /**
+   * Whether a chunk currently has anything to show. The identity chunks are the only
+   * optional ones: each stays active while the log parses (skeleton) and goes inactive
+   * when the parsed log carries no value for it (e.g. a cropped log with no USER_INFO).
+   */
+  private _chunkActive(chunk: Chunk): boolean {
+    const field = IDENTITY_CHUNKS.find((identity) => identity.chunk === chunk)?.field;
+    return !field || this.logIdentity === null || Boolean(this.logIdentity[field]);
   }
 
   private _measure(): void {

--- a/log-viewer/src/components/__tests__/NavBar.test.ts
+++ b/log-viewer/src/components/__tests__/NavBar.test.ts
@@ -10,6 +10,7 @@ jest.mock('#vscode-elements/vscode-icon.js', () => ({}));
 jest.mock('#vscode-elements/vscode-toolbar-button.js', () => ({}));
 jest.mock('#vscode-elements/vscode-button.js', () => ({}));
 
+import type { LogIdentityData } from '../../features/app/logIdentity.js';
 import type { IssueSeverity, LogIssue } from '../../features/notifications/types.js';
 
 import type { NavBar } from '../NavBar.js';
@@ -47,9 +48,12 @@ class StubResizeObserver {
  * jsdom lays nothing out, so every `offsetWidth` is 0 and the ladder would never engage.
  * With these widths each chunk costs its width + the 6px gap, `•••` costs 36 and the title
  * floor falls back to 140 (jsdom resolves no `min-width`), putting the stage boundaries at
- * 390 / 284 / 248 / 212 px.
+ * 598 / 542 / 476 / 390 / 284 / 248 / 212 px.
  */
 const DEFAULT_CHUNK_WIDTHS: Readonly<Record<string, number>> = {
+  'chunk--time': 50,
+  'chunk--user': 60,
+  'chunk--entry': 80,
   'chunk--meta': 100,
   'chunk--problems': 30,
   'chunk--inspector': 30,
@@ -119,7 +123,7 @@ async function resize(el: NavBar, width: number): Promise<NavBar> {
 }
 
 function inlineChunks(el: NavBar): string[] {
-  return ['meta', 'problems', 'inspector', 'bell'].filter((chunk) =>
+  return ['meta', 'entry', 'user', 'time', 'problems', 'inspector', 'bell'].filter((chunk) =>
     el.shadowRoot?.querySelector(`.chunk--${chunk}`),
   );
 }
@@ -142,11 +146,41 @@ describe('NavBar collapse ladder', () => {
   it('keeps everything inline when there is room', async () => {
     const el = await resize(await mount(), 800);
 
-    expect(inlineChunks(el)).toEqual(['meta', 'problems', 'inspector', 'bell']);
+    expect(inlineChunks(el)).toEqual([
+      'meta',
+      'entry',
+      'user',
+      'time',
+      'problems',
+      'inspector',
+      'bell',
+    ]);
     expect(el.shadowRoot?.querySelector('[slot="collapsed"]')).toBeNull();
   });
 
-  it('sheds log meta first, keeping its values in the title tooltip', async () => {
+  it('sheds the identity one item at a time — time, then user, then entry', async () => {
+    const el = await mount();
+
+    expect(inlineChunks(await resize(el, 560))).toEqual([
+      'meta',
+      'entry',
+      'user',
+      'problems',
+      'inspector',
+      'bell',
+    ]);
+    expect(inlineChunks(await resize(el, 500))).toEqual([
+      'meta',
+      'entry',
+      'problems',
+      'inspector',
+      'bell',
+    ]);
+    expect(inlineChunks(await resize(el, 420))).toEqual(['meta', 'problems', 'inspector', 'bell']);
+    expect(el.shadowRoot?.querySelector('[slot="collapsed"]')).toBeNull();
+  });
+
+  it('then log meta, keeping its values in the title tooltip', async () => {
     const el = await resize(await mount(), 350);
 
     expect(inlineChunks(el)).toEqual(['problems', 'inspector', 'bell']);
@@ -173,6 +207,49 @@ describe('NavBar collapse ladder', () => {
     expect(inlineChunks(el)).toEqual([]);
     expect(menuSections(el)).toEqual(['Notifications', 'Toggle Inspector', 'Log problems (2)']);
     expect(el.shadowRoot?.querySelector('header-menu')).not.toBeNull();
+  });
+
+  it('skips an identity item the log does not have, without freezing the ladder', async () => {
+    const el = await mount();
+    el.logIdentity = {
+      entryPoint: { label: 'Anonymous Apex', detail: 'execute_anonymous_apex' },
+      user: null,
+      startTime: { label: '16:35:06', detail: 'Started 16:35:06.123' },
+    } satisfies LogIdentityData;
+    await el.updateComplete;
+    await el.updateComplete;
+
+    expect(inlineChunks(await resize(el, 800))).toEqual([
+      'meta',
+      'entry',
+      'time',
+      'problems',
+      'inspector',
+      'bell',
+    ]);
+    // The absent item costs nothing, so time survives narrower than it would with a user.
+    expect(inlineChunks(await resize(el, 480))).toEqual([
+      'meta',
+      'entry',
+      'problems',
+      'inspector',
+      'bell',
+    ]);
+  });
+
+  it('folds the identity details into the title tooltip', async () => {
+    const el = await mount();
+    el.logIdentity = {
+      entryPoint: { label: 'Anonymous Apex', detail: 'execute_anonymous_apex' },
+      user: { label: 'tina.owen', detail: 'tina.owen@example.com' },
+      startTime: { label: '16:35:06', detail: 'Started 16:35:06.123 (GMT+01:00)' },
+    } satisfies LogIdentityData;
+    await el.updateComplete;
+
+    const details = el.shadowRoot?.querySelector('log-title')?.getAttribute('details') ?? '';
+    expect(details).toContain('execute_anonymous_apex');
+    expect(details).toContain('tina.owen@example.com');
+    expect(details).toContain('Started 16:35:06.123 (GMT+01:00)');
   });
 
   it('re-measures a collapsed chunk after its content changes', async () => {

--- a/log-viewer/src/features/app/AppHeader.ts
+++ b/log-viewer/src/features/app/AppHeader.ts
@@ -6,6 +6,7 @@ import { customElement, property } from 'lit/decorators.js';
 
 import type { ApexLog } from 'apex-log-parser';
 import type { LogIssue } from '../notifications/types.js';
+import type { LogIdentityData } from './logIdentity.js';
 
 // web components
 import '../../components/LogLevels.js';
@@ -33,6 +34,8 @@ export class AppHeader extends LitElement {
   logProblems: readonly LogIssue[] | null = null;
   @property({ attribute: false })
   notifications: readonly LogIssue[] = [];
+  @property({ attribute: false })
+  logIdentity: LogIdentityData | null = null;
   @property()
   timelineRoot: ApexLog | null = null;
 
@@ -61,6 +64,7 @@ export class AppHeader extends LitElement {
         .logDuration=${this.logDuration}
         .logProblems=${this.logProblems}
         .notifications=${this.notifications}
+        .logIdentity=${this.logIdentity}
       ></nav-bar>
       <log-levels .logSettings=${this.timelineRoot?.debugLevels}></log-levels>
       <find-widget></find-widget>

--- a/log-viewer/src/features/app/LogViewer.ts
+++ b/log-viewer/src/features/app/LogViewer.ts
@@ -17,6 +17,7 @@ import {
 } from '../../core/messaging/VSCodeExtensionMessenger.js';
 import { DatabaseAccess } from '../database/services/Database.js';
 import type { LogIssue } from '../notifications/types.js';
+import { deriveLogIdentity, type LogIdentityData } from './logIdentity.js';
 import { toLogIssue } from './logIssues.js';
 import { parserIssuesToNotifications } from './parserNotifications.js';
 
@@ -51,6 +52,9 @@ export class LogViewer extends LitElement {
   /** Notifications about the tool — today, parser diagnostics. */
   @property({ attribute: false })
   notifications: readonly LogIssue[] = [];
+  /** Transaction identity for the header. `null` until the first log is parsed. */
+  @property({ attribute: false })
+  logIdentity: LogIdentityData | null = null;
   @property()
   timelineRoot: ApexLog | null = null;
 
@@ -148,6 +152,7 @@ export class LogViewer extends LitElement {
         .logDuration=${this.logDuration}
         .logProblems=${this.logProblems}
         .notifications=${this.notifications}
+        .logIdentity=${this.logIdentity}
         .timelineRoot=${this.timelineRoot}
       ></app-header>
 
@@ -238,7 +243,15 @@ export class LogViewer extends LitElement {
       this.logProblems = [read.error];
     }
 
-    const apexLog = parse(logData);
+    let apexLog: ApexLog;
+    try {
+      apexLog = parse(logData);
+    } catch (err) {
+      // Resolve the identity even when parsing throws, or the header's identity
+      // skeletons would pulse forever with nothing left to fill them.
+      this.logIdentity = { entryPoint: null, user: null, startTime: null };
+      throw err;
+    }
 
     // The event-lookup service backs the inspector on every tab, so it is
     // created with the parsed log rather than by whichever tab loads first.
@@ -250,6 +263,9 @@ export class LogViewer extends LitElement {
     this.logSize = apexLog.size;
     this.timelineRoot = apexLog;
     this.logDuration = apexLog.duration.total;
+    // Raw text is needed for the user: USER_INFO precedes EXECUTION_STARTED, so the
+    // parser never sees it. See deriveLogIdentity.
+    this.logIdentity = deriveLogIdentity(apexLog, logData);
 
     // Rebuilt per load, never appended to: both surfaces describe *this* log, so a
     // previous log's problems must not carry over.

--- a/log-viewer/src/features/app/__tests__/logIdentity.test.ts
+++ b/log-viewer/src/features/app/__tests__/logIdentity.test.ts
@@ -1,0 +1,104 @@
+/*
+ * Copyright (c) 2026 Certinia Inc. All rights reserved.
+ */
+import { describe, expect, it } from '@jest/globals';
+import { parse } from 'apex-log-parser';
+
+import { deriveLogIdentity } from '../logIdentity.js';
+
+const USER_INFO_LINE =
+  '09:18:22.6 (6297619)|USER_INFO|[EXTERNAL]|005Ea00000R6orz|tina.owen@example.com|(GMT-07:00) Pacific Daylight Time (America/Los_Angeles)|GMT-07:00\n';
+
+/** A minimal parseable transaction around one CODE_UNIT_STARTED line. */
+function transaction(codeUnitStarted: string, prefix = USER_INFO_LINE): string {
+  return (
+    prefix +
+    '09:18:22.6 (6574780)|EXECUTION_STARTED\n' +
+    codeUnitStarted +
+    '09:18:22.10 (10000000)|CODE_UNIT_FINISHED|unit\n' +
+    '09:18:22.10 (11000000)|EXECUTION_FINISHED\n'
+  );
+}
+
+function identity(rawLog: string) {
+  return deriveLogIdentity(parse(rawLog), rawLog);
+}
+
+describe('entry point', () => {
+  it('maps anonymous apex to a friendly label, keeping the raw text as the detail', () => {
+    const log = transaction(
+      '09:18:22.6 (7000000)|CODE_UNIT_STARTED|[EXTERNAL]|execute_anonymous_apex\n',
+    );
+
+    expect(identity(log).entryPoint).toEqual({
+      label: 'Anonymous Apex',
+      detail: 'execute_anonymous_apex',
+    });
+  });
+
+  it('shows a VF page by its page name', () => {
+    const log = transaction(
+      '09:18:22.6 (7000000)|CODE_UNIT_STARTED|[EXTERNAL]|066d0000002m8ij|VF: /apex/SiteLogin\n',
+    );
+
+    expect(identity(log).entryPoint?.label).toBe('VF SiteLogin');
+  });
+
+  it('shows a trigger by its name, from the "on" form', () => {
+    const log = transaction(
+      '09:18:22.6 (7000000)|CODE_UNIT_STARTED|[EXTERNAL]|01qd0000000LOhy|MyTrigger on Account trigger event BeforeInsert|__sfdc_trigger/MyTrigger\n',
+    );
+
+    expect(identity(log).entryPoint?.label).toBe('Trigger MyTrigger');
+  });
+
+  it('shows a trigger by its name, from the raw path form', () => {
+    const log = transaction(
+      '09:18:22.6 (7000000)|CODE_UNIT_STARTED|[EXTERNAL]|__sfdc_trigger/ns/MyTrigger\n',
+    );
+
+    expect(identity(log).entryPoint?.label).toBe('Trigger MyTrigger');
+  });
+
+  it('is null when the log has no code unit', () => {
+    const log = USER_INFO_LINE + '09:18:22.6 (6574780)|EXECUTION_STARTED\n';
+
+    expect(identity(log).entryPoint).toBeNull();
+  });
+});
+
+describe('user and start time', () => {
+  const anonymous = '09:18:22.6 (7000000)|CODE_UNIT_STARTED|[EXTERNAL]|execute_anonymous_apex\n';
+
+  it('reads the user from USER_INFO, and puts its timezone on the start time', () => {
+    const { user, startTime } = identity(transaction(anonymous));
+
+    expect(user).toEqual({ label: 'tina.owen', detail: 'tina.owen@example.com' });
+    expect(startTime?.label).toBe('09:18:22');
+    expect(startTime?.detail).toMatch(
+      /^Started 09:18:22\S* \(GMT-07:00\) Pacific Daylight Time \(America\/Los_Angeles\)$/,
+    );
+  });
+
+  it('finds USER_INFO past a preamble longer than any fixed scan window', () => {
+    const preamble =
+      '64.0 APEX_CODE,FINE;APEX_PROFILING,INFO\n' +
+      `Execute Anonymous: ${'x'.repeat(8192)}\n` +
+      'Execute Anonymous: quoting |USER_INFO| inside the echo must not match\n';
+
+    const { user } = identity(transaction(anonymous, preamble + USER_INFO_LINE));
+
+    expect(user).toEqual({ label: 'tina.owen', detail: 'tina.owen@example.com' });
+  });
+
+  it('omits the user in a cropped log whose first event is not USER_INFO', () => {
+    const { user, startTime } = identity(transaction(anonymous, ''));
+
+    expect(user).toBeNull();
+    expect(startTime?.detail).toMatch(/^Started 09:18:22\S*$/);
+  });
+
+  it('derives nothing from an empty log', () => {
+    expect(identity('')).toEqual({ entryPoint: null, user: null, startTime: null });
+  });
+});

--- a/log-viewer/src/features/app/logIdentity.ts
+++ b/log-viewer/src/features/app/logIdentity.ts
@@ -1,0 +1,121 @@
+/*
+ * Copyright (c) 2026 Certinia Inc. All rights reserved.
+ */
+import { CodeUnitStartedLine, ExecutionStartedLine, type ApexLog } from 'apex-log-parser';
+
+import { formatWallClockTime } from '../../core/utility/Util.js';
+
+/** One header identity item: `label` is the compact display text, `detail` the tooltip. */
+export interface LogIdentityItem {
+  label: string;
+  detail: string;
+}
+
+/** The transaction identity shown in the header: what ran, who ran it, and when. */
+export interface LogIdentityData {
+  entryPoint: LogIdentityItem | null;
+  user: LogIdentityItem | null;
+  startTime: LogIdentityItem | null;
+}
+
+/**
+ * Derives the header identity from a parsed log. `rawLog` is needed for the user:
+ * parsing starts at `EXECUTION_STARTED`, so the `USER_INFO` line before it never
+ * becomes an event. TODO(spike): hoist USER_INFO onto `ApexLog` in the parser and
+ * drop the raw-text scan.
+ */
+export function deriveLogIdentity(log: ApexLog, rawLog: string): LogIdentityData {
+  const userInfo = parseUserInfo(rawLog);
+  return {
+    entryPoint: entryPointItem(log),
+    user: userInfo
+      ? { label: userInfo.username.split('@')[0] || userInfo.username, detail: userInfo.username }
+      : null,
+    // The timezone sits with the time, not the user: the log's timestamps are
+    // rendered in that zone, so it qualifies the clock reading.
+    startTime: startTimeItem(log, userInfo?.timezone),
+  };
+}
+
+function entryPointItem(log: ApexLog): LogIdentityItem | null {
+  const unit = firstCodeUnit(log);
+  return unit ? { label: entryPointLabel(unit), detail: unit.text } : null;
+}
+
+/**
+ * The first `CODE_UNIT_STARTED` stands in for the request's operation, the same
+ * field Salesforce's own debug-log list calls "Operation". It is usually nested
+ * under `EXECUTION_STARTED`, but sits at the root when that marker is absent.
+ */
+function firstCodeUnit(log: ApexLog): CodeUnitStartedLine | null {
+  for (const child of log.children) {
+    if (child instanceof CodeUnitStartedLine) {
+      return child;
+    }
+    if (child instanceof ExecutionStartedLine) {
+      const unit = child.children.find((c) => c instanceof CodeUnitStartedLine);
+      if (unit) {
+        return unit;
+      }
+    }
+  }
+  return null;
+}
+
+function entryPointLabel(unit: CodeUnitStartedLine): string {
+  const text = unit.text;
+  if (text === 'execute_anonymous_apex') {
+    return 'Anonymous Apex';
+  }
+  switch (unit.codeUnitType) {
+    case 'VF':
+      return `VF ${text.slice(text.lastIndexOf('/') + 1)}`;
+    case '__sfdc_trigger': {
+      // Two shapes: "MyTrigger on Account trigger event BeforeInsert", or the raw
+      // "__sfdc_trigger/ns/MyTrigger" path when the log omits the friendly form.
+      // Either way the name says enough.
+      const name = text.startsWith('__sfdc_trigger/')
+        ? text.slice(text.lastIndexOf('/') + 1)
+        : text.split(' on ')[0];
+      return `Trigger ${name}`;
+    }
+    default:
+      return text;
+  }
+}
+
+/** Matches an event line's `HH:MM:SS.f (elapsedNs)|` prefix. */
+const TIMESTAMPED_LINE = /^\d{2}:\d{2}:\d{2}\.\d+ \(\d+\)\|/;
+
+function parseUserInfo(rawLog: string): { username: string; timezone: string } | null {
+  // USER_INFO is the first *timestamped* line; only the untimestamped preamble
+  // (version header, `Execute Anonymous:` echoes) precedes it. Walking lines and
+  // stopping at the first event keeps the cost at the preamble's size, survives a
+  // preamble of any length, and can't match a `USER_INFO` quoted inside the echoes
+  // or some later event's payload. A cropped log bails at its first event line.
+  let start = 0;
+  while (start < rawLog.length) {
+    const nl = rawLog.indexOf('\n', start);
+    const eol = nl === -1 ? rawLog.length : nl;
+    const line = rawLog.slice(start, eol);
+    if (TIMESTAMPED_LINE.test(line)) {
+      // timestamp|USER_INFO|[EXTERNAL]|userId|username|timezone label|timezone offset
+      const parts = line.split('|');
+      const username = parts[1] === 'USER_INFO' ? (parts[4]?.trim() ?? '') : '';
+      return username ? { username, timezone: parts[5]?.trim() ?? '' } : null;
+    }
+    start = eol + 1;
+  }
+  return null;
+}
+
+function startTimeItem(log: ApexLog, timezone?: string): LogIdentityItem | null {
+  if (log.startTime === null) {
+    return null;
+  }
+  const full = formatWallClockTime(log.startTime);
+  const started = `Started ${full}`;
+  // A space, not the header's ` • ` separator — the label starts with "(GMT±HH:MM)",
+  // and a dot would make the tooltip read as two unrelated items.
+  return { label: full.slice(0, 8), detail: timezone ? `${started} ${timezone}` : started };
+}

--- a/log-viewer/src/styles/headerItem.styles.ts
+++ b/log-viewer/src/styles/headerItem.styles.ts
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) 2026 Certinia Inc. All rights reserved.
+ */
+import { css } from 'lit';
+
+/**
+ * The header's muted metadata idiom, shared by `log-meta` and `log-identity` so
+ * the two clusters cannot drift apart in size or colour. Hosts using it must
+ * also carry the tokens (`globalStyles` or `tokenStyles`).
+ */
+export const headerItemStyles = css`
+  :host {
+    display: inline-flex;
+    flex: 0 0 auto;
+    align-items: center;
+    font-size: var(--lana-text-meta);
+    color: var(--lana-fg-muted);
+  }
+`;

--- a/log-viewer/src/styles/tokens.css
+++ b/log-viewer/src/styles/tokens.css
@@ -48,6 +48,9 @@
      rather than states. */
   --lana-text-sm: calc(var(--vscode-font-size, 13px) * 0.85);
 
+  /* Header metadata (size · duration · identity) — just under the title size. */
+  --lana-text-meta: 0.9rem;
+
   /* Surfaces — the same registered colors VS Code's own chrome is built from.
      `surface-border` is absent before the size-token registry (stable 1.128 ships
      none of the `--vscode-surface-*` set), so its fallback chain is load-bearing. */


### PR DESCRIPTION
## What

The header now answers what ran, who ran it, and when. After the log size and duration, three muted items show:

- **Entry point** — the first code unit's label (`Anonymous Apex`, `Trigger MyTrigger`, `VF SiteLogin`, or the raw text).
- **User** — the local part of the username from `USER_INFO`.
- **Start time** — the wall-clock `HH:MM:SS`.

Hover an item for its full value: the raw entry point, the full email, or the start time with its timezone.

<img width="621" height="125" alt="image" src="https://github.com/user-attachments/assets/77a5acbf-fede-4dee-bf67-eb483ae6bf52" />


## Behaviour

- The items join the header's collapse ladder and shed one at a time as it narrows — time, then user, then entry point — before the size/duration meta. Shed values stay in the log-title tooltip.
- A log that lacks the data (for example a cropped log with no `USER_INFO` line) omits that item; skeletons show only while parsing.
- The user comes from a line scan of the raw log preamble, because parsing starts at `EXECUTION_STARTED` and never sees `USER_INFO`. A TODO marks the follow-up to hoist it onto `ApexLog` in the parser.

## Implementation notes

- `logIdentity.ts` derives the three items; `log-identity` renders one item with cap + tooltip.
- `NavBar` drives the ladder and the tooltip from one `IDENTITY_CHUNKS` table.
- `log-meta` and `log-identity` share the muted header-item style via a new `headerItemStyles` module and a `--lana-text-meta` token.

## Testing

- New `logIdentity.test.ts` covers the entry-point labels (anonymous, VF, both trigger forms), the `USER_INFO` scan (present, long preamble, cropped, empty), and the start-time item.
- `NavBar.test.ts` covers the shed order, absent items, and the tooltip fold-in.
- `pnpm lint` and the full test suite pass (110 suites, 1439 tests).

## Docs

README and CHANGELOG carry a one-line note for the new header items.
