### PR TITLE
refactor(log-viewer): abandon inspector builds with AbortSignal

### DIFF
--- a/log-viewer/src/components/CallTreeDetail.ts
+++ b/log-viewer/src/components/CallTreeDetail.ts
@@ -156,8 +156,8 @@ export class CallTreeDetail extends LitElement {
   // computed once per selection and shared across the mode tables.
   private _scoped: ScopedCallTree | null = null;
 
-  // Guards against a slow view-switch resolving after a newer one.
-  private _switchEpoch = 0;
+  // The build in flight; a newer view-switch aborts it, and so does a disconnect.
+  private _switch: AbortController | null = null;
 
   /** True while a scoped build is in flight. Read by the tables' placeholder,
    *  which Tabulator re-evaluates every time it shows one. */
@@ -370,6 +370,7 @@ export class CallTreeDetail extends LitElement {
     this._locateUnsubscribe = undefined;
     this._selectionClearUnsubscribe?.();
     this._selectionClearUnsubscribe = undefined;
+    this._switch?.abort();
     this._destroyTables();
   }
 
@@ -397,7 +398,7 @@ export class CallTreeDetail extends LitElement {
       const scoped = this.wholeLog
         ? await buildWholeLogCallTree(options)
         : await buildScopedCallTree(this.eventIndex, this.instances, options);
-      if (options.cancelled?.()) {
+      if (options.signal?.aborted) {
         // Abandoned rather than empty — don't cache the null over a scope that
         // was never walked.
         return null;
@@ -418,23 +419,16 @@ export class CallTreeDetail extends LitElement {
     }
   }
 
-  /**
-   * True once `epoch`'s work should be thrown away: a newer switch replaced it,
-   * or the component was disconnected mid-wait (e.g. the pane collapsed) —
-   * building into detached DOM that disconnectedCallback already ran past would
-   * leak the Tabulator.
-   */
-  private _superseded(epoch: number): boolean {
-    return epoch !== this._switchEpoch || !this.isConnected;
-  }
-
   private async _showActive(): Promise<void> {
-    const epoch = ++this._switchEpoch;
+    // A newer switch, or a disconnect, aborts this one: building into detached
+    // DOM that disconnectedCallback already ran past would leak the Tabulator.
+    this._switch?.abort();
+    const { signal } = (this._switch = new AbortController());
     // Wait for the now-visible host to lay out before Tabulator measures column
     // widths — building against a hidden/zero-width host makes columns overlap.
     await this.updateComplete;
     await waitForNextFrame();
-    if (this._superseded(epoch)) {
+    if (signal.aborted) {
       return;
     }
 
@@ -455,11 +449,8 @@ export class CallTreeDetail extends LitElement {
       // selection they don't describe.
       void built.table.setData([]);
     }
-    const data = await this._rows(mode, {
-      yieldFrame: waitForNextFrame,
-      cancelled: () => this._superseded(epoch),
-    });
-    if (!data || this._superseded(epoch)) {
+    const data = await this._rows(mode, { yieldFrame: waitForNextFrame, signal });
+    if (!data || signal.aborted) {
       return;
     }
     this._pending = false;

--- a/log-viewer/src/components/NamespaceTimeBar.ts
+++ b/log-viewer/src/components/NamespaceTimeBar.ts
@@ -69,8 +69,8 @@ export class NamespaceTimeBar extends LitElement {
    *  walk again, and a new log or selection does. */
   private _scopeKey: object | null | typeof UNRESOLVED = UNRESOLVED;
 
-  /** Bumped per walk; a walk whose epoch has moved on drops its result. */
-  private _walkEpoch = 0;
+  /** The walk in flight; a new scope aborts it, and so does a disconnect. */
+  private _walk: AbortController | null = null;
 
   /** The log's palette, so a namespace keeps its colour across scopes. Null until
    *  a scope resolves, which needs a log. */
@@ -105,6 +105,12 @@ export class NamespaceTimeBar extends LitElement {
     ></stacked-time-bar>`;
   }
 
+  disconnectedCallback(): void {
+    super.disconnectedCallback();
+    // Walking on into a detached host wastes frames and answers nobody.
+    this._walk?.abort();
+  }
+
   protected willUpdate(changed: PropertyValues): void {
     // A new log invalidates the scope, so the next render walks it again.
     if (changed.has('logStore')) {
@@ -129,7 +135,8 @@ export class NamespaceTimeBar extends LitElement {
       return;
     }
     this._scopeKey = scope?.key ?? null;
-    const epoch = ++this._walkEpoch;
+    this._walk?.abort();
+    const walk = (this._walk = new AbortController());
     if (!scope) {
       this._slices = [];
       return;
@@ -142,9 +149,9 @@ export class NamespaceTimeBar extends LitElement {
     }
     const slices = await scopedNamespaceSelfTimes(scope.key, scope.roots, {
       yieldFrame: waitForNextFrame,
-      cancelled: () => epoch !== this._walkEpoch || !this.isConnected,
+      signal: walk.signal,
     });
-    if (epoch !== this._walkEpoch) {
+    if (this._walk !== walk) {
       return;
     }
     if (slices) {

--- a/log-viewer/src/components/__tests__/scopedCallTree.test.ts
+++ b/log-viewer/src/components/__tests__/scopedCallTree.test.ts
@@ -242,7 +242,6 @@ describe('buildScopedCallTree', () => {
         yields += 1;
         return Promise.resolve();
       },
-      cancelled: () => false,
     };
 
     // Every clock read lands past the slice deadline, so each check yields —
@@ -270,7 +269,7 @@ describe('buildScopedCallTree', () => {
       // The first yield is the first chance to notice; nothing is returned after it.
       const tree = await buildScopedCallTree(instances[0]!, instances, {
         yieldFrame: () => Promise.resolve(),
-        cancelled: () => true,
+        signal: AbortSignal.abort(),
       });
       expect(tree).toBeNull();
     } finally {
@@ -330,7 +329,7 @@ describe('buildWholeLogCallTree', () => {
     try {
       const tree = await buildWholeLogCallTree({
         yieldFrame: () => Promise.resolve(),
-        cancelled: () => true,
+        signal: AbortSignal.abort(),
       });
       expect(tree).toBeNull();
     } finally {

--- a/log-viewer/src/core/utility/FrameBudget.ts
+++ b/log-viewer/src/core/utility/FrameBudget.ts
@@ -13,8 +13,8 @@ export const CHECK_EVERY = 256;
 export interface FrameBudgetOptions {
   /** Hands the frame back between work slices. */
   yieldFrame: () => Promise<void>;
-  /** Polled after each yield; true abandons the build, which then returns null. */
-  cancelled?: () => boolean;
+  /** Aborting it abandons the build, which then returns null. */
+  signal?: AbortSignal;
 }
 
 /** Returns false once the build has been abandoned. */
@@ -37,6 +37,6 @@ export function frameBudget(options: FrameBudgetOptions): Tick {
     }
     await options.yieldFrame();
     deadline = performance.now() + SLICE_MS;
-    return !options.cancelled?.();
+    return !options.signal?.aborted;
   };
 }

--- a/log-viewer/src/features/database/components/DatabaseTimeTree.ts
+++ b/log-viewer/src/features/database/components/DatabaseTimeTree.ts
@@ -155,6 +155,9 @@ export class DatabaseTime extends LitElement {
   /** eventIndex to the ids of the rows that name it, built on the first mark. */
   private _rowsByEvent: Map<number, number[]> | null = null;
 
+  /** The build in flight; a newer one aborts it, and so does a disconnect. */
+  private _building: AbortController | null = null;
+
   private readonly _logLoaded = new LogLoadedController(this, () => {
     void this._build();
   });
@@ -209,6 +212,7 @@ export class DatabaseTime extends LitElement {
     this._locateUnsubscribe = undefined;
     this._selectionClearUnsubscribe?.();
     this._selectionClearUnsubscribe = undefined;
+    this._building?.abort();
     // Rows go with the table, so the mark can't outlive them.
     this._locatedRow.clear();
     this._table?.destroy();
@@ -268,12 +272,14 @@ export class DatabaseTime extends LitElement {
 
   private async _build(): Promise<void> {
     const overview = currentDatabaseOverview();
+    this._building?.abort();
+    const { signal } = (this._building = new AbortController());
     // Wait for the host to lay out before Tabulator measures column widths —
     // building against a zero-width host makes the columns overlap.
     await this.updateComplete;
     await waitForNextFrame();
     const container = this._host();
-    if (!container || !this.isConnected) {
+    if (!container || signal.aborted) {
       return;
     }
 


### PR DESCRIPTION
## What

The inspector sections that build asynchronously each kept their own epoch
counter to spot a superseded build. `AbortController` already does that job,
so the counters are gone.

- `FrameBudgetOptions.cancelled?: () => boolean` becomes `signal?: AbortSignal`.
- `NamespaceTimeBar`, `CallTreeDetail` and `DatabaseTimeTree` each hold the
  build in flight; a newer build aborts the older one.
- `disconnectedCallback` aborts too. The Database time tree had no cancel at
  all, so a build waiting on a frame carried on after a disconnect.
- `CallTreeDetail._superseded()` and both epoch fields are removed.

No user-visible change, so no CHANGELOG or docs entry.

## Test

- Full suite: 130 suites, 1762 tests pass.
- `tsc -b --force`, eslint and prettier clean.
- Production build ok.
- Manual check pending: switch Call Tree detail views, move the selection
  mid-walk on the namespace bar, and reload a log on the Database tab.