### PR TITLE
feat(inspector): show the whole log on the Database tab 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - The Timeline governor strip plots heap as it's allocated, so you can see where it spikes.
 - 🧭 **Inspector**: select anything — a timeline frame, a call tree or analysis row, a SOQL/DML/SOSL statement — and inspect it without leaving the tab you're on. ([#113])
   - **A selection** shows its details and governor metrics as `used / limit`, the call stack that led to it, and its own subtree in **Time Order**, **Aggregated** or **Bottom-Up**. Click a frame in the call stack to walk up it — the details and subtree follow, and the stack stays anchored to what you selected.
-  - **Nothing selected** shows the whole log instead of an empty panel: a governor overview on every tab, time by category and governor trends on the Timeline, log-wide findings on Analysis, and the hot path and hot spots on the Call Tree.
+  - **Nothing selected** shows the whole log instead of an empty panel: a governor overview on every tab, time by category and governor trends on the Timeline, log-wide findings on Analysis, the hot path and hot spots on the Call Tree, and, on Database, which namespaces asked for and burned the database time, every call path that ends in a query, DML or search with total and self time, and how few statements hold the time. ([#61])
   - Every row is a link: click it to reveal the frame, row or statement behind it in the tab you're on. Hover works both ways without moving the view — hover a row to pick out what it names in the tab you're on, or hover there to mark the rows that name it, and what you click stays picked out until `Escape`. Right-click for copy actions.
   - Dock it left, right or bottom, drag to resize any section — double-click a divider to restore the defaults — and collapse the sections you don't need; the layout is remembered. `Escape` clears the selection and returns the whole-log view. ([#63])
 - 🗄️ **Database Analysis**: governor-limit visibility and SOSL usage. ([#162])
@@ -565,6 +565,7 @@ Skipped due to adopting odd numbering for pre releases and even number for relea
 [#162]: https://github.com/certinia/debug-log-analyzer/issues/162
 [#113]: https://github.com/certinia/debug-log-analyzer/issues/113
 [#63]: https://github.com/certinia/debug-log-analyzer/issues/63
+[#61]: https://github.com/certinia/debug-log-analyzer/issues/61
 [#32]: https://github.com/certinia/debug-log-analyzer/issues/32
 
 <!-- v1.20.1 -->

--- a/lana-docs/docs/docs/features/inspector.md
+++ b/lana-docs/docs/docs/features/inspector.md
@@ -20,39 +20,27 @@ hide_title: true
 
 Select anything — a Timeline frame, a Call Tree or Analysis row, a SOQL/DML/SOSL statement — and the inspector shows it in depth without you leaving the tab you're working in.
 
-It docks to the **right**, **left** or **bottom**, resizes by dragging its edge, and is toggled from the button in the header. It opens automatically on your first selection, then stays however you left it, including the next time you open a log. See [Settings](../settings.mdx#inspector).
+It docks to the **right**, **left** or **bottom**, resizes by dragging its edge, and is toggled from the button in the header. It opens on your first selection, then stays however you left it, including the next time you open a log. See [Settings](../settings.mdx#inspector).
 
 ### Sections
 
-- **Details** – The selection's type and timing, plus every governor metric it consumed as `used / limit` (SOQL, DML, SOSL, rows, heap net/gross/peak, throws). Zero-valued metrics are omitted, so what's left is what the statement actually did. SOQL and SOSL text is syntax highlighted with a copy button. For a SOQL statement it also reports **selectivity**, the **query plan** (leading operation, SObject type, indexed fields) and **cardinality**.
-- **Call stack** – The parent frames that led to the selection, outermost first, with total and self time as a percentage of the enclosing frame. Sortable.
-- **Call tree** – The selection scoped within its own execution, switchable between **Time Order**, **Aggregated** and **Bottom-Up** (as in the Chrome DevTools performance panel). Totals are relative to the selection, so a DML that fires triggers shows the triggered work beneath it. This scoping is what makes it different from the [Call Tree](./calltree.mdx) tab, which always shows the whole log. Zero-duration rows — heap allocations, statements, variable assignments — are left out; read those on the [Call Tree](./calltree.mdx) tab.
-- **SOQL issues** – SOQL only: optimization tips describing the query's performance and how to improve it.
+- **Details** – timing, plus every governor metric the selection consumed as `used / limit`. For SOQL also selectivity, query plan and cardinality, with the query text highlighted and copyable.
+- **Call stack** – the parent frames that led to the selection, outermost first, with total and self time.
+- **Call tree** – the selection's own execution in **Time Order**, **Aggregated** or **Bottom-Up**, scoped to the selection rather than the whole log like the [Call Tree](./calltree.mdx) tab.
+- **SOQL issues** – SOQL only: optimization tips for the query.
 
-Collapse any section by clicking its header, or drag the divider between two to resize them; double-click a divider to restore the default sizes. It's one panel, so your layout follows you from tab to tab, and is restored next time.
+Collapse a section by clicking its header, drag a divider to resize two of them, double-click a divider to restore the default sizes. It's one panel, so your layout follows you from tab to tab.
 
 ### Nothing selected
 
-With no selection the inspector shows the whole log. Every tab starts with a **Log overview** — the six governor metrics closest to their limit, each as `used / limit`, the same whole-transaction totals the timeline's metric strip shows. When the log has no `CUMULATIVE_LIMIT_USAGE` events the figures are estimated from the logged events instead, and a note says so. The **Timeline** tab adds:
+With nothing selected the inspector reads the whole log. Every tab opens with an **Overview** — the six governor metrics closest to their limit — then adds what its own tab can answer at log scope:
 
-- **Time by category** – the log's self time as one stacked bar, in the flame chart's own colours, with a legend. Self time, so the bar always totals the log.
-- **Governor usage over time** – small area charts of the metrics nearest their limits, drawn from the same data as the timeline's metric strip: `CUMULATIVE_LIMIT_USAGE` snapshots plus the log's own SOQL, DML and heap events. Without snapshots the figures are estimated. Hover a chart to read the value at any point in the log.
-- **Call tree** – every root event in the log, in the same three views as the scoped tree.
+- **Timeline** – time by category, governor usage over time, and the whole-log call tree.
+- **Call Tree** – the **hot path** the log spent its time in, and the **hot spots** with the most self time.
+- **Database** – **Namespace duration**: **Called from namespace** — the namespace that issued the statement — and, when they differ, **Ran in namespace**, the namespaces of whatever ran beneath it, such as a package trigger firing on your DML. **Call tree**: every call path that ends in a query, DML or search, with **Total Time** — the database time at or below the row — beside **Self Time**, the row's own code. A row with all total and no self is waiting on the database; the reverse is the Apex around it. **Database duration**: how few statements hold the time, with cost per row, how often each ran, and its duration split into self time and descendants, so a DML that is cheap in itself but fires seven seconds of triggers reads as one.
+- **Analysis** – **Findings**: what is slow or wrong in the log, and what to do about it.
 
-The **Analysis** tab adds:
-
-- **Findings** – what is slow or wrong in the log, and what to do about it. One pass over the log reports truncation (which makes every figure below it an undercount), governor breaches, exceptions, query-plan verdicts, SOQL optimization tips, statements repeated from one line — the usual sign of a query or DML in a loop — debug-statement cost, and the methods with the most self time. Query-plan verdicts need a `FINEST` log; without one the pane says the verdicts are unknown rather than reading clean. Each finding shows the code the log named with its figures; click it to reveal the row behind it in the Analysis grid.
-
-The **Call Tree** tab adds:
-
-- **Hot path** – the chain of calls the log spent most of its time in, entry point first. At each step, calls with the same signature count as one, so a method called 200 times shows once with a `200×` count. The path follows the biggest of these and stops where the time spreads out or a call's own work outweighs its children; every frame shows its time and share of the log. A truncated log heads the path with a warning, because timings below a cut-off call under-report.
-- **Hot spots** – the five signatures with the most self time across the whole log, each with its share of the log, plus its call count and average self time per call where it ran more than once. The average names the churn a self-time ranking hides: a cheap method called thousands of times.
-
-Rows in both sections carry a swatch in the flame chart's colour for their category, and a meter with two tones — solid for the time the call spent itself, faded for the time it spent in its children. A change of timeline theme repaints them.
-
-Every row in both sections is a link: click it to reveal that call in the tree (Time Order view).
-
-Select a row and the sections re-scope to it; deselect and the whole-log view returns.
+Every figure comes from the log itself, so a truncated log, a log without `Rows:` or one without `CUMULATIVE_LIMIT_USAGE` reports less rather than guessing, and says so. Ranked sections list their top eight and account for the rest in a final row. Select a row and every section re-scopes to it.
 
 ### Row actions
 

--- a/log-viewer/src/components/CategoryTimeBar.ts
+++ b/log-viewer/src/components/CategoryTimeBar.ts
@@ -1,200 +1,47 @@
 /*
  * Copyright (c) 2026 Certinia Inc. All rights reserved.
  */
-import { LitElement, css, html, svg } from 'lit';
-import { customElement, state } from 'lit/decorators.js';
-import { classMap } from 'lit/directives/class-map.js';
-import { styleMap } from 'lit/directives/style-map.js';
+import { LitElement, html } from 'lit';
+import { customElement } from 'lit/decorators.js';
 
 import { LogLoadedController } from '../core/events/LogLoadedController.js';
-import { formatDuration } from '../core/utility/Util.js';
 import { DatabaseAccess } from '../features/database/services/Database.js';
 import { globalStyles } from '../styles/global.styles.js';
 import { inspectorSectionStyles } from '../styles/inspectorSection.styles.js';
 import { CategoryPaletteController, categorySelfTimes } from './categoryTime.js';
+import './StackedTimeBar.js';
 
 /**
  * The whole log's self time split by category, as one stacked bar in the flame
  * chart's own palette — the Inspector's answer to Chrome DevTools' Summary
- * donut. Self time, so every nanosecond lands in exactly one slice and the bar
+ * donut. Self time, so every nanosecond lands in exactly one segment and the bar
  * always totals the log.
  */
 @customElement('category-time-bar')
 export class CategoryTimeBar extends LitElement {
-  /** The category under the pointer — over its slice or its legend item.
-   *  `onSlice` gates the bar's readout tip: only a slice hover shows it. */
-  @state()
-  private _hover: { category: string; onSlice: boolean } | null = null;
-
   private readonly _palette = new CategoryPaletteController(this);
 
   /** The bar has to follow the log itself. */
   private readonly _logLoaded = new LogLoadedController(this);
 
-  static styles = [
-    globalStyles,
-    inspectorSectionStyles,
-    css`
-      .chart {
-        position: relative;
-      }
-
-      .bar {
-        display: block;
-        width: 100%;
-        height: 12px;
-        border-radius: var(--lana-radius-sm);
-      }
-
-      /* The slice readout. The legend carries the same figures, but a narrow
-         or scrolled panel can push it out of view, so the bar answers too.
-         Anchored to the hovered slice's centre — not the pointer — so it never
-         lags, and below the bar because above it the section title covers it. */
-      .tip {
-        position: absolute;
-        top: calc(100% + var(--lana-space-3xs));
-        pointer-events: none;
-        white-space: nowrap;
-        font-size: var(--lana-text-sm);
-        color: var(--lana-fg);
-        padding: var(--lana-space-3xs) var(--lana-space-xs);
-        background: var(--lana-popover-bg);
-        border: var(--lana-stroke) solid var(--lana-surface-border);
-        border-radius: var(--lana-radius-sm);
-        box-shadow: var(--lana-shadow-popover);
-      }
-
-      .legend {
-        display: flex;
-        flex-wrap: wrap;
-        gap: 4px 18px;
-        padding-top: var(--lana-space-sm);
-      }
-
-      .legend__item {
-        display: flex;
-        align-items: baseline;
-        gap: 6px;
-        white-space: nowrap;
-      }
-
-      .legend__swatch {
-        width: 8px;
-        height: 8px;
-        border-radius: 2px;
-        align-self: center;
-        flex: none;
-      }
-
-      .legend__value {
-        font-family: var(--vscode-editor-font-family, monospace);
-        font-variant-numeric: tabular-nums;
-        font-size: var(--lana-text-sm);
-        color: var(--lana-fg-muted);
-      }
-
-      /* Hovering a slice or a legend item singles its category out: the other
-         slices recede and the matching legend figures come up to full strength.
-         The legend side matters — the thinnest slices are too small to hit. */
-      .bar__slice {
-        transition: opacity 0.15s ease;
-      }
-
-      .bar__slice--dim {
-        opacity: 0.45;
-      }
-
-      .legend__item--active .legend__value {
-        color: var(--lana-fg);
-      }
-    `,
-  ];
+  static styles = [globalStyles, inspectorSectionStyles];
 
   render() {
     const apexLog = DatabaseAccess.instance()?.getApexLog();
     const slices = apexLog ? categorySelfTimes(apexLog) : [];
-    const total = slices.reduce((sum, slice) => sum + slice.selfTime, 0);
-    if (!total) {
+    if (!slices.length) {
       return html`<p class="note">No categorised time was recorded in this log.</p>`;
     }
 
-    // Lay the slices out once; the tip and the rects share the geometry.
-    let x = 0;
-    const laid = slices.map((slice) => {
-      const start = x;
-      const width = (slice.selfTime / total) * 100;
-      x += width;
-      return { ...slice, start, width };
-    });
-    const hover = this._hover;
-    const tipSlice = hover?.onSlice ? laid.find((s) => s.category === hover.category) : undefined;
-    const tipCenter = tipSlice ? tipSlice.start + tipSlice.width / 2 : 0;
-
-    return html`
-      <div class="chart">
-        <svg
-          class="bar"
-          viewBox="0 0 100 4"
-          preserveAspectRatio="none"
-          role="img"
-          aria-label="Time by category"
-        >
-          ${laid.map(
-            (slice) => svg`<rect
-              class=${
-                hover !== null && hover.category !== slice.category
-                  ? 'bar__slice bar__slice--dim'
-                  : 'bar__slice'
-              }
-              x=${slice.start.toFixed(3)} y="0" width=${slice.width.toFixed(3)} height="4"
-              fill=${this._palette.colorFor(slice.category)}
-              @pointerenter=${() => (this._hover = { category: slice.category, onSlice: true })}
-              @pointerleave=${() => (this._hover = null)}
-            ></rect>`,
-          )}
-        </svg>
-        ${
-          tipSlice
-            ? html`<div
-                class="tip"
-                style=${styleMap(
-                  tipCenter <= 50
-                    ? { left: `${tipCenter.toFixed(1)}%` }
-                    : { right: `${(100 - tipCenter).toFixed(1)}%` },
-                )}
-              >
-                ${tipSlice.category} · ${this._readout(tipSlice.selfTime, total)}
-              </div>`
-            : ''
-        }
-      </div>
-      <div class="legend">
-        ${laid.map(
-          (slice) => html`
-            <span
-              class=${classMap({
-                legend__item: true,
-                'legend__item--active': hover?.category === slice.category,
-              })}
-              @pointerenter=${() => (this._hover = { category: slice.category, onSlice: false })}
-              @pointerleave=${() => (this._hover = null)}
-            >
-              <span
-                class="legend__swatch"
-                style=${styleMap({ background: this._palette.colorFor(slice.category) })}
-              ></span>
-              <span>${slice.category}</span>
-              <span class="legend__value"> ${this._readout(slice.selfTime, total)} </span>
-            </span>
-          `,
-        )}
-      </div>
-    `;
-  }
-
-  /** `duration · percent` — the tip and the legend show the same figures. */
-  private _readout(selfTime: number, total: number): string {
-    return `${formatDuration(selfTime)} · ${((selfTime / total) * 100).toFixed(1)}%`;
+    return html`<stacked-time-bar
+      legend
+      label="Time by category"
+      .segments=${slices.map((slice) => ({
+        label: slice.category,
+        timeNs: slice.selfTime,
+        color: this._palette.colorFor(slice.category),
+      }))}
+    ></stacked-time-bar>`;
   }
 }
 

--- a/log-viewer/src/components/PaneView.ts
+++ b/log-viewer/src/components/PaneView.ts
@@ -15,8 +15,6 @@ export interface PaneSection {
   content: TemplateResult;
   /** Optional count/label shown as a badge in the section header. */
   badge?: string;
-  /** Optional codicon name shown before the title, naming what the section answers. */
-  icon?: string;
   /** Default flex-grow weight when open, seeded on first render (default 1). */
   weight?: number;
   /**
@@ -278,7 +276,6 @@ export class PaneView extends LitElement {
             ? html`<vscode-icon name=${open ? 'chevron-down' : 'chevron-right'}></vscode-icon>`
             : nothing
         }
-        ${section.icon ? html`<vscode-icon name=${section.icon}></vscode-icon>` : nothing}
         <span class="pane-header__title">${section.title}</span>
         ${section.badge ? html`<vscode-badge>${section.badge}</vscode-badge>` : nothing}
       </div>

--- a/log-viewer/src/components/StackedTimeBar.ts
+++ b/log-viewer/src/components/StackedTimeBar.ts
@@ -1,0 +1,301 @@
+/*
+ * Copyright (c) 2026 Certinia Inc. All rights reserved.
+ */
+import { LitElement, css, html, svg, type TemplateResult } from 'lit';
+import { customElement, property, state } from 'lit/decorators.js';
+import { classMap } from 'lit/directives/class-map.js';
+import { styleMap } from 'lit/directives/style-map.js';
+
+import { formatDuration } from '../core/utility/Util.js';
+import { globalStyles } from '../styles/global.styles.js';
+
+/** One coloured length of a {@link StackedTimeBar}, measured in nanoseconds. */
+export interface StackedSegment {
+  label: string;
+  timeNs: number;
+  color: string;
+  /** What the segment is made of. A second line in `legendRows`, and in the tip. */
+  detail?: string;
+}
+
+/**
+ * Durations as one stacked bar: a segment per kind, in the flame chart's own
+ * colours, with a hover readout and an optional legend.
+ *
+ * `total` is the bar's denominator. Set it above the segments' sum and the
+ * shortfall stays unfilled, so the bar shows a share of something larger — the
+ * database against the whole log — rather than only a split of itself.
+ *
+ * Set `--stacked-bar-height` to size it; a row inside a list wants it thinner
+ * than a section's own chart.
+ */
+@customElement('stacked-time-bar')
+export class StackedTimeBar extends LitElement {
+  @property({ attribute: false })
+  segments: readonly StackedSegment[] = [];
+
+  /** Denominator (ns). Zero or below the segments' sum: the sum answers. */
+  @property({ type: Number })
+  total = 0;
+
+  /** Show the figures beneath the bar, one item per segment. */
+  @property({ type: Boolean })
+  legend = false;
+
+  /** One legend item per line, for a section too narrow to wrap them well. */
+  @property({ type: Boolean })
+  legendRows = false;
+
+  /** Accessible name for the bar itself. */
+  @property()
+  label = '';
+
+  /** The segment under the pointer — over the bar or its legend item.
+   *  `onBar` gates the readout tip: only a bar hover shows it. */
+  @state()
+  private _hover: { label: string; onBar: boolean } | null = null;
+
+  /** Where the pointer is across the bar (percent). Whole numbers, so a move
+   *  inside a pixel or two costs no render. */
+  @state()
+  private _pointerPercent: number | null = null;
+
+  static styles = [
+    globalStyles,
+    css`
+      .chart {
+        position: relative;
+      }
+
+      /* The unfilled remainder: the track shows through wherever the segments
+       stop, which is what makes the bar a share and not just a split. */
+      .bar {
+        display: block;
+        width: 100%;
+        height: var(--stacked-bar-height, 12px);
+        border-radius: var(--lana-radius-sm);
+        background: color-mix(in srgb, var(--lana-meter-fill) 22%, transparent);
+      }
+
+      /* The readout. The legend carries the same figures, but a narrow or
+       scrolled panel can push it out of view, so the bar answers too. It follows
+       the pointer along the bar, and sits below it because above it the section
+       title covers it. */
+      .tip {
+        position: absolute;
+        top: calc(100% + var(--lana-space-3xs));
+        z-index: 1;
+        pointer-events: none;
+        white-space: nowrap;
+        font-size: var(--lana-text-sm);
+        color: var(--lana-fg);
+        padding: var(--lana-space-3xs) var(--lana-space-xs);
+        background: var(--lana-popover-bg);
+        border: var(--lana-stroke) solid var(--lana-surface-border);
+        border-radius: var(--lana-radius-sm);
+        box-shadow: var(--lana-shadow-popover);
+      }
+
+      .legend {
+        display: flex;
+        flex-wrap: wrap;
+        gap: var(--lana-space-3xs) var(--lana-space-lg);
+        padding-top: var(--lana-space-sm);
+      }
+
+      /* A row per item: the name runs left, the figures right, so they line up
+       down the column however many items there are. */
+      .legend--rows {
+        flex-direction: column;
+        flex-wrap: nowrap;
+        gap: var(--lana-space-3xs);
+      }
+
+      /* A grid, so a segment's detail can hold a line of its own under the name
+         while the name and the figures stay in their columns. */
+      .legend--rows .legend__item {
+        display: grid;
+        grid-template-columns: auto minmax(0, 1fr) auto;
+        min-width: 0;
+        column-gap: var(--lana-space-2xs);
+        row-gap: var(--lana-space-3xs);
+      }
+
+      .legend__detail {
+        grid-column: 2 / -1;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        color: var(--lana-fg-muted);
+        font-family: var(--lana-font-mono);
+        font-variant-numeric: tabular-nums;
+      }
+
+      .legend--rows .legend__item > span:not([class]) {
+        overflow: hidden;
+        text-overflow: ellipsis;
+      }
+
+      .legend--rows .legend__value {
+        margin-left: auto;
+      }
+
+      .legend__item {
+        display: flex;
+        align-items: baseline;
+        gap: var(--lana-space-2xs);
+        white-space: nowrap;
+        font-size: var(--lana-text-sm);
+        color: var(--lana-fg);
+      }
+
+      .legend__swatch {
+        width: 8px;
+        height: 8px;
+        border-radius: 2px;
+        align-self: center;
+        flex: none;
+      }
+
+      .legend__value {
+        font-family: var(--lana-font-mono);
+        font-variant-numeric: tabular-nums;
+        color: var(--lana-fg-muted);
+      }
+
+      /* Hovering a segment or a legend item singles it out: the others recede and
+       the matching legend figures come up to full strength. The legend side
+       matters — the thinnest segments are too small to hit. */
+      .bar__slice {
+        transition: opacity 0.15s ease;
+      }
+
+      .bar__slice--dim {
+        opacity: 0.45;
+      }
+
+      .legend__item--active .legend__value {
+        color: var(--lana-fg);
+      }
+
+      @media (prefers-reduced-motion: reduce) {
+        .bar__slice {
+          transition: none;
+        }
+      }
+    `,
+  ];
+
+  render() {
+    const sum = this.segments.reduce((running, segment) => running + segment.timeNs, 0);
+    const denominator = Math.max(this.total, sum);
+    if (denominator <= 0) {
+      return html``;
+    }
+
+    // Lay the segments out once; the tip and the rects share the geometry.
+    let x = 0;
+    const laid = this.segments.map((segment) => {
+      const start = x;
+      const width = (segment.timeNs / denominator) * 100;
+      x += width;
+      return { ...segment, start, width };
+    });
+    const hover = this._hover;
+    const tipSlice = hover?.onBar ? laid.find((s) => s.label === hover.label) : undefined;
+    // The pointer where we have it, the segment's centre until the first move.
+    const tipCenter = this._pointerPercent ?? (tipSlice ? tipSlice.start + tipSlice.width / 2 : 0);
+
+    return html`
+      <div class="chart">
+        <svg
+          class="bar"
+          viewBox="0 0 100 4"
+          preserveAspectRatio="none"
+          role="img"
+          aria-label=${this.label}
+          @pointermove=${this._trackPointer}
+          @pointerleave=${() => (this._pointerPercent = null)}
+        >
+          ${laid.map(
+            (segment) => svg`<rect
+              class=${
+                hover !== null && hover.label !== segment.label
+                  ? 'bar__slice bar__slice--dim'
+                  : 'bar__slice'
+              }
+              x=${segment.start.toFixed(3)} y="0" width=${segment.width.toFixed(3)} height="4"
+              fill=${segment.color}
+              @pointerenter=${() => (this._hover = { label: segment.label, onBar: true })}
+              @pointerleave=${() => (this._hover = null)}
+            ></rect>`,
+          )}
+        </svg>
+        ${
+          tipSlice
+            ? html`<div
+                class="tip"
+                style=${styleMap(
+                  tipCenter <= 50
+                    ? { left: `${tipCenter.toFixed(1)}%` }
+                    : { right: `${(100 - tipCenter).toFixed(1)}%` },
+                )}
+              >
+                ${tipSlice.label} ·
+                ${readout(tipSlice.timeNs, denominator)}${
+                  tipSlice.detail ? ` · ${tipSlice.detail}` : ''
+                }
+              </div>`
+            : ''
+        }
+      </div>
+      ${this.legend ? this._legend(laid, denominator) : ''}
+    `;
+  }
+
+  private _trackPointer(event: PointerEvent) {
+    const bar = event.currentTarget as SVGElement;
+    const { left, width } = bar.getBoundingClientRect();
+    if (width <= 0) {
+      return;
+    }
+    const percent = ((event.clientX - left) / width) * 100;
+    this._pointerPercent = Math.min(100, Math.max(0, Math.round(percent)));
+  }
+
+  private _legend(laid: StackedSegment[], denominator: number): TemplateResult {
+    return html`<div class=${classMap({ legend: true, 'legend--rows': this.legendRows })}>
+      ${laid.map(
+        (segment) => html`
+          <span
+            class=${classMap({
+              legend__item: true,
+              'legend__item--active': this._hover?.label === segment.label,
+            })}
+            @pointerenter=${() => (this._hover = { label: segment.label, onBar: false })}
+            @pointerleave=${() => (this._hover = null)}
+          >
+            <span class="legend__swatch" style=${styleMap({ background: segment.color })}></span>
+            <span>${segment.label}</span>
+            <span class="legend__value">${readout(segment.timeNs, denominator)}</span>
+            ${
+              segment.detail && this.legendRows
+                ? html`<span class="legend__detail">${segment.detail}</span>`
+                : ''
+            }
+          </span>
+        `,
+      )}
+    </div>`;
+  }
+}
+
+/** `duration · percent` — the tip and the legend show the same figures. */
+function readout(timeNs: number, denominator: number): string {
+  return `${formatDuration(timeNs)} · ${((timeNs / denominator) * 100).toFixed(1)}%`;
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'stacked-time-bar': StackedTimeBar;
+  }
+}

--- a/log-viewer/src/components/__tests__/PaneView.test.ts
+++ b/log-viewer/src/components/__tests__/PaneView.test.ts
@@ -81,16 +81,6 @@ describe('PaneView', () => {
     expect(body(el, 'c')).not.toBeNull();
   });
 
-  it('renders a section icon after the twistie', async () => {
-    const el = document.createElement('pane-view') as PaneView;
-    el.sections = [{ id: 'a', title: 'A', icon: 'flame', content: html`<div></div>` }];
-    document.body.appendChild(el);
-    await el.updateComplete;
-
-    const icons = [...(header(el, 'a')?.querySelectorAll('vscode-icon') ?? [])];
-    expect(icons.map((icon) => icon.getAttribute('name'))).toEqual(['chevron-down', 'flame']);
-  });
-
   it('renders a sash between each pair of open sections (2 for 3 open)', async () => {
     const el = await mount('vertical');
     expect(el.shadowRoot?.querySelectorAll('.pane-sash').length).toBe(2);

--- a/log-viewer/src/components/__tests__/StackedTimeBar.test.ts
+++ b/log-viewer/src/components/__tests__/StackedTimeBar.test.ts
@@ -1,0 +1,98 @@
+/*
+ * Copyright (c) 2026 Certinia Inc. All rights reserved.
+ *
+ * @jest-environment jsdom
+ */
+import { beforeEach, describe, expect, it } from '@jest/globals';
+
+import '../StackedTimeBar.js';
+import type { StackedSegment } from '../StackedTimeBar.js';
+
+const SEGMENTS: StackedSegment[] = [
+  { label: 'SOQL', timeNs: 200_000_000, color: 'red' },
+  { label: 'DML', timeNs: 100_000_000, color: 'blue' },
+];
+
+async function mount(segments: StackedSegment[], total = 0, legend = false) {
+  const element = document.createElement('stacked-time-bar');
+  element.segments = segments;
+  element.total = total;
+  element.legend = legend;
+  document.body.append(element);
+  await element.updateComplete;
+  return element;
+}
+
+const widths = (element: Element) =>
+  [...(element.shadowRoot?.querySelectorAll('rect') ?? [])].map((rect) =>
+    Number(rect.getAttribute('width')),
+  );
+
+describe('stacked-time-bar', () => {
+  beforeEach(() => {
+    document.body.replaceChildren();
+  });
+
+  it('renders nothing without a length to show', async () => {
+    expect((await mount([])).shadowRoot?.querySelector('svg')).toBeNull();
+  });
+
+  it('splits itself when no total is set', async () => {
+    expect(widths(await mount(SEGMENTS))).toEqual([66.667, 33.333]);
+  });
+
+  it('leaves the shortfall unfilled when the total is larger than the segments', async () => {
+    // 300ms of a 1s log: the bar fills 30% and the rest of the log stays empty.
+    expect(widths(await mount(SEGMENTS, 1_000_000_000))).toEqual([20, 10]);
+  });
+
+  it('ignores a total below the segments, since the sum is the only honest length', async () => {
+    expect(widths(await mount(SEGMENTS, 1_000))).toEqual([66.667, 33.333]);
+  });
+
+  it('reads out the hovered segment against the total', async () => {
+    const element = await mount(SEGMENTS, 1_000_000_000);
+    element.shadowRoot?.querySelector('rect')?.dispatchEvent(new Event('pointerenter'));
+    await element.updateComplete;
+
+    const tip = element.shadowRoot?.querySelector('.tip')?.textContent?.replace(/\s+/g, ' ').trim();
+    expect(tip).toContain('SOQL');
+    expect(tip).toContain('20.0%');
+    // The other segment recedes while one is singled out.
+    expect(element.shadowRoot?.querySelectorAll('.bar__slice--dim')).toHaveLength(1);
+  });
+
+  it('follows the pointer along the bar', async () => {
+    const element = await mount(SEGMENTS);
+    const bar = element.shadowRoot?.querySelector('svg') as SVGElement;
+    // jsdom lays nothing out, so the bar is given a width to measure against.
+    bar.getBoundingClientRect = () => ({ left: 100, width: 200 }) as DOMRect;
+
+    element.shadowRoot?.querySelector('rect')?.dispatchEvent(new Event('pointerenter'));
+    // jsdom has no PointerEvent, and only clientX is read.
+    bar.dispatchEvent(Object.assign(new Event('pointermove'), { clientX: 130 }));
+    await element.updateComplete;
+
+    // 30px into 200px: the tip sits at 15%, not the segment's 33% centre.
+    expect(element.shadowRoot?.querySelector('.tip')?.getAttribute('style')).toContain(
+      'left:15.0%',
+    );
+  });
+
+  it('gives every segment its figures in the legend, and no tip', async () => {
+    const element = await mount(SEGMENTS, 0, true);
+    const items = [...(element.shadowRoot?.querySelectorAll('.legend__value') ?? [])].map(
+      (item) => item.textContent ?? '',
+    );
+
+    expect(items).toHaveLength(2);
+    expect(items[0]).toContain('66.7%');
+    expect(items[1]).toContain('33.3%');
+
+    element.shadowRoot?.querySelector('.legend__item')?.dispatchEvent(new Event('pointerenter'));
+    await element.updateComplete;
+    // A legend hover highlights, but the tip belongs to the bar.
+    expect(element.shadowRoot?.querySelector('.legend__item--active')).not.toBeNull();
+    expect(element.shadowRoot?.querySelector('.tip')).toBeNull();
+  });
+});

--- a/log-viewer/src/components/__tests__/detailSections.test.ts
+++ b/log-viewer/src/components/__tests__/detailSections.test.ts
@@ -15,6 +15,8 @@ jest.mock('../GovernorTrends.js', () => ({}));
 jest.mock('../HotPath.js', () => ({}));
 jest.mock('../HotSpots.js', () => ({}));
 jest.mock('../LogOverview.js', () => ({}));
+jest.mock('../../features/database/components/DatabaseOverview.js', () => ({}));
+jest.mock('../../features/database/components/DatabaseTimeTree.js', () => ({}));
 
 const databaseCalls: { eventIndex: number; type: string; activeEventIndex?: number | null }[] = [];
 jest.mock('../../features/database/components/databaseSections.js', () => ({
@@ -137,10 +139,21 @@ describe('buildDetailSections', () => {
     expect(vitals.getAttribute('label')).toBe('');
   });
 
-  it('builds only the whole-log overview for the database with nothing selected', async () => {
+  it('adds the whole-log database figures for the database with nothing selected', async () => {
     const sections = await buildDetailSections('database', null);
-    expect(sections.map((s) => s.id)).toEqual(['overview']);
-    expect(sections[0]?.title).toBe('Log overview');
+    expect(sections.map((s) => s.id)).toEqual([
+      'overview',
+      'database-namespaces',
+      'database-time',
+      'database-concentration',
+    ]);
+    expect(sections[0]?.title).toBe('Overview');
+    // The call-path grid soaks up the leftover space; the rest keep their own.
+    expect(sections.find((s) => s.id === 'database-time')?.weight).toBe(4);
+    expect(sections.find((s) => s.id === 'database-time')?.fit ?? 'fill').toBe('fill');
+    expect(sections.filter((s) => s.id !== 'database-time').every((s) => s.fit === 'content')).toBe(
+      true,
+    );
   });
 
   it('adds the hot path and hot spots to the call tree when nothing is selected', async () => {

--- a/log-viewer/src/components/detailSections.ts
+++ b/log-viewer/src/components/detailSections.ts
@@ -9,6 +9,8 @@ import type { PaneSection } from './PaneView.js';
 
 // web components
 import '../features/analysis/components/LogDiagnosticsView.js';
+import '../features/database/components/DatabaseOverview.js';
+import '../features/database/components/DatabaseTimeTree.js';
 import './CallStackDetail.js';
 import './CallTreeDetail.js';
 import './CategoryTimeBar.js';
@@ -25,8 +27,9 @@ import './LogOverview.js';
  * {@link buildDatabaseSections}.
  *
  * With nothing selected every source gets the whole-log analogue of what its tab
- * does: the shared **Log overview**, plus the sections that tab can answer at log
- * scope. Analysis adds **Findings**; the Timeline adds its charts and the
+ * does: the shared **Overview**, plus the sections that tab can answer at log
+ * scope. Analysis adds **Findings**; the Database tab adds its whole-log
+ * database figures; the Timeline adds its charts and the
  * whole-log call tree; the Call Tree adds the **Hot path** and **Hot spots** —
  * clickable routes into the tree it sits beside.
  *
@@ -50,8 +53,7 @@ export async function buildDetailSections(
     const sections: PaneSection[] = [
       {
         id: 'overview',
-        title: 'Log overview',
-        icon: 'pie-chart',
+        title: 'Overview',
         fit: 'content',
         content: html`<log-overview></log-overview>`,
       },
@@ -61,14 +63,12 @@ export async function buildDetailSections(
         {
           id: 'hot-path',
           title: 'Hot path',
-          icon: 'flame',
           fit: 'content',
           content: html`<hot-path></hot-path>`,
         },
         {
           id: 'hot-spots',
           title: 'Hot spots',
-          icon: 'dashboard',
           fit: 'content',
           content: html`<hot-spots></hot-spots>`,
         },
@@ -78,9 +78,35 @@ export async function buildDetailSections(
       sections.push({
         id: 'findings',
         title: 'Findings',
-        icon: 'checklist',
         content: html`<log-diagnostics></log-diagnostics>`,
       });
+    }
+    if (source === 'database') {
+      // The Database tab's whole-log analogue, widest question first: whose code
+      // holds the database time, which call paths reach it, and how few
+      // statements it comes down to.
+      sections.push(
+        {
+          id: 'database-namespaces',
+          title: 'Namespace duration',
+          fit: 'content',
+          content: html`<database-namespaces></database-namespaces>`,
+        },
+        {
+          // A grid sized to the pane it is in, so this section takes the space
+          // the sized-to-content ones leave.
+          id: 'database-time',
+          title: 'Call tree',
+          weight: 4,
+          content: html`<database-time></database-time>`,
+        },
+        {
+          id: 'database-concentration',
+          title: 'Database duration',
+          fit: 'content',
+          content: html`<database-concentration></database-concentration>`,
+        },
+      );
     }
     if (source === 'timeline') {
       // The Timeline's whole-log analogue: where the time went (by category and
@@ -89,14 +115,12 @@ export async function buildDetailSections(
         {
           id: 'category-time',
           title: 'Time by category',
-          icon: 'pie-chart',
           fit: 'content',
           content: html`<category-time-bar></category-time-bar>`,
         },
         {
           id: 'governor-trends',
           title: 'Governor usage over time',
-          icon: 'graph',
           fit: 'content',
           content: html`<governor-trends></governor-trends>`,
         },

--- a/log-viewer/src/features/database/components/DatabaseOverview.ts
+++ b/log-viewer/src/features/database/components/DatabaseOverview.ts
@@ -1,0 +1,441 @@
+/*
+ * Copyright (c) 2026 Certinia Inc. All rights reserved.
+ */
+import { LitElement, css, html, unsafeCSS, type TemplateResult } from 'lit';
+import { customElement } from 'lit/decorators.js';
+import { styleMap } from 'lit/directives/style-map.js';
+
+import { CategoryPaletteController } from '../../../components/categoryTime.js';
+import {
+  dispatchInspectorLocate,
+  dispatchInspectorReveal,
+} from '../../../components/inspectorReveal.js';
+import '../../../components/StackedTimeBar.js';
+import type { StackedSegment } from '../../../components/StackedTimeBar.js';
+import { LogLoadedController } from '../../../core/events/LogLoadedController.js';
+import { formatDuration, formatInteger } from '../../../core/utility/Util.js';
+import { globalStyles } from '../../../styles/global.styles.js';
+import { inspectorSectionStyles } from '../../../styles/inspectorSection.styles.js';
+import { revealRowStyles } from '../../../styles/revealRow.styles.js';
+import type { SoqlBudget } from '../../soql/format/budget.js';
+import { formatSOQLToTemplate } from '../../soql/format/formatter.js';
+import { soqlSyntaxStyles } from '../../soql/styles/soql-syntax.css.js';
+import {
+  concentration,
+  currentDatabaseOverview,
+  type DatabaseBreakdown,
+  type DatabaseOverview as Overview,
+  type DatabaseStatement,
+  NO_STATEMENTS,
+  type StatementKind,
+} from '../services/databaseOverview.js';
+
+/**
+ * How many rows a ranked section shows before it defers to the grids beside it.
+ * These sections are a springboard: the sortable, complete view is the tab.
+ */
+const MAX_ROWS = 8;
+
+/**
+ * The room a statement label has. Lines are clauses, not display lines: the row
+ * is one line whatever this holds, so the budget buys elisions — `+8 fields`,
+ * `… +2 conditions` — over a raw query cut off mid-word.
+ */
+const LABEL_BUDGET: SoqlBudget = { lines: 3, columns: 40 };
+
+/** The rows a ranked section shows, and the ones it leaves to the grids. */
+function topRows<T>(rows: readonly T[]): { shown: readonly T[]; rest: readonly T[] } {
+  return { shown: rows.slice(0, MAX_ROWS), rest: rows.slice(MAX_ROWS) };
+}
+
+/**
+ * A share. One decimal below 100 and none at exactly 100, so 99.9% is never
+ * rounded into a claim that something holds everything.
+ */
+function shareText(percent: number): string {
+  return percent >= 100 ? '100%' : `${percent.toFixed(1)}%`;
+}
+
+/**
+ * The three kinds in the flame chart's own colours. The parser categorises a
+ * search as SOQL, so SOSL has no hue of its own: it shows as a tint of the query
+ * hue, which keeps these graphics truthful against the chart.
+ */
+function kindColors(palette: CategoryPaletteController): Record<StatementKind, string> {
+  const soql = palette.colorFor('SOQL');
+  return {
+    SOQL: soql,
+    DML: palette.colorFor('DML'),
+    SOSL: `color-mix(in srgb, ${soql} 55%, transparent)`,
+  };
+}
+
+/**
+ * The namespace scale. Namespaces are names, not amounts, so they need telling
+ * apart and nothing more: a fixed colourblind-safe set (Okabe-Ito), literal
+ * because it is data and must not follow the host theme. A namespace's read and
+ * write split is on its own line instead, where it can be read exactly.
+ */
+const NAMESPACE_COLORS = [
+  '#0072b2',
+  '#d55e00',
+  '#009e73',
+  '#cc79a7',
+  '#e69f00',
+  '#56b4e9',
+  '#aa4499',
+  '#44aa99',
+] as const;
+
+const sectionStyles = [
+  globalStyles,
+  inspectorSectionStyles,
+  css`
+    .note {
+      padding: var(--lana-space-2xs) 0 0;
+    }
+  `,
+];
+
+/**
+ * Which statements own the database time. The grids sort by duration, but not by
+ * what makes a statement worth fixing: this ranks by self time, so a query
+ * inside a DML trigger is credited to itself and not to the DML, sums every time
+ * the log ran the same statement into one row, and gives each row the figures no
+ * grid holds — its cost per row it touched, how many times it ran, and how much
+ * of its duration is really the statements inside it.
+ *
+ * The meter is the statement's whole share of database time, solid up to its own
+ * self share, so a DML that is really a nested query reads as one at a glance.
+ */
+@customElement('database-concentration')
+export class DatabaseConcentration extends LitElement {
+  private readonly _palette = new CategoryPaletteController(this);
+  private readonly _logLoaded = new LogLoadedController(this);
+
+  static styles = [
+    ...sectionStyles,
+    revealRowStyles,
+    unsafeCSS(soqlSyntaxStyles),
+    css`
+      /* The sub line sheds parts by the dock's width, not the window's. */
+      :host {
+        container-type: inline-size;
+      }
+
+      /* Shed from the least telling: the database's share of the descendant time,
+         then the repeat count, then the cost per row. The share and the
+         self-against-descendants split are the row's point, so they always stay. */
+      @container (max-width: 22rem) {
+        .sub__database {
+          display: none;
+        }
+      }
+
+      @container (max-width: 19rem) {
+        .sub__repeats {
+          display: none;
+        }
+      }
+
+      @container (max-width: 16rem) {
+        .sub__rows {
+          display: none;
+        }
+      }
+
+      .headline {
+        margin: 0;
+        padding-bottom: var(--lana-space-xs);
+        font-size: var(--lana-text-sm);
+      }
+
+      .headline__figure {
+        color: var(--lana-fg);
+        font-family: var(--lana-font-mono);
+        font-variant-numeric: tabular-nums;
+      }
+
+      /* The tail: what every statement past the rows above holds, together. */
+      .tail {
+        display: flex;
+        gap: var(--lana-space-sm);
+        padding-top: var(--lana-space-2xs);
+        color: var(--lana-fg-muted);
+        font-size: var(--lana-text-sm);
+      }
+
+      .tail__value {
+        margin-left: auto;
+        font-family: var(--lana-font-mono);
+        font-variant-numeric: tabular-nums;
+      }
+    `,
+  ];
+
+  render() {
+    const overview = currentDatabaseOverview();
+    if (!overview?.ranked.length) {
+      return html`<p class="note">${NO_STATEMENTS}</p>`;
+    }
+    const { count, percent, total } = concentration(overview);
+    const { shown, rest } = topRows(overview.ranked);
+    const colors = kindColors(this._palette);
+    const databaseNs = overview.time.timeNs;
+    const shownNs = shown.reduce((running, statement) => running + statement.netNs, 0);
+
+    return html`
+      <p class="headline">
+        <span class="headline__figure">${formatInteger(count)}</span>
+        of
+        <span class="headline__figure">${formatInteger(total)}</span>
+        statement${total === 1 ? '' : 's'} ·
+        <span class="headline__figure">${shareText(percent)}</span>
+        of DB time ·
+        <span class="headline__figure">${shareText(overview.time.percentOfLog)}</span>
+        of log
+      </p>
+      ${shown.map((statement) => this._row(statement, databaseNs, colors))}
+      ${
+        rest.length > 0
+          ? html`<p class="tail">
+              <span>the other ${formatInteger(rest.length)} statements</span>
+              <span class="tail__value"
+                >${shareText(sharePercent(databaseNs - shownNs, databaseNs))}</span
+              >
+            </p>`
+          : ''
+      }
+    `;
+  }
+
+  private _row(
+    statement: DatabaseStatement,
+    databaseNs: number,
+    colors: Record<StatementKind, string>,
+  ) {
+    const own = sharePercent(statement.netNs, databaseNs);
+    return html`
+      <button
+        class="bleed-row reveal-row reveal-row--no-swatch"
+        type="button"
+        title=${rowTitle(statement)}
+        style=${styleMap({
+          '--row-hue': colors[statement.kind],
+          // Solid to the statement's self time, faded on to its total: the gap is
+          // its descendants.
+          '--self-pct': `${sharePercent(statement.selfNs, statement.timeNs).toFixed(1)}%`,
+        })}
+        @click=${() => dispatchInspectorReveal(this, statement.eventIndex)}
+        @pointerenter=${() => dispatchInspectorLocate(this, statement.eventIndexes)}
+        @pointerleave=${() => dispatchInspectorLocate(this, [])}
+      >
+        <span class="reveal-row__sr">${statement.kind}</span>
+        <span class="reveal-row__name" title=${statement.label}>${statementLabel(statement)}</span>
+        <span class="reveal-row__value reveal-row__value--primary"
+          >${formatDuration(statement.timeNs)}</span
+        >
+        <span class="reveal-row__sub">${subLine(statement, own)}</span>
+        <span class="reveal-row__meter"
+          ><span
+            class="reveal-row__meter-fill"
+            style=${styleMap({ width: `${sharePercent(statement.timeNs, databaseNs)}%` })}
+          ></span
+        ></span>
+      </button>
+    `;
+  }
+}
+
+/**
+ * Database time split across namespaces, as one bar per question with a row per
+ * namespace beneath it. Whose code holds the time — yours or a package's — is
+ * the thing to dig into; the grids hold one statement kind each, so none of them
+ * can be read across the three.
+ *
+ * Two bars, because a DML and the time it takes belong to different people. The
+ * first charges every statement to the namespace that issued it. The second
+ * charges whatever ran beneath it to its own namespace. A package whose trigger
+ * fires on your DML shows up only in the second, which is the finding. They are
+ * the same bar when nothing runs inside the statements, so the second is shown
+ * only when it says something new.
+ *
+ * Each namespace keeps one colour across both bars, and each row names its three
+ * kinds, so a namespace worth digging into says which grid to open.
+ */
+@customElement('database-namespaces')
+export class DatabaseNamespaces extends LitElement {
+  private readonly _logLoaded = new LogLoadedController(this);
+
+  static styles = [
+    ...sectionStyles,
+    css`
+      .bar + .bar {
+        padding-top: var(--lana-space-sm);
+      }
+
+      .bar__title {
+        padding-bottom: var(--lana-space-2xs);
+        font-size: var(--lana-text-sm);
+      }
+    `,
+  ];
+
+  render() {
+    const overview = currentDatabaseOverview();
+    if (!overview?.askedBy.length) {
+      return html`<p class="note">${NO_STATEMENTS}</p>`;
+    }
+    const colors = namespaceColors(overview);
+    const asked = this._bar('Called from namespace', overview.askedBy, colors);
+    // Identical bars would read as a finding where there is none.
+    if (sameSplit(overview.askedBy, overview.burnedIn)) {
+      return asked;
+    }
+    return html`${asked} ${this._bar('Ran in namespace', overview.burnedIn, colors)}`;
+  }
+
+  private _bar(title: string, namespaces: DatabaseBreakdown[], colors: Map<string, string>) {
+    const { shown, rest } = topRows(namespaces);
+    const segments: StackedSegment[] = shown.map((row) => ({
+      label: row.key,
+      timeNs: row.timeNs,
+      color: colors.get(row.key) ?? NAMESPACE_COLORS[0],
+      detail: kindSplit(row),
+    }));
+    // The tail is one segment, so the bar still totals the database time.
+    if (rest.length > 0) {
+      segments.push({
+        label: `${formatInteger(rest.length)} others`,
+        timeNs: rest.reduce((running, row) => running + row.timeNs, 0),
+        color: 'var(--lana-fg-muted)',
+      });
+    }
+
+    return html`
+      <div class="bar">
+        <p class="bar__title">${title}</p>
+        <stacked-time-bar legend legendRows label=${title} .segments=${segments}></stacked-time-bar>
+      </div>
+    `;
+  }
+}
+
+/** Whether two breakdowns hold the same namespaces for the same time. */
+function sameSplit(left: DatabaseBreakdown[], right: DatabaseBreakdown[]): boolean {
+  return (
+    left.length === right.length &&
+    left.every((row, index) => row.key === right[index]?.key && row.timeNs === right[index]?.timeNs)
+  );
+}
+
+/** `part` as a percentage of `whole`, or zero when there is no whole. */
+function sharePercent(part: number, whole: number): number {
+  return whole > 0 ? (part / whole) * 100 : 0;
+}
+
+/**
+ * The statement, highlighted and elided to fit one row. A DML names an operation
+ * and an object, so it has nothing to highlight.
+ */
+function statementLabel(statement: DatabaseStatement): TemplateResult | string {
+  if (statement.kind === 'DML') {
+    return statement.label;
+  }
+  return html`<span class="soql-block soql-inline"
+    >${formatSOQLToTemplate(statement.label, {
+      mode: 'pretty',
+      dialect: statement.kind === 'SOSL' ? 'sosl' : 'soql',
+      budget: LABEL_BUDGET,
+    })}</span
+  >`;
+}
+
+/**
+ * What the row's time is a share of, then the figures a grid row cannot give:
+ * how its duration splits into `self` and `desc` — the statement's own time
+ * against everything beneath it — what it cost per row it touched, which names a
+ * selectivity problem, how often it ran, which names a query in a loop, and how
+ * much of `desc` the database itself did.
+ *
+ * One line always, so the section stays scannable. Each part carries its own
+ * separator, so a narrow dock drops whole parts by container width instead of
+ * cutting a figure in half; the reveal title keeps the full reading.
+ */
+function subLine(statement: DatabaseStatement, ownPercent: number): TemplateResult {
+  const perRow = statement.rows > 0 ? statement.netNs / statement.rows / 1_000_000 : 0;
+  // Self is the total twice over when nothing ran inside the statement.
+  const descendantNs = statement.timeNs - statement.selfNs;
+  const databaseNs = statement.timeNs - statement.netNs;
+
+  return html`<span>${shareText(ownPercent)}</span>${
+      descendantNs > 0
+        ? html`<span class="sub__split">
+            · ${formatDuration(statement.selfNs)} self · ${formatDuration(descendantNs)} desc</span
+          >`
+        : ''
+    }<span class="sub__rows">
+      ·
+      ${
+        statement.rows > 0
+          ? `${perRow.toFixed(perRow < 1 ? 2 : 1)} ms/row`
+          : // The cost is real and the rows are not there: say so, rather than
+            // divide by a row the log never recorded.
+            'no rows'
+      }</span
+    >${
+      statement.repeats > 1
+        ? html`<span class="sub__repeats"> · ran ${formatInteger(statement.repeats)}×</span>`
+        : ''
+    }${
+      databaseNs > 0
+        ? html`<span class="sub__database"> · ${formatDuration(databaseNs)} db</span>`
+        : ''
+    }`;
+}
+
+/** The whole reading, for a row a narrow dock has shortened. */
+function rowTitle(statement: DatabaseStatement): string {
+  const databaseNs = statement.timeNs - statement.netNs;
+  const parts = ['Show this statement in the grid'];
+  if (databaseNs > 0) {
+    parts.push(`${formatDuration(databaseNs)} of the descendant time is database time`);
+  }
+  return parts.join(' · ');
+}
+
+/** `SOQL 1.2s · DML 340ms` — the kinds a namespace spent its time in. */
+function kindSplit(row: DatabaseBreakdown): string {
+  return (
+    [
+      ['SOQL', row.soqlTimeNs],
+      ['DML', row.dmlTimeNs],
+      ['SOSL', row.soslTimeNs],
+    ] as const
+  )
+    .filter(([, timeNs]) => timeNs > 0)
+    .map(([kind, timeNs]) => `${kind} ${formatDuration(timeNs)}`)
+    .join(' · ');
+}
+
+/**
+ * A colour per namespace, the same one on both bars, so a namespace that moves
+ * between them is followed by eye. Longest first, so the scale runs in the order
+ * the bars do.
+ */
+function namespaceColors(overview: Overview): Map<string, string> {
+  const colors = new Map<string, string>();
+  for (const { key } of [...overview.askedBy, ...overview.burnedIn]) {
+    if (!colors.has(key)) {
+      colors.set(key, NAMESPACE_COLORS[colors.size % NAMESPACE_COLORS.length]!);
+    }
+  }
+  return colors;
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'database-concentration': DatabaseConcentration;
+    'database-namespaces': DatabaseNamespaces;
+  }
+}

--- a/log-viewer/src/features/database/components/DatabaseTimeTree.ts
+++ b/log-viewer/src/features/database/components/DatabaseTimeTree.ts
@@ -1,0 +1,464 @@
+/*
+ * Copyright (c) 2026 Certinia Inc. All rights reserved.
+ */
+import { LitElement, css, html, unsafeCSS } from 'lit';
+import { customElement } from 'lit/decorators.js';
+import {
+  type CellComponent,
+  type ColumnDefinition,
+  type RowComponent,
+  Tabulator,
+} from 'tabulator-tables';
+
+import '../../../components/ContextMenu.js';
+import type { ContextMenu } from '../../../components/ContextMenu.js';
+import {
+  dispatchInspectorLocate,
+  dispatchInspectorReveal,
+} from '../../../components/inspectorReveal.js';
+import {
+  LOCATED_ROW_CLASS,
+  LocatedRowMarker,
+  rowIndexStamper,
+} from '../../../components/locatedRow.js';
+import { PANEL_ROW_MENU_ITEMS, runPanelRowAction } from '../../../components/panelRowMenu.js';
+import { eventBus } from '../../../core/events/EventBus.js';
+import { LogLoadedController } from '../../../core/events/LogLoadedController.js';
+import { SelectionEchoGuard } from '../../../core/events/SelectionEchoGuard.js';
+import { formatDuration, formatInteger } from '../../../core/utility/Util.js';
+import { globalStyles } from '../../../styles/global.styles.js';
+import { progressColumnWidth } from '../../../tabulator/format/measureWidth.js';
+import type { ProgressParams } from '../../../tabulator/format/ProgressMS.js';
+import dataGridStyles from '../../../tabulator/style/DataGrid.scss';
+import {
+  clipboardCopyOptions,
+  commonColumnDefaults,
+  createDurationBarColumn,
+  headerSortElement,
+  registerTableModules,
+  virtualScrollOptions,
+  waitForNextFrame,
+} from '../../call-tree/components/TableShared.js';
+import { soqlInlineElement } from '../../soql/format/inlineCell.js';
+import { soqlSyntaxStyles } from '../../soql/styles/soql-syntax.css.js';
+import {
+  type DatabaseCallNode,
+  currentDatabaseOverview,
+  NO_STATEMENTS,
+  type StatementKind,
+} from '../services/databaseOverview.js';
+
+/** One row of the database call tree. */
+export interface DatabaseTreeRow {
+  id: number;
+  label: string;
+  /** Set when the row is the statement itself, not a frame that led to one. */
+  kind: StatementKind | null;
+  /** Database time beneath the row (ns) — for a statement, its whole duration. */
+  timeNs: number;
+  /** The code's own time (ns): the row's frames, each less the children it ran. */
+  selfNs: number;
+  count: number;
+  eventIndexes: number[];
+  _children: DatabaseTreeRow[] | null;
+}
+
+/** The tree as Tabulator rows, ids assigned depth first. */
+export function databaseTreeRows(tree: readonly DatabaseCallNode[]): DatabaseTreeRow[] {
+  let nextId = 0;
+  const map = (nodes: readonly DatabaseCallNode[]): DatabaseTreeRow[] =>
+    nodes.map((node) => ({
+      id: nextId++,
+      label: node.label,
+      kind: node.kind,
+      timeNs: node.timeNs,
+      selfNs: node.selfNs,
+      count: node.count,
+      eventIndexes: node.eventIndexes,
+      _children: node.children.length ? map(node.children) : null,
+    }));
+  return map(tree);
+}
+
+/**
+ * Tree indent + the label: a query or a search renders as single-line (inline)
+ * SOQL, so it truncates cleanly; every other frame is plain text.
+ */
+function nameFormatter(cell: CellComponent): HTMLElement {
+  const row = cell.getRow();
+  // @ts-expect-error this.table is bound by tabulator but missing from the types
+  const childIndent: number = this.table?.options?.dataTreeChildIndent ?? 9;
+  // @ts-expect-error _row is private but is the only way to read the tree level
+  const treeLevel: number = row._row.modules.dataTree?.index ?? 0;
+  const treeIndent = treeLevel * childIndent;
+  if (treeIndent) {
+    cell.getElement().style.paddingLeft = `calc(${treeIndent + 4}px + var(--lana-group-indent, 0px))`;
+  }
+
+  const { label, kind } = cell.getData() as DatabaseTreeRow;
+  if (kind === 'SOQL' || kind === 'SOSL') {
+    return soqlInlineElement(label, kind === 'SOSL' ? 'sosl' : 'soql');
+  }
+  return document.createTextNode(label) as unknown as HTMLElement;
+}
+
+/**
+ * Where the database time was spent, as the call paths that reach it: only the
+ * branches that end in a query, a DML or a search, each carrying the database
+ * time beneath it. The grids name the statements; this names the code that ran
+ * them, which is what a fix has to change.
+ *
+ * Two figures that never overlap: total time is the database time beneath the
+ * row, each statement counted once however deep it nests, and self time is the
+ * row's own code with every child excluded. A path whose total is database time
+ * and whose self time is near zero is waiting on the database; the reverse is
+ * Apex around it. The grids beside sum each statement's whole duration, so a
+ * query inside a DML trigger is in both their totals and theirs read higher.
+ */
+@customElement('database-time')
+export class DatabaseTime extends LitElement {
+  private _table: Tabulator | null = null;
+  private _contextMenu: ContextMenu | null = null;
+  /** eventIndex of the row whose context menu is open. */
+  private _menuEventIndex = -1;
+
+  /** The self-time footer: every row's own code, child rows included, since a
+   *  tree footer sums only the roots. No filters here, so all of it counts. */
+  private _ownCodeTotalNs = 0;
+
+  /** Total-time bars: a share of the database time. Retargeted per log. */
+  private readonly _timeBarParams: ProgressParams = {
+    precision: 2,
+    totalValue: 0,
+    showPercentageText: true,
+  };
+
+  /**
+   * Own-code bars: a share of the own-code total, not of the database time. A
+   * frame's own code is Apex, which the database total does not bound, so sharing
+   * one denominator lets a compute-heavy frame read past 100%.
+   */
+  private readonly _selfBarParams: ProgressParams = {
+    precision: 2,
+    totalValue: 0,
+    showPercentageText: true,
+  };
+
+  /** Guards the mark this component sets itself, so it is never read as a pick. */
+  private _echoGuard = new SelectionEchoGuard();
+
+  /** Marks the row for the statement under the pointer in the grid beside. */
+  private _locatedRow = new LocatedRowMarker();
+  private _locateUnsubscribe?: () => void;
+  private _selectionClearUnsubscribe?: () => void;
+
+  /** eventIndex to the ids of the rows that name it, built on the first mark. */
+  private _rowsByEvent: Map<number, number[]> | null = null;
+
+  private readonly _logLoaded = new LogLoadedController(this, () => {
+    void this._build();
+  });
+
+  static styles = [
+    globalStyles,
+    unsafeCSS(dataGridStyles),
+    unsafeCSS(soqlSyntaxStyles),
+    css`
+      :host {
+        display: flex;
+        flex-direction: column;
+        height: 100%;
+        min-height: 0;
+      }
+      /* Tabulator mounts into this inner div, whose class Lit never rewrites.
+         Binding a class on the mount element itself would clobber the tabulator
+         classes Tabulator adds imperatively on every re-render, breaking the
+         header layout. */
+      .grid {
+        flex: 1 1 auto;
+        min-height: 0;
+      }
+      /* Name: single line, ellipsis — never wrap. */
+      .tabulator-cell.truncate {
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+      }
+      /* The statement under the pointer in the grid beside. */
+      .tabulator-row.${unsafeCSS(LOCATED_ROW_CLASS)} {
+        background-color: var(--lana-row-hover-bg);
+      }
+    `,
+  ];
+
+  connectedCallback(): void {
+    super.connectedCallback();
+    this._locateUnsubscribe = eventBus.on('detail:locate', ({ eventIndexes }) => {
+      this._locatedRow.mark(this._host(), this._rowIdsFor(eventIndexes));
+    });
+    // Escape clears the tab's selection; a picked row here is no selection of
+    // the grid, so this table drops its own.
+    this._selectionClearUnsubscribe = eventBus.on('selection:clear', () => {
+      this._dropPick();
+    });
+  }
+
+  disconnectedCallback(): void {
+    super.disconnectedCallback();
+    this._locateUnsubscribe?.();
+    this._locateUnsubscribe = undefined;
+    this._selectionClearUnsubscribe?.();
+    this._selectionClearUnsubscribe = undefined;
+    // Rows go with the table, so the mark can't outlive them.
+    this._locatedRow.clear();
+    this._table?.destroy();
+    this._table = null;
+    this._rowsByEvent = null;
+  }
+
+  firstUpdated(): void {
+    this._contextMenu = this.renderRoot.querySelector('context-menu');
+    void this._build();
+  }
+
+  render() {
+    return html`
+      <div class="grid"></div>
+      <context-menu
+        @menu-select=${(e: CustomEvent<{ itemId: string }>) =>
+          runPanelRowAction(e.detail.itemId, this._menuEventIndex)}
+      ></context-menu>
+    `;
+  }
+
+  private _host(): HTMLDivElement | null {
+    return this.renderRoot?.querySelector<HTMLDivElement>('.grid') ?? null;
+  }
+
+  /** The ids of the rows that name `eventIndexes`; one frame names several. */
+  private _rowIdsFor(eventIndexes: readonly number[]): number[] {
+    if (!eventIndexes.length || !this._table) {
+      return [];
+    }
+    const byEvent = (this._rowsByEvent ??= rowIdsByEventIndex(
+      this._table.getData() as DatabaseTreeRow[],
+    ));
+    const ids = new Set<number>();
+    for (const eventIndex of eventIndexes) {
+      for (const id of byEvent.get(eventIndex) ?? []) {
+        ids.add(id);
+      }
+    }
+    return [...ids];
+  }
+
+  /** Drops a picked row, and the mark it holds in the grid beside. */
+  private _dropPick(): void {
+    const selected = this._table?.getSelectedRows() ?? [];
+    if (!selected.length) {
+      return;
+    }
+    this._echoGuard.run(() => {
+      for (const row of selected) {
+        row.deselect();
+      }
+    });
+    dispatchInspectorLocate(this, [], true);
+  }
+
+  private async _build(): Promise<void> {
+    const overview = currentDatabaseOverview();
+    // Wait for the host to lay out before Tabulator measures column widths —
+    // building against a zero-width host makes the columns overlap.
+    await this.updateComplete;
+    await waitForNextFrame();
+    const container = this._host();
+    if (!container || !this.isConnected) {
+      return;
+    }
+
+    const rows = overview ? databaseTreeRows(overview.tree) : [];
+    this._ownCodeTotalNs = ownCodeTotal(rows);
+    // Each column is a share of its own footer, so both read 100% there.
+    this._timeBarParams.totalValue = overview?.time.timeNs ?? 0;
+    this._selfBarParams.totalValue = this._ownCodeTotalNs;
+    this._rowsByEvent = null;
+
+    if (this._table) {
+      void this._table.setData(rows);
+      return;
+    }
+    if (!overview) {
+      // No log yet, so there is nothing to size a new table against; the load
+      // event builds it once the figures exist.
+      return;
+    }
+
+    registerTableModules();
+    const table = new Tabulator(container, {
+      data: rows,
+      index: 'id',
+      layout: 'fitColumns',
+      height: '100%',
+      maxHeight: '100%',
+      placeholder: NO_STATEMENTS,
+      ...virtualScrollOptions,
+      dataTree: true,
+      dataTreeChildField: '_children',
+      dataTreeChildColumnCalcs: false,
+      dataTreeBranchElement: '<span/>',
+      columnCalcs: 'table',
+      rowKeyboardNavigation: true,
+      selectableRows: 'highlight',
+      // Lets the hover mark find a row by one DOM query.
+      rowFormatter: rowIndexStamper('id'),
+      ...clipboardCopyOptions,
+      headerSortElement,
+      columnDefaults: commonColumnDefaults,
+      columns: this._columns(progressColumnWidth(overview.time.logNs)),
+    });
+    table.on('rowContext', (e, row) => {
+      this._showRowMenu(e as MouseEvent, row, table);
+    });
+    // A statement row is one frame, so picking it reveals it in the grid; a
+    // merged row and a frame have no one statement to jump to, so the pick marks
+    // every occurrence instead and holds until it is dropped.
+    table.on('rowSelectionChanged', (_data, rows) => {
+      if (this._echoGuard.suppressed) {
+        return;
+      }
+      const row = rows[0]?.getData() as DatabaseTreeRow | undefined;
+      const eventIndex = revealable(row);
+      if (eventIndex !== null) {
+        dispatchInspectorReveal(this, eventIndex);
+      } else {
+        dispatchInspectorLocate(this, row?.eventIndexes ?? [], true);
+      }
+    });
+    table.on('rowMouseEnter', (_e, row) => {
+      dispatchInspectorLocate(this, (row.getData() as DatabaseTreeRow).eventIndexes);
+    });
+    table.on('rowMouseLeave', () => {
+      dispatchInspectorLocate(this, []);
+    });
+    this._table = table;
+  }
+
+  /** Row right-click menu: reveal in the Call Tree tab, or copy the frame. */
+  private _showRowMenu(event: MouseEvent, row: RowComponent, table: Tabulator): void {
+    if (!this._contextMenu || window.getSelection()?.type === 'Range') {
+      return;
+    }
+    event.preventDefault();
+
+    for (const selected of table.getSelectedRows()) {
+      selected.deselect();
+    }
+    row.select();
+
+    const { eventIndexes } = row.getData() as DatabaseTreeRow;
+    this._menuEventIndex = eventIndexes[0] ?? -1;
+    if (this._menuEventIndex < 0) {
+      return;
+    }
+    this._contextMenu.show(PANEL_ROW_MENU_ITEMS, event.clientX, event.clientY);
+  }
+
+  /**
+   * `barWidth` is sized from the whole log, so the bar columns keep one width
+   * whatever share of it the database holds.
+   */
+  private _columns(barWidth: number): ColumnDefinition[] {
+    const self = createDurationBarColumn({
+      title: 'Self Time',
+      field: 'selfNs',
+      barWidth,
+      barParams: this._selfBarParams,
+      bottomCalc: () => this._ownCodeTotalNs,
+    });
+
+    return [
+      {
+        title: 'Name',
+        field: 'label',
+        // Name absorbs the slack and truncates first; the numeric columns hold a
+        // fixed content width.
+        formatter: nameFormatter,
+        cssClass: 'datagrid-code-text truncate',
+        sorter: 'string',
+        widthGrow: 1,
+        widthShrink: 1,
+        minWidth: 140,
+        bottomCalc: () => 'Total',
+      },
+      createDurationBarColumn({
+        title: 'Total Time',
+        field: 'timeNs',
+        barWidth,
+        barParams: this._timeBarParams,
+        bottomCalc: 'sum',
+        tooltip: (_e, cell: CellComponent) => formatDuration(cell.getValue()),
+      }),
+      self,
+      {
+        title: 'Calls',
+        field: 'count',
+        sorter: 'number',
+        hozAlign: 'right',
+        headerHozAlign: 'right',
+        width: 56,
+        minWidth: 56,
+        widthGrow: 0,
+        widthShrink: 0,
+        cssClass: 'number-cell',
+        formatter: (cell: CellComponent) => formatInteger(cell.getValue()),
+      },
+    ];
+  }
+}
+
+/** Own code across the whole tree — a Tabulator tree footer sums only roots. */
+export function ownCodeTotal(rows: readonly DatabaseTreeRow[]): number {
+  let total = 0;
+  const stack = [...rows];
+  while (stack.length) {
+    const row = stack.pop()!; // non-empty: the loop condition just checked
+    total += row.selfNs;
+    for (const child of row._children ?? []) {
+      stack.push(child);
+    }
+  }
+  return total;
+}
+
+/** The statement a row reveals, or null when it is a frame or merges several. */
+function revealable(row: DatabaseTreeRow | undefined): number | null {
+  return row?.kind && row.eventIndexes.length === 1 ? (row.eventIndexes[0] ?? null) : null;
+}
+
+/** The rows keyed by each occurrence they stand for. */
+function rowIdsByEventIndex(rows: readonly DatabaseTreeRow[]): Map<number, number[]> {
+  const byEvent = new Map<number, number[]>();
+  const stack = [...rows];
+  while (stack.length) {
+    const row = stack.pop()!; // non-empty: the loop condition just checked
+    for (const eventIndex of row.eventIndexes) {
+      const ids = byEvent.get(eventIndex);
+      if (ids) {
+        ids.push(row.id);
+      } else {
+        byEvent.set(eventIndex, [row.id]);
+      }
+    }
+    for (const child of row._children ?? []) {
+      stack.push(child);
+    }
+  }
+  return byEvent;
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'database-time': DatabaseTime;
+  }
+}

--- a/log-viewer/src/features/database/components/__tests__/DatabaseOverview.test.ts
+++ b/log-viewer/src/features/database/components/__tests__/DatabaseOverview.test.ts
@@ -1,0 +1,486 @@
+/*
+ * Copyright (c) 2026 Certinia Inc. All rights reserved.
+ *
+ * @jest-environment jsdom
+ */
+import { beforeEach, describe, expect, it } from '@jest/globals';
+import type { ApexLog } from 'apex-log-parser';
+import type { LitElement } from 'lit';
+
+import type { StackedTimeBar } from '../../../../components/StackedTimeBar.js';
+import type {
+  DatabaseBreakdown,
+  DatabaseCallNode,
+  DatabaseOverview,
+  DatabaseStatement,
+} from '../../services/databaseOverview.js';
+
+const apexLog = {} as ApexLog;
+let overview: DatabaseOverview | null = null;
+
+// jsdom has no stylesheet for the icon element to adopt, so it is left unregistered.
+jest.mock('#vscode-elements/vscode-icon.js', () => ({}));
+// The tabulator ESM build and its module registrations don't load under jest; the
+// tree's grid is never built here, only its row mapper is exercised.
+jest.mock('tabulator-tables', () => ({
+  Tabulator: class {
+    static registerModule() {}
+  },
+  Module: class {},
+  Renderer: class {},
+}));
+jest.mock('../../services/Database.js', () => ({
+  DatabaseAccess: { instance: () => (overview ? { getApexLog: () => apexLog } : null) },
+}));
+// Only the log lookup is stubbed: `concentration` is a pure sum over the fixture,
+// so the sections are tested against the same figures they ship with.
+jest.mock('../../services/databaseOverview.js', () => ({
+  ...jest.requireActual('../../services/databaseOverview.js'),
+  currentDatabaseOverview: () => overview,
+}));
+
+import { databaseTreeRows, ownCodeTotal, type DatabaseTreeRow } from '../DatabaseTimeTree.js';
+import '../DatabaseOverview.js';
+
+const emptyOverview = (): DatabaseOverview => ({
+  time: {
+    timeNs: 0,
+    logNs: 1_000_000_000,
+    percentOfLog: 0,
+    soql: { timeNs: 0, statements: 0 },
+    dml: { timeNs: 0, statements: 0 },
+    sosl: { timeNs: 0, statements: 0 },
+  },
+  ranked: [],
+  tree: [],
+  askedBy: [],
+  burnedIn: [],
+});
+
+// The DML fires a trigger that holds a query, so its net time is 50ms short of
+// its total and its self time shorter still; the three net times sum to the 300ms
+// database total.
+const statements = (): DatabaseStatement[] => [
+  {
+    eventIndex: 11,
+    eventIndexes: [11],
+    kind: 'SOQL',
+    label: 'SELECT Id FROM Account',
+    timeNs: 150_000_000,
+    netNs: 150_000_000,
+    selfNs: 150_000_000,
+    rows: 200,
+    repeats: 1,
+  },
+  {
+    eventIndex: 22,
+    eventIndexes: [22, 23, 24],
+    kind: 'DML',
+    label: 'Update Case',
+    timeNs: 150_000_000,
+    netNs: 100_000_000,
+    selfNs: 30_000_000,
+    rows: 40,
+    repeats: 3,
+  },
+  {
+    eventIndex: 33,
+    eventIndexes: [33],
+    kind: 'SOQL',
+    label: 'SELECT Name FROM Contact',
+    timeNs: 50_000_000,
+    netNs: 50_000_000,
+    selfNs: 50_000_000,
+    rows: 100,
+    repeats: 1,
+  },
+];
+
+const node = (part: Partial<DatabaseCallNode> & { label: string }): DatabaseCallNode => ({
+  kind: null,
+  timeNs: 0,
+  selfNs: 0,
+  count: 1,
+  eventIndexes: [],
+  children: [],
+  ...part,
+});
+
+const tree = (): DatabaseCallNode[] => [
+  node({
+    label: 'apex://pkg.Entry',
+    timeNs: 300_000_000,
+    // A frame's self time is its own code, every child excluded.
+    selfNs: 20_000_000,
+    eventIndexes: [2],
+    children: [
+      node({
+        label: 'TaskService.run()',
+        timeNs: 300_000_000,
+        selfNs: 30_000_000,
+        eventIndexes: [5, 6],
+        count: 2,
+        children: [
+          node({
+            label: 'SELECT Id FROM Account',
+            kind: 'SOQL',
+            timeNs: 150_000_000,
+            selfNs: 150_000_000,
+            eventIndexes: [11],
+          }),
+          node({
+            label: 'Update Case',
+            kind: 'DML',
+            timeNs: 150_000_000,
+            selfNs: 100_000_000,
+            eventIndexes: [22],
+            children: [
+              node({
+                label: 'SELECT Name FROM Contact',
+                kind: 'SOQL',
+                timeNs: 50_000_000,
+                selfNs: 50_000_000,
+                eventIndexes: [33],
+              }),
+            ],
+          }),
+        ],
+      }),
+    ],
+  }),
+];
+
+const fullOverview = (): DatabaseOverview => ({
+  time: {
+    timeNs: 300_000_000,
+    logNs: 1_000_000_000,
+    percentOfLog: 30,
+    soql: { timeNs: 200_000_000, statements: 2 },
+    dml: { timeNs: 100_000_000, statements: 1 },
+    sosl: { timeNs: 0, statements: 0 },
+  },
+  ranked: statements(),
+  tree: tree(),
+  askedBy: namespaceSplit(),
+  // The same split by default, so the section shows one bar; a test overrides it
+  // to check the second.
+  burnedIn: namespaceSplit(),
+});
+
+const namespaceSplit = (): DatabaseBreakdown[] => [
+  {
+    key: 'pkg',
+    timeNs: 250_000_000,
+    soqlTimeNs: 200_000_000,
+    dmlTimeNs: 50_000_000,
+    soslTimeNs: 0,
+    statements: 3,
+    rowsRead: 300,
+    rowsWritten: 20,
+  },
+  {
+    key: 'default',
+    timeNs: 50_000_000,
+    soqlTimeNs: 0,
+    dmlTimeNs: 50_000_000,
+    soslTimeNs: 0,
+    statements: 1,
+    rowsRead: 0,
+    rowsWritten: 20,
+  },
+];
+
+async function mount<K extends keyof HTMLElementTagNameMap>(
+  tag: K,
+): Promise<HTMLElementTagNameMap[K] & LitElement> {
+  const element = document.createElement(tag);
+  document.body.append(element);
+  await (element as LitElement).updateComplete;
+  return element as HTMLElementTagNameMap[K] & LitElement;
+}
+
+const texts = (element: Element, selector: string) =>
+  [...(element.shadowRoot?.querySelectorAll(selector) ?? [])].map((node) =>
+    (node.textContent ?? '').replace(/\s+/g, ' ').trim(),
+  );
+
+const note = (element: Element) => element.shadowRoot?.querySelector('.note')?.textContent ?? '';
+
+describe('databaseTreeRows', () => {
+  /** Every row, in the order the grid holds them. */
+  const flatten = (rows: readonly DatabaseTreeRow[]): DatabaseTreeRow[] =>
+    rows.flatMap((row) => [row, ...flatten(row._children ?? [])]);
+
+  it('numbers the rows depth first, so a nested statement follows its parent', () => {
+    const rows = flatten(databaseTreeRows(tree()));
+
+    expect(rows.map((row) => [row.id, row.label])).toEqual([
+      [0, 'apex://pkg.Entry'],
+      [1, 'TaskService.run()'],
+      [2, 'SELECT Id FROM Account'],
+      [3, 'Update Case'],
+      [4, 'SELECT Name FROM Contact'],
+    ]);
+  });
+
+  it('carries both times, the kind and every occurrence', () => {
+    const rows = flatten(databaseTreeRows(tree()));
+
+    // The DML's total holds the query beneath it; its self time does not.
+    expect(rows[3]).toMatchObject({
+      kind: 'DML',
+      timeNs: 150_000_000,
+      selfNs: 100_000_000,
+      count: 1,
+      eventIndexes: [22],
+    });
+    // A frame has no kind, carries its own code as self time, and merges its calls.
+    expect(rows[1]).toMatchObject({
+      kind: null,
+      timeNs: 300_000_000,
+      selfNs: 30_000_000,
+      count: 2,
+      eventIndexes: [5, 6],
+    });
+  });
+
+  it('sums the own code of every row, since a tree footer sums only the roots', () => {
+    // 20ms + 30ms of frame code, and the statements' own 300ms.
+    expect(ownCodeTotal(databaseTreeRows(tree()))).toBe(350_000_000);
+  });
+
+  it('leaves a leaf with no children, so the grid draws no twistie', () => {
+    const rows = databaseTreeRows(tree());
+
+    expect(rows[0]?._children).toHaveLength(1);
+    expect(flatten(rows)[2]?._children).toBeNull();
+  });
+});
+
+describe('database-concentration', () => {
+  beforeEach(() => {
+    document.body.replaceChildren();
+    overview = null;
+  });
+
+  it('heads the section with how few statements hold the time, in one line', async () => {
+    overview = fullOverview();
+    const shown = texts(await mount('database-concentration'), '.headline');
+
+    // 150ms then 100ms of self time in 300ms crosses 75%.
+    expect(shown).toEqual(['2 of 3 statements · 83.3% of DB time · 30.0% of log']);
+  });
+
+  it('gives each row its total, its share, its cost per row and its repeats', async () => {
+    overview = fullOverview();
+    const element = await mount('database-concentration');
+    const shown = texts(element, '.reveal-row');
+
+    expect(shown[0]).toContain('SELECT Id FROM Account');
+    expect(shown[0]).toContain('50.0% · 0.75 ms/row');
+    // A statement that ran more than once says so; one that ran once does not.
+    // A statement with descendants splits its duration: 30ms its own, 120ms below,
+    // and 50ms of that 120ms is the nested statement the database itself ran.
+    expect(shown[1]).toContain('33.3% · 30 ms self · 120 ms desc · 2.5 ms/row · ran 3× · 50 ms db');
+    // A statement with nothing inside it names neither, since self is the total.
+    expect(shown[0]).not.toContain('self');
+    // The parts a narrow dock hides are the least telling ones, and the title
+    // keeps the whole reading whatever is on screen.
+    const rows = [...(element.shadowRoot?.querySelectorAll('.reveal-row') ?? [])];
+    expect(rows[1]?.querySelector('.sub__database')?.textContent).toContain('50 ms db');
+    expect(rows[1]?.getAttribute('title')).toContain('50 ms of the descendant time');
+    expect(rows[0]?.getAttribute('title')).toBe('Show this statement in the grid');
+    expect(shown[2]).toContain('16.7% · 0.50 ms/row');
+    // The figure is the total, so it matches the grid beside it.
+    expect(texts(element, '.reveal-row__value--primary')).toEqual(['150 ms', '150 ms', '50 ms']);
+    // The meter is the statement's whole share of database time, so the DML's
+    // runs to the 50% its total holds while its figure reads its own 33.3%.
+    const meters = [...(element.shadowRoot?.querySelectorAll('.reveal-row__meter-fill') ?? [])];
+    expect(meters.map((meter) => meter.getAttribute('style'))).toEqual([
+      'width:50%;',
+      'width:50%;',
+      expect.stringContaining('width:16.6'),
+    ]);
+  });
+
+  it('says a statement returned no rows rather than divide by a row it never had', async () => {
+    const none = fullOverview();
+    none.ranked = statements().map((statement) => ({ ...statement, rows: 0 }));
+    overview = none;
+    const shown = texts(await mount('database-concentration'), '.reveal-row');
+
+    expect(shown[0]).toContain('50.0% · no rows');
+  });
+
+  it('marks every occurrence of a statement on hover', async () => {
+    overview = fullOverview();
+    const element = await mount('database-concentration');
+    const located: number[][] = [];
+    document.addEventListener('inspector-locate', (event) => {
+      located.push((event as CustomEvent<{ eventIndexes: number[] }>).detail.eventIndexes);
+    });
+
+    element.shadowRoot
+      ?.querySelectorAll('.reveal-row')[1]
+      ?.dispatchEvent(new Event('pointerenter'));
+
+    expect(located).toEqual([[22, 23, 24]]);
+  });
+
+  it('accounts for the statements past the rows it shows', async () => {
+    const many = fullOverview();
+    many.ranked = Array.from({ length: 10 }, (_ignored, index) => ({
+      eventIndex: index,
+      eventIndexes: [index],
+      kind: 'SOQL' as const,
+      label: `SELECT Id FROM Object${index}`,
+      timeNs: 30_000_000,
+      netNs: 30_000_000,
+      selfNs: 30_000_000,
+      rows: 0,
+      repeats: 1,
+    }));
+    overview = many;
+    const element = await mount('database-concentration');
+
+    expect(texts(element, '.reveal-row')).toHaveLength(8);
+    expect(texts(element, '.tail')[0]).toBe('the other 2 statements 20.0%');
+  });
+
+  it('renders a query as highlighted SOQL, and a DML as its own text', async () => {
+    overview = fullOverview();
+    const element = await mount('database-concentration');
+    const names = [...(element.shadowRoot?.querySelectorAll('.reveal-row__name') ?? [])];
+
+    expect(names[0]?.querySelector('.soql-block')).not.toBeNull();
+    expect(names[1]?.querySelector('.soql-block')).toBeNull();
+    expect(names[1]?.textContent).toContain('Update Case');
+  });
+
+  it('reveals the statement behind a row', async () => {
+    overview = fullOverview();
+    const element = await mount('database-concentration');
+    const revealed: number[] = [];
+    document.addEventListener('inspector-reveal', (event) => {
+      revealed.push((event as CustomEvent<{ eventIndex: number }>).detail.eventIndex);
+    });
+
+    element.shadowRoot?.querySelector<HTMLButtonElement>('.reveal-row')?.click();
+
+    expect(revealed).toEqual([11]);
+  });
+
+  it('says so when the log records no statements', async () => {
+    overview = emptyOverview();
+    expect(note(await mount('database-concentration'))).toContain('no database statements');
+  });
+});
+
+describe('database-namespaces', () => {
+  beforeEach(() => {
+    document.body.replaceChildren();
+    overview = null;
+  });
+
+  const bar = (element: Element) =>
+    element.shadowRoot?.querySelector('stacked-time-bar') as StackedTimeBar;
+  const bars = (element: Element) =>
+    [...(element.shadowRoot?.querySelectorAll('stacked-time-bar') ?? [])] as StackedTimeBar[];
+
+  it('splits the bar by namespace, longest first, with a row per namespace', async () => {
+    overview = fullOverview();
+    const chart = bar(await mount('database-namespaces'));
+
+    expect(chart.segments.map((segment) => [segment.label, segment.timeNs])).toEqual([
+      ['pkg', 250_000_000],
+      ['default', 50_000_000],
+    ]);
+    // No `total`, so the bar is the split of database time itself.
+    expect(chart.total).toBe(0);
+    expect(chart.legend).toBe(true);
+    expect(chart.legendRows).toBe(true);
+  });
+
+  it('names the kinds a namespace spent its time in, zero kinds left out', async () => {
+    overview = fullOverview();
+    const chart = bar(await mount('database-namespaces'));
+
+    expect(chart.segments.map((segment) => segment.detail)).toEqual([
+      'SOQL 200 ms · DML 50 ms',
+      'DML 50 ms',
+    ]);
+  });
+
+  it('gives every namespace a colour of its own', async () => {
+    overview = fullOverview();
+    const chart = bar(await mount('database-namespaces'));
+    const colors = chart.segments.map((segment) => segment.color);
+
+    expect(new Set(colors).size).toBe(colors.length);
+  });
+
+  it('keeps a namespace on one colour across both bars', async () => {
+    const split = fullOverview();
+    const [asked, other] = namespaceSplit();
+    // The burned-in bar leads with the namespace the asked-for bar puts second.
+    split.burnedIn = [
+      { ...other!, key: 'default', timeNs: 180_000_000 },
+      { ...asked!, key: 'pkg', timeNs: 120_000_000 },
+    ];
+    overview = split;
+    const [askedBar, burnedBar] = bars(await mount('database-namespaces'));
+
+    const colorOf = (chart: StackedTimeBar, key: string) =>
+      chart.segments.find((segment) => segment.label === key)?.color;
+    expect(colorOf(burnedBar!, 'pkg')).toBe(colorOf(askedBar!, 'pkg'));
+    expect(colorOf(burnedBar!, 'default')).toBe(colorOf(askedBar!, 'default'));
+  });
+
+  it('shows one bar when nothing runs inside the statements', async () => {
+    overview = fullOverview();
+    const shown = bars(await mount('database-namespaces'));
+
+    // `askedBy` and `burnedIn` agree, so a second bar would say nothing new.
+    expect(shown).toHaveLength(1);
+    expect(shown[0]?.getAttribute('label')).toContain('Called from namespace');
+  });
+
+  it('adds the burned-in bar when code beneath the statements holds time', async () => {
+    const split = fullOverview();
+    const [asked, other] = namespaceSplit();
+    split.burnedIn = [
+      { ...asked!, key: 'pkg', timeNs: 180_000_000 },
+      { ...other!, key: 'trigPkg', timeNs: 120_000_000 },
+    ];
+    overview = split;
+    const shown = bars(await mount('database-namespaces'));
+
+    expect(shown).toHaveLength(2);
+    expect(shown[1]?.getAttribute('label')).toContain('Ran in namespace');
+    expect(shown[1]?.segments.map((segment) => segment.label)).toEqual(['pkg', 'trigPkg']);
+  });
+
+  it('collapses the namespaces past the eighth into one segment', async () => {
+    const many = fullOverview();
+    many.askedBy = Array.from({ length: 10 }, (_ignored, index) => ({
+      key: `ns${index}`,
+      timeNs: (10 - index) * 10_000_000,
+      soqlTimeNs: (10 - index) * 10_000_000,
+      dmlTimeNs: 0,
+      soslTimeNs: 0,
+      statements: 1,
+      rowsRead: 1,
+      rowsWritten: 0,
+    }));
+    overview = many;
+    const chart = bar(await mount('database-namespaces'));
+
+    expect(chart.segments).toHaveLength(9);
+    expect(chart.segments[8]).toMatchObject({ label: '2 others', timeNs: 30_000_000 });
+  });
+
+  it('says so when the log records no statements', async () => {
+    overview = emptyOverview();
+    expect(note(await mount('database-namespaces'))).toContain('no database statements');
+  });
+});

--- a/log-viewer/src/features/database/services/__tests__/databaseOverview.test.ts
+++ b/log-viewer/src/features/database/services/__tests__/databaseOverview.test.ts
@@ -1,0 +1,409 @@
+/*
+ * Copyright (c) 2026 Certinia Inc. All rights reserved.
+ */
+import { describe, expect, it } from '@jest/globals';
+import { parse } from 'apex-log-parser';
+
+import {
+  concentration,
+  databaseOverview,
+  dmlOperation,
+  UNKNOWN_OBJECT,
+} from '../databaseOverview.js';
+
+const HEAD =
+  '09:18:22.6 (6574780)|EXECUTION_STARTED\n' +
+  '09:18:22.6 (6586704)|CODE_UNIT_STARTED|[EXTERNAL]|066d0000002m8ij|apex://pkg.Entry\n';
+const TAIL =
+  '09:18:23.6 (1000000000)|CODE_UNIT_FINISHED|apex://pkg.Entry\n' +
+  '09:18:23.6 (1000100000)|EXECUTION_FINISHED\n';
+
+const soql = (start: number, end: number, rows: number, query: string, line = 1) =>
+  `09:18:22.6 (${start})|SOQL_EXECUTE_BEGIN|[${line}]|Aggregations:0|${query}\n` +
+  `09:18:22.6 (${end})|SOQL_EXECUTE_END|[${line}]|Rows:${rows}\n`;
+
+const dml = (start: number, end: number, op: string, type: string, rows: number, line = 2) =>
+  `09:18:22.6 (${start})|DML_BEGIN|[${line}]|Op:${op}|Type:${type}|Rows:${rows}\n` +
+  `09:18:22.6 (${end})|DML_END|[${line}]\n`;
+
+const sosl = (start: number, end: number, rows: number, line = 3) =>
+  `09:18:22.6 (${start})|SOSL_EXECUTE_BEGIN|[${line}]|FIND :term RETURNING Account(Id)\n` +
+  `09:18:22.6 (${end})|SOSL_EXECUTE_END|[${line}]|Rows:${rows}\n`;
+
+const overviewOf = (body: string) => databaseOverview(parse(HEAD + body + TAIL));
+
+describe('dmlOperation', () => {
+  it('reads the operation out of a DML line', () => {
+    expect(dmlOperation('DML Op:Insert Type:Account')).toEqual('Insert');
+  });
+
+  it('falls back to DML when the line names no operation', () => {
+    expect(dmlOperation('DML')).toEqual('DML');
+  });
+});
+
+describe('databaseOverview time', () => {
+  it('splits database time by statement kind and shares it against the log', () => {
+    const overview = overviewOf(
+      soql(10_000_000, 30_000_000, 5, 'SELECT Id FROM Account') +
+        dml(40_000_000, 50_000_000, 'Insert', 'Contact', 2) +
+        sosl(60_000_000, 70_000_000, 3),
+    );
+
+    expect(overview.time.soql).toEqual({ timeNs: 20_000_000, statements: 1 });
+    expect(overview.time.dml).toEqual({ timeNs: 10_000_000, statements: 1 });
+    expect(overview.time.sosl).toEqual({ timeNs: 10_000_000, statements: 1 });
+    expect(overview.time.timeNs).toEqual(40_000_000);
+    expect(overview.time.percentOfLog).toBeCloseTo(4.0, 1);
+    // The log's own duration is the spine's denominator, so it travels with the figures.
+    expect(overview.time.logNs).toBeGreaterThan(overview.time.timeNs);
+  });
+
+  it('reports zeroes for a log with no statements', () => {
+    const overview = overviewOf('');
+
+    expect(overview.time.timeNs).toEqual(0);
+    expect(overview.time.percentOfLog).toEqual(0);
+    expect(overview.ranked).toEqual([]);
+    expect(overview.tree).toEqual([]);
+    expect(overview.askedBy).toEqual([]);
+    expect(overview.burnedIn).toEqual([]);
+  });
+
+  it('computes once per log', () => {
+    const apexLog = parse(HEAD + soql(10_000_000, 20_000_000, 1, 'SELECT Id FROM Account') + TAIL);
+
+    expect(databaseOverview(apexLog)).toBe(databaseOverview(apexLog));
+  });
+});
+
+describe('databaseOverview statements', () => {
+  const body =
+    soql(10_000_000, 11_000_000, 5, 'SELECT Id FROM Account') +
+    soql(12_000_000, 42_000_000, 90, 'SELECT Name FROM Contact') +
+    dml(43_000_000, 45_000_000, 'Insert', 'Case', 3);
+
+  it('ranks every statement by its own time, longest first', () => {
+    const overview = overviewOf(body);
+
+    expect(overview.ranked).toEqual([
+      {
+        eventIndex: expect.any(Number),
+        eventIndexes: [expect.any(Number)],
+        kind: 'SOQL',
+        label: 'SELECT Name FROM Contact',
+        timeNs: 30_000_000,
+        netNs: 30_000_000,
+        selfNs: 30_000_000,
+        rows: 90,
+        repeats: 1,
+      },
+      {
+        eventIndex: expect.any(Number),
+        eventIndexes: [expect.any(Number)],
+        kind: 'DML',
+        label: 'Insert Case',
+        timeNs: 2_000_000,
+        netNs: 2_000_000,
+        selfNs: 2_000_000,
+        rows: 3,
+        repeats: 1,
+      },
+      {
+        eventIndex: expect.any(Number),
+        eventIndexes: [expect.any(Number)],
+        kind: 'SOQL',
+        label: 'SELECT Id FROM Account',
+        timeNs: 1_000_000,
+        netNs: 1_000_000,
+        selfNs: 1_000_000,
+        rows: 5,
+        repeats: 1,
+      },
+    ]);
+  });
+
+  it('sums every occurrence of the same statement into one row', () => {
+    const overview = overviewOf(
+      soql(10_000_000, 12_000_000, 3, 'SELECT Id FROM Account') +
+        soql(13_000_000, 15_000_000, 2, 'SELECT Id FROM Account', 4) +
+        dml(16_000_000, 19_000_000, 'Insert', 'Case', 1),
+    );
+
+    expect(
+      overview.ranked.map((statement) => [statement.label, statement.repeats, statement.timeNs]),
+    ).toEqual([
+      ['SELECT Id FROM Account', 2, 4_000_000],
+      ['Insert Case', 1, 3_000_000],
+    ]);
+    // The rows of every occurrence, and the slowest one to reveal.
+    expect(overview.ranked[0]).toMatchObject({
+      rows: 5,
+      eventIndexes: [expect.any(Number), expect.any(Number)],
+    });
+  });
+
+  it('gives every statement its own event index, so a row can be revealed', () => {
+    const indexes = overviewOf(body).ranked.map((statement) => statement.eventIndex);
+
+    expect(new Set(indexes).size).toEqual(indexes.length);
+  });
+
+  it('labels DML the log gives no SObject for', () => {
+    const overview = overviewOf(
+      '09:18:22.6 (10000000)|DML_BEGIN|[2]|Op:Insert|Rows:1\n' +
+        '09:18:22.6 (11000000)|DML_END|[2]\n',
+    );
+
+    expect(overview.ranked[0]?.label).toEqual(`Insert ${UNKNOWN_OBJECT}`);
+  });
+});
+
+describe('databaseOverview tree', () => {
+  const method = (start: number, end: number, name: string, body: string, line = 5) =>
+    `09:18:22.6 (${start})|METHOD_ENTRY|[${line}]|01p|${name}\n` +
+    body +
+    `09:18:22.6 (${end})|METHOD_EXIT|[${line}]|01p|${name}\n`;
+
+  it('keeps only the paths that end in a statement, each carrying its time', () => {
+    const overview = overviewOf(
+      method(
+        9_000_000,
+        45_000_000,
+        'Svc.load()',
+        soql(10_000_000, 40_000_000, 90, 'SELECT Name FROM Contact'),
+      ) + method(46_000_000, 47_000_000, 'Svc.idle()', ''),
+    );
+
+    // The execution marker names no code, so the path starts at the code unit.
+    const entry = overview.tree[0];
+    expect(entry).toMatchObject({ label: 'apex://pkg.Entry', kind: null, timeNs: 30_000_000 });
+    expect(entry?.children.map((node) => node.label)).toEqual(['Svc.load()']);
+    expect(entry?.children[0]?.children[0]).toMatchObject({
+      label: 'SELECT Name FROM Contact',
+      kind: 'SOQL',
+      timeNs: 30_000_000,
+      count: 1,
+    });
+  });
+
+  it('merges repeated frames into one node with a count and every occurrence', () => {
+    const call = (start: number, end: number, line: number) =>
+      method(
+        start,
+        end,
+        'Svc.load()',
+        soql(start + 100_000, end - 100_000, 1, 'SELECT Id FROM Account', line),
+      );
+    const overview = overviewOf(call(10_000_000, 20_000_000, 1) + call(21_000_000, 31_000_000, 2));
+
+    const frame = overview.tree[0]?.children[0];
+    expect(frame).toMatchObject({ label: 'Svc.load()', count: 2, timeNs: 19_600_000 });
+    expect(frame?.children[0]).toMatchObject({ kind: 'SOQL', count: 2 });
+    expect(frame?.children[0]?.eventIndexes).toHaveLength(2);
+  });
+
+  it('sorts each level longest first', () => {
+    const overview = overviewOf(
+      method(9_000_000, 12_000_000, 'Svc.fast()', soql(10_000_000, 11_000_000, 1, 'SELECT Id A')) +
+        method(
+          13_000_000,
+          45_000_000,
+          'Svc.slow()',
+          soql(14_000_000, 44_000_000, 1, 'SELECT Id B'),
+        ),
+    );
+
+    expect(overview.tree[0]?.children.map((node) => node.label)).toEqual([
+      'Svc.slow()',
+      'Svc.fast()',
+    ]);
+  });
+
+  it('splits a statement duration into its own time and its descendants', () => {
+    const overview = overviewOf(
+      '09:18:22.6 (10000000)|DML_BEGIN|[2]|Op:Insert|Type:Case|Rows:3\n' +
+        '09:18:22.6 (11000000)|CODE_UNIT_STARTED|[EXTERNAL]|01q000000000001|CaseTrigger\n' +
+        soql(12_000_000, 13_000_000, 1, 'SELECT Id FROM Account', 9) +
+        '09:18:22.6 (18000000)|CODE_UNIT_FINISHED|CaseTrigger\n' +
+        '09:18:22.6 (20000000)|DML_END|[2]\n',
+    );
+    const insert = overview.ranked.find((statement) => statement.kind === 'DML');
+
+    // 10ms in all: 3ms the insert's own, 7ms in the trigger it fired, and 1ms of
+    // that trigger time is the query — the only part the database did.
+    expect(insert).toMatchObject({ timeNs: 10_000_000, netNs: 9_000_000, selfNs: 3_000_000 });
+  });
+
+  it('nests a statement inside the statement that holds it, on a total/self split', () => {
+    const overview = overviewOf(
+      '09:18:22.6 (10000000)|DML_BEGIN|[2]|Op:Insert|Type:Case|Rows:3\n' +
+        soql(11_000_000, 12_000_000, 1, 'SELECT Id FROM Account', 9) +
+        '09:18:22.6 (13000000)|DML_END|[2]\n',
+    );
+
+    // The query owns its own time; the DML's total holds it, its net time does not.
+    expect(overview.time.soql).toEqual({ timeNs: 1_000_000, statements: 1 });
+    expect(overview.time.dml).toEqual({ timeNs: 2_000_000, statements: 1 });
+    expect(overview.time.timeNs).toEqual(3_000_000);
+    expect(
+      overview.ranked.map((statement) => [statement.kind, statement.timeNs, statement.netNs]),
+    ).toEqual([
+      ['DML', 3_000_000, 2_000_000],
+      ['SOQL', 1_000_000, 1_000_000],
+    ]);
+
+    const dmlNode = overview.tree[0]?.children[0];
+    expect(dmlNode).toMatchObject({ kind: 'DML', timeNs: 3_000_000, selfNs: 2_000_000 });
+    // The query is the DML's child, and takes no time up the path: the DML's
+    // total already holds it, so nothing is counted twice.
+    expect(dmlNode?.children[0]).toMatchObject({
+      kind: 'SOQL',
+      timeNs: 1_000_000,
+      selfNs: 1_000_000,
+    });
+    // A frame's total is the database time beneath it; its self is its own code,
+    // every child excluded, so the two never overlap.
+    expect(overview.tree[0]).toMatchObject({ timeNs: 3_000_000 });
+    expect(overview.tree[0]?.selfNs).toBeGreaterThan(3_000_000);
+  });
+
+  it('takes a frame own code from the frame, counted once per occurrence', () => {
+    const overview = overviewOf(
+      method(
+        10_000_000,
+        20_000_000,
+        'Svc.load()',
+        soql(11_000_000, 12_000_000, 1, 'SELECT Id FROM Account') +
+          dml(13_000_000, 15_000_000, 'Insert', 'Case', 1),
+      ),
+    );
+
+    // 10ms of frame less the 1ms query and the 2ms DML: the Apex around them,
+    // added once though two statement paths reach the frame.
+    expect(overview.tree[0]?.children[0]).toMatchObject({
+      label: 'Svc.load()',
+      timeNs: 3_000_000,
+      selfNs: 7_000_000,
+    });
+  });
+
+  it('nets every nested statement off the one that holds them, and adds up', () => {
+    const overview = overviewOf(
+      '09:18:22.6 (10000000)|DML_BEGIN|[2]|Op:Insert|Type:Case|Rows:3\n' +
+        soql(11_000_000, 13_000_000, 1, 'SELECT Id FROM Account', 9) +
+        soql(14_000_000, 17_000_000, 1, 'SELECT Id FROM Contact', 10) +
+        '09:18:22.6 (20000000)|DML_END|[2]\n',
+    );
+
+    expect(overview.ranked.map((statement) => statement.netNs)).toEqual([
+      5_000_000, // the DML's 10ms less the 5ms in its two queries
+      3_000_000,
+      2_000_000,
+    ]);
+    // Net times still sum to the database total.
+    expect(overview.time.timeNs).toEqual(10_000_000);
+  });
+});
+
+describe('concentration', () => {
+  it('counts the statements it takes to cross the target share', () => {
+    const overview = overviewOf(
+      soql(10_000_000, 40_000_000, 1, 'SELECT Id FROM Account') +
+        soql(41_000_000, 46_000_000, 1, 'SELECT Id FROM Contact') +
+        dml(47_000_000, 52_000_000, 'Insert', 'Case', 1),
+    );
+
+    expect(concentration(overview)).toEqual({ count: 1, percent: 75, total: 3 });
+  });
+
+  it('walks on when no single statement dominates', () => {
+    const overview = overviewOf(
+      soql(10_000_000, 20_000_000, 1, 'SELECT Id FROM Account') +
+        soql(21_000_000, 31_000_000, 1, 'SELECT Id FROM Contact'),
+    );
+
+    expect(concentration(overview)).toEqual({ count: 2, percent: 100, total: 2 });
+  });
+
+  it('takes a target of its own', () => {
+    const overview = overviewOf(
+      soql(10_000_000, 20_000_000, 1, 'SELECT Id FROM Account') +
+        soql(21_000_000, 31_000_000, 1, 'SELECT Id FROM Contact'),
+    );
+
+    expect(concentration(overview, 50)).toMatchObject({ count: 1, percent: 50 });
+  });
+
+  it('reports nothing held for a log with no statements', () => {
+    expect(concentration(overviewOf(''))).toEqual({ count: 0, percent: 0, total: 0 });
+  });
+});
+
+describe('databaseOverview namespaces', () => {
+  it('charges every kind to the namespace of the code that ran it', () => {
+    const overview = overviewOf(
+      soql(10_000_000, 30_000_000, 5, 'SELECT Id FROM Account') +
+        dml(31_000_000, 41_000_000, 'Insert', 'Account', 8),
+    );
+
+    expect(overview.askedBy).toEqual([
+      {
+        key: 'pkg',
+        timeNs: 30_000_000,
+        soqlTimeNs: 20_000_000,
+        dmlTimeNs: 10_000_000,
+        soslTimeNs: 0,
+        statements: 2,
+        rowsRead: 5,
+        rowsWritten: 8,
+      },
+    ]);
+    // Nothing runs inside these statements, so both questions have one answer.
+    expect(overview.burnedIn).toEqual(overview.askedBy);
+  });
+
+  it('counts a search as rows read for its caller namespace', () => {
+    const overview = overviewOf(sosl(10_000_000, 11_000_000, 7));
+
+    expect(overview.askedBy[0]).toMatchObject({
+      key: 'pkg',
+      soslTimeNs: 1_000_000,
+      rowsRead: 7,
+    });
+  });
+
+  it('ranks namespaces by their database time', () => {
+    const overview = overviewOf(
+      soql(10_000_000, 12_000_000, 1, 'SELECT Id FROM Account') +
+        '09:18:22.6 (13000000)|CODE_UNIT_STARTED|[EXTERNAL]|066d0000002m8ik|apex://other.Entry\n' +
+        soql(14_000_000, 44_000_000, 1, 'SELECT Id FROM Contact') +
+        '09:18:22.6 (45000000)|CODE_UNIT_FINISHED|apex://other.Entry\n',
+    );
+
+    expect(overview.askedBy.map((entry) => entry.key)).toEqual(['other', 'pkg']);
+  });
+
+  it('charges the code beneath a DML to its own namespace', () => {
+    // A trigger from another package fires on the caller's insert.
+    const overview = overviewOf(
+      '09:18:22.6 (10000000)|DML_BEGIN|[2]|Op:Insert|Type:Case|Rows:1\n' +
+        '09:18:22.6 (11000000)|CODE_UNIT_STARTED|[EXTERNAL]|01q|trig.CaseTrigger on Case trigger event BeforeInsert|__sfdc_trigger/trig/CaseTrigger\n' +
+        '09:18:22.6 (17000000)|CODE_UNIT_FINISHED|trig.CaseTrigger on Case trigger event BeforeInsert\n' +
+        '09:18:22.6 (20000000)|DML_END|[2]\n',
+    );
+
+    // Who asked: all 10ms against the caller.
+    expect(overview.askedBy.map((entry) => [entry.key, entry.timeNs])).toEqual([
+      ['pkg', 10_000_000],
+    ]);
+    // Where it went: 6ms in the trigger's package, the platform's own 4ms with
+    // the caller that asked for the save.
+    expect(overview.burnedIn.map((entry) => [entry.key, entry.timeNs])).toEqual([
+      ['trig', 6_000_000],
+      ['pkg', 4_000_000],
+    ]);
+    // The rows stay with the statement, so they follow the caller.
+    expect(overview.burnedIn[1]).toMatchObject({ statements: 1, rowsWritten: 1 });
+  });
+});

--- a/log-viewer/src/features/database/services/databaseOverview.ts
+++ b/log-viewer/src/features/database/services/databaseOverview.ts
@@ -1,0 +1,540 @@
+/*
+ * Copyright (c) 2026 Certinia Inc. All rights reserved.
+ */
+import {
+  type ApexLog,
+  DMLBeginLine,
+  type LogEvent,
+  SOQLExecuteBeginLine,
+  SOSLExecuteBeginLine,
+} from 'apex-log-parser';
+
+import { DEFAULT_NAMESPACE, getCallerNamespace } from '../../../core/utility/CallerNamespace.js';
+import { DatabaseAccess } from './Database.js';
+
+/** The label for a DML statement whose SObject the log never names. */
+export const UNKNOWN_OBJECT = 'Unknown';
+
+/** What every whole-log Database section says when the log holds nothing. */
+export const NO_STATEMENTS = 'The log records no database statements.';
+
+/**
+ * The share of database time the concentration read aims at. The first
+ * statements to cross it are the ones worth fixing; everything after them is
+ * tail.
+ */
+export const CONCENTRATION_SHARE = 75;
+
+export type StatementKind = 'SOQL' | 'DML' | 'SOSL';
+
+/** Time and statement count for one statement kind. */
+export interface StatementKindTime {
+  timeNs: number;
+  statements: number;
+}
+
+/** Where the transaction's database time went, by statement kind. */
+export interface DatabaseTime {
+  timeNs: number;
+  /** The log's own duration (ns) — the denominator the total is a share of. */
+  logNs: number;
+  /** Database time as a share of the log's own duration, 0-100. */
+  percentOfLog: number;
+  soql: StatementKindTime;
+  dml: StatementKindTime;
+  sosl: StatementKindTime;
+}
+
+/**
+ * One database statement and how long it took, summed across every time the log
+ * ran it — the same grouping the grids show as `(3)` on a repeated statement.
+ */
+export interface DatabaseStatement {
+  /** The slowest occurrence, so a click reveals the one worth reading. */
+  eventIndex: number;
+  /** Every occurrence, so hovering marks all of them in the grid. */
+  eventIndexes: number[];
+  kind: StatementKind;
+  /** The query text, or the operation and SObject for DML. */
+  label: string;
+  /** Whole duration (ns) across every occurrence, nested statements included. */
+  timeNs: number;
+  /**
+   * Duration (ns) net of the statements nested inside it, so the three kinds sum
+   * to the database total with nothing counted twice.
+   */
+  netNs: number;
+  /** Self time (ns): the statement line's own, every descendant excluded. */
+  selfNs: number;
+  rows: number;
+  /** Times the log ran this statement. */
+  repeats: number;
+}
+
+/**
+ * One frame on a call path that ends in a database statement, with the database
+ * time held beneath it. Frames with the same text under the same parent merge
+ * into one node, so a method called 200 times reads as one row with a count.
+ */
+export interface DatabaseCallNode {
+  label: string;
+  /** Set when the node is the statement itself, not a frame that led to one. */
+  kind: StatementKind | null;
+  /** Database time in this node's subtree (ns). */
+  timeNs: number;
+  /**
+   * The code's own time (ns): the frames merged here, each less every child it
+   * ran. A statement's children are its triggers, workflows and flows, so its own
+   * time is the platform's save or query work; a frame's is its Apex. The two
+   * columns therefore never overlap — database time below, own code here.
+   */
+  selfNs: number;
+  /** Frames merged into this node. */
+  count: number;
+  /** Every occurrence, so a row can reveal and locate all of them. */
+  eventIndexes: number[];
+  children: DatabaseCallNode[];
+}
+
+/**
+ * How few statements hold most of the database time — the verdict a sortable
+ * grid cannot give, since sorting names the slowest but never says the rest do
+ * not matter.
+ */
+export interface Concentration {
+  /** Statements it takes to cross {@link CONCENTRATION_SHARE}. */
+  count: number;
+  /** The share those statements hold, 0-100. */
+  percent: number;
+  total: number;
+}
+
+/**
+ * Database time and rows for one namespace, across all three statement kinds —
+ * the cross-kind total the three separate grids cannot give.
+ *
+ * Which namespace depends on the question: see {@link DatabaseOverview.askedBy}
+ * and {@link DatabaseOverview.burnedIn}.
+ */
+export interface DatabaseBreakdown {
+  key: string;
+  timeNs: number;
+  soqlTimeNs: number;
+  dmlTimeNs: number;
+  soslTimeNs: number;
+  statements: number;
+  rowsRead: number;
+  rowsWritten: number;
+}
+
+/**
+ * The Database tab's whole-log figures: database time by kind, the statements
+ * ranked by duration, the call paths that reach them, and time and rows by
+ * namespace.
+ *
+ * All of it is counts and sums over one walk. Rows come from the statement lines
+ * themselves, so a log missing `Rows:` reports zero rather than a guess.
+ *
+ * Every statement is counted, a trigger's query under a DML included: the DML's
+ * total holds the query, its net time does not, and the query owns its own time.
+ * Net times therefore sum to the database total, so shares of it hold whatever
+ * the nesting is.
+ */
+export interface DatabaseOverview {
+  time: DatabaseTime;
+  /** Every statement, longest first, occurrences of the same one summed. */
+  ranked: DatabaseStatement[];
+  /** Call paths that end in a statement, outermost frames first. */
+  tree: DatabaseCallNode[];
+  /**
+   * Who asked for the database time: each outermost statement's whole duration,
+   * charged to the namespace of the code that ran it.
+   */
+  askedBy: DatabaseBreakdown[];
+  /**
+   * Where that time went: every event beneath a statement charges its own self
+   * time to its own namespace, so a DML's trigger code counts against the
+   * package that wrote the trigger. The platform's own save and query work — the
+   * self time of the statement line itself — is charged to the caller that asked
+   * for it, since no namespace executed it.
+   */
+  burnedIn: DatabaseBreakdown[];
+}
+
+/** Memo per log: the tree never changes after parse, the sections re-render. */
+const cache = new WeakMap<ApexLog, DatabaseOverview>();
+
+/** The whole-log figures for the log on screen, or `null` before one resolves. */
+export function currentDatabaseOverview(): DatabaseOverview | null {
+  const apexLog = DatabaseAccess.instance()?.getApexLog();
+  return apexLog ? databaseOverview(apexLog) : null;
+}
+
+/** {@link DatabaseOverview} for a parsed log, computed once. */
+export function databaseOverview(root: ApexLog): DatabaseOverview {
+  const cached = cache.get(root);
+  if (cached) {
+    return cached;
+  }
+  const overview = compute(root);
+  cache.set(root, overview);
+  return overview;
+}
+
+/** The DML operation from a `DML Op:Insert Type:Account` line. */
+export function dmlOperation(text: string): string {
+  return /\bOp:(\w+)/.exec(text)?.[1] ?? 'DML';
+}
+
+/** {@link Concentration} for an overview, against a share of database time. */
+export function concentration(
+  overview: DatabaseOverview,
+  target = CONCENTRATION_SHARE,
+): Concentration {
+  const total = overview.ranked.length;
+  const databaseNs = overview.time.timeNs;
+  if (!total || databaseNs <= 0) {
+    return { count: 0, percent: 0, total };
+  }
+  let held = 0;
+  let count = 0;
+  for (const statement of overview.ranked) {
+    held += statement.netNs;
+    count += 1;
+    if ((held / databaseNs) * 100 >= target) {
+      break;
+    }
+  }
+  return { count, percent: (held / databaseNs) * 100, total };
+}
+
+/** The kind's own figures on {@link DatabaseTime}. */
+const KIND_TIME: Record<StatementKind, 'soql' | 'dml' | 'sosl'> = {
+  SOQL: 'soql',
+  DML: 'dml',
+  SOSL: 'sosl',
+};
+
+/** The kind's own time field on {@link DatabaseBreakdown}. */
+const KIND_BREAKDOWN: Record<StatementKind, 'soqlTimeNs' | 'dmlTimeNs' | 'soslTimeNs'> = {
+  SOQL: 'soqlTimeNs',
+  DML: 'dmlTimeNs',
+  SOSL: 'soslTimeNs',
+};
+
+/** A node while the tree is still being merged: children keyed for lookup. */
+interface TreeNode {
+  label: string;
+  kind: StatementKind | null;
+  timeNs: number;
+  selfNs: number;
+  events: Set<number>;
+  children: Map<string, TreeNode>;
+}
+
+/** What a log event is, when it is a database statement. */
+interface StatementFacts {
+  kind: StatementKind;
+  label: string;
+  rowsRead: number;
+  rowsWritten: number;
+}
+
+/** The statement a log event is, or `null` for any other frame. */
+function statementOf(event: LogEvent): StatementFacts | null {
+  if (event instanceof SOQLExecuteBeginLine) {
+    return { kind: 'SOQL', label: event.text, rowsRead: event.soqlRowCount.self, rowsWritten: 0 };
+  }
+  if (event instanceof DMLBeginLine) {
+    return {
+      kind: 'DML',
+      label: `${dmlOperation(event.text)} ${event.sObjectType ?? UNKNOWN_OBJECT}`,
+      rowsRead: 0,
+      rowsWritten: event.dmlRowCount.self,
+    };
+  }
+  if (event instanceof SOSLExecuteBeginLine) {
+    return { kind: 'SOSL', label: event.text, rowsRead: event.soslRowCount.self, rowsWritten: 0 };
+  }
+  return null;
+}
+
+function compute(root: ApexLog): DatabaseOverview {
+  const logNs = root.duration.total;
+  const time: DatabaseTime = {
+    timeNs: 0,
+    logNs,
+    percentOfLog: 0,
+    soql: { timeNs: 0, statements: 0 },
+    dml: { timeNs: 0, statements: 0 },
+    sosl: { timeNs: 0, statements: 0 },
+  };
+  const found: { event: LogEvent; facts: StatementFacts; enclosing: LogEvent | null }[] = [];
+  /** Time a statement holds in the statements inside it, so self time can net it off. */
+  const nested = new Map<LogEvent, number>();
+  /** Every statement found, so the tree walk classifies each event only once. */
+  const factsByEvent = new Map<LogEvent, StatementFacts>();
+
+  // Iterative: log depth is unbounded. Each frame carries the statement around
+  // it, so a nested statement is found without walking back up its parents.
+  const stack: { event: LogEvent; enclosing: LogEvent | null }[] = root.children.map((event) => ({
+    event,
+    enclosing: null,
+  }));
+  while (stack.length) {
+    const { event, enclosing } = stack.pop()!; // non-empty: the loop condition just checked
+    const facts = statementOf(event);
+    const inside = facts ? event : enclosing;
+    for (const child of event.children) {
+      stack.push({ event: child, enclosing: inside });
+    }
+    if (!facts) {
+      continue;
+    }
+    factsByEvent.set(event, facts);
+    found.push({ event, facts, enclosing });
+    if (enclosing) {
+      nested.set(enclosing, (nested.get(enclosing) ?? 0) + event.duration.total);
+    }
+  }
+
+  const statements = new Map<string, DatabaseStatement>();
+  const askedBy = new Map<string, DatabaseBreakdown>();
+  const burnedIn = new Map<string, DatabaseBreakdown>();
+  const roots = new Map<string, TreeNode>();
+  for (const { event, facts, enclosing } of found) {
+    const { kind, rowsRead, rowsWritten } = facts;
+    const timeNs = event.duration.total;
+    const netNs = Math.max(0, timeNs - (nested.get(event) ?? 0));
+    const kindTime = time[KIND_TIME[kind]];
+    kindTime.timeNs += netNs;
+    kindTime.statements += 1;
+    addStatement(statements, event, facts, timeNs, netNs);
+    addPath(roots, event, factsByEvent, timeNs, enclosing);
+    // The statements inside this one are counted where they are found, so only an
+    // outermost statement charges a namespace: its total is the whole cost.
+    if (!enclosing) {
+      const kindField = KIND_BREAKDOWN[kind];
+      const caller = getCallerNamespace(event);
+      addBreakdown(askedBy, {
+        key: caller,
+        kind: kindField,
+        timeNs,
+        statements: 1,
+        rowsRead,
+        rowsWritten,
+      });
+      addAttribution(burnedIn, event, kindField, caller, rowsRead, rowsWritten);
+    }
+  }
+
+  time.timeNs = time.soql.timeNs + time.dml.timeNs + time.sosl.timeNs;
+  time.percentOfLog = logNs > 0 ? (time.timeNs / logNs) * 100 : 0;
+
+  return {
+    time,
+    ranked: [...statements.values()].sort((a, b) => b.netNs - a.netNs),
+    tree: freeze(roots),
+    askedBy: byTime(askedBy),
+    burnedIn: byTime(burnedIn),
+  };
+}
+
+/** Merge one occurrence into its statement, so a query in a loop is one row. */
+function addStatement(
+  statements: Map<string, DatabaseStatement>,
+  event: LogEvent,
+  facts: StatementFacts,
+  timeNs: number,
+  netNs: number,
+): void {
+  const { kind, label, rowsRead, rowsWritten } = facts;
+  const key = `${kind}:${label}`;
+  const statement = statements.get(key);
+  if (!statement) {
+    statements.set(key, {
+      eventIndex: event.eventIndex,
+      eventIndexes: [event.eventIndex],
+      kind,
+      label,
+      timeNs,
+      netNs,
+      selfNs: event.duration.self,
+      rows: rowsRead + rowsWritten,
+      repeats: 1,
+    });
+    return;
+  }
+  // The slowest occurrence is the one a click should reveal.
+  if (netNs > statement.netNs) {
+    statement.eventIndex = event.eventIndex;
+  }
+  statement.eventIndexes.push(event.eventIndex);
+  statement.timeNs += timeNs;
+  statement.netNs += netNs;
+  statement.selfNs += event.duration.self;
+  statement.rows += rowsRead + rowsWritten;
+  statement.repeats += 1;
+}
+
+/**
+ * Charge one outermost statement's total across the namespaces that ran inside
+ * it. Each timed direct child — a trigger, a workflow, a flow — is charged its
+ * whole duration against its own namespace; what is left over is the platform's
+ * own save or query work, which no namespace executed, so it is charged to the
+ * caller that asked for it.
+ *
+ * Direct children only: the level below a DML is the trigger or workflow, which
+ * is the unit worth going to fix. Untimed marker lines are skipped.
+ */
+function addAttribution(
+  breakdowns: Map<string, DatabaseBreakdown>,
+  event: LogEvent,
+  kind: 'soqlTimeNs' | 'dmlTimeNs' | 'soslTimeNs',
+  caller: string,
+  rowsRead: number,
+  rowsWritten: number,
+): void {
+  let attributed = 0;
+  for (const child of event.children) {
+    if (!child.isParent || child.duration.total <= 0) {
+      continue;
+    }
+    attributed += child.duration.total;
+    addBreakdown(breakdowns, {
+      key: child.namespace || DEFAULT_NAMESPACE,
+      kind,
+      timeNs: child.duration.total,
+    });
+  }
+  // The rows belong to the statement itself, so they follow its platform time.
+  addBreakdown(breakdowns, {
+    key: caller,
+    kind,
+    timeNs: Math.max(0, event.duration.total - attributed),
+    statements: 1,
+    rowsRead,
+    rowsWritten,
+  });
+}
+
+/** Breakdowns as a list, the namespace holding the most time first. */
+function byTime(breakdowns: Map<string, DatabaseBreakdown>): DatabaseBreakdown[] {
+  return [...breakdowns.values()].sort((a, b) => b.timeNs - a.timeNs);
+}
+
+/** Merge one statement and the frames above it into the tree. */
+function addPath(
+  roots: Map<string, TreeNode>,
+  event: LogEvent,
+  factsByEvent: Map<LogEvent, StatementFacts>,
+  timeNs: number,
+  enclosing: LogEvent | null,
+): void {
+  // Outermost frame first; the root itself is no frame, so it stops the walk up.
+  const path: LogEvent[] = [];
+  for (let frame: LogEvent | null = event; frame?.parent; frame = frame.parent) {
+    // A marker line the log names after its own type — EXECUTION_STARTED — names
+    // no code, so it would be a row every path shares and none of them needs.
+    if (frame === event || frame.text !== frame.type) {
+      path.push(frame);
+    }
+  }
+  path.reverse();
+
+  // The statement around this one already counts its time, so it and everything
+  // above it take nothing; only the frames beneath it do.
+  const cutoff = enclosing ? path.indexOf(enclosing) : -1;
+
+  let level = roots;
+  path.forEach((frame, index) => {
+    const frameFacts = factsByEvent.get(frame);
+    const text = frameFacts ? frameFacts.label : frame.text || frame.type || 'Unknown';
+    const key = frameFacts ? `${frameFacts.kind}:${text}` : `frame:${text}`;
+    let node = level.get(key);
+    if (!node) {
+      node = {
+        label: text,
+        kind: frameFacts?.kind ?? null,
+        timeNs: 0,
+        selfNs: 0,
+        events: new Set(),
+        children: new Map(),
+      };
+      level.set(key, node);
+    }
+    if (index > cutoff) {
+      node.timeNs += timeNs;
+    }
+    // Own time comes from the frame itself, so a frame two statements both run
+    // counts it once however many paths reach this node.
+    if (!node.events.has(frame.eventIndex)) {
+      node.selfNs += frame.duration.self;
+      node.events.add(frame.eventIndex);
+    }
+    level = node.children;
+  });
+}
+
+/** The merged tree as plain nodes, each level longest first. */
+function freeze(roots: Map<string, TreeNode>): DatabaseCallNode[] {
+  const tree: DatabaseCallNode[] = [];
+  // Iterative: path depth is unbounded.
+  const stack: { from: Map<string, TreeNode>; into: DatabaseCallNode[] }[] = [
+    { from: roots, into: tree },
+  ];
+  while (stack.length) {
+    const { from, into } = stack.pop()!; // non-empty: the loop condition just checked
+    for (const node of [...from.values()].sort((a, b) => b.timeNs - a.timeNs)) {
+      const frozen: DatabaseCallNode = {
+        label: node.label,
+        kind: node.kind,
+        timeNs: node.timeNs,
+        selfNs: node.selfNs,
+        count: node.events.size,
+        eventIndexes: [...node.events].sort((a, b) => a - b),
+        children: [],
+      };
+      into.push(frozen);
+      if (node.children.size) {
+        stack.push({ from: node.children, into: frozen.children });
+      }
+    }
+  }
+  return tree;
+}
+
+/** Time, and the statement figures only a statement line itself carries. */
+interface BreakdownEntry {
+  key: string;
+  kind: 'soqlTimeNs' | 'dmlTimeNs' | 'soslTimeNs';
+  timeNs: number;
+  statements?: number;
+  rowsRead?: number;
+  rowsWritten?: number;
+}
+
+function addBreakdown(
+  breakdowns: Map<string, DatabaseBreakdown>,
+  { key, kind, timeNs, statements = 0, rowsRead = 0, rowsWritten = 0 }: BreakdownEntry,
+): void {
+  let breakdown = breakdowns.get(key);
+  if (!breakdown) {
+    breakdown = {
+      key,
+      timeNs: 0,
+      soqlTimeNs: 0,
+      dmlTimeNs: 0,
+      soslTimeNs: 0,
+      statements: 0,
+      rowsRead: 0,
+      rowsWritten: 0,
+    };
+    breakdowns.set(key, breakdown);
+  }
+  breakdown[kind] += timeNs;
+  breakdown.timeNs += timeNs;
+  breakdown.statements += statements;
+  breakdown.rowsRead += rowsRead;
+  breakdown.rowsWritten += rowsWritten;
+}

--- a/log-viewer/src/styles/revealRow.styles.ts
+++ b/log-viewer/src/styles/revealRow.styles.ts
@@ -41,6 +41,10 @@ export const bleedRowStyles = css`
  * the right edge, an optional full-width sub line and magnitude meter beneath
  * them. Layout only — the markup pairs it with the bleed-row shell.
  *
+ * The swatch is optional: a section whose rows carry none adds
+ * `.reveal-row--no-swatch`, or the name would take the swatch's fixed track and
+ * push the figures off the row.
+ *
  * The row's category hue arrives as `--row-hue` and the self-time share of its
  * own bar as `--self-pct`, both set inline on the row, so these rules stay
  * static. The palette is data (the flame chart's), which is why the hue is not a
@@ -57,6 +61,10 @@ export const revealRowStyles = [
       align-items: baseline;
       column-gap: var(--lana-space-sm);
       row-gap: var(--lana-space-3xs);
+    }
+
+    .reveal-row--no-swatch {
+      grid-template-columns: minmax(0, 1fr) auto;
     }
 
     /* Identity, never magnitude: the same hue the flame chart gives the category. */
@@ -89,8 +97,13 @@ export const revealRowStyles = [
       font-size: var(--lana-text-sm);
     }
 
+    /* A column of its own, wide enough for the longest reading and never wrapped,
+       so the figures line up down the section and the name is what truncates. */
     .reveal-row__value {
       justify-self: end;
+      min-width: 7ch;
+      white-space: nowrap;
+      text-align: right;
       color: var(--lana-fg-muted);
       font-family: var(--lana-font-mono);
       font-size: var(--lana-text-sm);


### PR DESCRIPTION
related #373
related #405

With nothing selected, the Database tab read as an empty panel. It now reads the whole log, in three sections that each answer something the grids beside cannot.

## Namespace duration

**Called from namespace** — the namespace that issued the statement — and, only when they differ, **Ran in namespace**, the namespaces of whatever ran beneath it. A package trigger firing on your DML shows up as your time asked for, their time spent. One colour per namespace, stable across both bars.

## Call tree

Every call path that ends in a query, DML or search, as a Tabulator tree with no depth cap. **Total Time** is the database time at or below the row; **Self Time** is the row's own code. A row with all total and no self is waiting on the database; the reverse is the Apex around it. Each column is a share of its own footer.

## Database duration

`2 of 7 statements · 96.0% of DB time · 68.1% of log`, then the statements themselves with cost per row, how often each ran, and the self/descendant split — so a DML that is cheap in itself but fires seven seconds of triggers reads as one. A final row accounts for everything outside the top eight.

## Counting

Every statement counts, a trigger's query under a DML included: the DML's total holds the query, its net time does not, and the query owns its own time. Net times therefore sum to the database total, so shares of it hold whatever the nesting is. SOQL, DML and SOSL throughout; SOSL renders as a tint of the query colour and its rows are per-query only, since the log carries no SOSL row total.

## Also

`CategoryTimeBar`'s stacked bar is extracted as the shared `StackedTimeBar`, so time by category and the namespace bars are one component. `.reveal-row--no-swatch` joins the shared row grid for sections whose rows carry no category swatch.

## Testing

- New suites for the service and the components; 1680 tests pass.
- `tsc -b --force` and eslint clean.
- Checked in the dev host on a log with trigger DML, in a light and a dark theme: bar and figure alignment at every dock width, the sub-line shedding parts as it narrows, reveal and locate marking the grids, and `Escape` clearing a picked row.
