### PR TITLE
refactor(log-viewer): make DatabaseView the only detail:select emitter (#901)

### DIFF
--- a/log-viewer/src/features/database/__tests__/gridSelection.test.ts
+++ b/log-viewer/src/features/database/__tests__/gridSelection.test.ts
@@ -1,17 +1,13 @@
 /*
  * Copyright (c) 2026 Certinia Inc. All rights reserved.
+ *
+ * @jest-environment jsdom
  */
-import { afterEach, beforeEach, describe, expect, it } from '@jest/globals';
+import { beforeEach, describe, expect, it } from '@jest/globals';
 
 import type { RowComponent } from 'tabulator-tables';
 
-import {
-  eventBus,
-  type DetailSelection,
-  type DetailSource,
-} from '../../../core/events/EventBus.js';
-import { SelectionEchoGuard } from '../../../core/events/SelectionEchoGuard.js';
-import { emitGridSelection } from '../components/gridSelection.js';
+import { reportGridSelection, type GridSelectionEvent } from '../components/gridSelection.js';
 
 interface StatementRow {
   eventIndex?: number;
@@ -25,47 +21,45 @@ function row(data: StatementRow): RowComponent {
 
 const soqlEventIndex = (data: StatementRow) => (data.soql ? data.eventIndex : undefined);
 
-describe('emitGridSelection', () => {
-  let seen: Array<{ source: DetailSource; selection: DetailSelection | null }>;
-  let off: () => void;
+describe('reportGridSelection', () => {
+  let host: HTMLElement;
+  let seen: GridSelectionEvent['detail'][];
 
   beforeEach(() => {
+    host = document.createElement('div');
     seen = [];
-    off = eventBus.on('detail:select', (d) => seen.push(d));
+    host.addEventListener('grid-selection', (event) =>
+      seen.push((event as GridSelectionEvent).detail),
+    );
   });
 
-  afterEach(() => off());
+  it('reports the picked row with the grid it came from', () => {
+    reportGridSelection(host, 'soql', [row({ eventIndex: 7, soql: 'SELECT' })], soqlEventIndex);
 
-  it('reports the picked row', () => {
-    emitGridSelection(
-      new SelectionEchoGuard(),
-      'soql',
-      [row({ eventIndex: 7, soql: 'SELECT' })],
-      soqlEventIndex,
+    expect(seen).toEqual([{ type: 'soql', eventIndex: 7 }]);
+  });
+
+  it('reports a cleared grid', () => {
+    reportGridSelection(host, 'soql', [], soqlEventIndex);
+
+    expect(seen).toEqual([{ type: 'soql', eventIndex: null }]);
+  });
+
+  it('says nothing for a row that holds no statement', () => {
+    reportGridSelection(host, 'soql', [row({ eventIndex: 7 })], soqlEventIndex);
+
+    expect(seen).toEqual([]);
+  });
+
+  it('reaches an ancestor, since only the parent view acts on it', () => {
+    const parent = document.createElement('div');
+    parent.append(host);
+    parent.addEventListener('grid-selection', (event) =>
+      seen.push((event as GridSelectionEvent).detail),
     );
 
-    expect(seen).toEqual([
-      { source: 'database', selection: { kind: 'event', eventIndex: 7, type: 'soql' } },
-    ]);
-  });
+    reportGridSelection(host, 'dml', [row({ eventIndex: 3, soql: 'SELECT' })], soqlEventIndex);
 
-  it('clears the inspector when the grid is cleared', () => {
-    emitGridSelection(new SelectionEchoGuard(), 'soql', [], soqlEventIndex);
-
-    expect(seen).toEqual([{ source: 'database', selection: null }]);
-  });
-
-  it('says nothing while a select on the inspector behalf is in flight', () => {
-    const guard = new SelectionEchoGuard();
-
-    guard.run(() => emitGridSelection(guard, 'soql', [], soqlEventIndex));
-
-    expect(seen).toEqual([]);
-  });
-
-  it('leaves the inspector alone for a row that holds no statement', () => {
-    emitGridSelection(new SelectionEchoGuard(), 'soql', [row({ eventIndex: 7 })], soqlEventIndex);
-
-    expect(seen).toEqual([]);
+    expect(seen).toHaveLength(2);
   });
 });

--- a/log-viewer/src/features/database/__tests__/revealRow.test.ts
+++ b/log-viewer/src/features/database/__tests__/revealRow.test.ts
@@ -5,7 +5,6 @@ import { describe, expect, it } from '@jest/globals';
 
 import type { Tabulator } from 'tabulator-tables';
 
-import { SelectionEchoGuard } from '../../../core/events/SelectionEchoGuard.js';
 import { selectRowByEventIndex } from '../components/revealRow.js';
 
 /** The slice of tabulator the helper touches: rows to scan, and a select on the match. */
@@ -37,37 +36,21 @@ function fakeTable(eventIndexes: number[]): {
 describe('selectRowByEventIndex', () => {
   it('selects the row that owns the event, clearing the previous one', () => {
     const grid = fakeTable([4, 9]);
-    const guard = new SelectionEchoGuard();
 
-    expect(selectRowByEventIndex(grid.table, guard, 9)).toBe(true);
+    expect(selectRowByEventIndex(grid.table, 9)).toBe(true);
     expect(grid.selected).toEqual([9]);
     expect(grid.deselects).toBe(1);
   });
 
   it('leaves a grid that does not own the event untouched', () => {
     const grid = fakeTable([4, 9]);
-    const guard = new SelectionEchoGuard();
 
-    expect(selectRowByEventIndex(grid.table, guard, 7)).toBe(false);
+    expect(selectRowByEventIndex(grid.table, 7)).toBe(false);
     expect(grid.selected).toEqual([]);
     expect(grid.deselects).toBe(0);
   });
 
-  it('suppresses the echo while it selects, so the inspector is not sent its own selection', () => {
-    const guard = new SelectionEchoGuard();
-    const during: boolean[] = [];
-    const table = {
-      getRows: () => [{ getData: () => ({ eventIndex: 1 }), select: () => {} }],
-      deselectRow: () => during.push(guard.suppressed),
-    } as unknown as Tabulator;
-
-    selectRowByEventIndex(table, guard, 1);
-
-    expect(during).toEqual([true]);
-    expect(guard.suppressed).toBe(false);
-  });
-
   it('reveals nothing when the grid has no table yet', () => {
-    expect(selectRowByEventIndex(null, new SelectionEchoGuard(), 1)).toBe(false);
+    expect(selectRowByEventIndex(null, 1)).toBe(false);
   });
 });

--- a/log-viewer/src/features/database/components/DMLView.ts
+++ b/log-viewer/src/features/database/components/DMLView.ts
@@ -9,13 +9,12 @@ import { customElement, property, state } from 'lit/decorators.js';
 import { Tabulator, type GroupComponent, type RowComponent } from 'tabulator-tables';
 
 import type { ApexLog, DMLBeginLine } from 'apex-log-parser';
-import { SelectionEchoGuard } from '../../../core/events/SelectionEchoGuard.js';
 import { vscodeMessenger } from '../../../core/messaging/VSCodeExtensionMessenger.js';
 import { getCallerNamespace } from '../../../core/utility/CallerNamespace.js';
 import { goToRow } from '../../call-tree/navigation.js';
 import { isVisible } from '../../../core/utility/Util.js';
 import { getSettings, updateSetting } from '../../settings/Settings.js';
-import { emitGridSelection } from './gridSelection.js';
+import { reportGridSelection } from './gridSelection.js';
 import { selectRowByEventIndex } from './revealRow.js';
 import {
   applyColumnView,
@@ -88,8 +87,6 @@ export class DMLView extends LitElement {
 
   dmlTable: Tabulator | null = null;
   holder: HTMLElement | null = null;
-  /** Guards the programmatic select made on the inspector's behalf. */
-  private _echoGuard = new SelectionEchoGuard();
   table: HTMLElement | null = null;
   findArgs: { text: string; count: number; options: { matchCase: boolean } } = {
     text: '',
@@ -435,25 +432,16 @@ export class DMLView extends LitElement {
     this.dmlTable?.copyToClipboard('all');
   }
 
-  /**
-   * Drops this grid's row highlight. Silent by default, for the clear that
-   * follows another grid being picked; `notify` leaves the grid's own
-   * selection-change path to report it, which is the user-driven (Escape) case.
-   */
-  deselectRows({ notify = false }: { notify?: boolean } = {}) {
-    if (notify) {
-      this.dmlTable?.deselectRow();
-      return;
-    }
-    this._echoGuard.run(() => this.dmlTable?.deselectRow());
+  /** Drops this grid's row highlight, reported upward like any other change. */
+  deselectRows() {
+    this.dmlTable?.deselectRow();
   }
 
   /**
-   * Select the row for `eventIndex`, without echoing `detail:select` back at the
-   * inspector that asked for it. Returns false when this grid has no such row.
+   * Select the row for `eventIndex`. Returns false when this grid has no such row.
    */
   selectByEventIndex(eventIndex: number): boolean {
-    return selectRowByEventIndex(this.dmlTable, this._echoGuard, eventIndex);
+    return selectRowByEventIndex(this.dmlTable, eventIndex);
   }
 
   _exportToCSV() {
@@ -708,7 +696,7 @@ export class DMLView extends LitElement {
     // navigation updates it too. RowKeyboardNavigation keeps a single row
     // selected across mouse and arrow-key navigation.
     this.dmlTable.on('rowSelectionChanged', (_data, rows) => {
-      emitGridSelection(this._echoGuard, 'dml', rows, (data: DMLRow) =>
+      reportGridSelection(this, 'dml', rows, (data: DMLRow) =>
         data.dml ? data.eventIndex : undefined,
       );
     });

--- a/log-viewer/src/features/database/components/DatabaseView.ts
+++ b/log-viewer/src/features/database/components/DatabaseView.ts
@@ -13,7 +13,8 @@ import type {
   SOSLExecuteBeginLine,
 } from 'apex-log-parser';
 
-import { eventBus } from '../../../core/events/EventBus.js';
+import { eventBus, type StatementType } from '../../../core/events/EventBus.js';
+import { SelectionEchoGuard } from '../../../core/events/SelectionEchoGuard.js';
 import { isVisible } from '../../../core/utility/Util.js';
 import { soslRowsMetric } from '../limits.js';
 import { DatabaseAccess } from '../services/Database.js';
@@ -29,12 +30,17 @@ import type { SOSLView } from './SOSLView.js';
 import './DMLView.js';
 import './DatabaseSection.js';
 import type { DatabaseMetric } from './DatabaseMetricCard.js';
+import type { GridSelectionEvent } from './gridSelection.js';
 import './GovernorSummary.js';
 import type { GaugeMetric } from './GovernorSummary.js';
 import './SOQLView.js';
 import './SOSLView.js';
 
-type SectionKind = 'dml' | 'soql' | 'sosl';
+/** A section is one statement type, so the two names are the same set. */
+type SectionKind = StatementType;
+
+/** The three grids this view drives share a selection contract. */
+type DatabaseGrid = DMLView | SOQLView | SOSLView;
 
 @customElement('database-view')
 export class DatabaseView extends LitElement {
@@ -74,9 +80,11 @@ export class DatabaseView extends LitElement {
   };
   findMap = {};
 
-  private _offDetailSelect: (() => void) | null = null;
   private _offInspectorReveal: (() => void) | null = null;
   private _offSelectionClear: (() => void) | null = null;
+
+  /** Guards the selects this view makes on the inspector's behalf. */
+  private _echoGuard = new SelectionEchoGuard();
 
   constructor() {
     super();
@@ -85,25 +93,6 @@ export class DatabaseView extends LitElement {
     document.addEventListener('lv-find-match', this._findHandler as EventListener);
     document.addEventListener('lv-find', this._findHandler as EventListener);
 
-    // Only one statement is "selected" across the three grids at a time — when
-    // one grid reports a selection, clear the other two. (The inspector
-    // owns rendering the detail; this just keeps the grids mutually exclusive.)
-    this._offDetailSelect = eventBus.on('detail:select', (d) => {
-      if (d.source !== 'database' || d.selection?.kind !== 'event') {
-        return;
-      }
-      const grids = [
-        ['dml', this._dmlView],
-        ['soql', this._soqlView],
-        ['sosl', this._soslView],
-      ] as const;
-      for (const [type, view] of grids) {
-        if (d.selection.type !== type) {
-          view?.deselectRows();
-        }
-      }
-    });
-
     // Reveal an inspector row here, but only while the Database tab is the tab
     // the inspector is showing. The eventIndex belongs to exactly one grid, so
     // each is offered it in turn until one owns it.
@@ -111,21 +100,49 @@ export class DatabaseView extends LitElement {
       if (d.source !== 'database') {
         return;
       }
-      const views = [this._dmlView, this._soqlView, this._soslView];
-      const owner = views.find((view) => view?.selectByEventIndex(d.eventIndex));
-      if (owner) {
-        views.filter((view) => view !== owner).forEach((view) => view?.deselectRows());
-      }
+      const views = this._views;
+      this._echoGuard.run(() => {
+        const owner = views.find((view) => view?.selectByEventIndex(d.eventIndex));
+        if (owner) {
+          views.filter((view) => view !== owner).forEach((view) => view?.deselectRows());
+        }
+      });
     });
 
     // Escape (app-wide) deselects here. Only one grid holds the selection, and
-    // it reports the clear itself — hence `notify`.
+    // its report of the clear reaches the inspector the same way a click does.
     this._offSelectionClear = eventBus.on('selection:clear', (d) => {
       if (d.source === 'database') {
-        [this._dmlView, this._soqlView, this._soslView].forEach((view) =>
-          view?.deselectRows({ notify: true }),
-        );
+        this._views.forEach((view) => view?.deselectRows());
       }
+    });
+  }
+
+  /**
+   * The database tab's only `detail:select` emitter. The three grids report
+   * their selection here; only one of them holds it at a time, so the two the
+   * pick did not land in are cleared under the guard — otherwise their nulls
+   * would arrive after the pick and undo it.
+   */
+  private _onGridSelection(event: GridSelectionEvent): void {
+    if (this._echoGuard.suppressed) {
+      return;
+    }
+    const { type, eventIndex } = event.detail;
+    if (eventIndex === null) {
+      eventBus.emit('detail:select', { source: 'database', selection: null });
+      return;
+    }
+    this._echoGuard.run(() => {
+      for (const [kind, view] of this._gridsByKind) {
+        if (kind !== type) {
+          view?.deselectRows();
+        }
+      }
+    });
+    eventBus.emit('detail:select', {
+      source: 'database',
+      selection: { kind: 'event', eventIndex, type },
     });
   }
 
@@ -134,12 +151,18 @@ export class DatabaseView extends LitElement {
     document.removeEventListener('db-find-results', this._findResults as EventListener);
     document.removeEventListener('lv-find-match', this._findHandler as EventListener);
     document.removeEventListener('lv-find', this._findHandler as EventListener);
-    this._offDetailSelect?.();
-    this._offDetailSelect = null;
     this._offInspectorReveal?.();
     this._offInspectorReveal = null;
     this._offSelectionClear?.();
     this._offSelectionClear = null;
+  }
+
+  firstUpdated(): void {
+    // One listener for all three grids: their reports bubble to this shadow
+    // root and stop there, so grids added later are heard without rebinding.
+    this.renderRoot.addEventListener('grid-selection', (event) =>
+      this._onGridSelection(event as GridSelectionEvent),
+    );
   }
 
   updated(changed: PropertyValues): void {
@@ -250,6 +273,19 @@ export class DatabaseView extends LitElement {
 
   private get _soslView(): SOSLView | null {
     return this.renderRoot?.querySelector('sosl-view') ?? null;
+  }
+
+  /** The three grids in view order, each with the statement type it holds. */
+  private get _gridsByKind(): ReadonlyArray<readonly [SectionKind, DatabaseGrid | null]> {
+    return [
+      ['dml', this._dmlView],
+      ['soql', this._soqlView],
+      ['sosl', this._soslView],
+    ];
+  }
+
+  private get _views(): ReadonlyArray<DatabaseGrid | null> {
+    return this._gridsByKind.map(([, view]) => view);
   }
 
   private _renderSection(kind: SectionKind) {

--- a/log-viewer/src/features/database/components/SOQLView.ts
+++ b/log-viewer/src/features/database/components/SOQLView.ts
@@ -14,7 +14,6 @@ import {
 } from 'tabulator-tables';
 
 import type { ApexLog, SOQLExecuteBeginLine } from 'apex-log-parser';
-import { SelectionEchoGuard } from '../../../core/events/SelectionEchoGuard.js';
 import { vscodeMessenger } from '../../../core/messaging/VSCodeExtensionMessenger.js';
 import { isVisible } from '../../../core/utility/Util.js';
 import { getCallerNamespace } from '../../../core/utility/CallerNamespace.js';
@@ -24,7 +23,7 @@ import { soqlGroupHeader } from '../../soql/format/groupHeader.js';
 import { soqlInlineElement } from '../../soql/format/inlineCell.js';
 import { soqlSyntaxStyles } from '../../soql/styles/soql-syntax.css.js';
 import { getSettings, updateSetting } from '../../settings/Settings.js';
-import { emitGridSelection } from './gridSelection.js';
+import { reportGridSelection } from './gridSelection.js';
 import { selectRowByEventIndex } from './revealRow.js';
 import {
   applyColumnView,
@@ -103,8 +102,6 @@ export class SOQLView extends LitElement {
 
   soqlTable: Tabulator | null = null;
   holder: HTMLElement | null = null;
-  /** Guards the programmatic select made on the inspector's behalf. */
-  private _echoGuard = new SelectionEchoGuard();
   table: HTMLElement | null = null;
 
   @state()
@@ -453,25 +450,16 @@ export class SOQLView extends LitElement {
     this.soqlTable?.copyToClipboard('all');
   }
 
-  /**
-   * Drops this grid's row highlight. Silent by default, for the clear that
-   * follows another grid being picked; `notify` leaves the grid's own
-   * selection-change path to report it, which is the user-driven (Escape) case.
-   */
-  deselectRows({ notify = false }: { notify?: boolean } = {}) {
-    if (notify) {
-      this.soqlTable?.deselectRow();
-      return;
-    }
-    this._echoGuard.run(() => this.soqlTable?.deselectRow());
+  /** Drops this grid's row highlight, reported upward like any other change. */
+  deselectRows() {
+    this.soqlTable?.deselectRow();
   }
 
   /**
-   * Select the row for `eventIndex`, without echoing `detail:select` back at the
-   * inspector that asked for it. Returns false when this grid has no such row.
+   * Select the row for `eventIndex`. Returns false when this grid has no such row.
    */
   selectByEventIndex(eventIndex: number): boolean {
-    return selectRowByEventIndex(this.soqlTable, this._echoGuard, eventIndex);
+    return selectRowByEventIndex(this.soqlTable, eventIndex);
   }
 
   _exportToCSV() {
@@ -859,7 +847,7 @@ export class SOQLView extends LitElement {
     // navigation updates it too. RowKeyboardNavigation keeps a single row
     // selected across mouse and arrow-key navigation.
     this.soqlTable.on('rowSelectionChanged', (_data, rows) => {
-      emitGridSelection(this._echoGuard, 'soql', rows, (data: GridSOQLData) =>
+      reportGridSelection(this, 'soql', rows, (data: GridSOQLData) =>
         data.soql ? data.eventIndex : undefined,
       );
     });

--- a/log-viewer/src/features/database/components/SOSLView.ts
+++ b/log-viewer/src/features/database/components/SOSLView.ts
@@ -9,13 +9,12 @@ import { customElement, property, state } from 'lit/decorators.js';
 import { Tabulator, type GroupComponent, type RowComponent } from 'tabulator-tables';
 
 import type { ApexLog, SOSLExecuteBeginLine } from 'apex-log-parser';
-import { SelectionEchoGuard } from '../../../core/events/SelectionEchoGuard.js';
 import { vscodeMessenger } from '../../../core/messaging/VSCodeExtensionMessenger.js';
 import { getCallerNamespace } from '../../../core/utility/CallerNamespace.js';
 import { goToRow } from '../../call-tree/navigation.js';
 import { isVisible } from '../../../core/utility/Util.js';
 import { getSettings, updateSetting } from '../../settings/Settings.js';
-import { emitGridSelection } from './gridSelection.js';
+import { reportGridSelection } from './gridSelection.js';
 import { selectRowByEventIndex } from './revealRow.js';
 import { soqlInlineElement } from '../../soql/format/inlineCell.js';
 import { soqlSyntaxStyles } from '../../soql/styles/soql-syntax.css.js';
@@ -89,8 +88,6 @@ export class SOSLView extends LitElement {
 
   soslTable: Tabulator | null = null;
   holder: HTMLElement | null = null;
-  /** Guards the programmatic select made on the inspector's behalf. */
-  private _echoGuard = new SelectionEchoGuard();
   table: HTMLElement | null = null;
   findArgs: { text: string; count: number; options: { matchCase: boolean } } = {
     text: '',
@@ -655,7 +652,7 @@ export class SOSLView extends LitElement {
     // Drive the detail panel off selection (not click) so keyboard row
     // navigation updates it too, matching the SOQL/DML grids.
     this.soslTable.on('rowSelectionChanged', (_data, rows) => {
-      emitGridSelection(this._echoGuard, 'sosl', rows, (data: SOSLRow) =>
+      reportGridSelection(this, 'sosl', rows, (data: SOSLRow) =>
         data.sosl ? data.eventIndex : undefined,
       );
     });
@@ -738,25 +735,16 @@ export class SOSLView extends LitElement {
     return this.holder;
   }
 
-  /**
-   * Drops this grid's row highlight. Silent by default, for the clear that
-   * follows another grid being picked; `notify` leaves the grid's own
-   * selection-change path to report it, which is the user-driven (Escape) case.
-   */
-  deselectRows({ notify = false }: { notify?: boolean } = {}) {
-    if (notify) {
-      this.soslTable?.deselectRow();
-      return;
-    }
-    this._echoGuard.run(() => this.soslTable?.deselectRow());
+  /** Drops this grid's row highlight, reported upward like any other change. */
+  deselectRows() {
+    this.soslTable?.deselectRow();
   }
 
   /**
-   * Select the row for `eventIndex`, without echoing `detail:select` back at the
-   * inspector that asked for it. Returns false when this grid has no such row.
+   * Select the row for `eventIndex`. Returns false when this grid has no such row.
    */
   selectByEventIndex(eventIndex: number): boolean {
-    return selectRowByEventIndex(this.soslTable, this._echoGuard, eventIndex);
+    return selectRowByEventIndex(this.soslTable, eventIndex);
   }
 
   downlodEncoder(defaultFileName: string) {

--- a/log-viewer/src/features/database/components/__tests__/DatabaseView.test.ts
+++ b/log-viewer/src/features/database/components/__tests__/DatabaseView.test.ts
@@ -1,0 +1,118 @@
+/*
+ * Copyright (c) 2026 Certinia Inc. All rights reserved.
+ *
+ * @jest-environment jsdom
+ */
+import { afterEach, beforeEach, describe, expect, it } from '@jest/globals';
+
+import {
+  eventBus,
+  type DetailSelection,
+  type DetailSource,
+  type StatementType,
+} from '../../../../core/events/EventBus.js';
+
+// The three grids and the summary bring tabulator and its stylesheets with them;
+// this suite only drives the selection contract between them and DatabaseView.
+jest.mock('../DMLView.js', () => ({}));
+jest.mock('../SOQLView.js', () => ({}));
+jest.mock('../SOSLView.js', () => ({}));
+jest.mock('../GovernorSummary.js', () => ({}));
+jest.mock('../DatabaseSection.js', () => ({}));
+jest.mock('../../services/Database.js', () => ({ DatabaseAccess: {} }));
+
+import '../DatabaseView.js';
+
+/** The slice of a grid DatabaseView drives, standing in for the real element. */
+interface FakeGrid extends HTMLElement {
+  deselects: number;
+  owns: number | null;
+}
+
+/**
+ * The grids render only once a log is loaded, so stand-ins are placed in the
+ * shadow root the same way: one element per statement type, found by tag.
+ */
+function fakeGrid(tag: string, owns: number | null = null): FakeGrid {
+  const grid = document.createElement(tag) as FakeGrid;
+  grid.deselects = 0;
+  grid.owns = owns;
+  Object.assign(grid, {
+    deselectRows: () => (grid.deselects += 1),
+    selectByEventIndex: (eventIndex: number) => eventIndex === grid.owns,
+  });
+  return grid;
+}
+
+describe('database-view selection', () => {
+  let view: HTMLElement;
+  let grids: Record<StatementType, FakeGrid>;
+  let seen: Array<{ source: DetailSource; selection: DetailSelection | null }>;
+  let off: () => void;
+
+  beforeEach(async () => {
+    document.body.replaceChildren();
+    view = document.createElement('database-view');
+    document.body.append(view);
+    await (view as HTMLElement & { updateComplete: Promise<unknown> }).updateComplete;
+    grids = {
+      dml: fakeGrid('dml-view'),
+      soql: fakeGrid('soql-view', 42),
+      sosl: fakeGrid('sosl-view'),
+    };
+    view.shadowRoot?.append(grids.dml, grids.soql, grids.sosl);
+    seen = [];
+    off = eventBus.on('detail:select', (d) => seen.push(d));
+  });
+
+  afterEach(() => {
+    off();
+    document.body.replaceChildren();
+  });
+
+  /** The grids report upward; DatabaseView alone turns that into a selection. */
+  const report = (type: StatementType, eventIndex: number | null) =>
+    grids[type].dispatchEvent(
+      new CustomEvent('grid-selection', { detail: { type, eventIndex }, bubbles: true }),
+    );
+
+  it('reports a picked row and clears the other two grids', () => {
+    report('soql', 7);
+
+    expect(seen).toEqual([
+      { source: 'database', selection: { kind: 'event', eventIndex: 7, type: 'soql' } },
+    ]);
+    expect([grids.dml.deselects, grids.soql.deselects, grids.sosl.deselects]).toEqual([1, 0, 1]);
+  });
+
+  it('says nothing for the clears its own pick caused', () => {
+    // The two cleared grids report their nulls; arriving after the pick, they
+    // would undo it.
+    grids.dml.addEventListener('grid-selection', () => report('dml', null));
+    report('soql', 7);
+
+    expect(seen).toHaveLength(1);
+  });
+
+  it('clears the inspector when the grid holding the selection is cleared', () => {
+    report('soql', null);
+
+    expect(seen).toEqual([{ source: 'database', selection: null }]);
+  });
+
+  it('says nothing for the select the inspector asked for', () => {
+    // The revealed grid reports the selection it was just given.
+    grids.soql.addEventListener('grid-selection', () => report('soql', 42));
+
+    eventBus.emit('inspector:reveal', { source: 'database', eventIndex: 42 });
+
+    expect(seen).toEqual([]);
+    expect([grids.dml.deselects, grids.sosl.deselects]).toEqual([1, 1]);
+  });
+
+  it('drops every grid selection on an app-wide clear', () => {
+    eventBus.emit('selection:clear', { source: 'database' });
+
+    expect([grids.dml.deselects, grids.soql.deselects, grids.sosl.deselects]).toEqual([1, 1, 1]);
+  });
+});

--- a/log-viewer/src/features/database/components/gridSelection.ts
+++ b/log-viewer/src/features/database/components/gridSelection.ts
@@ -3,44 +3,35 @@
  */
 import type { RowComponent } from 'tabulator-tables';
 
-import { eventBus, type StatementType } from '../../../core/events/EventBus.js';
-import type { SelectionEchoGuard } from '../../../core/events/SelectionEchoGuard.js';
+import type { StatementType } from '../../../core/events/EventBus.js';
+
+/** What a grid tells its parent: the picked statement, or null once cleared. */
+export type GridSelectionEvent = CustomEvent<{
+  type: StatementType;
+  eventIndex: number | null;
+}>;
 
 /**
- * Reports a database grid's selection to the inspector: the picked row, or
- * null once the grid is cleared, so the inspector stops showing the row the
- * user just deselected.
- *
- * Emits nothing while `guard` suppresses - that clear came from the inspector,
- * or from `DatabaseView` clearing the two grids the pick did not land in, and
- * its null would arrive after the pick and undo it.
+ * Reports a database grid's selection to `DatabaseView`, which owns the tab's
+ * mutual exclusion and is the only thing that emits `detail:select`. The event
+ * bubbles to that view's shadow root and no further.
  *
  * `eventIndexOf` returns undefined for a row that holds no statement, which is
  * reported as no change rather than as a clear.
  */
-export function emitGridSelection<T>(
-  guard: SelectionEchoGuard,
+export function reportGridSelection<T>(
+  host: HTMLElement,
   type: StatementType,
   rows: RowComponent[],
   eventIndexOf: (data: T) => number | undefined,
 ): void {
-  if (guard.suppressed) {
-    return;
-  }
-
   const data = rows[0]?.getData() as T | undefined;
-  if (!data) {
-    eventBus.emit('detail:select', { source: 'database', selection: null });
-    return;
-  }
-
-  const eventIndex = eventIndexOf(data);
+  const eventIndex = data ? eventIndexOf(data) : null;
   if (eventIndex === undefined) {
     return;
   }
 
-  eventBus.emit('detail:select', {
-    source: 'database',
-    selection: { kind: 'event', eventIndex, type },
-  });
+  host.dispatchEvent(
+    new CustomEvent('grid-selection', { detail: { type, eventIndex }, bubbles: true }),
+  );
 }

--- a/log-viewer/src/features/database/components/revealRow.ts
+++ b/log-viewer/src/features/database/components/revealRow.ts
@@ -3,25 +3,20 @@
  */
 import type { Tabulator } from 'tabulator-tables';
 
-import type { SelectionEchoGuard } from '../../../core/events/SelectionEchoGuard.js';
-
 /** The part of a database grid row that traces back to the log event it was built from. */
 interface EventRow {
   eventIndex?: number;
 }
 
 /**
- * Select the row for `eventIndex`, without echoing `detail:select` back at the
- * inspector that asked for it. Returns false when the grid has no such row.
+ * Select the row for `eventIndex`. Returns false when the grid has no such row.
  *
  * Shared by the DML, SOQL and SOSL grids: the inspector offers an eventIndex to
- * each in turn, and only the grid that owns it selects.
+ * each in turn, and only the grid that owns it selects. `DatabaseView` runs the
+ * call under its echo guard, so the selection is not reported back at the
+ * inspector that asked for it.
  */
-export function selectRowByEventIndex(
-  table: Tabulator | null,
-  guard: SelectionEchoGuard,
-  eventIndex: number,
-): boolean {
+export function selectRowByEventIndex(table: Tabulator | null, eventIndex: number): boolean {
   // The tabulator index is a synthetic row id, so the eventIndex is scanned for.
   const match = table
     ?.getRows()
@@ -30,9 +25,7 @@ export function selectRowByEventIndex(
     return false;
   }
 
-  guard.run(() => {
-    table.deselectRow();
-    match.select();
-  });
+  table.deselectRow();
+  match.select();
   return true;
 }


### PR DESCRIPTION
Closes #901.

## Problem

Each of the three database grids held its own `SelectionEchoGuard` and emitted `detail:select`. One contract lived in three files, and nothing owned the tab's mutual exclusion — each grid cleared its siblings and hoped the resulting nulls did not undo the pick.

## Change

The grids now report a selection upward as a bubbling `grid-selection` DOM event carrying the statement type. It is not `composed`, so it reaches `DatabaseView`'s shadow root and stops there.

`DatabaseView` holds the only guard, listens once on its shadow root, clears the two grids the pick did not land in, and is the only thing that emits `detail:select`.

Knock-on simplifications:

- `deselectRows({ notify })` becomes `deselectRows()` — a grid no longer decides whether a clear is reportable.
- `selectRowByEventIndex` drops its guard parameter; `DatabaseView` runs it under its own.
- The `detail:select` self-subscription in `DatabaseView` is gone; sibling clearing happens inline before the emit.
- `SectionKind` is now an alias of `StatementType` rather than a second spelling of the same set.

Behaviour is unchanged.

## Tests

New `DatabaseView` suite covering the contract that moved into it: reporting a pick and clearing the other two grids, ignoring the clears its own pick caused, clearing the inspector on a grid clear, staying silent for the inspector's own reveal, and dropping every selection on `selection:clear`. The echo-suppression cases leave the two helper suites, which no longer own that behaviour.

Full run: 121 suites, 1552 tests.