### PR TITLE
feat(inspector): list the statements behind each Analysis finding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - ⬆️ **Requires VS Code 1.102 or newer**.
+- 📏 **Governor figures**: every whole-log readout — the overview gauges, the governor trends, the Database overview and the Analysis findings — reports a metric at its peak, the level the governor charges the transaction at. The Timeline governor strip still plots the log as recorded.
 - 📊 **Timeline**
   - **Governor limits strip**: tooltip rows keep a stable order and always show the `used / limit` value, so figures no longer jump around as you move the pointer. ([#827])
   - **Timeline zooming**: consistent, smooth zoom across platforms and input devices — a Windows mouse wheel no longer over-zooms in large jumps, fast scrolls stay bounded, and zooming in then back out returns to the same level.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - **Nothing selected** shows the whole log instead of an empty panel: a governor overview on every tab, time by category and governor trends on the Timeline, log-wide findings on Analysis, and the hot path and hot spots on the Call Tree.
   - Every row is a link: click it to reveal the frame, row or statement behind it in the tab you're on. Hover works both ways without moving the view — hover a row to pick out what it names in the tab you're on, or hover there to mark the rows that name it, and what you click stays picked out until `Escape`. Right-click for copy actions.
   - Dock it left, right or bottom, drag to resize any section — double-click a divider to restore the defaults — and collapse the sections you don't need; the layout is remembered. `Escape` clears the selection and returns the whole-log view. ([#63])
+- 🔁 **Row-at-a-time finding**: Analysis reports one query built per record and run a row at a time.
+- 🔍 **Finding evidence**: each Analysis finding lists the statements behind it, most repeated first, with how often each ran and how many there are in all; click one to open it in the grid.
 - 🗄️ **Database Analysis**: governor-limit visibility and SOSL usage. ([#162])
   - 📏 **Governor-limit overview**: SOQL, SOSL, DML and query/DML rows shown as `used / limit`, colored as they approach the limit.
   - 🧮 **Found vs Counted**: each section reconciles statements found in the log against the governor-counted total, flagging queries that didn't consume the limit (e.g. custom metadata, which is free unless it selects a long text area field or runs in a Flow).

--- a/lana-docs/docs/docs/features/inspector.md
+++ b/lana-docs/docs/docs/features/inspector.md
@@ -41,7 +41,7 @@ With no selection the inspector shows the whole log. Every tab starts with a **L
 
 The **Analysis** tab adds:
 
-- **Findings** – what is slow or wrong in the log, and what to do about it. One pass over the log reports truncation (which makes every figure below it an undercount), governor breaches, exceptions, query-plan verdicts, SOQL optimization tips, statements repeated from one line — the usual sign of a query or DML in a loop — debug-statement cost, and the methods with the most self time. Query-plan verdicts need a `FINEST` log; without one the pane says the verdicts are unknown rather than reading clean. Each finding shows the code the log named with its figures; click it to reveal the row behind it in the Analysis grid.
+- **Findings** – what is slow or wrong in the log, and what to do about it. One pass over the log reports truncation, which heads the list because every figure below it may then be undercounted, governor usage at its peak against its limit — only where the log carries its cumulative totals, and an error only where the log says the governor stopped the transaction — exceptions, query-plan verdicts, SOQL optimization tips, statements repeated from one call site, one query built per record and run a row at a time — the usual sign of a query in a loop — debug-statement cost, and the methods with the most self time. Query-plan verdicts need a `FINEST` log; without one the pane says the verdicts are unknown rather than reading clean. Each finding lists the code the log named, most repeated first with how many times each ran and how many there are in all; click a statement to reveal the row behind it in the Analysis grid.
 
 The **Call Tree** tab adds:
 

--- a/log-viewer/src/components/__tests__/logOverviewMetrics.test.ts
+++ b/log-viewer/src/components/__tests__/logOverviewMetrics.test.ts
@@ -3,11 +3,57 @@
  */
 import { describe, expect, it } from '@jest/globals';
 
-import { seriesGauges } from '../logOverviewMetrics.js';
-import { seriesEvent, timeSeries } from './limitsTestUtils.js';
+import { GOVERNOR_METRICS, limitTotals, seriesGauges } from '../logOverviewMetrics.js';
+import { emptyLimits, seriesEvent, timeSeries } from './limitsTestUtils.js';
+
+describe('limitTotals', () => {
+  it('reads every metric as it rises', () => {
+    const totals = limitTotals(
+      timeSeries([
+        seriesEvent(1_000, { soqlQueries: { used: 20, limit: 100 } }),
+        seriesEvent(2_000, {
+          soqlQueries: { used: 186, limit: 100 },
+          cpuTime: { used: 10_712, limit: 10_000 },
+        }),
+      ]),
+    );
+
+    expect(totals.soqlQueries).toEqual({ used: 186, limit: 100 });
+    expect(totals.cpuTime).toEqual({ used: 10_712, limit: 10_000 });
+  });
+
+  it('reads every metric from its peak: a later report can be lower', () => {
+    const totals = limitTotals(
+      timeSeries([
+        seriesEvent(1_000, {
+          heapSize: { used: 5_000_000, limit: 6_000_000 },
+          cpuTime: { used: 10_712, limit: 10_000 },
+          soqlQueries: { used: 101, limit: 100 },
+        }),
+        seriesEvent(2_000, {
+          heapSize: { used: 1_000_000, limit: 6_000_000 },
+          cpuTime: { used: 9_991, limit: 10_000 },
+          soqlQueries: { used: 67, limit: 100 },
+        }),
+      ]),
+    );
+
+    // The governor charged the transaction at its highest point, breach included.
+    expect(totals.heapSize).toEqual({ used: 5_000_000, limit: 6_000_000 });
+    expect(totals.cpuTime).toEqual({ used: 10_712, limit: 10_000 });
+    expect(totals.soqlQueries).toEqual({ used: 101, limit: 100 });
+  });
+
+  it('holds every governor metric, at zero where the series has none', () => {
+    const totals = limitTotals(timeSeries([]));
+
+    expect(totals).toEqual(emptyLimits());
+    expect(Object.keys(totals)).toHaveLength(GOVERNOR_METRICS.length);
+  });
+});
 
 describe('seriesGauges', () => {
-  it('reads each metric from the last event: the series is dense', () => {
+  it('reads each metric as it rises', () => {
     const gauges = seriesGauges(
       timeSeries([
         seriesEvent(1_000, { soqlQueries: { used: 20, limit: 100 } }),
@@ -41,7 +87,7 @@ describe('seriesGauges', () => {
     expect(gauges.map((g) => g.label)).not.toContain('DML');
   });
 
-  it('reads heap from its peak, not the last event: deallocations pull the line down', () => {
+  it('reads each metric from its peak, not the last event', () => {
     const gauges = seriesGauges(
       timeSeries([
         seriesEvent(1_000, { heapSize: { used: 5_000_000, limit: 6_000_000 } }),

--- a/log-viewer/src/components/logOverviewMetrics.ts
+++ b/log-viewer/src/components/logOverviewMetrics.ts
@@ -48,7 +48,7 @@ export const GOVERNOR_METRICS: ReadonlyArray<{ key: keyof Limits; label: string 
   { key: 'mobileApexPushCalls', label: 'Mobile Push Calls' },
 ];
 
-/** A metric's highest level across the series, for the non-monotonic metrics. */
+/** A metric's highest level across the series. */
 function peakUsed(series: HeatStripTimeSeries, key: keyof Limits): number {
   let peak = 0;
   for (const event of series.events) {
@@ -60,7 +60,7 @@ function peakUsed(series: HeatStripTimeSeries, key: keyof Limits): number {
   return peak;
 }
 
-/** A governor metric's level (final, or the peak for heap), ranked against its limit. */
+/** A governor metric's peak level, ranked against its limit. */
 export interface RankedLimitMetric {
   key: keyof Limits;
   label: string;
@@ -70,36 +70,55 @@ export interface RankedLimitMetric {
   ratio: number;
 }
 
+/** Memo of {@link limitTotals} per series: every surface asks for the same log. */
+const totalsCache = new WeakMap<HeatStripTimeSeries, Limits>();
+
 /**
- * The governor metrics closest to a limit, tightest first, capped at `max`,
- * read from the metric strip's time series — the same source the timeline and
- * the trend charts draw, so every surface shows one figure per metric. The
- * series is dense (every event carries every known metric forward), so the
- * last event holds each metric's final level. Heap is the one non-monotonic
- * metric — deallocations pull the line back down — so it reads its peak across
- * the series, matching the "Maximum heap size" governor. A metric with no
- * consumption is left out.
+ * Whole-log usage and limit for every governor metric, read from the metric
+ * strip's time series — the one source every governor surface shares, so a
+ * metric reads the same on the strip, the trend charts, the gauges, the
+ * Database overview and the Analysis findings.
+ *
+ * Every metric reads its **peak** across the series, not its final level. No
+ * metric is monotonic: heap falls on a deallocation, and the log's own
+ * cumulative reports can fall too (a later block reporting a lower total than
+ * an earlier one). A governor charges the transaction at its highest point, so
+ * the peak is what breached and what the reader must be told. The metric strip
+ * keeps drawing the series itself, dips included — it shows what the log says
+ * happened.
  *
  * These are whole-transaction totals: the series sums usage across
  * namespaces, so in a namespaced org a metric can pass 100% of a single
  * namespace's limit without a breach (#862) — accepted so every surface
  * matches the charts and the strip.
  */
-export function rankedLimitMetrics(series: HeatStripTimeSeries, max: number): RankedLimitMetric[] {
-  const final = series.events[series.events.length - 1]?.values;
-  if (!final) {
-    return [];
+export function limitTotals(series: HeatStripTimeSeries): Limits {
+  let totals = totalsCache.get(series);
+  if (totals) {
+    return totals;
   }
+  const final = series.events[series.events.length - 1]?.values;
+  totals = {} as Limits;
+  for (const { key } of GOVERNOR_METRICS) {
+    totals[key] = {
+      used: peakUsed(series, key),
+      limit: final?.get(key)?.limit ?? 0,
+    };
+  }
+  totalsCache.set(series, totals);
+  return totals;
+}
 
+/**
+ * The governor metrics closest to a limit, tightest first, capped at `max`,
+ * from {@link limitTotals}. A metric with no consumption, or no limit, is left
+ * out.
+ */
+export function rankedLimitMetrics(series: HeatStripTimeSeries, max: number): RankedLimitMetric[] {
+  const totals = limitTotals(series);
   return GOVERNOR_METRICS.flatMap<RankedLimitMetric>(({ key, label }) => {
-    const value = final.get(key);
-    if (!value || value.limit <= 0) {
-      return [];
-    }
-    const used = key === 'heapSize' ? peakUsed(series, key) : value.used;
-    return used > 0
-      ? [{ key, label, used, limit: value.limit, ratio: (used / value.limit) * 100 }]
-      : [];
+    const { used, limit } = totals[key];
+    return limit > 0 && used > 0 ? [{ key, label, used, limit, ratio: (used / limit) * 100 }] : [];
   })
     .sort((a, b) => b.ratio - a.ratio)
     .slice(0, max);

--- a/log-viewer/src/features/analysis/components/LogDiagnosticsView.ts
+++ b/log-viewer/src/features/analysis/components/LogDiagnosticsView.ts
@@ -2,29 +2,54 @@
  * Copyright (c) 2026 Certinia Inc. All rights reserved.
  */
 import '#vscode-elements/vscode-icon.js';
-import { LitElement, css, html } from 'lit';
+import { LitElement, css, html, unsafeCSS } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
 
 import { dispatchInspectorReveal } from '../../../components/inspectorReveal.js';
 import { eventBus } from '../../../core/events/EventBus.js';
+import { formatSOQLToTemplate } from '../../soql/format/formatter.js';
+import { soqlSyntaxStyles } from '../../soql/styles/soql-syntax.css.js';
 import { globalStyles } from '../../../styles/global.styles.js';
 import { bleedRowStyles } from '../../../styles/revealRow.styles.js';
 import { severityIcon, severityStyles } from '../../../styles/severity.styles.js';
 import {
   computeLogDiagnostics,
   type Diagnostic,
+  type DiagnosticEvidence,
   type LogDiagnostics,
 } from '../services/LogDiagnostics.js';
+
+/**
+ * Lines a listed query gets. A clause takes a line, so this is what decides how
+ * far down the query the render reaches: below four, `FROM` and `WHERE` give way
+ * to a `+N clauses` marker and the statement is no longer recognisable.
+ */
+const EVIDENCE_LINES = 4;
+
+/** Characters per line where the pane has no layout to measure. */
+const FALLBACK_COLUMNS = 60;
+
+const PROBE_TEXT = 'SELECT0123456789';
+
+const textWidth = document.createElement('canvas').getContext('2d');
+
+/** A character of the element's own font, so a wider dock shows more of a query. */
+function charWidthOf(element: HTMLElement): number {
+  if (!textWidth) {
+    return 0;
+  }
+  const style = getComputedStyle(element);
+  textWidth.font = `${style.fontSize} ${style.fontFamily}`;
+  return textWidth.measureText(PROBE_TEXT).width / PROBE_TEXT.length;
+}
 
 /**
  * The Analysis tab's whole-log findings: what the log says is slow or wrong, and
  * what to do about it. The list is the shape every comparable tool uses for this.
  *
- * Two absences are reported rather than hidden. A truncated log makes every
- * figure below it an undercount, so it heads the pane; and without FINEST
- * database logging there are no query plans, which says nothing about the
- * queries — so the pane says the verdicts are unknown instead of leaving them
- * looking clean.
+ * An absence is reported rather than hidden: without FINEST database logging
+ * there are no query plans, which says nothing about the queries — so the pane
+ * says the verdicts are unknown instead of leaving them looking clean.
  */
 @customElement('log-diagnostics')
 export class LogDiagnosticsView extends LitElement {
@@ -33,24 +58,53 @@ export class LogDiagnosticsView extends LitElement {
 
   private _offLogLoaded: (() => void) | null = null;
 
+  private _columns = FALLBACK_COLUMNS;
+
+  private _resize: ResizeObserver | null = null;
+
   override connectedCallback() {
     super.connectedCallback();
     void this._analyse();
     // The inspector paints before the first log is parsed, and it rebuilds only
     // on a tab change or a selection.
     this._offLogLoaded = eventBus.on('log:loaded', () => void this._analyse());
+    if (typeof ResizeObserver !== 'undefined') {
+      this._resize = new ResizeObserver(() => this._measure());
+      this._resize.observe(this);
+    }
   }
 
   override disconnectedCallback() {
     this._offLogLoaded?.();
     this._offLogLoaded = null;
+    this._resize?.disconnect();
+    this._resize = null;
     super.disconnectedCallback();
+  }
+
+  override updated() {
+    this._measure();
+  }
+
+  /** Fit the listed queries to the pane, from a line already on screen. */
+  private _measure(): void {
+    const line = this.shadowRoot?.querySelector<HTMLElement>('.evidence__text--code');
+    if (!line) {
+      return;
+    }
+    const charWidth = charWidthOf(line);
+    const columns = charWidth ? Math.floor(line.clientWidth / charWidth) : 0;
+    if (columns > 0 && columns !== this._columns) {
+      this._columns = columns;
+      this.requestUpdate();
+    }
   }
 
   static styles = [
     globalStyles,
     severityStyles,
     bleedRowStyles,
+    unsafeCSS(soqlSyntaxStyles),
     css`
       :host {
         display: block;
@@ -184,6 +238,31 @@ export class LogDiagnosticsView extends LitElement {
         overflow-wrap: anywhere;
       }
 
+      /* A clause per line, cut at the same count the budget renders, so a wrapped
+         clause cannot push the list apart. The whole statement is one click away. */
+      .evidence__text--code {
+        display: -webkit-box;
+        -webkit-box-orient: vertical;
+        -webkit-line-clamp: 4;
+        line-clamp: 4;
+        min-width: 0;
+        overflow: hidden;
+      }
+
+      /* How many lines the finding has, when it lists only the most repeated. */
+      .evidence__head {
+        margin: var(--lana-space-sm) 0 0;
+        color: var(--lana-fg-muted);
+        font-size: var(--lana-text-sm);
+      }
+
+      /* How many times this one line ran. */
+      .evidence__count {
+        flex: 0 0 auto;
+        color: var(--lana-fg-muted);
+        font-variant-numeric: tabular-nums;
+      }
+
       /* The evidence names one event, so it is the way back to that row. */
       .evidence--link {
         cursor: pointer;
@@ -213,10 +292,6 @@ export class LogDiagnosticsView extends LitElement {
         color: var(--lana-fg-muted);
         font-size: var(--lana-text-sm);
       }
-
-      .truncated {
-        color: var(--lana-severity-warning);
-      }
     `,
   ];
 
@@ -227,7 +302,7 @@ export class LogDiagnosticsView extends LitElement {
     }
 
     return html`
-      ${result.truncation ? html`<p class="note truncated">${result.truncation}</p>` : ''}
+      ${this._caveats(result).map((caveat) => html`<p class="note">${caveat}</p>`)}
       ${
         result.diagnostics.length
           ? result.diagnostics.map((diagnostic) => {
@@ -253,7 +328,6 @@ export class LogDiagnosticsView extends LitElement {
             })
           : html`<p class="note">No findings.</p>`
       }
-      ${this._caveats(result).map((caveat) => html`<p class="note">${caveat}</p>`)}
     `;
   }
 
@@ -270,24 +344,44 @@ export class LogDiagnosticsView extends LitElement {
   }
 
   /**
-   * The log line behind the finding. A log-wide finding names no single event, so
-   * that one is text only; every other one is the way back to its row in the grid.
+   * The log lines behind the finding — one for most, one per statement for a
+   * finding about a query written several ways. A line that names no single event
+   * is text only; every other one is the way back to its row in the grid.
    */
   private _evidence(diagnostic: Diagnostic) {
-    if (!diagnostic.evidence) {
-      return '';
-    }
-    const text = html`<span class="evidence__text">${diagnostic.evidence}</span>`;
-    if (diagnostic.eventIndex < 0) {
-      return html`<div class="evidence">${text}</div>`;
+    const evidence = diagnostic.evidence ?? [];
+    const total = diagnostic.evidenceTotal ?? 0;
+    return [
+      total > evidence.length
+        ? html`<p class="evidence__head">
+            ${evidence.length} of ${total} statements, most repeated first.
+          </p>`
+        : '',
+      ...evidence.map((line) => this._evidenceLine(line)),
+    ];
+  }
+
+  private _evidenceLine({ text, eventIndex, count, dialect }: DiagnosticEvidence) {
+    const body = dialect
+      ? html`<span class="evidence__text evidence__text--code soql-block"
+          >${formatSOQLToTemplate(text, {
+            mode: 'pretty',
+            dialect,
+            budget: { lines: EVIDENCE_LINES, columns: this._columns },
+          })}</span
+        >`
+      : html`<span class="evidence__text">${text}</span>`;
+    const ran = count && count > 1 ? html`<span class="evidence__count">${count}×</span>` : '';
+    if (eventIndex < 0) {
+      return html`<div class="evidence" title=${text}>${body}${ran}</div>`;
     }
     return html`<button
       class="evidence evidence--link"
       type="button"
-      title="Show this in the grid"
-      @click=${() => dispatchInspectorReveal(this, diagnostic.eventIndex)}
+      title=${text}
+      @click=${() => dispatchInspectorReveal(this, eventIndex)}
     >
-      ${text}
+      ${body}${ran}
       <vscode-icon class="evidence__go" name="arrow-right"></vscode-icon>
     </button>`;
   }
@@ -297,7 +391,7 @@ export class LogDiagnosticsView extends LitElement {
     const caveats: string[] = [];
     if (!result.queryPlansKnown) {
       caveats.push(
-        'This log holds no query plans, so how selective the queries are is unknown. Re-run with the Database log level at FINEST to see them.',
+        'To see query plan findings, re-run the log with the Database log level at FINEST.',
       );
     }
     const { linted, distinct } = result.lintedQueries;

--- a/log-viewer/src/features/analysis/components/__tests__/LogDiagnosticsView.test.ts
+++ b/log-viewer/src/features/analysis/components/__tests__/LogDiagnosticsView.test.ts
@@ -11,7 +11,6 @@ jest.mock('#vscode-elements/vscode-icon.js', () => ({}));
 
 let result: LogDiagnostics = {
   diagnostics: [],
-  truncation: null,
   queryPlansKnown: true,
   lintedQueries: { linted: 0, distinct: 0 },
 };
@@ -40,7 +39,6 @@ describe('log-diagnostics', () => {
     document.body.replaceChildren();
     result = {
       diagnostics: [],
-      truncation: null,
       queryPlansKnown: true,
       lintedQueries: { linted: 0, distinct: 0 },
     };
@@ -86,7 +84,7 @@ describe('log-diagnostics', () => {
         message: 'why',
         count: 2,
         eventIndex: 1,
-        evidence: 'Class.A.run: line 31, column 1',
+        evidence: [{ text: 'Class.A.run: line 31, column 1', eventIndex: 1 }],
       },
     ];
     const element = await view();
@@ -95,6 +93,59 @@ describe('log-diagnostics', () => {
       'System.LimitException: Apex CPU time limit exceeded',
     ]);
     expect(text(element, '.evidence')).toEqual(['Class.A.run: line 31, column 1']);
+  });
+
+  it('lists a line per statement when the finding names several', async () => {
+    result.diagnostics = [
+      {
+        id: 'a',
+        severity: 'Warning',
+        summary: '23 Contact queries, one row at a time.',
+        message: 'why',
+        count: 23,
+        eventIndex: 4,
+        evidence: [
+          { text: "SELECT Id FROM Contact WHERE Id = '003a'", eventIndex: 4 },
+          { text: "SELECT Id FROM Contact WHERE Id = '003b'", eventIndex: 9 },
+        ],
+      },
+    ];
+    const element = await view();
+    const seen: number[] = [];
+    element.addEventListener('inspector-reveal', (e) => {
+      seen.push((e as CustomEvent<{ eventIndex: number }>).detail.eventIndex);
+    });
+
+    // Each statement is its own way back into the grid.
+    expect(text(element, '.evidence')).toEqual([
+      "SELECT Id FROM Contact WHERE Id = '003a'",
+      "SELECT Id FROM Contact WHERE Id = '003b'",
+    ]);
+    element.shadowRoot!.querySelectorAll<HTMLButtonElement>('.evidence--link')[1]?.click();
+    expect(seen).toEqual([9]);
+  });
+
+  it('heads a listed set with how many there are, and counts each line', async () => {
+    result.diagnostics = [
+      {
+        id: 'a',
+        severity: 'Warning',
+        summary: '23 Contact queries, one row at a time.',
+        message: 'why',
+        count: 23,
+        eventIndex: 4,
+        evidence: [
+          { text: "SELECT Id FROM Contact WHERE Id = '003a'", eventIndex: 4, count: 3 },
+          { text: "SELECT Id FROM Contact WHERE Id = '003b'", eventIndex: 9, count: 1 },
+        ],
+        evidenceTotal: 11,
+      },
+    ];
+    const element = await view();
+
+    expect(text(element, '.evidence__head')).toEqual(['2 of 11 statements, most repeated first.']);
+    // One run is the norm here, so only a repeat is worth a figure.
+    expect(text(element, '.evidence__count')).toEqual(['3×']);
   });
 
   it('states the cause as figures, not as prose', async () => {
@@ -125,7 +176,7 @@ describe('log-diagnostics', () => {
         message: 'why',
         count: 1,
         eventIndex: 7,
-        evidence: 'SELECT Id FROM Account',
+        evidence: [{ text: 'SELECT Id FROM Account', eventIndex: 7 }],
       },
     ];
     const element = await view();
@@ -148,7 +199,7 @@ describe('log-diagnostics', () => {
         message: 'why',
         count: 1,
         eventIndex: -1,
-        evidence: 'System.debug',
+        evidence: [{ text: 'System.debug', eventIndex: -1 }],
       },
     ];
     const element = await view();
@@ -174,16 +225,10 @@ describe('log-diagnostics', () => {
     );
   });
 
-  it('heads the pane with the truncation note', async () => {
-    result.truncation = 'The maximum log size has been reached.';
-    const element = await view();
-    expect(text(element, '.truncated')).toEqual(['The maximum log size has been reached.']);
-  });
-
   it('reports absent query plans rather than leaving the queries looking clean', async () => {
     result.queryPlansKnown = false;
     const element = await view();
-    expect(text(element, '.note').join(' ')).toContain('no query plans');
+    expect(text(element, '.note').join(' ')).toContain('Database log level at FINEST');
   });
 
   it('reports how much of the log the SOQL rules covered when they were capped', async () => {

--- a/log-viewer/src/features/analysis/services/LogDiagnostics.ts
+++ b/log-viewer/src/features/analysis/services/LogDiagnostics.ts
@@ -3,17 +3,19 @@
  */
 import type {
   ApexLog,
-  GovernorLimits,
+  DMLBeginLine,
   Limits,
   LogEvent,
   SOQLExecuteBeginLine,
 } from 'apex-log-parser';
 
-import { GOVERNOR_METRICS } from '../../../components/logOverviewMetrics.js';
-import { DEFAULT_NAMESPACE } from '../../../core/utility/CallerNamespace.js';
+import { GOVERNOR_METRICS, limitTotals } from '../../../components/logOverviewMetrics.js';
 import { formatByteSize, formatDuration, formatInteger } from '../../../core/utility/Util.js';
 import { getEventKey } from '../../call-tree/utils/Aggregation.js';
 import { DatabaseAccess } from '../../database/services/Database.js';
+import { deriveSoqlObject } from '../../database/services/sobjectClassification.js';
+import type { Dialect } from '../../soql/format/tokenize.js';
+import { apexLimitTimeSeries } from '../../timeline/optimised/apex-limit-series.js';
 import {
   QueryPlanCostRule,
   SEVERITY_TYPES,
@@ -39,6 +41,15 @@ const HOT_SPOT_SHARE = 0.2;
 const MAX_LINTED_QUERIES = 250;
 
 /**
+ * Where a finding sits in its severity band, ahead of any count. Truncation
+ * caveats every figure below it, and a governor limit is the transaction's
+ * hardest constraint — while every governor finding carries a count of 1, so
+ * counting alone would bury it under whatever repeated most.
+ */
+const TIER = { truncation: 0, limit: 1, other: 2 } as const;
+type DiagnosticTier = (typeof TIER)[keyof typeof TIER];
+
+/**
  * What is behind a finding, when the log names one thing: what it is, and the
  * figures for it. Structured rather than folded into the prose, so the figures
  * read as figures.
@@ -53,6 +64,30 @@ export interface DiagnosticCause {
 }
 
 /**
+ * A log line behind a finding — the statement it read, or the frame the
+ * transaction stopped on — and the event it points at. Without one a finding
+ * names a problem the reader cannot tie back to anything.
+ */
+export interface DiagnosticEvidence {
+  text: string;
+  /** The event it points at, or -1 when it names no single event. */
+  eventIndex: number;
+  /** How many times this line ran, where the finding lists several. */
+  count?: number;
+  /** Set where the text is a query, so it reads as one highlighted line. */
+  dialect?: Dialect;
+}
+
+/** One line of evidence, for a finding that names a single event. */
+function oneLine(
+  text: string | undefined,
+  eventIndex: number,
+  dialect?: Dialect,
+): DiagnosticEvidence[] | undefined {
+  return text ? [{ text, eventIndex, dialect }] : undefined;
+}
+
+/**
  * One finding about the log as a whole. `summary` and `message` follow
  * {@link SOQLLinterRule}: a short statement of the problem, then the
  * prescriptive detail.
@@ -61,6 +96,8 @@ export interface Diagnostic {
   /** Stable key. Identical findings share one, so they group with a count. */
   id: string;
   severity: Severity;
+  /** Its {@link TIER}, when it outranks the counts. Defaults to `other`. */
+  tier?: DiagnosticTier;
   summary: string;
   message: string;
   /** The figure behind the finding, shown beside the summary. */
@@ -70,23 +107,25 @@ export interface Diagnostic {
   /** The first event that raised it, or -1 when the finding is log-wide. */
   eventIndex: number;
   /**
-   * The line of the log the finding points at — the statement it read, or the
-   * frame the transaction stopped on. Without it a finding names a problem the
-   * reader cannot tie back to anything.
+   * The lines of the log behind the finding. Most findings name one; a finding
+   * about a statement written several ways names each of them, so the reader can
+   * open any one of them in the grid.
    */
-  evidence?: string;
+  evidence?: DiagnosticEvidence[];
+  /**
+   * How many lines are behind the finding, where {@link evidence} lists only the
+   * most repeated of them. The list says so itself, so the prose need not.
+   */
+  evidenceTotal?: number;
   /** The one thing behind the finding, when the log names one. */
   cause?: DiagnosticCause;
 }
 
 export interface LogDiagnostics {
-  /** Findings, highest severity first, then most frequent. */
-  diagnostics: Diagnostic[];
   /**
-   * Set when the log is truncated. Every figure below it is an undercount, so
-   * this frames the whole pane rather than being one finding in it.
+   * Findings, highest severity first, then by {@link TIER}, then most frequent.
    */
-  truncation: string | null;
+  diagnostics: Diagnostic[];
   /**
    * False when the log holds no query plan lines. The plans need FINEST database
    * logging, and their absence says nothing about the queries — so the pane must
@@ -99,7 +138,6 @@ export interface LogDiagnostics {
 
 const EMPTY: LogDiagnostics = {
   diagnostics: [],
-  truncation: null,
   queryPlansKnown: false,
   lintedQueries: { linted: 0, distinct: 0 },
 };
@@ -195,15 +233,20 @@ function hotSpot(selfTime: Map<string, number>, totalSelf: number): HotSpot | nu
  * cause the reader wants: the exception row itself takes no time and says only
  * that the transaction ended. The log root is skipped, since it is not code.
  */
-function enclosingMethodIndex(event: LogEvent): number {
+function enclosingFrame(event: LogEvent): LogEvent | null {
   let node = event.parent;
   while (node) {
     if (node.isParent && node.parent) {
-      return node.eventIndex;
+      return node;
     }
     node = node.parent;
   }
-  return event.eventIndex;
+  return null;
+}
+
+/** See {@link enclosingFrame}; the event itself where the log names no frame. */
+function enclosingMethodIndex(event: LogEvent): number {
+  return enclosingFrame(event)?.eventIndex ?? event.eventIndex;
 }
 
 /** A governor breach the log reported as an exception, with where it stopped. */
@@ -219,15 +262,19 @@ interface Breach {
  * metric ran out. It is therefore merged into that metric's finding, so one
  * breach is one row.
  *
- * Only the default namespace is read. A log reports usage per namespace, but not
- * whether a package is certified — and only a certified package gets a budget of
- * its own. Some metrics, CPU time among them, are shared whatever the namespace.
- * A per-namespace figure against a per-namespace limit would therefore be a
- * guess, so this reports the one scope the log makes certain (#862).
+ * Figures come from {@link limitTotals}, so a metric reads the same here as on
+ * every other governor surface. Those figures sum usage over every namespace and,
+ * without a cumulative snapshot, measure it against the synchronous defaults — so
+ * a ratio alone never reads as a breach. Only a `LimitException` says the governor
+ * stopped the transaction.
+ *
+ * @param reported - Whether the log carries a cumulative limit snapshot. Without
+ *   one the limits are assumed, and a ratio over an assumed limit says nothing.
  */
 function limitDiagnostics(
-  limits: GovernorLimits,
+  totals: Limits,
   limitExceptions: LogEvent[],
+  reported: boolean,
   hotSpot: HotSpot | null,
 ): Diagnostic[] {
   const breaches = new Map<keyof Limits, Breach>();
@@ -249,19 +296,18 @@ function limitDiagnostics(
     });
   }
 
-  const forNamespace = limits.byNamespace.get(DEFAULT_NAMESPACE);
   const found: Diagnostic[] = [];
   for (const { key, label } of GOVERNOR_METRICS) {
     const breach = breaches.get(key);
-    const metric = forNamespace?.[key];
-    const known = metric && metric.limit > 0 && metric.used > 0;
-    const ratio = known ? metric.used / metric.limit : 0;
-    if (!breach && (!known || ratio < NEAR_LIMIT_RATIO)) {
+    const { used, limit } = totals[key];
+    // A metric with no usage, or no limit reported, has no figures to show.
+    const known = used > 0 && limit > 0;
+    const ratio = known ? used / limit : 0;
+    if (!breach && (!reported || ratio < NEAR_LIMIT_RATIO)) {
       continue;
     }
 
     const format = LIMIT_FORMATS[key] ?? formatInteger;
-    const exceeded = breach !== undefined || ratio >= 1;
     const cause: DiagnosticCause | undefined =
       key === 'cpuTime' && hotSpot
         ? {
@@ -272,19 +318,20 @@ function limitDiagnostics(
         : undefined;
     found.push({
       id: `limit|${key}`,
-      severity: exceeded ? 'Error' : 'Warning',
-      summary: exceeded
+      severity: breach ? 'Error' : 'Warning',
+      tier: TIER.limit,
+      summary: breach
         ? `${label} limit exceeded.`
         : `${label} is at ${Math.round(ratio * 100)}% of its limit.`,
-      meta: known ? `${format(metric.used)} / ${format(metric.limit)}` : undefined,
+      meta: known ? `${format(used)} / ${format(limit)}` : undefined,
       message: breach
         ? 'The governor stopped the transaction here.'
         : known
-          ? `${format(metric.used)} of ${format(metric.limit)} used.`
+          ? `${format(used)} of ${format(limit)} used.`
           : '',
       count: 1,
       eventIndex: breach?.eventIndex ?? -1,
-      evidence: breach?.frame,
+      evidence: oneLine(breach?.frame, breach?.eventIndex ?? -1),
       cause,
     });
   }
@@ -329,6 +376,7 @@ function exceptionDiagnostics(exceptions: LogEvent[]): Diagnostic[] {
       .map((event) => splitException(event.text).frame)
       .find((first) => first.length > 0);
     const thrownIn = group.events[0];
+    const eventIndex = thrownIn ? enclosingMethodIndex(thrownIn) : group.eventIndex;
     return {
       id: `exception|${head}`,
       severity: 'Error' as Severity,
@@ -338,10 +386,44 @@ function exceptionDiagnostics(exceptions: LogEvent[]): Diagnostic[] {
         ? 'Nothing caught this exception, so the transaction rolled back.'
         : 'Even a caught exception costs CPU time, and a thrown-and-caught exception used as flow control is expensive.',
       count: Math.max(thrown, 1),
-      eventIndex: thrownIn ? enclosingMethodIndex(thrownIn) : group.eventIndex,
-      evidence: frame,
+      eventIndex,
+      evidence: oneLine(frame, eventIndex),
     };
   });
+}
+
+/** The byte figure the platform put in its own `*** Skipped N bytes` line. */
+const SKIPPED_BYTES = /Skipped\s+([\d,]+)\s+bytes/i;
+
+/**
+ * The log's own truncation, as the finding that caveats all the others.
+ *
+ * The platform drops a section of the log when it grows too large, so every
+ * figure the pane reports may be an undercount. Several regions are one finding:
+ * the caveat is the same and the reader acts on it once.
+ */
+function truncationDiagnostics(log: ApexLog): Diagnostic[] {
+  const skips = log.logIssues.filter((issue) => issue.type === 'skip');
+  if (!skips.length) {
+    return [];
+  }
+  const bytes = skips.reduce((total, issue) => {
+    const figure = SKIPPED_BYTES.exec(issue.description)?.[1];
+    return total + (figure ? Number(figure.replaceAll(',', '')) : 0);
+  }, 0);
+  return [
+    {
+      id: 'truncated',
+      severity: 'Error',
+      tier: TIER.truncation,
+      summary: skips.length > 1 ? `Log truncated in ${skips.length} places` : 'Log truncated',
+      meta: bytes > 0 ? formatByteSize(bytes) : undefined,
+      message:
+        'A section of the log was skipped, so the figures here may be undercounted. Narrow the log levels, or log a smaller transaction.',
+      count: skips.length,
+      eventIndex: skips[0]?.eventIndex ?? -1,
+    },
+  ];
 }
 
 /**
@@ -365,28 +447,48 @@ function logIssueDiagnostics(log: ApexLog): Diagnostic[] {
 }
 
 /**
+ * Where a statement ran: the frame it ran in, and the line inside it. A line
+ * number is not an identity of its own — every class has a line 214 — so two
+ * classes running the same statement at the same line are two call sites.
+ */
+function callSite(event: LogEvent): string | null {
+  return typeof event.lineNumber === 'number'
+    ? `${enclosingFrame(event)?.text ?? ''}|${event.lineNumber}`
+    : null;
+}
+
+/**
  * Statements that ran many times. A log has no loop markers, so it cannot say
  * "SOQL in a loop" — but "line 214 ran 340 queries" is the same signal and is
  * what a developer acts on.
  */
 function repetitionDiagnostics(statements: LogEvent[], label: string): Diagnostic[] {
   const found: Diagnostic[] = [];
+  // DML logs as its operation and object, so only SOQL text is a query.
+  const dialect = label === 'SOQL' ? 'soql' : undefined;
 
-  const perLine = groupBy(statements, (event) =>
-    typeof event.lineNumber === 'number' ? `${event.lineNumber}|${event.text}` : null,
-  );
+  const perLine = groupBy(statements, (event) => {
+    const site = callSite(event);
+    return site === null ? null : `${site}|${event.text}`;
+  });
   for (const [key, group] of perLine) {
     if (group.count < REPEAT_THRESHOLD) {
       continue;
     }
+    // The frame names the call site; the line alone would read the same for every
+    // class that happens to run its statement at that line.
+    const first = group.events[0];
+    const frame = first ? enclosingFrame(first)?.text : undefined;
+    const line = typeof first?.lineNumber === 'number' ? `line ${first.lineNumber}` : '';
+    const from = frame ?? line;
     found.push({
       id: `repeat-line|${label}|${key}`,
       severity: 'Warning',
-      summary: `${group.count} ${label} statements from line ${group.events[0]?.lineNumber}.`,
-      message: `The same statement ran ${group.count} times from one line, which is the usual sign of ${label} inside a loop. Move it out of the loop and work on the whole collection at once.`,
+      summary: `${group.count} ${label} statements from ${[frame, line].filter(Boolean).join(', ')}.`,
+      message: `Possible ${label} in a loop: it executed ${group.count} times from ${from}. Move it out of the loop and work on the whole collection at once.`,
       count: group.count,
       eventIndex: group.eventIndex,
-      evidence: group.events[0]?.text,
+      evidence: oneLine(group.events[0]?.text, group.eventIndex, dialect),
     });
   }
 
@@ -394,21 +496,126 @@ function repetitionDiagnostics(statements: LogEvent[], label: string): Diagnosti
   // so the fix is to run it once and re-use the result.
   const perText = groupBy(statements, (event) => event.text);
   for (const [text, group] of perText) {
-    const lines = new Set(group.events.map((event) => event.lineNumber));
-    if (group.count < REPEAT_THRESHOLD || lines.size < 2) {
+    const sites = new Set(group.events.map(callSite));
+    if (group.count < REPEAT_THRESHOLD || sites.size < 2) {
       continue;
     }
     found.push({
       id: `repeat-text|${label}|${text}`,
       severity: 'Warning',
-      summary: `${group.count} identical ${label} statements, from ${lines.size} lines.`,
-      message: `The same statement ran ${group.count} times from ${lines.size} places. Run it once and pass the result around, or cache it for the transaction.`,
+      summary: `${group.count} identical ${label} statements, from ${sites.size} lines.`,
+      message: `The same statement ran ${group.count} times from ${sites.size} places. Run it once and pass the result around, or cache it for the transaction.`,
       count: group.count,
       eventIndex: group.eventIndex,
-      evidence: text,
+      evidence: oneLine(text, group.eventIndex, dialect),
     });
   }
 
+  return found;
+}
+
+/** Mean rows per statement at or below which a group is working one row at a time. */
+const ROW_AT_A_TIME_ROWS = 1.5;
+/** How many of a group's statements the finding lists. */
+const MAX_EVIDENCE = 5;
+
+/**
+ * The values a query embeds in its own text: quoted strings, and numbers outside
+ * a word. A bind is logged as its compiled name (`:tmpVar1`), so it holds no
+ * value to fold and its digits are inside a word.
+ */
+const SOQL_LITERAL = /'(?:[^']|'')*'|\b\d+\b/g;
+
+/** One query with the values it embeds folded away, so two calls of it match. */
+function soqlShape(text: string): string {
+  return text.replace(SOQL_LITERAL, '?');
+}
+
+/** Calls of one query shape, and the statements they were written as. */
+interface ShapeGroup {
+  object: string;
+  count: number;
+  rows: number;
+  eventIndex: number;
+  /** Each statement as written, with how often it ran and where it first ran. */
+  texts: Map<string, DiagnosticEvidence & { count: number }>;
+}
+
+/**
+ * One query run per record, built by string concatenation so its values sit in
+ * its own text: many calls of one shape, returning about a row each.
+ *
+ * {@link repetitionDiagnostics} keys on the statement text, and a compiled query
+ * logs its binds as names (`WHERE Id = :tmpVar1`), so a loop over a compiled
+ * query repeats one exact text and that rule already names it. Only a query built
+ * as a string embeds the record's values, spreading one call site over as many
+ * texts as there were records — each text below the repeat threshold, the shape
+ * as a whole well past it. Hence the shape key, and hence a group of one text is
+ * left to that rule.
+ *
+ * Queries on one object are not grouped: different fields or a different filter
+ * are different queries, written that way for reasons the log cannot see.
+ *
+ * DML is not read here: its text is only the operation and the object, so every
+ * repeat of one operation shares a text and {@link repetitionDiagnostics} has it.
+ */
+function rowAtATimeDiagnostics(queries: SOQLExecuteBeginLine[]): Diagnostic[] {
+  const groups = new Map<string, ShapeGroup>();
+
+  for (const query of queries) {
+    const shape = soqlShape(query.text);
+    let group = groups.get(shape);
+    if (!group) {
+      // Only sniffed once per shape: the whole group queries the same object.
+      const object = deriveSoqlObject(query);
+      if (!object) {
+        continue;
+      }
+      group = { object, count: 0, rows: 0, eventIndex: query.eventIndex, texts: new Map() };
+      groups.set(shape, group);
+    }
+    group.count++;
+    group.rows += query.soqlRowCount.self;
+    const text = group.texts.get(query.text);
+    if (text) {
+      text.count++;
+    } else {
+      group.texts.set(query.text, { text: query.text, eventIndex: query.eventIndex, count: 1 });
+    }
+  }
+
+  const found: Diagnostic[] = [];
+  for (const [shape, group] of groups) {
+    const { object, count, rows, texts } = group;
+    // No rows is absent evidence, not a row at a time: an end line the log
+    // truncated away carries the row count with it.
+    if (
+      count < REPEAT_THRESHOLD ||
+      texts.size < 2 ||
+      rows === 0 ||
+      rows > count * ROW_AT_A_TIME_ROWS
+    ) {
+      continue;
+    }
+    const each = (rows / count).toFixed(1);
+    const listed = [...texts.values()].sort((a, b) => b.count - a.count).slice(0, MAX_EVIDENCE);
+    found.push({
+      id: `row-at-a-time|${shape}`,
+      severity: 'Warning',
+      summary: `${count} ${object} queries, one row at a time.`,
+      meta: `${formatInteger(rows)} rows`,
+      message: `The ${count} queries returned ${formatInteger(rows)} rows between them, ${each} each, written as ${texts.size} statements that differ only in the values built into them. Query once with an \`IN :ids\` filter and map the results by key.`,
+      count,
+      eventIndex: group.eventIndex,
+      evidence: listed.map(({ text, eventIndex, count: ran }) => ({
+        text,
+        eventIndex,
+        count: ran,
+        dialect: 'soql' as const,
+      })),
+      evidenceTotal: texts.size,
+    });
+  }
   return found;
 }
 
@@ -473,7 +680,7 @@ function queryPlanDiagnostics(queries: SOQLExecuteBeginLine[]): {
         meta: sObject,
         count: group.count,
         eventIndex: group.eventIndex,
-        evidence: group.query,
+        evidence: oneLine(group.query, group.eventIndex, 'soql'),
       };
     }),
     ...[...scans].map(([sObject, group]) => {
@@ -486,7 +693,7 @@ function queryPlanDiagnostics(queries: SOQLExecuteBeginLine[]): {
         meta: sObject,
         count: group.count,
         eventIndex: group.eventIndex,
-        evidence: group.query,
+        evidence: oneLine(group.query, group.eventIndex, 'soql'),
       };
     }),
   ];
@@ -533,10 +740,14 @@ async function soqlLintDiagnostics(queries: SOQLExecuteBeginLine[]): Promise<{
     const stack = database?.getStackByEventIndex(group.eventIndex).reverse() ?? [];
     for (const rule of await linter.lint(text, stack)) {
       const id = `soql|${rule.summary}`;
+      const line = {
+        text,
+        eventIndex: group.eventIndex,
+        count: group.count,
+        dialect: 'soql',
+      } as const;
       const seen = grouped.get(id);
-      if (seen) {
-        seen.count += group.count;
-      } else {
+      if (!seen) {
         grouped.set(id, {
           id,
           severity: rule.severity,
@@ -544,10 +755,18 @@ async function soqlLintDiagnostics(queries: SOQLExecuteBeginLine[]): Promise<{
           message: rule.message,
           count: group.count,
           eventIndex: group.eventIndex,
-          // The queries are in most-repeated order, so this is the query the rule
-          // fired on most — what the finding is about.
-          evidence: text,
+          evidence: [line],
+          evidenceTotal: 1,
         });
+        continue;
+      }
+      // The count is executions, so a rule several queries raise reads far above
+      // any one of them. Each query is listed, so the count reconciles with what
+      // the reader can open. The queries arrive most-repeated first.
+      seen.count += group.count;
+      seen.evidenceTotal = (seen.evidenceTotal ?? 0) + 1;
+      if ((seen.evidence?.length ?? 0) < MAX_EVIDENCE) {
+        seen.evidence?.push(line);
       }
     }
   }
@@ -573,7 +792,7 @@ export async function computeLogDiagnostics(): Promise<LogDiagnostics> {
   }
 
   const queries: SOQLExecuteBeginLine[] = [];
-  const dml: LogEvent[] = [];
+  const dml: DMLBeginLine[] = [];
   const debugLines: LogEvent[] = [];
   const selfTime = new Map<string, number>();
   let totalSelf = 0;
@@ -583,7 +802,7 @@ export async function computeLogDiagnostics(): Promise<LogDiagnostics> {
         queries.push(event as SOQLExecuteBeginLine);
         break;
       case 'DML_BEGIN':
-        dml.push(event);
+        dml.push(event as DMLBeginLine);
         break;
       case 'USER_DEBUG':
         debugLines.push(event);
@@ -605,24 +824,31 @@ export async function computeLogDiagnostics(): Promise<LogDiagnostics> {
   const isLimit = (event: LogEvent) => event.text.includes('System.LimitException');
   const limitExceptions = log.exceptions.filter(isLimit);
   const others = log.exceptions.filter((event) => !isLimit(event));
-  const diagnostics = [
-    ...limitDiagnostics(log.governorLimits, limitExceptions, hotSpot(selfTime, totalSelf)),
+  const ranked = [
+    ...truncationDiagnostics(log),
+    ...limitDiagnostics(
+      limitTotals(apexLimitTimeSeries(log)),
+      limitExceptions,
+      log.governorLimits.snapshots.length > 0,
+      hotSpot(selfTime, totalSelf),
+    ),
     ...logIssueDiagnostics(log),
     ...exceptionDiagnostics(others),
     ...plans.diagnostics,
     ...lint.diagnostics,
     ...repetitionDiagnostics(queries, 'SOQL'),
     ...repetitionDiagnostics(dml, 'DML'),
+    ...rowAtATimeDiagnostics(queries),
     ...debugDiagnostics(debugLines),
   ].sort(
     (a, b) =>
-      SEVERITY_TYPES.indexOf(a.severity) - SEVERITY_TYPES.indexOf(b.severity) || b.count - a.count,
+      SEVERITY_TYPES.indexOf(a.severity) - SEVERITY_TYPES.indexOf(b.severity) ||
+      (a.tier ?? TIER.other) - (b.tier ?? TIER.other) ||
+      b.count - a.count,
   );
 
-  const truncation = log.logIssues.find((issue) => issue.type === 'skip');
   return {
-    diagnostics,
-    truncation: truncation ? truncation.description : null,
+    diagnostics: ranked,
     queryPlansKnown: plans.queryPlansKnown,
     lintedQueries: lint.lintedQueries,
   };

--- a/log-viewer/src/features/analysis/services/__tests__/LogDiagnostics.test.ts
+++ b/log-viewer/src/features/analysis/services/__tests__/LogDiagnostics.test.ts
@@ -25,28 +25,46 @@ function event(fields: Partial<LogEvent>): LogEvent {
     lineNumber: null,
     children: [],
     duration: { self: 0, total: 0 },
+    soqlRowCount: { self: 0, total: 0 },
+    dmlRowCount: { self: 0, total: 0 },
     ...fields,
   } as LogEvent;
 }
 
-function apexLog(fields: Partial<ApexLog> & { namespaceLimits?: Limits }): ApexLog {
-  const { namespaceLimits, ...rest } = fields;
-  const governorLimits = {
+/**
+ * One cumulative snapshot per namespace, as a log reports `LIMIT_USAGE_FOR_NS`.
+ * The findings read the metric-strip series, which is built from these.
+ */
+function governorLimitsOf(namespaceLimits: Record<string, Limits>): GovernorLimits {
+  const byNamespace = new Map(Object.entries(namespaceLimits));
+  return {
     ...emptyLimits(),
-    byNamespace: new Map(namespaceLimits ? [['default', namespaceLimits]] : []),
-    snapshots: [],
+    byNamespace,
+    snapshots: [...byNamespace].map(([namespace, limits], index) => ({
+      timestamp: index + 1,
+      namespace,
+      limits,
+    })),
   } as GovernorLimits;
+}
+
+function apexLog(fields: Partial<ApexLog> & { namespaceLimits?: Record<string, Limits> }): ApexLog {
+  const { namespaceLimits, ...rest } = fields;
   // Same reason as `event`: only the fields the engine reads are supplied.
   return {
     eventsById: [],
+    children: [],
     exceptions: [],
     logIssues: [],
-    governorLimits,
+    governorLimits: governorLimitsOf(namespaceLimits ?? {}),
     ...rest,
   } as ApexLog;
 }
 
 const soql = (fields: Partial<LogEvent>) => event({ type: 'SOQL_EXECUTE_BEGIN', ...fields });
+
+const dml = (fields: Partial<LogEvent> & { sObjectType?: string }) =>
+  event({ type: 'DML_BEGIN', ...fields } as Partial<LogEvent>);
 
 describe('computeLogDiagnostics', () => {
   beforeEach(() => {
@@ -63,30 +81,65 @@ describe('computeLogDiagnostics', () => {
     const namespaceLimits = emptyLimits();
     namespaceLimits.cpuTime = { used: 10_000, limit: 10_000 };
     namespaceLimits.soqlQueries = { used: 85, limit: 100 };
-    log = apexLog({ namespaceLimits });
+    log = apexLog({ namespaceLimits: { default: namespaceLimits } });
 
     const { diagnostics } = await computeLogDiagnostics();
     expect(diagnostics.map((d) => [d.severity, d.summary, d.meta])).toEqual([
-      ['Error', 'CPU Time limit exceeded.', '10,000 ms / 10,000 ms'],
+      ['Warning', 'CPU Time is at 100% of its limit.', '10,000 ms / 10,000 ms'],
       ['Warning', 'SOQL is at 85% of its limit.', '85 / 100'],
     ]);
+  });
+
+  it('leaves every limit alone when the log reports no cumulative totals', async () => {
+    log = apexLog({
+      eventsById: Array.from({ length: 3 }, (_, index) =>
+        event({ type: 'METHOD_ENTRY', eventIndex: index, duration: { self: 9e9, total: 9e9 } }),
+      ),
+    });
+
+    const { diagnostics } = await computeLogDiagnostics();
+    expect(diagnostics.some((d) => d.id.startsWith('limit|'))).toBe(false);
   });
 
   it('leaves a metric below the near-limit share out', async () => {
     const namespaceLimits = emptyLimits();
     namespaceLimits.soqlQueries = { used: 40, limit: 100 };
-    log = apexLog({ namespaceLimits });
+    log = apexLog({ namespaceLimits: { default: namespaceLimits } });
 
     expect((await computeLogDiagnostics()).diagnostics).toEqual([]);
   });
 
-  it('leaves another namespace alone, because the log cannot say it has its own budget', async () => {
-    const namespaceLimits = emptyLimits();
-    namespaceLimits.cpuTime = { used: 9_000, limit: 10_000 };
-    log = apexLog({});
-    log.governorLimits.byNamespace = new Map([['pkg', namespaceLimits]]);
+  it('sums usage over every namespace, since a limit is shared unless a package is certified', async () => {
+    const forNamespace = (used: number) => {
+      const limits = emptyLimits();
+      limits.soqlQueries = { used, limit: 100 };
+      return limits;
+    };
+    log = apexLog({ namespaceLimits: { default: forNamespace(14), pkg: forNamespace(173) } });
 
-    expect((await computeLogDiagnostics()).diagnostics).toEqual([]);
+    const { diagnostics } = await computeLogDiagnostics();
+    // A summed share can pass 100% without a breach: a certified package has its
+    // own limits. Only the log saying the governor stopped it makes that an error.
+    expect(diagnostics.map((d) => [d.severity, d.summary, d.meta])).toEqual([
+      ['Warning', 'SOQL is at 187% of its limit.', '187 / 100'],
+    ]);
+  });
+
+  it('heads a severity band with the governor limit, whatever the counts below it', async () => {
+    const namespaceLimits = emptyLimits();
+    namespaceLimits.soqlQueries = { used: 85, limit: 100 };
+    log = apexLog({
+      namespaceLimits: { default: namespaceLimits },
+      eventsById: Array.from({ length: 6 }, (_, index) =>
+        soql({ eventIndex: index, lineNumber: 214, text: 'SELECT Id FROM Account WHERE Id = :id' }),
+      ),
+    });
+
+    const warnings = (await computeLogDiagnostics()).diagnostics.filter(
+      (d) => d.severity === 'Warning',
+    );
+    expect(warnings[0]?.id).toBe('limit|soqlQueries');
+    expect(warnings.some((d) => d.count > 1)).toBe(true);
   });
 
   it('groups a statement repeated from one line', async () => {
@@ -130,6 +183,223 @@ describe('computeLogDiagnostics', () => {
     expect(diagnostics.some((d) => d.id.startsWith('repeat-line|'))).toBe(false);
   });
 
+  it('leaves DML from several lines to the repeated-statement rule', async () => {
+    log = apexLog({
+      eventsById: Array.from({ length: 6 }, (_, index) =>
+        dml({
+          eventIndex: index,
+          lineNumber: 10 + index,
+          text: 'DML Op:Insert Type:Account',
+          sObjectType: 'Account',
+          dmlRowCount: { self: 1, total: 1 },
+        } as Partial<LogEvent>),
+      ),
+    });
+
+    const { diagnostics } = await computeLogDiagnostics();
+    // DML text is the operation and the object, so every repeat shares a text and
+    // that rule already groups them.
+    expect(diagnostics.map((d) => d.id)).toEqual(['repeat-text|DML|DML Op:Insert Type:Account']);
+  });
+
+  /** A query built as a string, so the record's id sits in its own text. */
+  const dynamicSoql = (index: number, object = 'Contact') =>
+    `SELECT Id FROM ${object} WHERE Id = '003a00000000${index}' LIMIT 1`;
+
+  it('reports one query built per record, run a row at a time', async () => {
+    log = apexLog({
+      eventsById: Array.from({ length: 5 }, (_, index) =>
+        soql({
+          eventIndex: index,
+          lineNumber: 40 + index,
+          text: dynamicSoql(index),
+          soqlRowCount: { self: 1, total: 1 },
+        } as Partial<LogEvent>),
+      ),
+    });
+
+    const found = (await computeLogDiagnostics()).diagnostics.find((d) =>
+      d.id.startsWith('row-at-a-time|'),
+    );
+    expect(found?.summary).toBe('5 Contact queries, one row at a time.');
+    expect(found?.message).toContain('IN :ids');
+    // Each statement is listed, so the reader can open any of them in the grid.
+    expect(found?.evidence).toHaveLength(5);
+  });
+
+  it('lists the five most repeated statements, with how many there are and how often each ran', async () => {
+    log = apexLog({
+      eventsById: Array.from({ length: 12 }, (_, index) =>
+        soql({
+          eventIndex: index,
+          lineNumber: 40,
+          // The first statement runs twice, so it heads the list.
+          text: dynamicSoql(index === 11 ? 0 : index),
+          soqlRowCount: { self: 1, total: 1 },
+        } as Partial<LogEvent>),
+      ),
+    });
+
+    const found = (await computeLogDiagnostics()).diagnostics.find((d) =>
+      d.id.startsWith('row-at-a-time|'),
+    );
+    expect(found?.count).toBe(12);
+    expect(found?.evidence).toHaveLength(5);
+    expect(found?.evidence?.[0]).toEqual({
+      text: dynamicSoql(0),
+      eventIndex: 0,
+      count: 2,
+      dialect: 'soql',
+    });
+    expect(found?.evidenceTotal).toBe(11);
+    expect(found?.message).toContain('11 statements');
+  });
+
+  it('stays quiet when no rows were counted: the evidence is absent, not one row', async () => {
+    log = apexLog({
+      eventsById: Array.from({ length: 5 }, (_, index) =>
+        soql({
+          eventIndex: index,
+          lineNumber: 40 + index,
+          text: dynamicSoql(index),
+          soqlRowCount: { self: 0, total: 0 },
+        } as Partial<LogEvent>),
+      ),
+    });
+
+    const { diagnostics } = await computeLogDiagnostics();
+    expect(diagnostics.some((d) => d.id.startsWith('row-at-a-time|'))).toBe(false);
+  });
+
+  it('keeps one query built per record quiet when each returns many rows', async () => {
+    log = apexLog({
+      eventsById: Array.from({ length: 6 }, (_, index) =>
+        soql({
+          eventIndex: index,
+          lineNumber: 10 + index,
+          text: `SELECT Id FROM Account WHERE Name = 'Acme ${index}'`,
+          soqlRowCount: { self: 200, total: 200 },
+        } as Partial<LogEvent>),
+      ),
+    });
+
+    const { diagnostics } = await computeLogDiagnostics();
+    expect(diagnostics.some((d) => d.id.startsWith('row-at-a-time|'))).toBe(false);
+  });
+
+  it('leaves a bulkified query to the repeated-statement rules', async () => {
+    log = apexLog({
+      eventsById: Array.from({ length: 6 }, (_, index) =>
+        soql({
+          eventIndex: index,
+          lineNumber: 42,
+          // A compiled bind logs as its name, so every call shares one text.
+          text: 'SELECT Id FROM Account WHERE Id IN :idSet',
+          soqlRowCount: { self: 200, total: 200 },
+        } as Partial<LogEvent>),
+      ),
+    });
+
+    const { diagnostics } = await computeLogDiagnostics();
+    expect(diagnostics.some((d) => d.id.startsWith('repeat-line|'))).toBe(true);
+    expect(diagnostics.some((d) => d.id.startsWith('row-at-a-time|'))).toBe(false);
+  });
+
+  it('leaves statements from one line to the per-line rule', async () => {
+    log = apexLog({
+      eventsById: Array.from({ length: 6 }, (_, index) =>
+        soql({
+          eventIndex: index,
+          lineNumber: 42,
+          text: 'SELECT Id FROM Account WHERE Id = :id LIMIT 1',
+          soqlRowCount: { self: 1, total: 1 },
+        } as Partial<LogEvent>),
+      ),
+    });
+
+    const { diagnostics } = await computeLogDiagnostics();
+    expect(diagnostics.some((d) => d.id.startsWith('repeat-line|'))).toBe(true);
+    expect(diagnostics.some((d) => d.id.startsWith('row-at-a-time|'))).toBe(false);
+  });
+
+  it('reports a loop on one line whose query text carries the record values', async () => {
+    log = apexLog({
+      eventsById: Array.from({ length: 6 }, (_, index) =>
+        soql({
+          eventIndex: index,
+          lineNumber: 42,
+          text: dynamicSoql(index, 'Account'),
+          soqlRowCount: { self: 1, total: 1 },
+        } as Partial<LogEvent>),
+      ),
+    });
+
+    const { diagnostics } = await computeLogDiagnostics();
+    // Every text differs, so neither repetition rule sees the loop.
+    expect(diagnostics.some((d) => d.id.startsWith('repeat-line|'))).toBe(false);
+    expect(diagnostics.some((d) => d.id.startsWith('repeat-text|'))).toBe(false);
+    expect(diagnostics.some((d) => d.id.startsWith('row-at-a-time|'))).toBe(true);
+  });
+
+  it('counts one line in two classes as two call sites', async () => {
+    const root = event({
+      type: 'EXECUTION_STARTED',
+      eventIndex: 0,
+      isParent: true,
+    } as Partial<LogEvent>);
+    const frames = ['Class.A.run()', 'Class.B.run()'].map((text, index) =>
+      event({
+        type: 'METHOD_ENTRY',
+        eventIndex: index + 1,
+        text,
+        isParent: true,
+        parent: root,
+      } as Partial<LogEvent>),
+    );
+    const statements = frames.flatMap((frame, klass) =>
+      Array.from({ length: 6 }, (_, run) =>
+        soql({
+          eventIndex: 10 + klass * 6 + run,
+          lineNumber: 42,
+          text: 'SELECT Id FROM Account WHERE Id = :id LIMIT 1',
+          parent: frame,
+          soqlRowCount: { self: 1, total: 1 },
+        } as Partial<LogEvent>),
+      ),
+    );
+    log = apexLog({ eventsById: [root, ...frames, ...statements] });
+
+    const { diagnostics } = await computeLogDiagnostics();
+    const repeats = diagnostics.filter((d) => d.id.startsWith('repeat-line|'));
+    // Line 42 in two classes is two loops, not one finding of twelve.
+    expect(repeats.map((d) => d.count)).toEqual([6, 6]);
+    // The frame names which of the two, where line 42 alone would not.
+    expect(repeats.map((d) => d.summary)).toEqual([
+      '6 SOQL statements from Class.A.run(), line 42.',
+      '6 SOQL statements from Class.B.run(), line 42.',
+    ]);
+    expect(repeats[0]?.message).toContain(
+      'Possible SOQL in a loop: it executed 6 times from Class.A.run().',
+    );
+  });
+
+  it('leaves one identical statement from several lines to the repeated-statement rule', async () => {
+    log = apexLog({
+      eventsById: Array.from({ length: 6 }, (_, index) =>
+        soql({
+          eventIndex: index,
+          lineNumber: 40 + index,
+          text: 'SELECT Id FROM Account WHERE Id = :id LIMIT 1',
+          soqlRowCount: { self: 1, total: 1 },
+        } as Partial<LogEvent>),
+      ),
+    });
+
+    const { diagnostics } = await computeLogDiagnostics();
+    expect(diagnostics.some((d) => d.id.startsWith('repeat-text|'))).toBe(true);
+    expect(diagnostics.some((d) => d.id.startsWith('row-at-a-time|'))).toBe(false);
+  });
+
   it('runs the SOQL rules once per distinct query and carries the count', async () => {
     log = apexLog({
       eventsById: Array.from({ length: 3 }, (_, index) =>
@@ -141,8 +411,31 @@ describe('computeLogDiagnostics', () => {
     const unbounded = diagnostics.find((d) => d.summary.startsWith('SOQL is unbounded'));
     expect(unbounded?.count).toBe(3);
     // The rule names a problem; the query it read is what ties it to the grid.
-    expect(unbounded?.evidence).toBe('SELECT Id FROM Account');
+    expect(unbounded?.evidence).toEqual([
+      { text: 'SELECT Id FROM Account', eventIndex: 0, count: 3, dialect: 'soql' },
+    ]);
     expect(lintedQueries).toEqual({ linted: 1, distinct: 1 });
+  });
+
+  it('lists every query a SOQL rule fired on, most repeated first', async () => {
+    // Three queries raise the same rule, each running a different number of times.
+    const texts = ['SELECT Id FROM Account', 'SELECT Id FROM Contact', 'SELECT Id FROM Lead'];
+    log = apexLog({
+      eventsById: texts.flatMap((text, index) =>
+        Array.from({ length: 3 - index }, (_, run) => soql({ eventIndex: index * 3 + run, text })),
+      ),
+    });
+
+    const { diagnostics } = await computeLogDiagnostics();
+    const unbounded = diagnostics.find((d) => d.summary.startsWith('SOQL is unbounded'));
+    // The count is executions across all three, so the list is what reconciles it.
+    expect(unbounded?.count).toBe(6);
+    expect(unbounded?.evidenceTotal).toBe(3);
+    expect(unbounded?.evidence?.map((e) => [e.text, e.count])).toEqual([
+      [texts[0], 3],
+      [texts[1], 2],
+      [texts[2], 1],
+    ]);
   });
 
   it('reads the query plan verdicts, and knows when there are none', async () => {
@@ -163,9 +456,9 @@ describe('computeLogDiagnostics', () => {
       ['Query is not selective.', 'Account'],
       ['Full table scan.', 'Account'],
     ]);
-    expect(diagnostics.map((d) => d.evidence)).toEqual([
-      'SELECT Id FROM Account LIMIT 1',
-      'SELECT Id FROM Account LIMIT 1',
+    expect(diagnostics.map((d) => d.evidence?.map((e) => e.text))).toEqual([
+      ['SELECT Id FROM Account LIMIT 1'],
+      ['SELECT Id FROM Account LIMIT 1'],
     ]);
     // The query is the row to reveal, not the plan line under it (eventIndex 1).
     expect(diagnostics.map((d) => d.eventIndex)).toEqual([0, 0]);
@@ -176,25 +469,40 @@ describe('computeLogDiagnostics', () => {
     expect((await computeLogDiagnostics()).queryPlansKnown).toBe(false);
   });
 
-  it('frames a truncated log rather than listing it as a finding', async () => {
+  it('heads the findings with a truncated log, ahead of the other issues', async () => {
     log = apexLog({
       logIssues: [
-        {
-          summary: 'Max-Size-reached',
-          description: 'The maximum log size has been reached. Part of the log has been truncated.',
-          type: 'skip',
-        },
         {
           summary: 'Unexpected-End',
           description: 'An entry event was found without a corresponding exit event',
           type: 'unexpected',
         },
+        {
+          summary: 'Max-Size-reached',
+          description: 'The maximum log size has been reached. Part of the log has been truncated.',
+          type: 'skip',
+        },
       ],
     });
 
-    const { diagnostics, truncation } = await computeLogDiagnostics();
-    expect(truncation).toContain('maximum log size');
-    expect(diagnostics.map((d) => d.summary)).toEqual(['Unexpected-End']);
+    const { diagnostics } = await computeLogDiagnostics();
+    expect(diagnostics.map((d) => d.summary)).toEqual(['Log truncated', 'Unexpected-End']);
+    expect(diagnostics[0]?.severity).toBe('Error');
+    expect(diagnostics[0]?.meta).toBeUndefined();
+    expect(diagnostics[0]?.message).toContain('may be undercounted');
+  });
+
+  it('sums the bytes the log said it skipped, over every skipped region', async () => {
+    const skipped = (bytes: string) => ({
+      summary: 'Skipped-Lines',
+      description: `*** Skipped ${bytes} bytes of detailed log. A section of the log has been skipped and the log has been truncated.`,
+      type: 'skip' as const,
+    });
+    log = apexLog({ logIssues: [skipped('1,000,000'), skipped('2,000,000')] });
+
+    const { diagnostics } = await computeLogDiagnostics();
+    expect(diagnostics[0]?.summary).toBe('Log truncated in 2 places');
+    expect(diagnostics[0]?.meta).toBe('3 MB');
   });
 
   it('groups exceptions by their text, counting the throws', async () => {
@@ -230,7 +538,7 @@ describe('computeLogDiagnostics', () => {
     expect(diagnostics).toHaveLength(1);
     expect(diagnostics[0]?.summary).toBe(message);
     expect(diagnostics[0]?.count).toBe(2);
-    expect(diagnostics[0]?.evidence).toBe('Class.A.run: line 31, column 1');
+    expect(diagnostics[0]?.evidence?.[0]?.text).toBe('Class.A.run: line 31, column 1');
   });
 
   it('marks an exception nothing caught', async () => {
@@ -254,7 +562,7 @@ describe('computeLogDiagnostics', () => {
     const namespaceLimits = emptyLimits();
     namespaceLimits.cpuTime = { used: 15_163, limit: 10_000 };
     log = apexLog({
-      namespaceLimits,
+      namespaceLimits: { default: namespaceLimits },
       exceptions: [
         event({ type: 'EXCEPTION_THROWN', eventIndex: 4, text: message }),
         event({
@@ -270,7 +578,7 @@ describe('computeLogDiagnostics', () => {
     expect(diagnostics[0]?.summary).toBe('CPU Time limit exceeded.');
     expect(diagnostics[0]?.meta).toBe('15,163 ms / 10,000 ms');
     expect(diagnostics[0]?.eventIndex).toBe(4);
-    expect(diagnostics[0]?.evidence).toBe('Class.A.run: line 31, column 1');
+    expect(diagnostics[0]?.evidence?.[0]?.text).toBe('Class.A.run: line 31, column 1');
   });
 
   it('still reports a limit exception when the log holds no cumulative totals', async () => {
@@ -294,7 +602,7 @@ describe('computeLogDiagnostics', () => {
     const namespaceLimits = emptyLimits();
     namespaceLimits.cpuTime = { used: 15_163, limit: 10_000 };
     log = apexLog({
-      namespaceLimits,
+      namespaceLimits: { default: namespaceLimits },
       eventsById: [
         event({ type: 'METHOD_ENTRY', text: 'Slow.run()', duration: { self: 9e9, total: 9e9 } }),
         event({ type: 'METHOD_ENTRY', text: 'Fast.run()', duration: { self: 1e9, total: 1e9 } }),
@@ -345,7 +653,7 @@ describe('computeLogDiagnostics', () => {
     const namespaceLimits = emptyLimits();
     namespaceLimits.cpuTime = { used: 9_000, limit: 10_000 };
     log = apexLog({
-      namespaceLimits,
+      namespaceLimits: { default: namespaceLimits },
       exceptions: [event({ text: 'System.QueryException: List has no rows' })],
       eventsById: Array.from({ length: 50 }, (_, index) =>
         event({ type: 'USER_DEBUG', eventIndex: index, text: 'DEBUG|hello' }),

--- a/log-viewer/src/features/database/components/DatabaseView.ts
+++ b/log-viewer/src/features/database/components/DatabaseView.ts
@@ -454,7 +454,12 @@ export class DatabaseView extends LitElement {
     const limits = this._limits;
     const gauges: GaugeMetric[] = [];
     const add = (label: string, found: number, metric: { used: number; limit: number }) => {
-      gauges.push({ label, found, used: this._used(metric.used), limit: this._limit(metric.limit) });
+      gauges.push({
+        label,
+        found,
+        used: this._used(metric.used),
+        limit: this._limit(metric.limit),
+      });
     };
     const z = { used: 0, limit: 0 };
     add('DML', this._count('dml'), limits?.dmlStatements ?? z);

--- a/log-viewer/src/features/database/components/DatabaseView.ts
+++ b/log-viewer/src/features/database/components/DatabaseView.ts
@@ -13,7 +13,9 @@ import type {
   SOSLExecuteBeginLine,
 } from 'apex-log-parser';
 
+import { limitTotals } from '../../../components/logOverviewMetrics.js';
 import { eventBus, type StatementType } from '../../../core/events/EventBus.js';
+import { apexLimitTimeSeries } from '../../timeline/optimised/apex-limit-series.js';
 import { InspectorEmphasis } from '../../../components/inspectorEmphasis.js';
 import { SelectionEchoGuard } from '../../../core/events/SelectionEchoGuard.js';
 import { isVisible } from '../../../core/utility/Util.js';
@@ -205,6 +207,9 @@ export class DatabaseView extends LitElement {
     }
   }
 
+  /** The shared whole-log totals, so a figure here matches every other surface. */
+  private _limits: Limits | undefined;
+
   private async _loadData(): Promise<void> {
     const root = this.timelineRoot;
     if (!root) {
@@ -218,6 +223,8 @@ export class DatabaseView extends LitElement {
     this.dmlLines = db.getDMLLines();
     this.soqlLines = db.getSOQLLines();
     this.soslLines = db.getSOSLLines();
+    // A full pass over every event: too costly to run from render().
+    this._limits = limitTotals(apexLimitTimeSeries(root));
     this.loaded = true;
     // Collapse types the transaction never touched (usually SOSL).
     this.collapsed = {
@@ -362,10 +369,6 @@ export class DatabaseView extends LitElement {
     this.collapsed = { ...this.collapsed, [kind]: !this.collapsed[kind] };
   }
 
-  private get _limits(): Limits | undefined {
-    return this.timelineRoot?.governorLimits;
-  }
-
   /** Cumulative limits are only present when the log recorded a usage snapshot. */
   private get _hasLimits(): boolean {
     return (this.timelineRoot?.governorLimits.snapshots.length ?? 0) > 0;
@@ -394,6 +397,11 @@ export class DatabaseView extends LitElement {
     return this._hasLimits ? value : null;
   }
 
+  /** Without a snapshot the limit is the platform default, which is a guess here, so hide it. */
+  private _limit(value: number): number {
+    return this._hasLimits ? value : 0;
+  }
+
   private _isEmpty(kind: SectionKind): boolean {
     const limits = this._limits;
     const consumed = limits ? SECTION_META[kind].statement(limits).used : 0;
@@ -410,7 +418,7 @@ export class DatabaseView extends LitElement {
         label: SECTION_META[kind].statementLabel,
         found: this._count(kind),
         used: this._used(statement.used),
-        limit: statement.limit,
+        limit: this._limit(statement.limit),
       },
     ];
     if (kind === 'sosl') {
@@ -428,7 +436,7 @@ export class DatabaseView extends LitElement {
         label: 'Rows',
         found: this._rows(kind),
         used: this._used(rows.used),
-        limit: rows.limit,
+        limit: this._limit(rows.limit),
       });
     }
     return metrics;
@@ -446,7 +454,7 @@ export class DatabaseView extends LitElement {
     const limits = this._limits;
     const gauges: GaugeMetric[] = [];
     const add = (label: string, found: number, metric: { used: number; limit: number }) => {
-      gauges.push({ label, found, used: this._used(metric.used), limit: metric.limit });
+      gauges.push({ label, found, used: this._used(metric.used), limit: this._limit(metric.limit) });
     };
     const z = { used: 0, limit: 0 };
     add('DML', this._count('dml'), limits?.dmlStatements ?? z);

--- a/log-viewer/src/features/timeline/optimised/apex-limit-series.ts
+++ b/log-viewer/src/features/timeline/optimised/apex-limit-series.ts
@@ -125,6 +125,7 @@ function buildApexLimitTimeSeries(apexLog: ApexLog): HeatStripTimeSeries {
         namespace: snapshot.namespace,
         metric,
         used: value.used,
+        scope: 'cumulative',
       });
       if (value.limit > 0) {
         metricLimits.set(metric, Math.max(metricLimits.get(metric) ?? 0, value.limit));
@@ -200,6 +201,8 @@ function buildApexLimitTimeSeries(apexLog: ApexLog): HeatStripTimeSeries {
             namespace,
             metric: usage.metric,
             used: usage.used,
+            // Each of these lines reports the block it closes, not the transaction.
+            scope: 'scoped',
           });
         }
         break;

--- a/log-viewer/src/features/timeline/optimised/metric-strip/governor-timeline.test.ts
+++ b/log-viewer/src/features/timeline/optimised/metric-strip/governor-timeline.test.ts
@@ -33,7 +33,22 @@ const absolute = (
   metric: string,
   used: number,
   namespace = 'default',
-): LimitObservation => ({ kind: 'absolute', timestamp, namespace, metric, used });
+): LimitObservation => ({
+  kind: 'absolute',
+  timestamp,
+  namespace,
+  metric,
+  used,
+  scope: 'cumulative',
+});
+
+/** A point-in-time LIMIT_USAGE-style report: scoped to its block, so never authoritative. */
+const scoped = (
+  timestamp: number,
+  metric: string,
+  used: number,
+  namespace = 'default',
+): LimitObservation => ({ kind: 'absolute', timestamp, namespace, metric, used, scope: 'scoped' });
 
 const build = (observations: LimitObservation[]) =>
   buildGovernorTimeSeries(observations, METRICS, LIMITS);
@@ -73,14 +88,38 @@ describe('buildGovernorTimeSeries', () => {
     expect(corrected?.tracked).toBe(1);
   });
 
-  it('keeps a monotonic line from dipping when an absolute comes in low (max floor)', () => {
+  it('follows the reported figure down when we counted more than the governor charged', () => {
     const series = build([
       absolute(0, 'soqlQueries', 0),
       delta(10, 'soqlQueries', 5),
       absolute(20, 'soqlQueries', 2),
     ]);
-    expect(series.events[2]?.values.get('soqlQueries')?.used).toBe(5);
+    // The report is what the governor charged, so it wins over our count.
+    expect(series.events[2]?.values.get('soqlQueries')?.used).toBe(2);
     expect(series.events[2]?.values.get('soqlQueries')?.tracked).toBeUndefined();
+  });
+
+  it('never counts past the highest figure the log reported', () => {
+    const series = build([
+      absolute(0, 'soqlQueries', 3),
+      delta(10, 'soqlQueries', 1),
+      delta(20, 'soqlQueries', 1),
+    ]);
+    expect(series.events.map((e) => e.values.get('soqlQueries')?.used)).toEqual([3, 3, 3]);
+  });
+
+  it('keeps counting past a scoped report, which measures one block only', () => {
+    const series = build([
+      scoped(0, 'soqlQueries', 0),
+      delta(10, 'soqlQueries', 1),
+      delta(20, 'soqlQueries', 1),
+    ]);
+    expect(series.events.map((e) => e.values.get('soqlQueries')?.used)).toEqual([0, 1, 2]);
+  });
+
+  it('never lets a scoped report pull a counted line down', () => {
+    const series = build([delta(10, 'soqlQueries', 5), scoped(20, 'soqlQueries', 2)]);
+    expect(series.events[1]?.values.get('soqlQueries')?.used).toBe(5);
   });
 
   it('continues accumulating deltas after a corrective baseline', () => {
@@ -89,6 +128,7 @@ describe('buildGovernorTimeSeries', () => {
       delta(10, 'soqlQueries', 1),
       absolute(20, 'soqlQueries', 3),
       delta(30, 'soqlQueries', 1),
+      absolute(40, 'soqlQueries', 5),
     ]);
     expect(series.events[3]?.values.get('soqlQueries')?.used).toBe(4);
   });
@@ -146,10 +186,11 @@ describe('buildGovernorTimeSeries — heap reconciliation', () => {
       delta(10, 'heapSize', 50000),
       absolute(20, 'heapSize', 200000), // peak > tracked 50000: snaps up, then +30000
       delta(30, 'heapSize', 30000),
+      absolute(40, 'heapSize', 240000), // a later peak, so the +30000 has room to show
     ];
-    expect(heapUsed(obs)).toEqual([50000, 200000, 230000]);
+    expect(heapUsed(obs)).toEqual([50000, 200000, 230000, 240000]);
     // Our lower observed count is surfaced (grey) once cumulative-anchored.
-    expect(heapTracked(obs)).toEqual([undefined, 50000, 80000]);
+    expect(heapTracked(obs)).toEqual([undefined, 50000, 80000, 80000]);
   });
 
   it('steps to the cumulative with no divergence when there are no HEAP_ALLOCATE events (FINE log)', () => {

--- a/log-viewer/src/features/timeline/optimised/metric-strip/governor-timeline.ts
+++ b/log-viewer/src/features/timeline/optimised/metric-strip/governor-timeline.ts
@@ -15,10 +15,13 @@
  *
  * Two observation kinds:
  * - `delta`    — adds to `tracked` (and therefore to `displayed`); marks the metric delta-tracked.
- * - `absolute` — corrective. Sets the baseline to `max(reported, displayed)`. The `max` floor keeps
- *   monotonic counters from dipping when a subset-scoped report or fluctuating heap comes in low.
- *   For heap, `reported` is the authoritative cumulative "Maximum heap size" (a peak, often our only
- *   source since FINE logs emit no HEAP_ALLOCATE events).
+ * - `absolute` — corrective. A `cumulative` report is authoritative and sets the baseline outright;
+ *   a `scoped` one measures a single block, so it only ever raises the baseline. For heap, the
+ *   cumulative "Maximum heap size" is often our only source (FINE logs emit no HEAP_ALLOCATE events).
+ *
+ * A cumulative figure is also a ceiling. Counting can only fall short of what the governor charged —
+ * a truncated log drops events the report still counted — so `displayed` never passes the highest
+ * cumulative report for the same namespace and metric, and the strip agrees with those totals.
  *
  * At each observation timestamp a single combined point is emitted, summing the last-known
  * per-namespace values (carry-forward step merge). `tracked` is surfaced on the emitted value only
@@ -42,13 +45,19 @@ export interface LimitDeltaObservation {
   delta: number;
 }
 
-/** A cumulative "used" report that corrects the running total. Limit is resolved separately. */
+/** A reported "used" figure that corrects the running total. Limit is resolved separately. */
 export interface LimitAbsoluteObservation {
   kind: 'absolute';
   timestamp: number;
   namespace: string;
   metric: string;
   used: number;
+  /**
+   * Whether the figure is a whole-transaction cumulative total. Only those are authoritative:
+   * a point-in-time report is scoped to the block that emitted it, so it can read below the
+   * transaction total without contradicting it.
+   */
+  scope: 'cumulative' | 'scoped';
 }
 
 export type LimitObservation = LimitDeltaObservation | LimitAbsoluteObservation;
@@ -62,9 +71,12 @@ interface MetricState {
   trackedAtBaseline: number;
   /** Whether this metric ever received a delta observation. */
   sawDelta: boolean;
+  /** Highest cumulative figure the log itself reported, or `Infinity` when it reported none. */
+  cap: number;
 }
 
-const displayedOf = (s: MetricState): number => s.baseline + (s.tracked - s.trackedAtBaseline);
+const displayedOf = (s: MetricState): number =>
+  Math.min(s.baseline + (s.tracked - s.trackedAtBaseline), s.cap);
 
 /** Target max emitted points per metric per namespace (drives the delta-coalescing threshold). */
 const POINT_BUDGET = 500;
@@ -135,6 +147,27 @@ function coalesceDeltas(
 }
 
 /**
+ * The highest cumulative figure the log reported per namespace and metric. Counting can only ever
+ * fall short of it — a truncated log drops events the report still counted — so it caps `displayed`.
+ * Scoped reports are left out: they measure one block, not the transaction.
+ */
+function reportedCaps(observations: LimitObservation[]): Map<string, Map<string, number>> {
+  const caps = new Map<string, Map<string, number>>();
+  for (const obs of observations) {
+    if (obs.kind !== 'absolute' || obs.scope !== 'cumulative') {
+      continue;
+    }
+    let byMetric = caps.get(obs.namespace);
+    if (!byMetric) {
+      byMetric = new Map();
+      caps.set(obs.namespace, byMetric);
+    }
+    byMetric.set(obs.metric, Math.max(byMetric.get(obs.metric) ?? 0, obs.used));
+  }
+  return caps;
+}
+
+/**
  * Fold granular observations into a dense combined-namespace time series.
  *
  * @param observations - Delta and absolute observations, any order.
@@ -156,6 +189,8 @@ export function buildGovernorTimeSeries(
   // heap allocation on huge logs (bounds points to ~POINT_BUDGET per metric per namespace).
   const sorted = coalesceDeltas(sortByTime(observations), limits);
 
+  const caps = reportedCaps(sorted);
+
   // namespace -> metric -> state
   const state = new Map<string, Map<string, MetricState>>();
   const getState = (ns: string, metric: string): MetricState => {
@@ -166,7 +201,13 @@ export function buildGovernorTimeSeries(
     }
     let s = byMetric.get(metric);
     if (!s) {
-      s = { tracked: 0, baseline: 0, trackedAtBaseline: 0, sawDelta: false };
+      s = {
+        tracked: 0,
+        baseline: 0,
+        trackedAtBaseline: 0,
+        sawDelta: false,
+        cap: caps.get(ns)?.get(metric) ?? Infinity,
+      };
       byMetric.set(metric, s);
     }
     return s;
@@ -184,7 +225,9 @@ export function buildGovernorTimeSeries(
         s.tracked += obs.delta;
         s.sawDelta = true;
       } else {
-        s.baseline = Math.max(obs.used, displayedOf(s));
+        // A cumulative total is authoritative; a scoped report only ever raises the line, since
+        // it measures one block and may read below the transaction total.
+        s.baseline = obs.scope === 'cumulative' ? obs.used : Math.max(obs.used, displayedOf(s));
         s.trackedAtBaseline = s.tracked;
       }
       idx++;


### PR DESCRIPTION
## What

Two changes to the whole-log Analysis findings, plus a correction to every governor readout.

### Findings list the statements behind them

A finding now lists up to five of the statements it grouped, most repeated first, each with how
many times it ran, headed by how many there are in all. A query renders through the SOQL
formatter, fitted to the pane's measured width, so its `FROM` and `WHERE` stay readable however
long the field list is. Clicking a statement reveals its row in the Analysis grid.

### A row-at-a-time finding

One query built per record and run a row at a time spreads a single call site over as many
statement texts as there were records, so repetition rules never see it. The new rule groups by
call site instead of by text and names it.

Repetition findings now name the enclosing frame rather than the line alone: a line number reads
the same for every class that happens to query at that line, so several loops in different
classes were indistinguishable.

### Governor figures at their peak

Every whole-log readout — the overview gauges, the governor trends, the Database overview and the
findings — reported the metric's **final** level, which under-reports any metric that falls back
before the log ends. They now all read the **peak**, the level the governor charges the
transaction at, from one shared memoised total. The timeline governor strip still plots the log as
recorded.

## Testing

- `pnpm test` — 128 suites, 1712 tests pass
- `pnpm lint` — clean
- Production build — clean
- Checked in the dev host on a FINEST log, light and dark themes
