### PR TITLE
feat(inspector): follow the frame walked to in the call stack

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Shown together in the **Memory** view (total + self); peak also appears in the **Governor Limits** view and feeds the Gov Avg/Peak columns. Method tooltips show net heap retained.
   - The Timeline governor strip plots heap as it's allocated, so you can see where it spikes.
 - 🧭 **Inspector**: select anything — a timeline frame, a call tree or analysis row, a SOQL/DML/SOSL statement — and inspect it without leaving the tab you're on. ([#113])
-  - **A selection** shows its details and governor metrics as `used / limit`, the call stack that led to it, and its own subtree in **Time Order**, **Aggregated** or **Bottom-Up**.
+  - **A selection** shows its details and governor metrics as `used / limit`, the call stack that led to it, and its own subtree in **Time Order**, **Aggregated** or **Bottom-Up**. Click a frame in the call stack to walk up it — the details and subtree follow, and the stack stays anchored to what you selected.
   - **Nothing selected** shows the whole log instead of an empty panel: a governor overview on every tab, time by category and governor trends on the Timeline, log-wide findings on Analysis, and the hot path and hot spots on the Call Tree.
   - Every row is a link: click it to reveal the frame, row or statement behind it in the tab you're on. Right-click for copy actions.
   - Dock it left, right or bottom, drag to resize, and collapse the sections you don't need — the layout is remembered. `Escape` clears the selection and returns the whole-log view. ([#63])

--- a/log-viewer/src/components/CallStackDetail.ts
+++ b/log-viewer/src/components/CallStackDetail.ts
@@ -14,6 +14,7 @@ import {
 } from '../features/call-tree/components/TableShared.js';
 import { soqlInlineElement } from '../features/soql/format/inlineCell.js';
 import { soqlSyntaxStyles } from '../features/soql/styles/soql-syntax.css.js';
+import { SelectionEchoGuard } from '../core/events/SelectionEchoGuard.js';
 import { globalStyles } from '../styles/global.styles.js';
 import { progressColumnWidth } from '../tabulator/format/measureWidth.js';
 import dataGridStyles from '../tabulator/style/DataGrid.scss';
