### PR TITLE
feat: timeline legend as toolbar chips with per-category self time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - **Governor limits strip**: tooltip rows keep a stable order and always show the `used / limit` value, so figures no longer jump around as you move the pointer. ([#827])
   - **Timeline zooming**: consistent, smooth zoom across platforms and input devices — a Windows mouse wheel no longer over-zooms in large jumps, fast scrolls stay bounded, and zooming in then back out returns to the same level.
   - **Truncation markers** now end where the log recovers, so trusted sections are no longer flagged. ([#828])
+  - **Legend**: moved from below the chart to the toolbar above it, restyled as colour-dot chips, and each chip now shows the log's self time in that category. Event tooltips name the category next to its colour swatch.
 - 🏷️ **Call Tree names**: rows no longer carry a raw `EVENT_TYPE:` prefix in front of text that already identifies them, so `WF_CRITERIA_BEGIN: WF_CRITERIA : ON_ALL_CHANGES` reads as `WF_CRITERIA : ON_ALL_CHANGES`. Frames whose text can't stand alone keep the type, and the ones that needed naming now say what they are — `(code unit)`, `(constructor)`, `(managed package)`, `(flow)`. A **Type** column is available in every view from the **Columns** menu if you want the raw types back.
 - 🗂️ **Call Tree + Database styling**: VS Code style tree icons, and rows indent under their group headings. ([#832]).
 - 🎛️ **Modernised dropdowns**: searchable, compact controls that carry the field and value in one place (e.g. `Group: Namespace`, `Type: All`) ([#848]).

--- a/log-viewer/src/components/OverflowList.ts
+++ b/log-viewer/src/components/OverflowList.ts
@@ -15,8 +15,6 @@ import { computeVisibleCount } from './overflowFit.js';
 
 /** Space reserved for the overflow toggle once the row can't fit every item (px). */
 const OVERFLOW_RESERVE = 56;
-/** Gap between items, in px — the source of truth for both the `.items` CSS gap and the fit math. */
-const ITEMS_GAP = 6;
 /** Shared by the toggle's `popovertarget`/`aria-controls` and the panel's `id` — must match. */
 const PANEL_ID = 'overflow-list-panel';
 
@@ -53,6 +51,10 @@ export class OverflowList extends LitElement {
   @property({ attribute: 'icon' })
   icon = 'chevron-down';
 
+  /** Gap between inline items (px) — drives both the row layout and the fit math. */
+  @property({ type: Number })
+  gap = 6;
+
   /** How many items fit inline; the rest are moved into the popover menu. */
   @state()
   private visibleCount = Number.POSITIVE_INFINITY;
@@ -85,7 +87,6 @@ export class OverflowList extends LitElement {
         display: flex;
         flex-wrap: nowrap;
         align-items: center;
-        gap: ${ITEMS_GAP}px;
         min-width: 0;
         overflow: hidden;
         flex: 1 1 auto;
@@ -279,7 +280,7 @@ export class OverflowList extends LitElement {
     }
     if (!this.itemWidths) {
       this._measure();
-    } else if (changed.has('collapseFrom') || changed.has('minVisible')) {
+    } else if (changed.has('collapseFrom') || changed.has('minVisible') || changed.has('gap')) {
       this._recompute(this.lastWidth);
     }
   }
@@ -315,7 +316,7 @@ export class OverflowList extends LitElement {
     }
     // Fit the visible run from the appropriate end (reverse for start-collapse).
     const ordered = this.collapseFrom === 'start' ? [...widths].reverse() : widths;
-    const fit = computeVisibleCount(ordered, avail, ITEMS_GAP, OVERFLOW_RESERVE);
+    const fit = computeVisibleCount(ordered, avail, this.gap, OVERFLOW_RESERVE);
     this.visibleCount = Math.max(fit, Math.min(this.minVisible, widths.length));
     this._applyOverflow();
   }
@@ -363,7 +364,7 @@ export class OverflowList extends LitElement {
     return html`<div class="container ${this.collapseFrom}">
       <div class="bar">
         ${fromStart ? toggle : ''}
-        <div class="items"><slot></slot></div>
+        <div class="items" style="gap: ${this.gap}px"><slot></slot></div>
         ${fromStart ? '' : toggle}
       </div>
       ${

--- a/log-viewer/src/features/timeline/__tests__/TimelineKey.test.ts
+++ b/log-viewer/src/features/timeline/__tests__/TimelineKey.test.ts
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2026 Certinia Inc. All rights reserved.
+ *
+ * @jest-environment jsdom
+ */
+import { describe, expect, it } from '@jest/globals';
+
+// jsdom can't run the real element (vscode-icon reads document.baseURI).
+jest.mock('../../../components/OverflowList.js', () => ({}));
+
+import type { TimelineKeyEntry, Timelinekey } from '../components/TimelineKey.js';
+import '../components/TimelineKey.js';
+
+async function mount(entries: TimelineKeyEntry[]): Promise<Timelinekey> {
+  const el = document.createElement('timeline-key') as Timelinekey;
+  el.timelineKeys = entries;
+  document.body.appendChild(el);
+  await el.updateComplete;
+  return el;
+}
+
+function chips(el: Timelinekey): HTMLElement[] {
+  return [...(el.shadowRoot?.querySelectorAll<HTMLElement>('.chip') ?? [])];
+}
+
+describe('TimelineKey', () => {
+  it('renders one chip per entry, with dot color, label and data-category', async () => {
+    const el = await mount([
+      { label: 'Apex', fillColor: 'rgb(43, 143, 129)', selfTimeNs: 12_100_000_000 },
+      { label: 'SOQL', fillColor: 'rgb(109, 76, 125)', selfTimeNs: 500_000 },
+    ]);
+
+    const rendered = chips(el);
+    expect(rendered).toHaveLength(2);
+
+    const [apex] = rendered;
+    expect(apex?.dataset['category']).toBe('Apex');
+    expect(apex?.textContent).toContain('Apex');
+    const dot = apex?.querySelector<HTMLElement>('.chip__dot');
+    expect(dot?.style.backgroundColor).toBe('rgb(43, 143, 129)');
+  });
+
+  it('shows the compact self time when present', async () => {
+    const el = await mount([
+      { label: 'Apex', fillColor: 'rgb(0, 0, 0)', selfTimeNs: 12_100_000_000 },
+    ]);
+
+    expect(chips(el)[0]?.querySelector('.chip__time')?.textContent).toBe('12.1s');
+  });
+
+  it('omits the time when self time is unknown', async () => {
+    const el = await mount([{ label: 'Method', fillColor: 'rgb(0, 0, 0)' }]);
+
+    expect(chips(el)[0]?.querySelector('.chip__time')).toBeNull();
+  });
+
+  it('keeps the chip itself unfilled — only the dot carries the category color', async () => {
+    const el = await mount([{ label: 'DML', fillColor: 'rgb(176, 104, 104)' }]);
+
+    expect(chips(el)[0]?.getAttribute('style')).toBeNull();
+  });
+});

--- a/log-viewer/src/features/timeline/__tests__/category-self-time.test.ts
+++ b/log-viewer/src/features/timeline/__tests__/category-self-time.test.ts
@@ -1,0 +1,112 @@
+/*
+ * Copyright (c) 2026 Certinia Inc. All rights reserved.
+ */
+import { describe, expect, it } from '@jest/globals';
+import type { ApexLog, LogCategory, LogEvent } from 'apex-log-parser';
+
+import type { TimelineColors } from '../themes/Themes.js';
+import { categorySelfTimes, toTimelineKeys } from '../utils/category-self-time.js';
+
+function node(category: LogCategory, self: number, children: LogEvent[] = []): LogEvent {
+  return {
+    category,
+    duration: { self, total: self },
+    children,
+  } as unknown as LogEvent;
+}
+
+function log(children: LogEvent[]): ApexLog {
+  return node('', 0, children) as ApexLog;
+}
+
+describe('categorySelfTimes', () => {
+  it('sums self time per category across siblings and nesting', () => {
+    const root = log([
+      node('Apex', 10, [node('SOQL', 5), node('Apex', 3)]),
+      node('DML', 7),
+      node('Apex', 2),
+    ]);
+
+    const totals = categorySelfTimes(root);
+
+    expect(totals.get('Apex')).toBe(15);
+    expect(totals.get('SOQL')).toBe(5);
+    expect(totals.get('DML')).toBe(7);
+  });
+
+  it('counts only self time, so a parent excludes its children', () => {
+    const root = log([node('Apex', 10, [node('Apex', 4)])]);
+
+    expect(categorySelfTimes(root).get('Apex')).toBe(14);
+  });
+
+  it('skips uncategorised events but still walks their children', () => {
+    const root = log([node('', 100, [node('SOQL', 5)])]);
+
+    const totals = categorySelfTimes(root);
+
+    expect(totals.get('SOQL')).toBe(5);
+    expect(totals.has('')).toBe(false);
+  });
+
+  it('returns an empty map for an empty log', () => {
+    expect(categorySelfTimes(log([])).size).toBe(0);
+  });
+
+  it('handles a 5000-deep chain without a stack overflow', () => {
+    let chain = node('Apex', 1);
+    for (let i = 0; i < 4999; i++) {
+      chain = node('Apex', 1, [chain]);
+    }
+
+    expect(categorySelfTimes(log([chain])).get('Apex')).toBe(5000);
+  });
+});
+
+describe('toTimelineKeys', () => {
+  const colors: TimelineColors = {
+    apex: '#a1',
+    codeUnit: '#a2',
+    system: '#a3',
+    automation: '#a4',
+    dml: '#a5',
+    soql: '#a6',
+    callout: '#a7',
+    validation: '#a8',
+  };
+
+  it('builds the legend in category order with the palette colors', () => {
+    const keys = toTimelineKeys(colors);
+
+    expect(keys.map((k) => k.label)).toEqual([
+      'Apex',
+      'Code Unit',
+      'System',
+      'Automation',
+      'DML',
+      'SOQL',
+      'Callout',
+    ]);
+    expect(keys.map((k) => k.fillColor)).toEqual(['#a1', '#a2', '#a3', '#a4', '#a5', '#a6', '#a7']);
+    expect(keys.every((k) => k.selfTimeNs === undefined)).toBe(true);
+  });
+
+  it('attaches self time per category when provided', () => {
+    const selfTimes = new Map<LogCategory, number>([
+      ['Apex', 15],
+      ['SOQL', 5],
+    ]);
+
+    const keys = toTimelineKeys(colors, selfTimes);
+
+    expect(keys.find((k) => k.label === 'Apex')?.selfTimeNs).toBe(15);
+    expect(keys.find((k) => k.label === 'SOQL')?.selfTimeNs).toBe(5);
+  });
+
+  it('reads 0 for a category the log never used', () => {
+    const keys = toTimelineKeys(colors, new Map<LogCategory, number>([['Apex', 15]]));
+
+    expect(keys.find((k) => k.label === 'DML')?.selfTimeNs).toBe(0);
+    expect(keys.find((k) => k.label === 'Callout')?.selfTimeNs).toBe(0);
+  });
+});

--- a/log-viewer/src/features/timeline/__tests__/tooltip.test.ts
+++ b/log-viewer/src/features/timeline/__tests__/tooltip.test.ts
@@ -373,6 +373,35 @@ describe('FrameTooltipRenderer', () => {
       frameTooltipRenderer.hide();
     });
 
+    it('should display a category row with a swatch in the category color', () => {
+      frameTooltipRenderer.destroy();
+      frameTooltipRenderer = new FrameTooltipRenderer(container, {
+        categoryColors: { Apex: '#88ae58' },
+        cursorOffset: 10,
+        enableFlip: true,
+      });
+      const event = createEvent(0, 100, 'Event', 'Apex');
+
+      frameTooltipRenderer.show(event, 100, 100);
+
+      const swatch = container.querySelector('.tooltip-swatch') as HTMLElement;
+      expect(swatch).not.toBeNull();
+      expect(swatch.style.backgroundColor).toBe('rgb(136, 174, 88)');
+      expect(swatch.parentElement?.textContent).toContain('Apex');
+
+      frameTooltipRenderer.hide();
+    });
+
+    it('should not display a category row for an uncategorised event', () => {
+      const event = createEvent(0, 100, 'Event', '');
+
+      frameTooltipRenderer.show(event, 100, 100);
+
+      expect(container.querySelector('.tooltip-swatch')).toBeNull();
+
+      frameTooltipRenderer.hide();
+    });
+
     it('should display wall-clock time row when apexLog has startTime', () => {
       frameTooltipRenderer.destroy();
       const mockApexLog = {

--- a/log-viewer/src/features/timeline/components/TimelineKey.ts
+++ b/log-viewer/src/features/timeline/components/TimelineKey.ts
@@ -3,97 +3,81 @@
  */
 import { LitElement, css, html } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
+import { repeat } from 'lit/directives/repeat.js';
 
-import type { TimelineGroup } from '../services/Timeline.js';
+import { formatDuration } from '../../../core/utility/Util.js';
+
+// web components
+import '../../../components/OverflowList.js';
 
 // styles
 import { globalStyles } from '../../../styles/global.styles.js';
 
+/** One legend chip: category color dot, label, and (when known) the log's self time in that category. */
+export interface TimelineKeyEntry {
+  label: string;
+  fillColor: string;
+  /** Total self time (ns) spent in this category; omitted on the legacy timeline. */
+  selfTimeNs?: number;
+}
+
 @customElement('timeline-key')
 export class Timelinekey extends LitElement {
   @property()
-  timelineKeys: TimelineGroup[] = [];
-
-  constructor() {
-    super();
-  }
+  timelineKeys: TimelineKeyEntry[] = [];
 
   static styles = [
     globalStyles,
     css`
       :host {
-        margin-top: 5px;
+        display: block;
+        min-width: 0;
       }
-      .timeline-key__entry {
-        display: inline-block;
-        font-size: 0.9rem;
-        padding: 4px;
-        margin-right: 5px;
-        font-family: monospace;
+
+      .chip {
+        display: inline-flex;
+        align-items: center;
+        gap: var(--lana-space-2xs);
+        font-size: var(--lana-text-md);
+        color: var(--lana-fg-muted);
+        white-space: nowrap;
+      }
+
+      .chip__dot {
+        width: 8px;
+        height: 8px;
+        border-radius: 50%;
+        flex: 0 0 auto;
+      }
+
+      /* The time is the data: mono like the header vitals, full foreground against the muted label. */
+      .chip__time {
+        font-family: var(--vscode-editor-font-family, monospace);
+        font-variant-numeric: tabular-nums;
+        color: var(--lana-fg);
       }
     `,
   ];
 
   render() {
-    const keyParts = [];
-    for (const keyMeta of this.timelineKeys) {
-      const textColor = this.getContrastingTextColor(keyMeta.fillColor);
-      keyParts.push(
-        html`<div
-          class="timeline-key__entry"
-          style="background-color:${keyMeta.fillColor}; color:${textColor}"
-        >
-          <span>${keyMeta.label}</span>
-        </div>`,
-      );
-    }
-
-    return keyParts;
-  }
-
-  /**
-   * Calculate relative luminance of a hex color to determine if it's dark or light.
-   * Supports #RGB, #RGBA, #RRGGBB, and #RRGGBBAA formats.
-   * Uses WCAG formula: https://www.w3.org/TR/WCAG20/#relativeluminancedef
-   */
-  private getContrastingTextColor(hexColor: string): string {
-    // Remove # if present
-    let hex = hexColor.replace('#', '');
-
-    // Normalize to 6-digit RGB format
-    if (hex.length === 3) {
-      // #RGB -> #RRGGBB
-      hex = hex
-        .split('')
-        .map((char) => char + char)
-        .join('');
-    } else if (hex.length === 4) {
-      // #RGBA -> #RRGGBB (ignore alpha)
-      hex = hex
-        .substring(0, 3)
-        .split('')
-        .map((char) => char + char)
-        .join('');
-    } else if (hex.length === 8) {
-      // #RRGGBBAA -> #RRGGBB (ignore alpha)
-      hex = hex.substring(0, 6);
-    }
-
-    // Parse RGB values
-    const r = parseInt(hex.substring(0, 2), 16) / 255;
-    const g = parseInt(hex.substring(2, 4), 16) / 255;
-    const b = parseInt(hex.substring(4, 6), 16) / 255;
-
-    // Apply gamma correction for sRGB
-    const rLin = r <= 0.03928 ? r / 12.92 : Math.pow((r + 0.055) / 1.055, 2.4);
-    const gLin = g <= 0.03928 ? g / 12.92 : Math.pow((g + 0.055) / 1.055, 2.4);
-    const bLin = b <= 0.03928 ? b / 12.92 : Math.pow((b + 0.055) / 1.055, 2.4);
-
-    // W3C relative luminance formula
-    const luminance = 0.2126 * rLin + 0.7152 * gLin + 0.0722 * bLin;
-
-    // Use dark text for light backgrounds, light text for dark backgrounds
-    // Threshold of 0.179 corresponds to ~50% perceived brightness
-    return luminance > 0.179 ? '#1e1e1e' : '#e3e3e3';
+    return html`<overflow-list menu-heading="Categories" gap="12">
+      ${repeat(
+        this.timelineKeys,
+        (entry) => entry.label,
+        (entry) =>
+          // data-category is the seam for the interactivity follow-up (hover/click → highlight).
+          html`<span class="chip" data-category="${entry.label}">
+            <span class="chip__dot" style="background-color: ${entry.fillColor}"></span>
+            <span>${entry.label}</span>
+            ${
+              entry.selfTimeNs !== undefined
+                ? html`<span class="chip__time"
+                    >${formatDuration(entry.selfTimeNs, { compact: true })}</span
+                  >`
+                : ''
+            }
+          </span>`,
+      )}
+    </overflow-list>`;
   }
 }

--- a/log-viewer/src/features/timeline/components/TimelineView.ts
+++ b/log-viewer/src/features/timeline/components/TimelineView.ts
@@ -2,19 +2,21 @@
  * Copyright (c) 2023 Certinia Inc. All rights reserved.
  */
 import '#vscode-elements/vscode-toolbar-button.js';
-import { LitElement, css, html } from 'lit';
+import { LitElement, css, html, type PropertyValues } from 'lit';
 import { customElement, property, query, state } from 'lit/decorators.js';
 
-import type { ApexLog } from 'apex-log-parser';
+import type { ApexLog, LogCategory } from 'apex-log-parser';
 import { VSCodeExtensionMessenger } from '../../../core/messaging/VSCodeExtensionMessenger.js';
 import { subscribeSettings, type LanaSettings } from '../../settings/Settings.js';
-import { type TimelineGroup, keyMap, setColors } from '../services/Timeline.js';
+import { keyMap, setColors } from '../services/Timeline.js';
 
 import { DEFAULT_THEME_NAME, sameColors, type TimelineColors } from '../themes/Themes.js';
 import { addCustomThemes, getTheme } from '../themes/ThemeSelector.js';
 
+import { categorySelfTimes, toTimelineKeys } from '../utils/category-self-time.js';
 import type { TimeDisplayMode } from '../types/flamechart.types.js';
 import type { TimelineFlameChart } from './TimelineFlameChart.js';
+import type { TimelineKeyEntry } from './TimelineKey.js';
 
 // styles
 import { globalStyles } from '../../../styles/global.styles.js';
@@ -53,7 +55,10 @@ export class TimelineView extends LitElement {
   activeTheme: string | null = null;
 
   @state()
-  private timelineKeys: TimelineGroup[] = [];
+  private timelineKeys: TimelineKeyEntry[] = [];
+
+  /** Per-category self time for the loaded log; drives the legend durations. */
+  private selfTimes?: Map<LogCategory, number>;
 
   @state()
   private useLegacyTimeline: boolean | null = null;
@@ -138,31 +143,38 @@ export class TimelineView extends LitElement {
         width: 100%;
         height: 100%;
         /* inset previously provided by the tab panel's padding */
-        padding: 10px 6px;
+        padding: var(--lana-space-md) var(--lana-space-xs);
         box-sizing: border-box;
       }
 
       .timeline-toolbar {
         display: flex;
         align-items: center;
-        justify-content: flex-end;
-        gap: 4px;
+        justify-content: space-between;
+        gap: var(--lana-space-sm);
+        min-width: 0;
+        flex: 0 0 auto;
+        margin-bottom: var(--lana-space-sm);
+      }
+
+      .timeline-toolbar timeline-key {
+        flex: 1 1 auto;
+        min-width: 0;
+      }
+
+      .timeline-toolbar vscode-toolbar-button {
         flex: 0 0 auto;
       }
 
       /* The chart takes every row the container gives it, and the renderer scrolls
-         when the call depth needs more; the key and the toolbar keep their own
-         height. The zero min-height lets the chart shrink below its content, which
-         a flex item does not do by default. */
+         when the call depth needs more; the toolbar keeps its own height. The zero
+         min-height lets the chart shrink below its content, which a flex item does
+         not do by default. */
       timeline-flame-chart,
       timeline-legacy,
       timeline-skeleton {
         flex: 1 1 0;
         min-height: 0;
-      }
-
-      timeline-key {
-        flex: 0 0 auto;
       }
     `,
   ];
@@ -206,6 +218,10 @@ export class TimelineView extends LitElement {
         this.appliedCustomThemes = customThemes;
         addCustomThemes(customThemes);
         this.setTheme(themeName);
+      } else {
+        // A legacy → modern toggle re-enters here with the theme unchanged, so the
+        // legend may still hold the legacy keyMap entries.
+        this.rebuildTimelineKeys();
       }
     } else {
       setColors(timeline.colors);
@@ -226,41 +242,53 @@ export class TimelineView extends LitElement {
     });
   }
 
+  protected willUpdate(changed: PropertyValues): void {
+    if (changed.has('timelineRoot')) {
+      this.selfTimes = this.timelineRoot ? categorySelfTimes(this.timelineRoot) : undefined;
+      this.rebuildTimelineKeys();
+    }
+  }
+
   render() {
     if (!this.timelineRoot || this.useLegacyTimeline === null) {
-      return html`<timeline-skeleton></timeline-skeleton>
-        <timeline-key .timelineKeys="${this.timelineKeys}"></timeline-key>`;
+      return html`<timeline-skeleton></timeline-skeleton>`;
     }
 
-    if (!this.useLegacyTimeline) {
-      const hasWallClock = this.timelineRoot?.startTime !== null;
-      const isWallClock = this.timeDisplayMode === 'wallClock';
+    const toolbar = html`<div class="timeline-toolbar">
+      <timeline-key .timelineKeys="${this.timelineKeys}"></timeline-key>
+      ${this.renderTimeDisplayToggle()}
+    </div>`;
 
-      return html`${
-          hasWallClock
-            ? html`<div class="timeline-toolbar">
-                <vscode-toolbar-button
-                  icon="${isWallClock ? 'history' : 'clockface'}"
-                  label="${isWallClock ? 'Show elapsed time' : 'Show wall-clock time'}"
-                  title="${isWallClock ? 'Show elapsed time' : 'Show wall-clock time'}"
-                  @click=${() => this.toggleTimeDisplay()}
-                ></vscode-toolbar-button>
-              </div>`
-            : ''
-        }
-        <timeline-flame-chart
+    if (this.useLegacyTimeline) {
+      return html`${toolbar}
+        <timeline-legacy
           .apexLog=${this.timelineRoot}
           .themeName=${this.activeTheme}
-          .navigateToEventIndex=${this.navigateToEventIndex}
-          .navigateToTimestamp=${this.navigateToTimestamp}
-        ></timeline-flame-chart>
-        <timeline-key .timelineKeys="${this.timelineKeys}"></timeline-key>`;
+        ></timeline-legacy>`;
     }
-    return html`<timeline-legacy
+    return html`${toolbar}
+      <timeline-flame-chart
         .apexLog=${this.timelineRoot}
         .themeName=${this.activeTheme}
-      ></timeline-legacy
-      ><timeline-key .timelineKeys="${this.timelineKeys}"></timeline-key>`;
+        .navigateToEventIndex=${this.navigateToEventIndex}
+        .navigateToTimestamp=${this.navigateToTimestamp}
+      ></timeline-flame-chart>`;
+  }
+
+  /** The elapsed/wall-clock switch. Legacy has no such mode, nor do logs without a start time. */
+  private renderTimeDisplayToggle() {
+    if (this.useLegacyTimeline || this.timelineRoot?.startTime === null) {
+      return '';
+    }
+
+    const isWallClock = this.timeDisplayMode === 'wallClock';
+    const label = isWallClock ? 'Show elapsed time' : 'Show wall-clock time';
+    return html`<vscode-toolbar-button
+      icon="${isWallClock ? 'history' : 'clockface'}"
+      label="${label}"
+      title="${label}"
+      @click=${() => this.toggleTimeDisplay()}
+    ></vscode-toolbar-button>`;
   }
 
   private toggleTimeDisplay(): void {
@@ -270,7 +298,18 @@ export class TimelineView extends LitElement {
 
   private setTheme(themeName: string) {
     this.activeTheme = themeName ?? DEFAULT_THEME_NAME;
-    this.timelineKeys = this.toTimelineKeys(getTheme(themeName));
+    this.rebuildTimelineKeys();
+  }
+
+  /** Rebuilds the legend from the active palette + the log's per-category self times. */
+  private rebuildTimelineKeys(): void {
+    if (this.useLegacyTimeline) {
+      return; // legacy keys come from keyMap in applyTimelineSettings
+    }
+    this.timelineKeys = toTimelineKeys(
+      getTheme(this.activeTheme ?? DEFAULT_THEME_NAME),
+      this.selfTimes,
+    );
   }
 
   private toTheme(themeSettings: ThemeSettings): { [key: string]: TimelineColors } {
@@ -288,43 +327,5 @@ export class TimelineView extends LitElement {
       };
     }
     return themes;
-  }
-
-  private toTimelineKeys(colors: TimelineColors): TimelineGroup[] {
-    return [
-      {
-        label: 'Apex',
-        fillColor: colors.apex,
-      },
-      {
-        label: 'Code Unit',
-        fillColor: colors.codeUnit,
-      },
-      {
-        label: 'System',
-        fillColor: colors.system,
-      },
-      {
-        label: 'Automation',
-        fillColor: colors.automation,
-      },
-      {
-        label: 'DML',
-        fillColor: colors.dml,
-      },
-      {
-        label: 'SOQL',
-        fillColor: colors.soql,
-      },
-      {
-        label: 'Callout',
-        fillColor: colors.callout,
-      },
-      //NOTE: add back once the parser is updated to include validation events
-      // {
-      //   label: 'Validation',
-      //   fillColor: colors.validation,
-      // },
-    ];
   }
 }

--- a/log-viewer/src/features/timeline/optimised/FrameTooltipRenderer.ts
+++ b/log-viewer/src/features/timeline/optimised/FrameTooltipRenderer.ts
@@ -402,6 +402,7 @@ export class FrameTooltipRenderer {
         rows,
         this.options.categoryColors[event.category] || '',
         descriptionHtml,
+        event.category,
       );
     }
 
@@ -419,6 +420,8 @@ export class FrameTooltipRenderer {
     rows: { label: string; value: string }[],
     color: string,
     descriptionHtml?: string,
+    /** Category label for the swatch row; `color` fills the swatch. */
+    categoryName?: string,
   ) {
     const tooltipBody = document.createElement('div');
     tooltipBody.className = 'timeline-tooltip';
@@ -443,6 +446,22 @@ export class FrameTooltipRenderer {
       descriptionDiv.textContent = description;
     }
     tooltipBody.appendChild(descriptionDiv);
+
+    if (categoryName && color) {
+      const categoryRow = document.createElement('div');
+      categoryRow.className = 'tooltip-category';
+
+      const swatch = document.createElement('span');
+      swatch.className = 'tooltip-swatch';
+      swatch.style.backgroundColor = color;
+
+      const name = document.createElement('span');
+      name.textContent = categoryName;
+
+      categoryRow.appendChild(swatch);
+      categoryRow.appendChild(name);
+      tooltipBody.appendChild(categoryRow);
+    }
 
     rows.forEach(({ label, value }) => {
       const row = document.createElement('div');

--- a/log-viewer/src/features/timeline/styles/timeline.css.ts
+++ b/log-viewer/src/features/timeline/styles/timeline.css.ts
@@ -35,6 +35,21 @@ export const tooltipStyles = `${soqlSyntaxStyles}
         word-break: break-all;
       }
 
+      .tooltip-category {
+        display: flex;
+        align-items: center;
+        gap: var(--lana-space-2xs);
+        padding: var(--lana-space-3xs) 0;
+        color: var(--tl-description-foreground, #999);
+      }
+
+      .tooltip-swatch {
+        width: 8px;
+        height: 8px;
+        border-radius: var(--lana-radius-sm);
+        flex: 0 0 auto;
+      }
+
       .tooltip-row {
         display: flex;
         justify-content: space-between;

--- a/log-viewer/src/features/timeline/utils/category-self-time.ts
+++ b/log-viewer/src/features/timeline/utils/category-self-time.ts
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2026 Certinia Inc. All rights reserved.
+ */
+import { LOG_CATEGORY, type ApexLog, type LogCategory, type LogEvent } from 'apex-log-parser';
+
+import type { TimelineKeyEntry } from '../components/TimelineKey.js';
+import type { TimelineColors } from '../themes/Themes.js';
+
+/**
+ * Sums self time (ns) per category across the whole event tree. Self time partitions
+ * the wall clock, so the sums add up to the log duration with no double counting.
+ * Iterative walk — deep logs would overflow a recursive one.
+ */
+export function categorySelfTimes(root: ApexLog): Map<LogCategory, number> {
+  const totals = new Map<LogCategory, number>();
+  const stack: LogEvent[] = [root];
+  for (let node = stack.pop(); node; node = stack.pop()) {
+    if (node.category) {
+      totals.set(node.category, (totals.get(node.category) ?? 0) + node.duration.self);
+    }
+    for (const child of node.children) {
+      stack.push(child);
+    }
+  }
+  return totals;
+}
+
+/** Legend order; labels double as the `LogCategory` keys used by `categorySelfTimes`. */
+const KEY_CATEGORIES: readonly { category: LogCategory; colorKey: keyof TimelineColors }[] = [
+  { category: LOG_CATEGORY.Apex, colorKey: 'apex' },
+  { category: LOG_CATEGORY.CodeUnit, colorKey: 'codeUnit' },
+  { category: LOG_CATEGORY.System, colorKey: 'system' },
+  { category: LOG_CATEGORY.Automation, colorKey: 'automation' },
+  { category: LOG_CATEGORY.DML, colorKey: 'dml' },
+  { category: LOG_CATEGORY.SOQL, colorKey: 'soql' },
+  { category: LOG_CATEGORY.Callout, colorKey: 'callout' },
+  //NOTE: add Validation back once the parser is updated to include validation events
+];
+
+/** Builds the legend entries for a palette, attaching per-category self time when known. */
+export function toTimelineKeys(
+  colors: TimelineColors,
+  selfTimes?: Map<LogCategory, number>,
+): TimelineKeyEntry[] {
+  return KEY_CATEGORIES.map(({ category, colorKey }) => ({
+    label: category,
+    fillColor: colors[colorKey],
+    // A category the log never used still reads 0 — an absent time means "unknown", not "none".
+    selfTimeNs: selfTimes ? (selfTimes.get(category) ?? 0) : undefined,
+  }));
+}

--- a/log-viewer/src/styles/tokens.css
+++ b/log-viewer/src/styles/tokens.css
@@ -48,6 +48,10 @@
      rather than states. */
   --lana-text-sm: calc(var(--vscode-font-size, 13px) * 0.85);
 
+  /* Half a step down — mixed-case secondary text; 12px at the host's default 13px.
+     (11px suits only uppercase micro-labels, whose caps height carries the size.) */
+  --lana-text-md: calc(var(--vscode-font-size, 13px) * 0.92);
+
   /* Surfaces — the same registered colors VS Code's own chrome is built from.
      `surface-border` is absent before the size-token registry (stable 1.128 ships
      none of the `--vscode-surface-*` set), so its fallback chain is load-bearing. */
@@ -70,6 +74,9 @@
   /* Badges — small count/kind pills, matching VS Code's own badge chrome. */
   --lana-badge-bg: var(--vscode-badge-background, #616161);
   --lana-badge-fg: var(--vscode-badge-foreground, #f8f8f8);
+
+  /* Primary text. */
+  --lana-fg: var(--vscode-foreground, #cccccc);
 
   /* Secondary text — metadata that must not compete with the content it annotates. */
   --lana-fg-muted: var(--vscode-descriptionForeground, rgba(204, 204, 204, 0.7));


### PR DESCRIPTION
# 📝 PR Overview

Moves the timeline legend from its own row below the flame chart into the toolbar above it, and makes it carry data: each category chip shows the log's self time in that category. The chart gains the freed height. Frame tooltips now name their category next to a colour swatch, so a colour decodes in place.

## 🛠️ Changes made

- **Legend → toolbar chips**: quiet dot + label chips in the toolbar row, clock button stays right. Each chip shows per-category self time in the editor mono font. Self time partitions the wall clock, so the chips sum to the log duration. A category the log never used reads 0. Narrow panels collapse chips into the overflow menu.
- **Per-category self time**: new `categorySelfTimes` util — one iterative O(n) pass, safe on deep logs.
- **Tooltip category row**: swatch + category name above the limit rows; the border tint is unchanged. Uncategorised events show no row.
- **`overflow-list` gap property**: item gap is now a reactive property that drives both the row layout and the fit math.
- **Tokens**: `--lana-fg` (primary text) and `--lana-text-md` (mixed-case secondary text; 11px suits only uppercase micro-labels).
- Legacy timeline keeps the same toolbar layout with duration-less chips.

## 🧩 Type of change (check all applicable)

- [x] ✨ New feature – adds new functionality

## 📷 Screenshots / gifs / video [optional]

_Reviewed in the dev host in light and dark themes._

## 🔗 Related Issues

## ✅ Tests added?

- [x] 👍 yes

`category-self-time` (sums, parent self excludes children, empty log, 5000-deep chain), `TimelineKey` chip rendering, tooltip category row.

## 📚 Docs updated?

- [x] 🔖 CHANGELOG.md

## Anything else we need to know? [optional]

- The self-time walk can count `Validation` time with no chip to show it — harmless; the chip returns when the parser emits validation events.
- Skeleton → loaded shows a one-row layout shift; accepted.
- Pre-existing: `FrameTooltipRenderer` sets `descriptionDiv.innerHTML`; not touched here.
- Interactive legend (hover/click a chip → highlight the category) is a follow-up.
