### PR TITLE
feat(parser): count Flow and Process Builder database usage (#871)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - 🧭 **Inspector call stack**: cumulative limit and profiling frames appeared in the stack, so the path to a selection read wrong; the stack now excludes them, like the call tree already did.
 - 🐛 **Go to Code**: Match methods with namespace/`System`-qualified parameter types. ([#834])
 - 📐 **Timeline height**: the Flame Chart stopped short of the bottom of its panel, leaving a strip of empty space; it now fills the panel and follows the Inspector as you resize or re-dock it.
+- 🗄️ **Flow database usage**: SOQL and DML run by a Flow or Process Builder element went uncounted, because the log never reports it as a statement; the element's own usage is now counted and rolls up like any other. Needs `WORKFLOW` at `FINER` or above. ([#871])
 
 ## [1.20.1] 2026-07-23
 
@@ -555,6 +556,7 @@ Skipped due to adopting odd numbering for pre releases and even number for relea
 <!-- Unreleased -->
 
 [#873]: https://github.com/certinia/debug-log-analyzer/issues/873
+[#871]: https://github.com/certinia/debug-log-analyzer/issues/871
 [#834]: https://github.com/certinia/debug-log-analyzer/issues/834
 [#576]: https://github.com/certinia/debug-log-analyzer/issues/576
 [#832]: https://github.com/certinia/debug-log-analyzer/issues/832

--- a/apex-log-parser/__tests__/FlowDatabaseAttribution.test.ts
+++ b/apex-log-parser/__tests__/FlowDatabaseAttribution.test.ts
@@ -162,6 +162,22 @@ describe('flow database attribution (via parse)', () => {
     expect(apexLog.soqlCount.total).toBe(snapshot?.limits.soqlQueries.used);
   });
 
+  it('clamps the summed deltas to the rise in the running total when a line repeats', () => {
+    const log =
+      '09:18:22.6 (100)|EXECUTION_STARTED\n' +
+      '09:18:22.6 (200)|FLOW_ELEMENT_BEGIN|abc-1|FlowRecordUpdate|Update_Account\n' +
+      '09:18:22.6 (210)|FLOW_ELEMENT_LIMIT_USAGE|1 DML statements, total 1 out of 150\n' +
+      '09:18:22.6 (220)|FLOW_ELEMENT_LIMIT_USAGE|1 DML statements, total 1 out of 150\n' +
+      '09:18:22.6 (230)|FLOW_ELEMENT_END|abc-1|FlowRecordUpdate|Update_Account\n' +
+      '09:19:13.82 (51595120059)|EXECUTION_FINISHED\n';
+    const apexLog = parse(log);
+    const element = flatten(apexLog).find((e) => e.type === 'FLOW_ELEMENT_BEGIN');
+
+    // The deltas sum to 2 but the total only rose by 1, so only 1 is attributed.
+    expect(element?.dmlCount.self).toBe(1);
+    expect(apexLog.dmlCount.total).toBe(1);
+  });
+
   it('attributes a nested element residual to the enclosing element before it is measured', () => {
     const log =
       '09:18:22.6 (100)|EXECUTION_STARTED\n' +

--- a/apex-log-parser/__tests__/FlowDatabaseAttribution.test.ts
+++ b/apex-log-parser/__tests__/FlowDatabaseAttribution.test.ts
@@ -1,0 +1,214 @@
+/*
+ * Copyright (c) 2026 Certinia Inc. All rights reserved.
+ */
+import { describe, expect, it } from '@jest/globals';
+import { parse } from '../src/index.js';
+import type { LogEvent } from '../src/index.js';
+
+/** Depth-first flatten of the parsed tree into a flat event list. */
+function flatten(root: LogEvent): LogEvent[] {
+  const out: LogEvent[] = [];
+  const walk = (event: LogEvent): void => {
+    out.push(event);
+    for (const child of event.children ?? []) {
+      walk(child);
+    }
+  };
+  for (const child of root.children ?? []) {
+    walk(child);
+  }
+  return out;
+}
+
+const CUMULATIVE_BLOCK =
+  '09:18:22.6 (500)|CUMULATIVE_LIMIT_USAGE\n' +
+  '09:18:22.6 (500)|LIMIT_USAGE_FOR_NS|(default)|\n' +
+  '  Number of SOQL queries: 1 out of 100\n' +
+  '  Number of query rows: 1 out of 50000\n' +
+  '  Number of SOSL queries: 0 out of 20\n' +
+  '  Number of DML statements: 1 out of 150\n' +
+  '  Number of Publish Immediate DML: 0 out of 150\n' +
+  '  Number of DML rows: 1 out of 10000\n' +
+  '  Maximum CPU time: 100 out of 10000\n' +
+  '  Maximum heap size: 100 out of 6000000\n' +
+  '  Number of callouts: 0 out of 100\n' +
+  '  Number of Email Invocations: 0 out of 10\n' +
+  '  Number of future calls: 0 out of 50\n' +
+  '  Number of queueable jobs added to the queue: 0 out of 50\n' +
+  '  Number of Mobile Apex push calls: 0 out of 10\n' +
+  '09:18:22.6 (500)|CUMULATIVE_LIMIT_USAGE_END\n';
+
+describe('flow database attribution (via parse)', () => {
+  it('seeds the bulk element self counters from FLOW_BULK_ELEMENT_LIMIT_USAGE deltas and rolls up to ancestor totals', () => {
+    const log =
+      '09:18:22.6 (100)|EXECUTION_STARTED\n' +
+      '09:18:22.6 (200)|FLOW_BULK_ELEMENT_BEGIN|FlowRecordUpdate|Update_Account\n' +
+      '09:18:22.6 (210)|FLOW_BULK_ELEMENT_LIMIT_USAGE|1 SOQL queries, total 1 out of 100\n' +
+      '09:18:22.6 (220)|FLOW_BULK_ELEMENT_LIMIT_USAGE|1 SOQL query rows, total 1 out of 50000\n' +
+      '09:18:22.6 (230)|FLOW_BULK_ELEMENT_LIMIT_USAGE|1 DML statements, total 1 out of 150\n' +
+      '09:18:22.6 (240)|FLOW_BULK_ELEMENT_LIMIT_USAGE|1 DML rows, total 1 out of 10000\n' +
+      '09:18:22.6 (250)|FLOW_BULK_ELEMENT_LIMIT_USAGE|75 ms CPU time, total 75 out of 15000\n' +
+      '09:18:22.6 (260)|FLOW_BULK_ELEMENT_END|FlowRecordUpdate|Update_Account|1|60\n' +
+      '09:19:13.82 (51595120059)|EXECUTION_FINISHED\n';
+    const apexLog = parse(log);
+    const events = flatten(apexLog);
+    const bulkElement = events.find((e) => e.type === 'FLOW_BULK_ELEMENT_BEGIN');
+
+    expect(bulkElement?.soqlCount.self).toBe(1);
+    expect(bulkElement?.soqlRowCount.self).toBe(1);
+    expect(bulkElement?.dmlCount.self).toBe(1);
+    expect(bulkElement?.dmlRowCount.self).toBe(1);
+    // CPU time is not a DB metric - it must not be attributed to dmlCount/soqlCount etc.
+    expect(bulkElement?.soslCount.self).toBe(0);
+
+    // Rolls up to the root (ApexLog) totals.
+    expect(apexLog.soqlCount.total).toBe(1);
+    expect(apexLog.soqlRowCount.total).toBe(1);
+    expect(apexLog.dmlCount.total).toBe(1);
+    expect(apexLog.dmlRowCount.total).toBe(1);
+  });
+
+  it('seeds the (non-bulk) element self counters from FLOW_ELEMENT_LIMIT_USAGE deltas', () => {
+    const log =
+      '09:18:22.6 (100)|EXECUTION_STARTED\n' +
+      '09:18:22.6 (200)|FLOW_ELEMENT_BEGIN|abc-1|FlowRecordUpdate|Update_Account\n' +
+      '09:18:22.6 (210)|FLOW_ELEMENT_LIMIT_USAGE|1 DML statements, total 1 out of 150\n' +
+      '09:18:22.6 (220)|FLOW_ELEMENT_LIMIT_USAGE|1 DML rows, total 1 out of 10000\n' +
+      '09:18:22.6 (230)|FLOW_ELEMENT_END|abc-1|FlowRecordUpdate|Update_Account\n' +
+      '09:19:13.82 (51595120059)|EXECUTION_FINISHED\n';
+    const apexLog = parse(log);
+    const events = flatten(apexLog);
+    const element = events.find((e) => e.type === 'FLOW_ELEMENT_BEGIN');
+
+    expect(element?.dmlCount.self).toBe(1);
+    expect(element?.dmlRowCount.self).toBe(1);
+    expect(apexLog.dmlCount.total).toBe(1);
+  });
+
+  it('attributes the leading delta, not the running total, when a later element reports a higher total', () => {
+    const log =
+      '09:18:22.6 (100)|EXECUTION_STARTED\n' +
+      '09:18:22.6 (200)|FLOW_BULK_ELEMENT_BEGIN|FlowRecordUpdate|myRule_1_A1\n' +
+      '09:18:22.6 (210)|FLOW_BULK_ELEMENT_LIMIT_USAGE|1 DML statements, total 2 out of 150\n' +
+      '09:18:22.6 (220)|FLOW_BULK_ELEMENT_END|FlowRecordUpdate|myRule_1_A1|1|102\n' +
+      '09:18:22.6 (300)|FLOW_BULK_ELEMENT_BEGIN|FlowRecordUpdate|account_update_luke\n' +
+      '09:18:22.6 (310)|FLOW_BULK_ELEMENT_LIMIT_USAGE|1 DML statements, total 3 out of 150\n' +
+      '09:18:22.6 (320)|FLOW_BULK_ELEMENT_END|FlowRecordUpdate|account_update_luke|1|18\n' +
+      '09:19:13.82 (51595120059)|EXECUTION_FINISHED\n';
+    const apexLog = parse(log);
+    const elements = flatten(apexLog).filter((e) => e.type === 'FLOW_BULK_ELEMENT_BEGIN');
+
+    expect(elements.map((e) => e.dmlCount.self)).toEqual([1, 1]);
+    expect(apexLog.dmlCount.total).toBe(2);
+  });
+
+  it('reconciles bulk element deltas against the CUMULATIVE_LIMIT_USAGE snapshot', () => {
+    const log =
+      '09:18:22.6 (100)|EXECUTION_STARTED\n' +
+      '09:18:22.6 (200)|FLOW_BULK_ELEMENT_BEGIN|FlowRecordUpdate|Update_Account\n' +
+      '09:18:22.6 (210)|FLOW_BULK_ELEMENT_LIMIT_USAGE|1 SOQL queries, total 1 out of 100\n' +
+      '09:18:22.6 (220)|FLOW_BULK_ELEMENT_LIMIT_USAGE|1 SOQL query rows, total 1 out of 50000\n' +
+      '09:18:22.6 (230)|FLOW_BULK_ELEMENT_LIMIT_USAGE|1 DML statements, total 1 out of 150\n' +
+      '09:18:22.6 (240)|FLOW_BULK_ELEMENT_LIMIT_USAGE|1 DML rows, total 1 out of 10000\n' +
+      '09:18:22.6 (260)|FLOW_BULK_ELEMENT_END|FlowRecordUpdate|Update_Account|1|60\n' +
+      CUMULATIVE_BLOCK +
+      '09:19:13.82 (51595120059)|EXECUTION_FINISHED\n';
+    const apexLog = parse(log);
+    const snapshot = apexLog.governorLimits.snapshots.at(-1);
+
+    expect(apexLog.soqlCount.total).toBe(snapshot?.limits.soqlQueries.used);
+    expect(apexLog.soqlRowCount.total).toBe(snapshot?.limits.queryRows.used);
+    expect(apexLog.dmlCount.total).toBe(snapshot?.limits.dmlStatements.used);
+    expect(apexLog.dmlRowCount.total).toBe(snapshot?.limits.dmlRows.used);
+  });
+
+  it('attributes only the residual when the element subtree logged its own statements', () => {
+    const log =
+      '09:18:22.6 (100)|EXECUTION_STARTED\n' +
+      '09:18:22.6 (200)|FLOW_ELEMENT_BEGIN|abc-1|FlowActionCall|Call_Apex\n' +
+      '09:18:22.6 (205)|CODE_UNIT_STARTED|[EXTERNAL]|01p|MyAction.invoke\n' +
+      '09:18:22.6 (206)|SOQL_EXECUTE_BEGIN|[3]|Aggregations:0|SELECT Id FROM Account\n' +
+      '09:18:22.6 (207)|SOQL_EXECUTE_END|[3]|Rows:1\n' +
+      '09:18:22.6 (208)|CODE_UNIT_FINISHED|MyAction.invoke\n' +
+      '09:18:22.6 (210)|FLOW_ELEMENT_LIMIT_USAGE|2 SOQL queries, total 2 out of 100\n' +
+      '09:18:22.6 (230)|FLOW_ELEMENT_END|abc-1|FlowActionCall|Call_Apex\n' +
+      '09:19:13.82 (51595120059)|EXECUTION_FINISHED\n';
+    const apexLog = parse(log);
+    const element = flatten(apexLog).find((e) => e.type === 'FLOW_ELEMENT_BEGIN');
+
+    // The reported 2 covers the 1 query the subtree logged, so only 1 is attributed.
+    expect(element?.soqlCount.self).toBe(1);
+    expect(element?.soqlCount.total).toBe(2);
+    expect(apexLog.soqlCount.total).toBe(2);
+  });
+
+  it('attributes nothing when the element subtree already logged the whole reported count', () => {
+    const log =
+      '09:18:22.6 (100)|EXECUTION_STARTED\n' +
+      '09:18:22.6 (200)|FLOW_ELEMENT_BEGIN|abc-1|FlowActionCall|Call_Apex\n' +
+      '09:18:22.6 (205)|CODE_UNIT_STARTED|[EXTERNAL]|01p|MyAction.invoke\n' +
+      '09:18:22.6 (206)|SOQL_EXECUTE_BEGIN|[3]|Aggregations:0|SELECT Id FROM Account\n' +
+      '09:18:22.6 (207)|SOQL_EXECUTE_END|[3]|Rows:1\n' +
+      '09:18:22.6 (208)|CODE_UNIT_FINISHED|MyAction.invoke\n' +
+      '09:18:22.6 (210)|FLOW_ELEMENT_LIMIT_USAGE|1 SOQL queries, total 1 out of 100\n' +
+      '09:18:22.6 (230)|FLOW_ELEMENT_END|abc-1|FlowActionCall|Call_Apex\n' +
+      CUMULATIVE_BLOCK +
+      '09:19:13.82 (51595120059)|EXECUTION_FINISHED\n';
+    const apexLog = parse(log);
+    const element = flatten(apexLog).find((e) => e.type === 'FLOW_ELEMENT_BEGIN');
+    const snapshot = apexLog.governorLimits.snapshots.at(-1);
+
+    expect(element?.soqlCount.self).toBe(0);
+    expect(apexLog.soqlCount.total).toBe(snapshot?.limits.soqlQueries.used);
+  });
+
+  it('attributes a nested element residual to the enclosing element before it is measured', () => {
+    const log =
+      '09:18:22.6 (100)|EXECUTION_STARTED\n' +
+      '09:18:22.6 (200)|FLOW_ELEMENT_BEGIN|abc-1|FlowSubflow|Call_Subflow\n' +
+      '09:18:22.6 (205)|FLOW_ELEMENT_BEGIN|abc-2|FlowRecordUpdate|Update_Account\n' +
+      '09:18:22.6 (206)|FLOW_ELEMENT_LIMIT_USAGE|1 DML statements, total 1 out of 150\n' +
+      '09:18:22.6 (207)|FLOW_ELEMENT_END|abc-2|FlowRecordUpdate|Update_Account\n' +
+      '09:18:22.6 (210)|FLOW_ELEMENT_LIMIT_USAGE|1 DML statements, total 1 out of 150\n' +
+      '09:18:22.6 (230)|FLOW_ELEMENT_END|abc-1|FlowSubflow|Call_Subflow\n' +
+      '09:19:13.82 (51595120059)|EXECUTION_FINISHED\n';
+    const apexLog = parse(log);
+    const [outer, inner] = flatten(apexLog).filter((e) => e.type === 'FLOW_ELEMENT_BEGIN');
+
+    // The subflow reports the same statement its child reported, so it is counted once.
+    expect(inner?.dmlCount.self).toBe(1);
+    expect(outer?.dmlCount.self).toBe(0);
+    expect(outer?.dmlCount.total).toBe(1);
+    expect(apexLog.dmlCount.total).toBe(1);
+  });
+
+  it('attributes the usage of a flow element the log truncated before its END line', () => {
+    const log =
+      '09:18:22.6 (100)|EXECUTION_STARTED\n' +
+      '09:18:22.6 (200)|FLOW_BULK_ELEMENT_BEGIN|FlowRecordUpdate|Update_Account\n' +
+      '09:18:22.6 (210)|FLOW_BULK_ELEMENT_LIMIT_USAGE|1 DML statements, total 1 out of 150\n';
+    const apexLog = parse(log);
+    const bulkElement = flatten(apexLog).find((e) => e.type === 'FLOW_BULK_ELEMENT_BEGIN');
+
+    expect(bulkElement?.dmlCount.self).toBe(1);
+    expect(apexLog.dmlCount.total).toBe(1);
+  });
+
+  it('does not crash and does not fabricate counts at FINE level (no _LIMIT_USAGE lines emitted)', () => {
+    const log =
+      '09:18:22.6 (100)|EXECUTION_STARTED\n' +
+      '09:18:22.6 (200)|FLOW_BULK_ELEMENT_BEGIN|FlowRecordUpdate|Update_Account\n' +
+      '09:18:22.6 (260)|FLOW_BULK_ELEMENT_END|FlowRecordUpdate|Update_Account|1|60\n' +
+      '09:19:13.82 (51595120059)|EXECUTION_FINISHED\n';
+
+    expect(() => parse(log)).not.toThrow();
+
+    const apexLog = parse(log);
+    const events = flatten(apexLog);
+    const bulkElement = events.find((e) => e.type === 'FLOW_BULK_ELEMENT_BEGIN');
+
+    expect(bulkElement?.soqlCount.self).toBe(0);
+    expect(bulkElement?.dmlCount.self).toBe(0);
+    expect(apexLog.dmlCount.total).toBe(0);
+  });
+});

--- a/apex-log-parser/__tests__/GranularLimits.test.ts
+++ b/apex-log-parser/__tests__/GranularLimits.test.ts
@@ -46,6 +46,7 @@ describe('granular limit parsing (via parse)', () => {
     '09:18:22.6 (300)|LIMIT_USAGE|[89]|SOQL|1|100\n' +
     '09:18:22.6 (350)|LIMIT_USAGE|[89]|FIELDS_DESCRIBES|1|100\n' +
     '09:18:22.6 (400)|FLOW_BULK_ELEMENT_LIMIT_USAGE|1 SOQL queries, total 5 out of 100\n' +
+    '09:18:22.6 (410)|FLOW_BULK_ELEMENT_LIMIT_USAGE|SOQL queries, total 6 out of 100\n' +
     '09:18:22.6 (420)|FLOW_ELEMENT_LIMIT_USAGE|2 ms CPU time, total 10 out of 15000\n' +
     '09:18:22.6 (450)|FLOW_INTERVIEW_FINISHED_LIMIT_USAGE|DML statements: 3 out of 150\n' +
     CUMULATIVE_BLOCK +
@@ -78,6 +79,15 @@ describe('granular limit parsing (via parse)', () => {
       used: 10,
       limit: 15000,
       delta: 2,
+    });
+  });
+
+  it('keeps a running-total report whose head has no leading count, with a zero delta', () => {
+    expect(byType('FLOW_BULK_ELEMENT_LIMIT_USAGE')[1]?.limitUsage).toEqual({
+      metric: 'soqlQueries',
+      used: 6,
+      limit: 100,
+      delta: 0,
     });
   });
 

--- a/apex-log-parser/__tests__/GranularLimits.test.ts
+++ b/apex-log-parser/__tests__/GranularLimits.test.ts
@@ -66,16 +66,18 @@ describe('granular limit parsing (via parse)', () => {
     expect(describes?.limitUsage).toBeNull();
   });
 
-  it('parses flow running-total reports (uses the total as used)', () => {
+  it('parses flow running-total reports (uses the total as used, the leading count as delta)', () => {
     expect(byType('FLOW_BULK_ELEMENT_LIMIT_USAGE')[0]?.limitUsage).toEqual({
       metric: 'soqlQueries',
       used: 5,
       limit: 100,
+      delta: 1,
     });
     expect(byType('FLOW_ELEMENT_LIMIT_USAGE')[0]?.limitUsage).toEqual({
       metric: 'cpuTime',
       used: 10,
       limit: 15000,
+      delta: 2,
     });
   });
 

--- a/apex-log-parser/src/ApexLogParser.ts
+++ b/apex-log-parser/src/ApexLogParser.ts
@@ -2,7 +2,7 @@
  * Copyright (c) 2020 Certinia Inc. All rights reserved.
  */
 
-import { ApexLog, type LogEvent } from './LogEvents.js';
+import { ApexLog, applyFlowDbResiduals, type LogEvent } from './LogEvents.js';
 import { getLogEventClass } from './LogLineMapping.js';
 import type { GovernorLimits, IssueType, Limits, LogEventType, LogIssue } from './types.js';
 
@@ -65,6 +65,12 @@ export class ApexLogParser {
     byNamespace: new Map<string, Limits>(),
     snapshots: [],
   };
+
+  /**
+   * Flow elements that may report their own database usage, in log order. Their usage is attributed
+   * once the tree is aggregated - see {@link applyFlowDbResiduals}.
+   */
+  readonly flowDbElements: LogEvent[] = [];
 
   /**
    * Takes string input of a log and returns the ApexLog class, which represents a log tree
@@ -287,6 +293,7 @@ export class ApexLogParser {
     rootMethod.setTimes();
     this.mergeManagedPackageEvents(rootMethod);
     this.aggregateTotals([rootMethod]);
+    applyFlowDbResiduals(this.flowDbElements);
     return rootMethod;
   }
 

--- a/apex-log-parser/src/LogEvents.ts
+++ b/apex-log-parser/src/LogEvents.ts
@@ -1733,20 +1733,28 @@ export function applyFlowDbResiduals(elements: LogEvent[]): void {
   let i = elements.length;
   while (i--) {
     const element = elements[i]!;
-    let deltas: Map<LimitMetricKey, number> | null = null;
+    let reports: Map<LimitMetricKey, FlowDbReport> | null = null;
     for (const child of element.children) {
       if (!(child instanceof FlowRunningTotalLimitUsageLine) || !child.limitUsage) {
         continue;
       }
-      const { metric, delta } = child.limitUsage;
-      deltas ??= new Map();
-      deltas.set(metric, (deltas.get(metric) ?? 0) + delta);
+      const { metric, used, delta } = child.limitUsage;
+      reports ??= new Map();
+      const report = reports.get(metric);
+      if (report) {
+        report.summed += delta;
+        report.after = used;
+      } else {
+        reports.set(metric, { summed: delta, before: used - delta, after: used });
+      }
     }
-    if (!deltas) {
+    if (!reports) {
       continue;
     }
-    for (const [metric, delta] of deltas) {
+    for (const [metric, report] of reports) {
       const counter = flowDbCounter(element, metric);
+      // A repeated or cumulative line would over-attribute, so the reported rise is the ceiling.
+      const delta = Math.min(report.summed, report.after - report.before);
       const residual = counter ? delta - counter.total : 0;
       if (!counter || residual <= 0) {
         continue;
@@ -1761,6 +1769,13 @@ export function applyFlowDbResiduals(elements: LogEvent[]): void {
       }
     }
   }
+}
+
+/** The running totals a flow element's limit-usage children report for one metric. */
+interface FlowDbReport {
+  summed: number;
+  before: number;
+  after: number;
 }
 
 function flowDbCounter(target: LogEvent, metric: LimitMetricKey): SelfTotal | null {

--- a/apex-log-parser/src/LogEvents.ts
+++ b/apex-log-parser/src/LogEvents.ts
@@ -16,7 +16,7 @@ import type {
   SelfTotal,
 } from './types.js';
 import { DEBUG_CATEGORY, LOG_CATEGORY, LOG_LEVEL } from './types.js';
-import type { LimitObservation } from './limits.js';
+import type { LimitMetricKey, LimitObservation, RunningTotalObservation } from './limits.js';
 import { parseCodedLimit, parseLabelledLimit, parseTotalLimit } from './limits.js';
 
 /**
@@ -1710,12 +1710,83 @@ export class FlowCreateInterviewErrorLine extends LogEvent {
   }
 }
 
+/**
+ * Attribute the database usage a flow element's FLOW_*_LIMIT_USAGE children report (SOQL/DML/rows
+ * only - CPU and heap are not counters) onto the element that ran it. The log emits no
+ * SOQL_EXECUTE_BEGIN or DML_BEGIN for a flow element's own database work, so the reported count is
+ * the only record of it.
+ *
+ * That count is the rise in the transaction's governor counter across the element, so it also
+ * covers any statement the element's subtree logged for itself. Only the residual - the part no
+ * logged statement accounts for - is attributed, which keeps the totals at or below what the log
+ * reports. Where a subtree statement did not consume the limit (custom metadata SOQL, for example)
+ * the residual understates it, because the log never says which statements were free.
+ *
+ * `self` sits on the element rather than the reporting child, unlike the statement lines, so the
+ * element is credited for the work it did itself.
+ *
+ * Runs after `aggregateTotals`, so each element's `total` already covers its subtree and the
+ * residual has to be added to every ancestor here. Elements are visited innermost first, so a
+ * nested element's residual is part of its parent's total before the parent is measured.
+ */
+export function applyFlowDbResiduals(elements: LogEvent[]): void {
+  let i = elements.length;
+  while (i--) {
+    const element = elements[i]!;
+    let deltas: Map<LimitMetricKey, number> | null = null;
+    for (const child of element.children) {
+      if (!(child instanceof FlowRunningTotalLimitUsageLine) || !child.limitUsage) {
+        continue;
+      }
+      const { metric, delta } = child.limitUsage;
+      deltas ??= new Map();
+      deltas.set(metric, (deltas.get(metric) ?? 0) + delta);
+    }
+    if (!deltas) {
+      continue;
+    }
+    for (const [metric, delta] of deltas) {
+      const counter = flowDbCounter(element, metric);
+      const residual = counter ? delta - counter.total : 0;
+      if (!counter || residual <= 0) {
+        continue;
+      }
+      counter.self += residual;
+      counter.total += residual;
+      for (let ancestor = element.parent; ancestor; ancestor = ancestor.parent) {
+        const ancestorCounter = flowDbCounter(ancestor, metric);
+        if (ancestorCounter) {
+          ancestorCounter.total += residual;
+        }
+      }
+    }
+  }
+}
+
+function flowDbCounter(target: LogEvent, metric: LimitMetricKey): SelfTotal | null {
+  switch (metric) {
+    case 'soqlQueries':
+      return target.soqlCount;
+    case 'queryRows':
+      return target.soqlRowCount;
+    case 'soslQueries':
+      return target.soslCount;
+    case 'dmlStatements':
+      return target.dmlCount;
+    case 'dmlRows':
+      return target.dmlRowCount;
+    default:
+      return null;
+  }
+}
+
 export class FlowElementBeginLine extends DurationLogEvent {
   debugCategory = DEBUG_CATEGORY.Workflow;
   debugLevel = LOG_LEVEL.Fine;
   constructor(parser: ApexLogParser, parts: string[]) {
     super(parser, parts, ['FLOW_ELEMENT_END'], LOG_CATEGORY.Automation, 'custom');
     this.text = parts[3] + ' ' + parts[4];
+    parser.flowDbElements.push(this);
   }
 }
 
@@ -1821,17 +1892,23 @@ export class FlowElementFaultLine extends LogEvent {
   }
 }
 
-export class FlowElementLimitUsageLine extends LogEvent {
+/**
+ * A flow limit-usage line reporting a running total, e.g. "1 SOQL queries, total 1 out of 100".
+ * The enclosing flow element reads the delta from these children - see `applyFlowDbResiduals`.
+ */
+class FlowRunningTotalLimitUsageLine extends LogEvent {
   debugCategory = DEBUG_CATEGORY.Workflow;
   debugLevel = LOG_LEVEL.Finer;
   /** Governor-limit observation. Example: "2 ms CPU time, total 10 out of 15000". */
-  limitUsage: LimitObservation | null = null;
+  limitUsage: RunningTotalObservation | null;
   constructor(parser: ApexLogParser, parts: string[]) {
     super(parser, parts);
-    this.text = `${parts[2]}`;
+    this.text = parts[2] ?? '';
     this.limitUsage = parseTotalLimit(this.text);
   }
 }
+
+export class FlowElementLimitUsageLine extends FlowRunningTotalLimitUsageLine {}
 
 export class FlowInterviewFinishedLimitUsageLine extends LogEvent {
   debugCategory = DEBUG_CATEGORY.Workflow;
@@ -1896,6 +1973,7 @@ export class FlowBulkElementBeginLine extends DurationLogEvent {
   constructor(parser: ApexLogParser, parts: string[]) {
     super(parser, parts, ['FLOW_BULK_ELEMENT_END'], LOG_CATEGORY.Automation, 'custom');
     this.text = `${parts[2]} - ${parts[3]}`;
+    parser.flowDbElements.push(this);
   }
 }
 
@@ -1917,17 +1995,7 @@ export class FlowBulkElementNotSupportedLine extends LogEvent {
   }
 }
 
-export class FlowBulkElementLimitUsageLine extends LogEvent {
-  debugCategory = DEBUG_CATEGORY.Workflow;
-  debugLevel = LOG_LEVEL.Finer;
-  /** Governor-limit observation. Example: "1 SOQL queries, total 1 out of 100". */
-  limitUsage: LimitObservation | null = null;
-  constructor(parser: ApexLogParser, parts: string[]) {
-    super(parser, parts);
-    this.text = parts[2] || '';
-    this.limitUsage = parseTotalLimit(this.text);
-  }
-}
+export class FlowBulkElementLimitUsageLine extends FlowRunningTotalLimitUsageLine {}
 
 export class PNInvalidAppLine extends LogEvent {
   debugLevel = LOG_LEVEL.Error;

--- a/apex-log-parser/src/index.ts
+++ b/apex-log-parser/src/index.ts
@@ -45,7 +45,7 @@ export {
 } from './LogEvents.js';
 
 // Governor-limit observation types (the .limitUsage field type crosses into the log-viewer).
-export type { LimitMetricKey, LimitObservation } from './limits.js';
+export type { LimitMetricKey, LimitObservation, RunningTotalObservation } from './limits.js';
 
 // Mapping
 export { getLogEventClass, lineTypeMap } from './LogLineMapping.js';

--- a/apex-log-parser/src/limits.ts
+++ b/apex-log-parser/src/limits.ts
@@ -120,12 +120,11 @@ export function parseTotalLimit(body: string): RunningTotalObservation | null {
   if (comma === -1) {
     return null;
   }
-  const head = COUNT_LABEL_RE.exec(body.slice(0, comma).trim());
-  if (!head) {
-    return null;
-  }
-  const observation = used(LIMIT_LABELS.get(head[2]!), body.slice(comma + 1));
-  return observation ? { ...observation, delta: toInt(head[1]!) } : null;
+  // A head with no leading count still reports a usable total, so keep it with a zero delta.
+  const head = body.slice(0, comma).trim();
+  const counted = COUNT_LABEL_RE.exec(head);
+  const observation = used(LIMIT_LABELS.get(counted ? counted[2]! : head), body.slice(comma + 1));
+  return observation ? { ...observation, delta: counted ? toInt(counted[1]!) : 0 } : null;
 }
 
 /**

--- a/apex-log-parser/src/limits.ts
+++ b/apex-log-parser/src/limits.ts
@@ -27,6 +27,14 @@ export interface LimitObservation {
 }
 
 /**
+ * A running-total observation, e.g. "1 SOQL queries, total 1 out of 100". `delta` is the leading
+ * incremental count: how much the reporting event itself used since the last report.
+ */
+export interface RunningTotalObservation extends LimitObservation {
+  delta: number;
+}
+
+/**
  * Every known governor-limit label → metric key. Covers the cumulative block ("Number of …" /
  * "Maximum …"), the flow colon reports, and the flow running-total reports ("ms CPU time").
  * Labels not present here are not tracked governor limits (e.g. FIELDS_DESCRIBES).
@@ -76,6 +84,9 @@ const LIMIT_USAGE_CODES = new Map<string, LimitMetricKey>([
 /** Matches "<used> out of <limit>" or "<used>/<limit>". */
 const USED_OF_RE = /(\d+)\s*(?:out of|\/)\s*(\d+)/;
 
+/** Matches the "<count> <label>" head of a running-total line, e.g. "1 SOQL queries". */
+const COUNT_LABEL_RE = /^(\d+)\s+(.+)$/;
+
 function toInt(value: string): number {
   return parseInt(value, 10);
 }
@@ -102,18 +113,19 @@ export function parseLabelledLimit(body: string): LimitObservation | null {
 
 /**
  * Parse a running-total limit line, e.g. "1 SOQL queries, total 1 out of 100". Uses the reported
- * running total as `used`. Returns null for untracked labels.
+ * running total as `used` and the leading count as `delta`. Returns null for untracked labels.
  */
-export function parseTotalLimit(body: string): LimitObservation | null {
+export function parseTotalLimit(body: string): RunningTotalObservation | null {
   const comma = body.indexOf(',');
   if (comma === -1) {
     return null;
   }
-  const label = body
-    .slice(0, comma)
-    .replace(/^\d+\s+/, '')
-    .trim();
-  return used(LIMIT_LABELS.get(label), body.slice(comma + 1));
+  const head = COUNT_LABEL_RE.exec(body.slice(0, comma).trim());
+  if (!head) {
+    return null;
+  }
+  const observation = used(LIMIT_LABELS.get(head[2]!), body.slice(comma + 1));
+  return observation ? { ...observation, delta: toInt(head[1]!) } : null;
 }
 
 /**

--- a/lana-docs/docs/docs/features/governor-limits-heap.md
+++ b/lana-docs/docs/docs/features/governor-limits-heap.md
@@ -40,6 +40,16 @@ The Database tab reconciles the statements found in the log against the governor
 Some logs contain no `CUMULATIVE_LIMIT_USAGE` block at all. Where the log never reports a total, no limit is shown rather than a guessed one.
 :::
 
+### Flow and Process Builder usage
+
+A Flow or Process Builder element runs its own SOQL and DML, but the log never reports it as a statement — there is no `SOQL_EXECUTE_BEGIN` or `DML_BEGIN` line to find. Instead the element reports how much it used, and that usage is counted against the element and rolls up through its callers like any other.
+
+The figure the element reports also covers anything its own subtree logged, such as Apex it called, so only the part no logged statement accounts for is added. Where the element is the only thing that ran, that is all of it.
+
+:::note
+This needs `WORKFLOW` at `FINER` or above. At `FINE` the log reports no Flow usage at all, so Flow elements show none.
+:::
+
 ### Heap: net, gross and peak
 
 Heap is the awkward one. Memory is freed as well as allocated, so a single number hides what actually happened — a loop that allocates and frees the same buffer a thousand times looks identical to one that leaks. Every method and call path therefore carries three heap metrics, each with a total and a self variant:


### PR DESCRIPTION
> **Do not merge until we are satisfied it is fully correct.** The trade-off below is real and needs a decision, not just a green CI run.

Closes #871.

## The problem

Salesforce emits no `SOQL_EXECUTE_BEGIN` or `DML_BEGIN` for the database work a Flow or Process Builder element does itself. The only record is the count the element reports:

```
FLOW_BULK_ELEMENT_LIMIT_USAGE|1 DML statements, total 2 out of 150
```

Without this, that work is invisible in every table and column view.

## What this does

The reported count is the rise in the transaction's governor counter across the element, so it also covers anything the element's subtree logged for itself — Apex it called, a trigger its DML fired, elements inside a subflow. Attributing the whole count would double-count that work.

So only the **residual** is attributed: the reported count less what the subtree already logged, floored at zero. Every line either becomes accurate or stays as it is today; none can report more than the log itself claims for the element.

`applyFlowDbResiduals` runs after `aggregateTotals`, because the residual needs the subtree totals to exist. Elements register in `parser.flowDbElements` at parse time, so an element the log truncated before its `END` line is still counted. Elements are visited innermost first, so a subflow does not re-count what its children reported.

Needs `WORKFLOW` at `FINER` or above — at `FINE` the log reports no flow usage at all.

## The known limitation

The parser cannot tell a limit-consuming statement from a free one. Where a subtree statement consumed no limit — custom metadata SOQL, a managed-package describe — the residual subtracts it anyway and **understates** the element. That is the same direction as today's behaviour, never an overstatement.

## Validation

Against a corpus of real logs, over the 16 flow-delta logs that carry a `CUMULATIVE_LIMIT_USAGE` block:

- **12 now match the cumulative snapshot exactly.** All 12 were under before.
- **4 already exceeded the snapshot before this change**, from logged-but-free statements and the per-namespace summing in #862. The residual adds to them.
- **1 log contradicts itself:** its flow reports `total 3 out of 150` DML while its cumulative block reports 0 and 1 across two namespaces. No attribution scheme satisfies both numbers.

So the guarantee is per element, not per transaction: a transaction total can still pass a snapshot where free statements were logged or namespaces split. That gap is pre-existing and stays visible in the Database tab's found-vs-counted row.

## Tests

`apex-log-parser/__tests__/FlowDatabaseAttribution.test.ts` covers bulk and non-bulk elements, delta-not-running-total, subtree residual, subtree covering the whole reported count reconciled against the snapshot, nested subflow, a truncated element, and `FINE` level fabricating nothing.