@@ -27,14 +28,26 @@ import { PANEL_ROW_MENU_ITEMS, runPanelRowAction } from './panelRowMenu.js';
  * The lineage of parent frames that led to an event, outermost first, as a
  * small resizable table (Frame | Total | Self) that mirrors the Call Tree —
  * same `progressFormatterMS` bars (percent of the stack's root frame), column
- * headers, resizable columns. Clicking a frame jumps to it.
+ * headers, resizable columns.
+ *
+ * The list is anchored: `eventIndex` is the frame the stack was built for and
+ * never moves while the user walks it. Clicking a frame makes it the active one
+ * — the row the rest of the inspector follows — which the inspector feeds back
+ * as `activeEventIndex`, so no frame is lost on the way down.
  */
 @customElement('call-stack-detail')
 export class CallStackDetail extends LitElement {
+  /** The frame the stack was built for; the list stays anchored to it. */
   @property({ type: Number })
   eventIndex = -1;
 
+  /** The frame in the stack the inspector is following. */
+  @property({ type: Number })
+  activeEventIndex = -1;
+
   private _table: Tabulator | null = null;
+  /** Guards the select made to mark the active frame. */
+  private _echoGuard = new SelectionEchoGuard();
   private _contextMenu: ContextMenu | null = null;
   /** eventIndex of the row whose context menu is open. */
   private _menuEventIndex = -1;
@@ -76,6 +89,9 @@ export class CallStackDetail extends LitElement {
   updated(changed: PropertyValues) {
     if (changed.has('eventIndex')) {
       this._rebuild();
+    } else if (changed.has('activeEventIndex')) {
+      // The anchor holds, so the rows are unchanged — only the mark moves.
+      this._markActive();
     }
   }
 
@@ -151,12 +167,35 @@ export class CallStackDetail extends LitElement {
     this._table.on('rowContext', (e, row) => {
       this._showRowMenu(e as MouseEvent, row);
     });
-    // Selecting a frame reveals it in the tab on screen; the inspector adds the
-    // source, since only it knows which tab that is.
+    // Selecting a frame makes it the active one and reveals it in the tab on
+    // screen; the inspector adds the source, since only it knows which tab that
+    // is. The mark this table sets itself is not a pick, so it is guarded.
     this._table.on('rowSelectionChanged', (_data, rows) => {
+      if (this._echoGuard.suppressed) {
+        return;
+      }
       const eventIndex = (rows[0]?.getData() as CallStackRow | undefined)?.eventIndex;
       if (eventIndex !== undefined) {
         dispatchInspectorReveal(this, eventIndex);
+      }
+    });
+    this._table.on('tableBuilt', () => {
+      this._markActive();
+    });
+  }
+
+  /** Marks the active frame in the list, without reporting it as a new pick. */
+  private _markActive(): void {
+    const table = this._table;
+    if (!table) {
+      return;
+    }
+    this._echoGuard.run(() => {
+      for (const selected of table.getSelectedRows()) {
+        selected.deselect();
+      }
+      if (this.activeEventIndex >= 0) {
+        table.selectRow([this.activeEventIndex]);
       }
     });
   }

--- a/log-viewer/src/components/LogInspector.ts
+++ b/log-viewer/src/components/LogInspector.ts
@@ -48,6 +48,10 @@ export class LogInspector extends LitElement {
 
   // Latest selection per source; the bar renders the active tab's entry.
   private _selections = new Map<DetailSource, DetailSelection>();
+  // The frame walked to inside that selection's call stack, per source. Held
+  // apart from the selection so the call stack keeps its anchor while Details
+  // and the call tree follow the walk.
+  private _activeFrames = new Map<DetailSource, number>();
   // The user's last open/closed choice, or null if they've never made one —
   // which is the only state that lets a selection auto-open the panel.
   @state()
@@ -153,6 +157,8 @@ export class LogInspector extends LitElement {
   }
 
   private _onSelect(detail: { source: DetailSource; selection: DetailSelection | null }): void {
+    // A pick in the tab itself is a new anchor, so any walk down the old stack ends.
+    this._activeFrames.delete(detail.source);
     if (detail.selection) {
       this._selections.set(detail.source, detail.selection);
       // Only shows the panel while the user has never chosen for themselves,
@@ -171,11 +177,22 @@ export class LogInspector extends LitElement {
    * An inspector row asks to be revealed. Only the active tab's own view acts on
    * it, so the source is stamped here - a call-tree selection must never move
    * the timeline.
+   *
+   * The revealed row also becomes the active frame: the tab's own selection
+   * moves, and Details and the call tree follow, while the selection that
+   * anchors the call stack stays where the user left it.
    */
   private _onReveal = (e: InspectorRevealEvent): void => {
     const source = this._activeSource;
-    if (source) {
-      eventBus.emit('inspector:reveal', { source, eventIndex: e.detail.eventIndex });
+    if (!source) {
+      return;
+    }
+    eventBus.emit('inspector:reveal', { source, eventIndex: e.detail.eventIndex });
+    // Without a selection the sections are the whole-log ones, which have no
+    // frame to follow; the whole-log rows only reveal.
+    if (this._selections.has(source)) {
+      this._activeFrames.set(source, e.detail.eventIndex);
+      this._scheduleRebuild();
     }
   };
 
@@ -202,7 +219,11 @@ export class LogInspector extends LitElement {
     const epoch = ++this._rebuildEpoch;
     const source = this._activeSource;
     const sections = source
-      ? await buildDetailSections(source, this._selections.get(source) ?? null)
+      ? await buildDetailSections(
+          source,
+          this._selections.get(source) ?? null,
+          this._activeFrames.get(source) ?? null,
+        )
       : [];
     // Drop a slow build that a newer selection already superseded.
     if (epoch === this._rebuildEpoch) {

--- a/log-viewer/src/components/__tests__/CallStackDetail.test.ts
+++ b/log-viewer/src/components/__tests__/CallStackDetail.test.ts
@@ -12,6 +12,7 @@ jest.mock('../../tabulator/format/Progress.css', () => ({}));
 // Capture the options the component hands to Tabulator. The real ESM build (and
 // its module registrations) doesn't load under jest.
 const built: Record<string, unknown>[] = [];
+const selected: number[][] = [];
 type TableHandler = (...args: unknown[]) => void;
 const handlers: Record<string, TableHandler> = {};
 jest.mock('tabulator-tables', () => ({
@@ -26,6 +27,9 @@ jest.mock('tabulator-tables', () => ({
     destroy() {}
     getSelectedRows() {
       return [];
+    }
+    selectRow(indexes: number[]) {
+      selected.push(indexes);
     }
   },
   Module: class {},
@@ -86,6 +90,39 @@ describe('CallStackDetail', () => {
     handlers.rowSelectionChanged?.([], [{ getData: () => ({ eventIndex: 11 }) }]);
 
     expect(seen).toEqual([11]);
+    el.remove();
+  });
+
+  it('marks the active frame once the table is built, without calling it a pick', async () => {
+    const el = await mount(4);
+    el.activeEventIndex = 4;
+    await el.updateComplete;
+    // The rows arrive with `tableBuilt`, so the mark made before it is the one
+    // under test here.
+    selected.length = 0;
+
+    const seen: number[] = [];
+    const listener = (e: Event) => seen.push((e as InspectorRevealEvent).detail.eventIndex);
+    document.addEventListener(INSPECTOR_REVEAL_EVENT, listener);
+    handlers.tableBuilt?.();
+    document.removeEventListener(INSPECTOR_REVEAL_EVENT, listener);
+
+    expect(selected).toEqual([[4]]);
+    expect(seen).toEqual([]);
+    el.remove();
+  });
+
+  it('moves the mark without rebuilding, since the anchor holds the rows', async () => {
+    const el = await mount(4);
+    handlers.tableBuilt?.();
+    built.length = 0;
+    selected.length = 0;
+
+    el.activeEventIndex = 12;
+    await el.updateComplete;
+
+    expect(selected).toEqual([[12]]);
+    expect(built).toEqual([]);
     el.remove();
   });
 });

--- a/log-viewer/src/components/__tests__/LogInspector.test.ts
+++ b/log-viewer/src/components/__tests__/LogInspector.test.ts
@@ -39,15 +39,21 @@ jest.mock('../../features/settings/Settings.js', () => ({
 let deferSections = false;
 const pendingSections: Array<() => void> = [];
 jest.mock('../detailSections.js', () => ({
-  buildDetailSections: (_source: string, selection: { eventIndex?: number } | null) => {
-    // The marker carries the selection through to the rendered content, so a
-    // stale build resolving late is distinguishable from the one that supersedes it.
+  buildDetailSections: (
+    _source: string,
+    selection: { eventIndex?: number } | null,
+    activeEventIndex: number | null,
+  ) => {
+    // The markers carry the anchor and the active frame through to the rendered
+    // content, so a stale build resolving late is distinguishable from the one
+    // that supersedes it, and a walk is distinguishable from a new pick.
     const sections = selection
       ? [
           {
             id: 'vitals',
             title: 'Details',
-            content: html`<div class="marker">${selection.eventIndex}</div>`,
+            content: html`<div class="marker">${selection.eventIndex}</div>
+              <div class="active">${activeEventIndex ?? '-'}</div>`,
           },
           { id: 'callstack', title: 'Call stack', content: html`<div>c</div>` },
         ]
@@ -130,6 +136,11 @@ function select(source: 'timeline' | 'database', eventIndex: number): void {
 
 function marker(el: LogInspector): string | null {
   return paneView(el).shadowRoot?.querySelector('.marker')?.textContent ?? null;
+}
+
+/** The frame the sections follow, `-` while the anchor is what is shown. */
+function activeMarker(el: LogInspector): string | null {
+  return paneView(el).shadowRoot?.querySelector('.active')?.textContent ?? null;
 }
 
 describe('LogInspector', () => {
@@ -251,6 +262,49 @@ describe('LogInspector', () => {
     off();
 
     expect(seen).toEqual([{ source: 'calltree', eventIndex: 5 }]);
+  });
+
+  it('follows a revealed frame while the selection that anchors the stack holds', async () => {
+    const el = await mount('timeline-tab');
+    select('timeline', 1);
+    await flush(el);
+    expect([marker(el), activeMarker(el)]).toEqual(['1', '-']);
+
+    dispatchInspectorReveal(dockLayout(el), 5);
+    await flush(el);
+
+    // The anchor is what the call stack is built from, so it must not move.
+    expect([marker(el), activeMarker(el)]).toEqual(['1', '5']);
+  });
+
+  it('ends the walk when the tab reports a new pick of its own', async () => {
+    const el = await mount('timeline-tab');
+    select('timeline', 1);
+    await flush(el);
+    dispatchInspectorReveal(dockLayout(el), 5);
+    await flush(el);
+
+    select('timeline', 7);
+    await flush(el);
+
+    expect([marker(el), activeMarker(el)]).toEqual(['7', '-']);
+  });
+
+  it('keeps each tab walking its own stack', async () => {
+    const el = await mount('timeline-tab');
+    select('timeline', 1);
+    select('database', 2);
+    await flush(el);
+    dispatchInspectorReveal(dockLayout(el), 5);
+    await flush(el);
+
+    el.activeTab = 'database-tab';
+    await flush(el);
+    expect([marker(el), activeMarker(el)]).toEqual(['2', '-']);
+
+    el.activeTab = 'timeline-tab';
+    await flush(el);
+    expect([marker(el), activeMarker(el)]).toEqual(['1', '5']);
   });
 
   it('drops a reveal from a tab with no inspectable view', async () => {

--- a/log-viewer/src/components/__tests__/detailSections.test.ts
+++ b/log-viewer/src/components/__tests__/detailSections.test.ts
@@ -16,15 +16,37 @@ jest.mock('../HotPath.js', () => ({}));
 jest.mock('../HotSpots.js', () => ({}));
 jest.mock('../LogOverview.js', () => ({}));
 
-const databaseCalls: { eventIndex: number; type: string }[] = [];
+const databaseCalls: { eventIndex: number; type: string; activeEventIndex?: number | null }[] = [];
 jest.mock('../../features/database/components/databaseSections.js', () => ({
-  buildDatabaseSections: async (selection: { eventIndex: number; type: string }) => {
+  buildDatabaseSections: async (selection: {
+    eventIndex: number;
+    type: string;
+    activeEventIndex?: number | null;
+  }) => {
     databaseCalls.push(selection);
     return [{ id: 'vitals', title: 'Details', content: undefined }];
   },
 }));
 
+import { render, type TemplateResult } from 'lit';
+
 import { buildDetailSections } from '../detailSections.js';
+import type { PaneSection } from '../PaneView.js';
+
+/**
+ * The section content is a template, so it is rendered to read what each
+ * component was handed. The components are stubbed above, so nothing upgrades —
+ * only the attributes and properties are set.
+ */
+function rendered(sections: PaneSection[], id: string, tag: string): Element {
+  const host = document.createElement('div');
+  render(sections.find((s) => s.id === id)?.content as TemplateResult, host);
+  const el = host.querySelector(tag);
+  if (!el) {
+    throw new Error(`${tag} not rendered for section ${id}`);
+  }
+  return el;
+}
 
 describe('buildDetailSections', () => {
   it('builds the shared trio for a timeline frame', async () => {
@@ -44,8 +66,36 @@ describe('buildDetailSections', () => {
       type: 'soql',
     });
 
-    expect(databaseCalls).toEqual([{ eventIndex: 9, type: 'soql' }]);
+    expect(databaseCalls).toEqual([{ eventIndex: 9, type: 'soql', activeEventIndex: null }]);
     expect(sections.map((s) => s.id)).toEqual(['vitals']);
+  });
+
+  it('passes the frame walked to on to the database sections', async () => {
+    databaseCalls.length = 0;
+    await buildDetailSections('database', { kind: 'event', eventIndex: 9, type: 'soql' }, 4);
+
+    expect(databaseCalls).toEqual([{ eventIndex: 9, type: 'soql', activeEventIndex: 4 }]);
+  });
+
+  it('anchors the call stack to the selection while the rest follows the active frame', async () => {
+    const sections = await buildDetailSections('timeline', { kind: 'event', eventIndex: 4 }, 2);
+
+    expect(rendered(sections, 'callstack', 'call-stack-detail').getAttribute('eventIndex')).toBe(
+      '4',
+    );
+    expect(
+      rendered(sections, 'callstack', 'call-stack-detail').getAttribute('activeEventIndex'),
+    ).toBe('2');
+    expect(rendered(sections, 'vitals', 'event-vitals').getAttribute('eventIndex')).toBe('2');
+    expect(rendered(sections, 'calltree', 'call-tree-detail').getAttribute('eventIndex')).toBe('2');
+  });
+
+  it('marks the selection itself active while the user has not walked the stack', async () => {
+    const sections = await buildDetailSections('timeline', { kind: 'event', eventIndex: 4 });
+
+    expect(
+      rendered(sections, 'callstack', 'call-stack-detail').getAttribute('activeEventIndex'),
+    ).toBe('4');
   });
 
   it('keeps the shared trio for a database selection that has no statement type', async () => {
@@ -63,6 +113,25 @@ describe('buildDetailSections', () => {
       label: 'MyClass.run()',
     });
     expect(sections.map((s) => s.id)).toEqual(['vitals', 'callstack', 'calltree']);
+    expect(
+      (rendered(sections, 'vitals', 'event-vitals') as HTMLElement & { instances: number[] | null })
+        .instances,
+    ).toEqual([11, 12, 13]);
+  });
+
+  it('drops the aggregate once a single frame in its stack is the one being followed', async () => {
+    const sections = await buildDetailSections(
+      'analysis',
+      { kind: 'aggregate', instances: [11, 12, 13], label: 'MyClass.run()' },
+      8,
+    );
+
+    const vitals = rendered(sections, 'vitals', 'event-vitals') as HTMLElement & {
+      instances: number[] | null;
+    };
+    expect(vitals.getAttribute('eventIndex')).toBe('8');
+    expect(vitals.instances).toBeNull();
+    expect(vitals.getAttribute('label')).toBe('');
   });
 
   it('builds only the whole-log overview for the database with nothing selected', async () => {

--- a/log-viewer/src/components/detailSections.ts
+++ b/log-viewer/src/components/detailSections.ts
@@ -34,10 +34,15 @@ import './LogOverview.js';
  * range: an explicit row/frame `selection` always wins. A range or other
  * ambient scope only applies when `selection` is `null`, so it belongs inside
  * the `!selection` branch — never above it.
+ *
+ * `activeEventIndex` is the frame the user walked to inside the selection's own
+ * call stack. Details and the call tree follow it; the call stack stays anchored
+ * to `selection`, so walking down a stack never puts a frame out of reach.
  */
 export async function buildDetailSections(
   source: DetailSource,
   selection: DetailSelection | null,
+  activeEventIndex: number | null = null,
 ): Promise<PaneSection[]> {
   // Nothing selected: the whole log is the scope. `DetailDock`'s own empty
   // state still covers the moment before a tab id resolves.
@@ -110,14 +115,22 @@ export async function buildDetailSections(
 
   // The Database grids resolve statement-specific vitals and SOQL lint issues.
   if (source === 'database' && selection.kind === 'event' && selection.type) {
-    return buildDatabaseSections({ eventIndex: selection.eventIndex, type: selection.type });
+    return buildDatabaseSections({
+      eventIndex: selection.eventIndex,
+      type: selection.type,
+      activeEventIndex,
+    });
   }
 
   const isAggregate = selection.kind === 'aggregate';
   // An aggregate scopes to all its occurrences; a single frame to itself.
-  const eventIndex = isAggregate ? (selection.instances[0] ?? -1) : selection.eventIndex;
-  const instances = isAggregate ? selection.instances : null;
-  const label = isAggregate ? selection.label : '';
+  const anchorIndex = isAggregate ? (selection.instances[0] ?? -1) : selection.eventIndex;
+  const active = activeEventIndex ?? anchorIndex;
+  // One frame in the stack is being followed, so the aggregate no longer
+  // describes what Details and the call tree are showing.
+  const following = active !== anchorIndex;
+  const instances = isAggregate && !following ? selection.instances : null;
+  const label = isAggregate && !following ? selection.label : '';
 
   return [
     {
@@ -125,7 +138,7 @@ export async function buildDetailSections(
       title: 'Details',
       fit: 'content',
       content: html`<event-vitals
-        eventIndex=${eventIndex}
+        eventIndex=${active}
         .instances=${instances}
         label=${label}
       ></event-vitals>`,
@@ -134,14 +147,17 @@ export async function buildDetailSections(
       id: 'callstack',
       title: 'Call stack',
       weight: 3,
-      content: html`<call-stack-detail eventIndex=${eventIndex}></call-stack-detail>`,
+      content: html`<call-stack-detail
+        eventIndex=${anchorIndex}
+        activeEventIndex=${active}
+      ></call-stack-detail>`,
     },
     {
       id: 'calltree',
       title: 'Call tree',
       weight: 4,
       content: html`<call-tree-detail
-        eventIndex=${eventIndex}
+        eventIndex=${active}
         .instances=${instances}
       ></call-tree-detail>`,
     },

--- a/log-viewer/src/features/database/components/__tests__/databaseSections.test.ts
+++ b/log-viewer/src/features/database/components/__tests__/databaseSections.test.ts
@@ -17,7 +17,25 @@ jest.mock('../../../soql/components/SOQLLinterIssues.js', () => ({
   ],
 }));
 
+import { render, type TemplateResult } from 'lit';
+
+import type { PaneSection } from '../../../../components/PaneView.js';
 import { buildDatabaseSections } from '../databaseSections.js';
+
+/**
+ * The section content is a template, so it is rendered to read what each
+ * component was handed. The components are stubbed above, so nothing upgrades —
+ * only the attributes are set.
+ */
+function rendered(sections: PaneSection[], id: string, tag: string): Element {
+  const host = document.createElement('div');
+  render(sections.find((s) => s.id === id)?.content as TemplateResult, host);
+  const el = host.querySelector(tag);
+  if (!el) {
+    throw new Error(`${tag} not rendered for section ${id}`);
+  }
+  return el;
+}
 
 describe('buildDatabaseSections', () => {
   it('builds vitals + call stack + call tree + issues for a SOQL selection, badged by count', async () => {
@@ -38,5 +56,32 @@ describe('buildDatabaseSections', () => {
   it('builds vitals + call stack + call tree (no issues) for a SOSL selection', async () => {
     const sections = await buildDatabaseSections({ eventIndex: 7, type: 'sosl' });
     expect(sections.map((s) => s.id)).toEqual(['vitals', 'callstack', 'calltree']);
+  });
+
+  it('anchors the call stack and the SOQL issues to the statement the user picked', async () => {
+    const sections = await buildDatabaseSections({
+      eventIndex: 3,
+      type: 'soql',
+      activeEventIndex: 1,
+    });
+
+    const stack = rendered(sections, 'callstack', 'call-stack-detail');
+    expect(stack.getAttribute('eventIndex')).toBe('3');
+    expect(stack.getAttribute('activeEventIndex')).toBe('1');
+    expect(sections.find((s) => s.id === 'issues')?.badge).toBe('2');
+  });
+
+  it('drops the statement shape from the vitals once an ancestor frame is followed', async () => {
+    const sections = await buildDatabaseSections({
+      eventIndex: 3,
+      type: 'soql',
+      activeEventIndex: 1,
+    });
+
+    const vitals = rendered(sections, 'vitals', 'event-vitals');
+    expect(vitals.getAttribute('eventIndex')).toBe('1');
+    // An ancestor method is not a statement, so it has no statement type.
+    expect(vitals.hasAttribute('type')).toBe(false);
+    expect(rendered(sections, 'calltree', 'call-tree-detail').getAttribute('eventIndex')).toBe('1');
   });
 });

--- a/log-viewer/src/features/database/components/databaseSections.ts
+++ b/log-viewer/src/features/database/components/databaseSections.ts
@@ -2,6 +2,7 @@
  * Copyright (c) 2025 Certinia Inc. All rights reserved.
  */
 import { html } from 'lit';
+import { ifDefined } from 'lit/directives/if-defined.js';
 
 import type { PaneSection } from '../../../components/PaneView.js';
 import { computeSoqlIssues } from '../../soql/components/SOQLLinterIssues.js';
@@ -15,15 +16,24 @@ import '../../soql/components/SOQLLinterIssues.js';
 export interface DetailSelection {
   eventIndex: number;
   type: 'dml' | 'soql' | 'sosl';
+  /** The frame walked to in the statement's call stack, if it is not the statement. */
+  activeEventIndex?: number | null;
 }
 
 /**
  * Build the details-panel sections for a selected DML/SOQL statement. The
  * components resolve their own data from `DatabaseAccess` by eventIndex; only
  * the SOQL issue count is pre-resolved here so it can badge the section header.
+ *
+ * Details and the call tree follow the active frame; the call stack and the SOQL
+ * issues stay anchored to the statement the user picked.
  */
 export async function buildDatabaseSections(selection: DetailSelection): Promise<PaneSection[]> {
   const { eventIndex, type } = selection;
+  const active = selection.activeEventIndex ?? eventIndex;
+  // An ancestor method is not a statement, so the statement-shaped vitals do
+  // not apply to it.
+  const activeType = active === eventIndex ? type : undefined;
 
   // The vitals are a fixed set of figures, so they take their own height; the
   // fill sections share the leftover space, the call tree getting the most,
@@ -33,19 +43,25 @@ export async function buildDatabaseSections(selection: DetailSelection): Promise
       id: 'vitals',
       title: 'Details',
       fit: 'content',
-      content: html`<event-vitals eventIndex=${eventIndex} type=${type}></event-vitals>`,
+      content: html`<event-vitals
+        eventIndex=${active}
+        type=${ifDefined(activeType)}
+      ></event-vitals>`,
     },
     {
       id: 'callstack',
       title: 'Call stack',
       weight: 3,
-      content: html`<call-stack-detail eventIndex=${eventIndex}></call-stack-detail>`,
+      content: html`<call-stack-detail
+        eventIndex=${eventIndex}
+        activeEventIndex=${active}
+      ></call-stack-detail>`,
     },
     {
       id: 'calltree',
       title: 'Call tree',
       weight: 4,
-      content: html`<call-tree-detail eventIndex=${eventIndex}></call-tree-detail>`,
+      content: html`<call-tree-detail eventIndex=${active}></call-tree-detail>`,
     },
   ];
 


### PR DESCRIPTION
## What

Clicking a frame in the Inspector's **Call stack** moved the tab's own selection and revealed the frame, but the Inspector did not move: **Details** and **Call tree** stayed on the original selection, so walking up a stack told you nothing new.

The clicked frame now becomes the **active** frame:

| Gesture | Main view | Call stack list | Details / Call tree |
| --- | --- | --- | --- |
| Click a Call stack row | selection moves + scrolls | unchanged, clicked row marked active | follow the active frame |
| Click a main-view row | normal selection | rebuilt from the new anchor | follow |

The Call stack stays **anchored** to the selection it was built for, so walking up it never puts a frame out of reach. A fresh pick in the tab is a new anchor and ends the walk. Each tab walks its own stack.

## How

`LogInspector` holds `_activeFrames`, keyed by `DetailSource`, beside `_selections`. `_onReveal` sets it, `_onSelect` clears it. A reveal with no selection is ignored — the whole-log sections have no frame to follow.

`buildDetailSections` / `buildDatabaseSections` take the active frame and split it from the anchor: `call-stack-detail` gets both, `event-vitals` and `call-tree-detail` get the active one.

`CallStackDetail` marks the active row through a `SelectionEchoGuard`, so its own mark is not reported back as a pick, and moves the mark without rebuilding, since the anchor holds the rows.

Two cases where the selection stops describing what is on screen once a frame is followed:

- An **aggregate** selection drops its instances and label.
- On **Database**, an ancestor method is not a statement, so Details loses the statement shape; the SOQL issues stay anchored.

## Out of scope

Hovering a Call stack row to locate it in the main view (highlight the match, dim the rest) is a follow-up: dimming touches the canvas timeline renderer plus three grids and does not belong in this diff.

## Testing

`tsc -b`, eslint and prettier clean. jest 121 suites / 1563 tests, +11 covering the follow, the walk ending on a new pick, per-tab isolation, the anchor holding, the guarded mark, and both aggregate and Database cases.

Checked by hand in the extension dev host across the Timeline, Call Tree, Analysis and Database tabs.