### PR TITLE
refactor(log-viewer): cut direct --vscode-* uses from 267 to 87

### DIFF
--- a/.claude/rules/log-viewer.md
+++ b/.claude/rules/log-viewer.md
@@ -28,11 +28,28 @@ Webview UI. Applies when working under `log-viewer/`.
 
 ## UI appearance
 
-- **Use a `--lana-*` token for every color, radius, space, shadow and border width.** Write no new
-  literals, and replace the literals in the code you touch. Older files still hold literals; we
-  convert them file by file.
-- **Put a new token in `styles/tokens.css` as `var(--vscode-…, <literal>)`.** The literal is the
-  value a host outside VS Code gets, so one stylesheet can re-skin the app.
+- **Never write a raw literal for a color, radius, space, shadow or border width.** Use a
+  `--lana-*` token, or the `--vscode-*` var the value comes from. Replace the literals in the code
+  you touch; older files still hold them and we convert file by file.
+- **A `--lana-*` token when the value is more than one var, and the plain `--vscode-*` var when it
+  is not.** Give a value a token when any of these holds:
+  1. the role appears in three or more files;
+  2. VS Code has no var for it, so it is a scale or a role of ours (`--lana-space-*`,
+     `--lana-pane-min`);
+  3. the value is a chain, a `calc` or a `color-mix`, not a single var;
+  4. the var is absent in a VS Code we support, so a fallback is needed — `cornerRadius-*`,
+     `spacing-size*` and `strokeThickness` ship in no stable release.
+
+  Otherwise use the var directly. A token wrapping one already-semantic var used in one file
+  (`--vscode-editorCursor-foreground`) only adds a name to learn and a hop to trace.
+
+- **Put a new token in `styles/tokens.css` as `var(--vscode-…, <literal>)`.** The literal is what a
+  host outside VS Code falls back to, and what covers a var VS Code has yet to register.
+- **Never define or override a `--vscode-*` name.** An override is global to the webview, so
+  re-skinning one role changes every other consumer of that var, and shadowing a platform name
+  leaves no way to tell what the var means. A host outside VS Code supplies the whole `--vscode-*`
+  block once instead. The one exception is skinning a `vscode-elements` component, which reads its
+  own `--vscode-*` names: scope the override to that element, never to `:host` or `:root`.
 - **Data palettes stay literal.** The timeline categories (`timeline/themes/Themes.ts`) and the
   metric-strip tiers (`metric-strip/metric-strip-colors.ts`) show meaning, not chrome, so they do
   not follow the host theme.

--- a/log-viewer/src/components/AnchoredPopover.ts
+++ b/log-viewer/src/components/AnchoredPopover.ts
@@ -113,7 +113,7 @@ export class AnchoredPopover extends LitElement {
         padding: 2px 8px 6px;
         font-weight: 600;
         font-size: 12px;
-        color: var(--vscode-foreground);
+        color: var(--lana-fg);
       }
 
       .panel__empty {
@@ -122,7 +122,7 @@ export class AnchoredPopover extends LitElement {
         gap: 6px;
         padding: 8px;
         font-size: 12px;
-        color: var(--vscode-descriptionForeground);
+        color: var(--lana-fg-muted);
       }
 
       /* Hidden until the slot reports content, so the empty message shows instead. */

--- a/log-viewer/src/components/CodeBlock.ts
+++ b/log-viewer/src/components/CodeBlock.ts
@@ -40,15 +40,15 @@ export class CodeBlock extends LitElement {
         position: relative;
         overflow: auto;
         padding: var(--lana-space-sm);
-        border: 1px solid var(--vscode-widget-border, transparent);
+        border: 1px solid var(--lana-surface-border);
         border-radius: var(--lana-radius-sm);
-        background-color: var(--vscode-textCodeBlock-background, var(--vscode-editor-background));
+        background-color: var(--lana-code-bg);
       }
 
       pre {
         margin: 0;
-        font-family: var(--vscode-editor-font-family, monospace);
-        font-size: var(--vscode-editor-font-size, 0.9em);
+        font-family: var(--lana-font-mono);
+        font-size: var(--lana-text-mono);
         white-space: pre-wrap;
         word-break: break-word;
       }
@@ -59,8 +59,8 @@ export class CodeBlock extends LitElement {
         right: var(--lana-space-2xs);
         opacity: 0;
         transition: opacity 0.1s ease;
-        color: var(--vscode-icon-foreground);
-        background-color: var(--vscode-textCodeBlock-background, var(--vscode-editor-background));
+        color: var(--lana-icon-fg);
+        background-color: var(--lana-code-bg);
       }
       .code-block:hover .copy,
       .code-block:focus-within .copy,

--- a/log-viewer/src/components/ContextMenu.ts
+++ b/log-viewer/src/components/ContextMenu.ts
@@ -110,7 +110,7 @@ export class ContextMenu extends LitElement {
       }
 
       .menu-item:hover:not(.disabled) {
-        background-color: var(--vscode-list-hoverBackground);
+        background-color: var(--lana-row-hover-bg);
       }
 
       .menu-item.disabled {

--- a/log-viewer/src/components/DetailDock.ts
+++ b/log-viewer/src/components/DetailDock.ts
@@ -47,8 +47,8 @@ export class DetailDock extends LitElement {
         height: 100%;
         overflow: hidden;
         background-color: var(--vscode-sideBar-background);
-        color: var(--vscode-sideBar-foreground, var(--vscode-foreground));
-        font-family: var(--vscode-font-family);
+        color: var(--vscode-sideBar-foreground, var(--lana-fg));
+        font-family: var(--lana-font-ui);
         font-size: var(--vscode-font-size);
         /* Match the docked edge (the DockLayout gutter) so the panel reads as a
            deliberate region rather than blending into the tab header above. */
@@ -78,17 +78,14 @@ export class DetailDock extends LitElement {
 
       vscode-icon {
         flex: 0 0 auto;
-        color: var(--vscode-icon-foreground);
+        color: var(--lana-icon-fg);
         border-radius: var(--lana-radius-sm);
       }
       vscode-icon:hover {
-        background-color: var(--vscode-toolbar-hoverBackground);
+        background-color: var(--lana-toolbar-hover-bg);
       }
       vscode-icon:active {
-        background-color: var(
-          --vscode-toolbar-activeBackground,
-          var(--vscode-toolbar-hoverBackground)
-        );
+        background-color: var(--vscode-toolbar-activeBackground, var(--lana-toolbar-hover-bg));
       }
 
       pane-view {
@@ -99,7 +96,7 @@ export class DetailDock extends LitElement {
       .empty {
         flex: 1 1 auto;
         padding: var(--lana-space-md) var(--lana-space-lg);
-        color: var(--vscode-descriptionForeground);
+        color: var(--lana-fg-muted);
       }
     `,
   ];

--- a/log-viewer/src/components/DotSeparator.ts
+++ b/log-viewer/src/components/DotSeparator.ts
@@ -4,15 +4,20 @@
 import { LitElement, css, html } from 'lit';
 import { customElement } from 'lit/decorators.js';
 
+import { tokenStyles } from '../styles/tokens.styles.js';
+
 @customElement('dot-separator')
 export class DotSeparator extends LitElement {
-  static styles = css`
-    :host {
-      color: var(--vscode-descriptionForeground, #999);
-      opacity: 0.5;
-      flex: 0 0 auto;
-    }
-  `;
+  static styles = [
+    tokenStyles,
+    css`
+      :host {
+        color: var(--lana-fg-muted);
+        opacity: 0.5;
+        flex: 0 0 auto;
+      }
+    `,
+  ];
 
   render() {
     return html`<span class="metadata__separator">•</span>`;

--- a/log-viewer/src/components/EventVitals.ts
+++ b/log-viewer/src/components/EventVitals.ts
@@ -126,10 +126,10 @@ export class EventVitals extends LitElement {
         }
       }
       .label {
-        color: var(--vscode-descriptionForeground);
+        color: var(--lana-fg-muted);
       }
       .value {
-        font-family: var(--vscode-editor-font-family, monospace);
+        font-family: var(--lana-font-mono);
         font-variant-numeric: tabular-nums;
         overflow-wrap: anywhere;
       }
@@ -138,7 +138,7 @@ export class EventVitals extends LitElement {
          colour is the theme's own secondary token — not a lower alpha — because
          thinning contrast to de-emphasise costs legibility. */
       .qualifier {
-        color: var(--vscode-descriptionForeground);
+        color: var(--lana-fg-muted);
         font-size: 0.9em;
       }
       .pill {
@@ -147,7 +147,7 @@ export class EventVitals extends LitElement {
         border-radius: var(--lana-radius-sm);
         font-size: 0.85em;
         line-height: 1.4;
-        color: var(--vscode-editor-background);
+        color: var(--lana-editor-bg);
       }
       .pill--yes {
         background-color: var(--vscode-charts-green, #388a34);
@@ -156,7 +156,7 @@ export class EventVitals extends LitElement {
         background-color: var(--vscode-charts-red, #d13438);
       }
       .empty {
-        color: var(--vscode-descriptionForeground);
+        color: var(--lana-fg-muted);
       }
     `,
   ];

--- a/log-viewer/src/components/GovernorTrends.ts
+++ b/log-viewer/src/components/GovernorTrends.ts
@@ -122,7 +122,7 @@ export class GovernorTrends extends LitElement {
          the chart under the pointer. */
       .trend__value {
         display: block;
-        font-family: var(--vscode-editor-font-family, monospace);
+        font-family: var(--lana-font-mono);
         font-variant-numeric: tabular-nums;
         font-size: var(--lana-text-sm);
         white-space: nowrap;
@@ -138,17 +138,17 @@ export class GovernorTrends extends LitElement {
         display: block;
         width: 100%;
         height: 44px;
-        border-bottom: 1px solid var(--vscode-editorWidget-border, var(--vscode-panel-border));
+        border-bottom: 1px solid var(--lana-surface-border);
       }
 
       .trend--safe {
-        color: var(--vscode-charts-green, #388a34);
+        color: var(--lana-severity-ok);
       }
       .trend--warn {
-        color: var(--vscode-charts-yellow, var(--vscode-editorWarning-foreground));
+        color: var(--lana-severity-warning);
       }
       .trend--danger {
-        color: var(--vscode-errorForeground, #f14c4c);
+        color: var(--lana-severity-error);
       }
 
       .trend__area {

--- a/log-viewer/src/components/LogProblemsChip.ts
+++ b/log-viewer/src/components/LogProblemsChip.ts
@@ -53,7 +53,7 @@ export class LogProblemsChip extends LitElement {
          color on its own :host, and a specified value beats an inherited one (outer-tree
          author styles do win over :host). */
       .problems--clean vscode-icon {
-        color: var(--vscode-descriptionForeground);
+        color: var(--lana-fg-muted);
       }
 
       .skeleton {

--- a/log-viewer/src/components/LogTitle.ts
+++ b/log-viewer/src/components/LogTitle.ts
@@ -55,12 +55,12 @@ export class LogTitle extends LitElement {
       }
 
       a.title-item {
-        color: var(--vscode-editor-foreground);
+        color: var(--lana-editor-fg);
 
         &:hover,
         &:active {
-          background-color: var(--vscode-toolbar-hoverBackground, rgba(90, 93, 94, 0.31));
-          color: var(--vscode-editor-foreground);
+          background-color: var(--lana-toolbar-hover-bg);
+          color: var(--lana-editor-fg);
           text-decoration: none;
         }
       }

--- a/log-viewer/src/components/NavBar.ts
+++ b/log-viewer/src/components/NavBar.ts
@@ -127,7 +127,7 @@ export class NavBar extends LitElement {
         /* VS Code's side-bar/panel title height, so this row reads as a title bar rather
            than as content pressed against the top edge (and the count badges have room). */
         min-height: 35px;
-        color: var(--vscode-editor-foreground);
+        color: var(--lana-editor-fg);
       }
 
       .navbar {
@@ -135,7 +135,7 @@ export class NavBar extends LitElement {
         /* Wide enough to read as a gap: the count badge overhangs its control by 3px. */
         gap: 16px;
         justify-content: space-between;
-        font-family: var(--vscode-font-family);
+        font-family: var(--lana-font-ui);
         align-items: center;
         min-width: 0;
       }
@@ -180,13 +180,13 @@ export class NavBar extends LitElement {
         padding: 4px 8px 2px;
         font-size: 11px;
         font-weight: 600;
-        color: var(--vscode-descriptionForeground);
+        color: var(--lana-fg-muted);
       }
 
       .menu-section__empty {
         padding: 2px 8px 4px;
         font-size: 12px;
-        color: var(--vscode-descriptionForeground);
+        color: var(--lana-fg-muted);
       }
     `,
   ];

--- a/log-viewer/src/components/OverflowList.ts
+++ b/log-viewer/src/components/OverflowList.ts
@@ -105,10 +105,10 @@ export class OverflowList extends LitElement {
         align-items: center;
         gap: 4px;
         padding: 2px 6px;
-        border: 1px solid var(--vscode-settings-dropdownBorder, #3c3c3c);
+        border: 1px solid var(--lana-control-border);
         border-radius: 4px;
-        background-color: var(--vscode-settings-dropdownBackground, #313131);
-        color: var(--vscode-foreground);
+        background-color: var(--lana-control-bg);
+        color: var(--lana-fg);
         font: inherit;
         font-size: 11px;
         line-height: 1;
@@ -119,11 +119,11 @@ export class OverflowList extends LitElement {
       }
 
       .overflow:hover {
-        background-color: var(--vscode-list-hoverBackground);
+        background-color: var(--lana-row-hover-bg);
       }
 
       .overflow:focus-visible {
-        outline: 1px solid var(--vscode-focusBorder);
+        outline: 1px solid var(--lana-focus-border);
         outline-offset: 1px;
       }
 
@@ -132,7 +132,7 @@ export class OverflowList extends LitElement {
       }
 
       .overflow__chevron {
-        color: var(--vscode-descriptionForeground);
+        color: var(--lana-fg-muted);
         transition: transform 120ms ease;
       }
 
@@ -168,8 +168,8 @@ export class OverflowList extends LitElement {
         border: var(--lana-stroke) solid var(--filter-popover-border-color);
         border-radius: var(--filter-popover-radius);
         box-shadow: var(--filter-popover-shadow);
-        color: var(--vscode-menu-foreground, var(--vscode-foreground));
-        font-family: var(--vscode-font-family);
+        color: var(--vscode-menu-foreground, var(--lana-fg));
+        font-family: var(--lana-font-ui);
       }
 
       .container.end .panel {
@@ -184,7 +184,7 @@ export class OverflowList extends LitElement {
         padding: 2px 10px 6px;
         font-weight: 600;
         font-size: 12px;
-        color: var(--vscode-foreground);
+        color: var(--lana-fg);
       }
 
       .menu-items {

--- a/log-viewer/src/components/PaneView.ts
+++ b/log-viewer/src/components/PaneView.ts
@@ -139,14 +139,14 @@ export class PaneView extends LitElement {
         cursor: pointer;
       }
       .pane-header--button:hover {
-        background-color: var(--vscode-list-hoverBackground);
+        background-color: var(--lana-row-hover-bg);
       }
       .pane-header:focus-visible {
-        outline: 1px solid var(--vscode-focusBorder);
+        outline: 1px solid var(--lana-focus-border);
         outline-offset: -1px;
       }
       .pane-header vscode-icon {
-        color: var(--vscode-icon-foreground);
+        color: var(--lana-icon-fg);
         flex: 0 0 auto;
       }
       .pane-header__title {

--- a/log-viewer/src/components/VsChip.ts
+++ b/log-viewer/src/components/VsChip.ts
@@ -25,24 +25,24 @@ export class VsChip extends LitElement {
         align-items: baseline;
         gap: 6px;
         padding: 2px 6px;
-        border: 1px solid var(--vscode-settings-dropdownBorder, #3c3c3c);
+        border: 1px solid var(--lana-control-border);
         border-radius: 4px;
-        background-color: var(--vscode-settings-dropdownBackground, #313131);
+        background-color: var(--lana-control-bg);
         white-space: nowrap;
-        font-family: var(--vscode-editor-font-family, monospace);
+        font-family: var(--lana-font-mono);
         font-weight: 600;
         font-size: 11px;
-        color: var(--vscode-foreground);
+        color: var(--lana-fg);
       }
 
       /* Small uppercase leading label; overrides the host's mono/value styling. */
       ::slotted([slot='lead']) {
-        font-family: var(--vscode-font-family);
+        font-family: var(--lana-font-ui);
         font-size: 10px;
         font-weight: 400;
         letter-spacing: 0.05em;
         text-transform: uppercase;
-        color: var(--vscode-descriptionForeground);
+        color: var(--lana-fg-muted);
       }
     `,
   ];

--- a/log-viewer/src/components/VsSelect.ts
+++ b/log-viewer/src/components/VsSelect.ts
@@ -68,7 +68,7 @@ export const selectSizingStyles = css`
   .vs-panel-label {
     grid-column: 1;
     font-size: var(--filter-control-font-size);
-    color: var(--vscode-foreground);
+    color: var(--lana-fg);
     white-space: nowrap;
   }
 
@@ -118,9 +118,9 @@ export const selectSizingStyles = css`
      Current value is shown by the checkmark (.option-check), not a fill. */
   .option.active,
   .option.active:hover {
-    background-color: var(--vscode-list-hoverBackground);
-    color: var(--vscode-foreground);
-    outline-color: var(--vscode-list-hoverBackground);
+    background-color: var(--lana-row-hover-bg);
+    color: var(--lana-fg);
+    outline-color: var(--lana-row-hover-bg);
   }
 
   /* Same 16px marker column as the facet checklist's checkbox (.vs-checkbox), so
@@ -132,7 +132,7 @@ export const selectSizingStyles = css`
     flex-shrink: 0;
     width: 16px;
     height: 16px;
-    color: var(--vscode-foreground);
+    color: var(--lana-fg);
   }
 
   .option:not(.selected) .option-check {
@@ -152,7 +152,7 @@ export const selectSizingStyles = css`
   }
 
   :host(:not([dense])) .face:hover {
-    background-color: var(--vscode-toolbar-hoverBackground);
+    background-color: var(--lana-toolbar-hover-bg);
   }
 
   /* Combobox face: size to placeholder/value (like the select face's fit-content
@@ -168,11 +168,11 @@ export const selectSizingStyles = css`
   }
 
   .face-prefix {
-    color: var(--vscode-descriptionForeground);
+    color: var(--lana-fg-muted);
   }
 
   .face-value {
-    color: var(--vscode-foreground);
+    color: var(--lana-fg);
   }
 
   .face.active .face-value {
@@ -181,7 +181,7 @@ export const selectSizingStyles = css`
 
   /* Inactive placeholder is muted. */
   .face:not(.active) .face-value {
-    color: var(--vscode-descriptionForeground);
+    color: var(--lana-fg-muted);
   }
 
   .face-prefix + .face-value {

--- a/log-viewer/src/components/datagrid-facet-filter.ts
+++ b/log-viewer/src/components/datagrid-facet-filter.ts
@@ -58,7 +58,7 @@ export class DatagridFacetFilter extends LitElement {
         grid-column: 1;
         font-size: var(--filter-control-font-size);
         font-weight: 600;
-        color: var(--vscode-foreground);
+        color: var(--lana-fg);
         /* Nudge onto the first option row's baseline. */
         padding-top: 3px;
       }
@@ -80,8 +80,8 @@ export class DatagridFacetFilter extends LitElement {
 
       .facet-trigger__count {
         font-weight: 600;
-        color: var(--vscode-badge-foreground);
-        background-color: var(--vscode-badge-background);
+        color: var(--lana-badge-fg);
+        background-color: var(--lana-badge-bg);
         border-radius: 999px;
         padding: 0 5px;
         font-size: 10px;
@@ -94,7 +94,7 @@ export class DatagridFacetFilter extends LitElement {
       }
 
       .facet-trigger__chevron {
-        color: var(--vscode-descriptionForeground);
+        color: var(--lana-fg-muted);
       }
 
       .facet-popover {
@@ -136,7 +136,7 @@ export class DatagridFacetFilter extends LitElement {
 
       .facet-popover__empty {
         padding: 6px 8px;
-        color: var(--vscode-descriptionForeground);
+        color: var(--lana-fg-muted);
         font-size: 12px;
       }
 
@@ -151,7 +151,7 @@ export class DatagridFacetFilter extends LitElement {
         padding: 4px 8px;
         border: none;
         background: none;
-        color: var(--vscode-textLink-foreground);
+        color: var(--lana-link-fg);
         font: inherit;
         font-size: 12px;
         text-align: left;
@@ -164,7 +164,7 @@ export class DatagridFacetFilter extends LitElement {
       }
 
       .facet-popover__clear:hover {
-        color: var(--vscode-textLink-activeForeground);
+        color: var(--lana-link-fg-active);
       }
     `,
   ];

--- a/log-viewer/src/components/datagrid-range-filter.ts
+++ b/log-viewer/src/components/datagrid-range-filter.ts
@@ -59,7 +59,7 @@ export class DatagridRangeFilter extends LitElement {
       .range-panel__label {
         grid-column: 1;
         font-size: var(--filter-control-font-size);
-        color: var(--vscode-foreground);
+        color: var(--lana-fg);
         white-space: nowrap;
       }
 
@@ -72,7 +72,7 @@ export class DatagridRangeFilter extends LitElement {
 
       .range-panel__unit {
         font-size: 11px;
-        color: var(--vscode-descriptionForeground);
+        color: var(--lana-fg-muted);
       }
 
       .range-trigger {
@@ -80,7 +80,7 @@ export class DatagridRangeFilter extends LitElement {
       }
 
       .range-trigger__chevron {
-        color: var(--vscode-descriptionForeground);
+        color: var(--lana-fg-muted);
       }
 
       .range-popover {
@@ -135,7 +135,7 @@ export class DatagridRangeFilter extends LitElement {
       }
 
       .range-popover__input:focus {
-        outline: 1px solid var(--vscode-focusBorder);
+        outline: 1px solid var(--lana-focus-border);
         outline-offset: -1px;
       }
 
@@ -144,14 +144,14 @@ export class DatagridRangeFilter extends LitElement {
         padding: 2px 0;
         border: none;
         background: none;
-        color: var(--vscode-textLink-foreground);
+        color: var(--lana-link-fg);
         font: inherit;
         font-size: 12px;
         cursor: pointer;
       }
 
       .range-popover__clear:hover {
-        color: var(--vscode-textLink-activeForeground);
+        color: var(--lana-link-fg-active);
       }
     `,
   ];

--- a/log-viewer/src/features/analysis/components/LogDiagnosticsView.ts
+++ b/log-viewer/src/features/analysis/components/LogDiagnosticsView.ts
@@ -206,7 +206,7 @@ export class LogDiagnosticsView extends LitElement {
       }
 
       .rollup__seg:focus-visible {
-        outline: var(--lana-stroke) solid var(--vscode-focusBorder);
+        outline: var(--lana-stroke) solid var(--lana-focus-border);
         outline-offset: var(--lana-stroke);
       }
 
@@ -343,7 +343,7 @@ export class LogDiagnosticsView extends LitElement {
       .cause__value {
         flex: 0 0 auto;
         margin-left: auto;
-        color: var(--vscode-foreground);
+        color: var(--lana-fg);
         font-family: var(--lana-font-mono);
         font-size: var(--lana-text-sm);
         font-variant-numeric: tabular-nums;
@@ -364,7 +364,7 @@ export class LogDiagnosticsView extends LitElement {
         border-radius: var(--lana-radius-sm);
         padding: var(--lana-space-2xs) var(--lana-space-xs);
         background-color: var(--lana-code-bg);
-        color: var(--vscode-foreground);
+        color: var(--lana-fg);
         font-family: var(--lana-font-mono);
         font-size: var(--lana-text-sm);
         text-align: left;
@@ -410,12 +410,12 @@ export class LogDiagnosticsView extends LitElement {
       }
 
       .evidence--link:hover {
-        border-color: var(--vscode-focusBorder);
+        border-color: var(--lana-focus-border);
         background-color: var(--lana-row-hover-bg);
       }
 
       .evidence--link:focus-visible {
-        outline: var(--lana-stroke) solid var(--vscode-focusBorder);
+        outline: var(--lana-stroke) solid var(--lana-focus-border);
         outline-offset: var(--lana-stroke);
       }
 
@@ -425,7 +425,7 @@ export class LogDiagnosticsView extends LitElement {
       }
 
       .evidence--link:hover .evidence__go {
-        color: var(--vscode-foreground);
+        color: var(--lana-fg);
       }
 
       .note {

--- a/log-viewer/src/features/app/LogViewer.ts
+++ b/log-viewer/src/features/app/LogViewer.ts
@@ -95,7 +95,7 @@ export class LogViewer extends LitElement {
       }
 
       vscode-tabs {
-        --vscode-panel-background: var(--vscode-editor-background);
+        --vscode-panel-background: var(--lana-editor-bg);
 
         display: flex;
         flex-direction: column;
@@ -124,7 +124,7 @@ export class LogViewer extends LitElement {
         display: flex;
         align-items: center;
         column-gap: 0.3em;
-        font-family: var(--vscode-font-family);
+        font-family: var(--lana-font-ui);
         font-size: var(--vscode-font-size, 13px);
         text-transform: none;
       }

--- a/log-viewer/src/features/database/components/DatabaseMetricCard.ts
+++ b/log-viewer/src/features/database/components/DatabaseMetricCard.ts
@@ -78,19 +78,19 @@ export class DatabaseMetricCard extends LitElement {
         font-size: 0.72rem;
         letter-spacing: 0.06em;
         text-transform: uppercase;
-        color: var(--vscode-descriptionForeground);
+        color: var(--lana-fg-muted);
       }
 
       .stat__seen {
-        font-family: var(--vscode-editor-font-family, monospace);
+        font-family: var(--lana-font-mono);
         font-variant-numeric: tabular-nums;
       }
 
       .stat__used {
-        font-family: var(--vscode-editor-font-family, monospace);
+        font-family: var(--lana-font-mono);
         font-variant-numeric: tabular-nums;
         font-size: 0.8rem;
-        color: var(--vscode-descriptionForeground);
+        color: var(--lana-fg-muted);
       }
 
       .stat__used.na {
@@ -98,7 +98,7 @@ export class DatabaseMetricCard extends LitElement {
       }
 
       .stat__sep {
-        color: var(--vscode-descriptionForeground);
+        color: var(--lana-fg-muted);
       }
 
       .stat__track {
@@ -106,7 +106,7 @@ export class DatabaseMetricCard extends LitElement {
         width: 100%;
         height: 3px;
         border-radius: 2px;
-        background: var(--vscode-editorWidget-border, var(--vscode-panel-border));
+        background: var(--lana-surface-border);
         overflow: hidden;
       }
 
@@ -118,13 +118,13 @@ export class DatabaseMetricCard extends LitElement {
       }
 
       .stat__fill--safe {
-        background: var(--vscode-charts-green, #388a34);
+        background: var(--lana-severity-ok);
       }
       .stat__fill--warn {
-        background: var(--vscode-charts-yellow, var(--vscode-editorWarning-foreground));
+        background: var(--lana-severity-warning);
       }
       .stat__fill--danger {
-        background: var(--vscode-errorForeground, #f14c4c);
+        background: var(--lana-severity-error);
       }
 
       @media (prefers-reduced-motion: reduce) {

--- a/log-viewer/src/features/database/components/DatabaseSection.ts
+++ b/log-viewer/src/features/database/components/DatabaseSection.ts
@@ -54,7 +54,7 @@ export class DatabaseSection extends LitElement {
       }
 
       .header:hover {
-        background: var(--vscode-list-hoverBackground);
+        background: var(--lana-row-hover-bg);
       }
 
       .title-group {
@@ -65,7 +65,7 @@ export class DatabaseSection extends LitElement {
 
       .chevron {
         flex: 0 0 auto;
-        color: var(--vscode-descriptionForeground);
+        color: var(--lana-fg-muted);
         transition: transform 150ms ease;
       }
 

--- a/log-viewer/src/features/database/components/DatabaseView.ts
+++ b/log-viewer/src/features/database/components/DatabaseView.ts
@@ -241,7 +241,7 @@ export class DatabaseView extends LitElement {
         display: flex;
         height: 100%;
         width: 100%;
-        background-color: var(--vscode-editor-background);
+        background-color: var(--lana-editor-bg);
       }
 
       .db-grids {
@@ -256,7 +256,7 @@ export class DatabaseView extends LitElement {
       }
 
       governor-summary {
-        border-bottom: var(--lana-stroke) solid var(--vscode-panel-border);
+        border-bottom: var(--lana-stroke) solid var(--lana-surface-border);
         /* Left inset matches the sections' content edge. */
         padding: var(--lana-space-sm) var(--lana-space-md) var(--lana-space-md)
           var(--lana-section-inset);
@@ -289,7 +289,7 @@ export class DatabaseView extends LitElement {
 
       .db-panel + .db-panel {
         margin-top: 16px;
-        border-top: 1px solid var(--vscode-panel-border);
+        border-top: 1px solid var(--lana-surface-border);
         padding-top: 8px;
       }
     `,

--- a/log-viewer/src/features/database/components/GovernorSummary.ts
+++ b/log-viewer/src/features/database/components/GovernorSummary.ts
@@ -83,12 +83,12 @@ export class GovernorSummary extends LitElement {
         font-size: 0.7rem;
         letter-spacing: 0.06em;
         text-transform: uppercase;
-        color: var(--vscode-descriptionForeground);
+        color: var(--lana-fg-muted);
         white-space: nowrap;
       }
 
       .gauge__value {
-        font-family: var(--vscode-editor-font-family, monospace);
+        font-family: var(--lana-font-mono);
         font-variant-numeric: tabular-nums;
         font-size: 0.95rem;
         white-space: nowrap;
@@ -96,7 +96,7 @@ export class GovernorSummary extends LitElement {
 
       .gauge__limit,
       .gauge__na {
-        color: var(--vscode-descriptionForeground);
+        color: var(--lana-fg-muted);
       }
 
       .gauge__na {
@@ -107,7 +107,7 @@ export class GovernorSummary extends LitElement {
       .gauge__track {
         height: 5px;
         border-radius: 3px;
-        background: var(--vscode-editorWidget-border, var(--vscode-panel-border));
+        background: var(--lana-surface-border);
         overflow: hidden;
       }
 
@@ -118,13 +118,13 @@ export class GovernorSummary extends LitElement {
       }
 
       .gauge__fill--safe {
-        background: var(--vscode-charts-green, #388a34);
+        background: var(--lana-severity-ok);
       }
       .gauge__fill--warn {
-        background: var(--vscode-charts-yellow, var(--vscode-editorWarning-foreground));
+        background: var(--lana-severity-warning);
       }
       .gauge__fill--danger {
-        background: var(--vscode-errorForeground, #f14c4c);
+        background: var(--lana-severity-error);
       }
 
       @media (prefers-reduced-motion: reduce) {

--- a/log-viewer/src/features/find/components/FindWidget.ts
+++ b/log-viewer/src/features/find/components/FindWidget.ts
@@ -49,14 +49,14 @@ export class FindWidget extends LitElement {
         max-width: 420px;
         border: 1px solid var(--vscode-contrastBorder);
         color: var(--vscode-editorWidget-foreground);
-        background: var(--vscode-editorWidget-background);
+        background: var(--lana-popover-bg);
         z-index: 1;
         display: flex;
-        border-bottom: 1px solid var(--vscode-widget-border);
+        border-bottom: 1px solid var(--lana-surface-border);
         border-bottom-left-radius: 4px;
         border-bottom-right-radius: 4px;
-        border-left: 1px solid var(--vscode-widget-border);
-        border-right: 1px solid var(--vscode-widget-border);
+        border-left: 1px solid var(--lana-surface-border);
+        border-right: 1px solid var(--lana-surface-border);
         box-sizing: border-box;
         margin-top: 3px;
         height: 33px;

--- a/log-viewer/src/features/notifications/components/IssueList.ts
+++ b/log-viewer/src/features/notifications/components/IssueList.ts
@@ -75,7 +75,7 @@ export class IssueList extends LitElement {
       }
 
       .issue--action:hover {
-        background-color: var(--vscode-list-hoverBackground);
+        background-color: var(--lana-row-hover-bg);
       }
 
       .issue__body {
@@ -141,9 +141,9 @@ export class IssueList extends LitElement {
       /* Stack traces are code: keep their line breaks and their font, so each
          "at Class.method" frame reads as a frame, not one run-on paragraph. */
       .issue__message {
-        font-size: var(--vscode-editor-font-size);
-        font-family: var(--vscode-editor-font-family);
-        color: var(--vscode-descriptionForeground);
+        font-size: var(--lana-text-mono);
+        font-family: var(--lana-font-mono);
+        color: var(--lana-fg-muted);
         white-space: pre-wrap;
       }
 

--- a/log-viewer/src/features/soql/components/SOQLLinterIssues.ts
+++ b/log-viewer/src/features/soql/components/SOQLLinterIssues.ts
@@ -94,7 +94,7 @@ export class SOQLLinterIssues extends LitElement {
         margin: 2px 0 4px 20px;
       }
       .empty {
-        color: var(--vscode-descriptionForeground);
+        color: var(--lana-fg-muted);
       }
     `,
   ];

--- a/log-viewer/src/features/soql/styles/soql-syntax.css.ts
+++ b/log-viewer/src/features/soql/styles/soql-syntax.css.ts
@@ -5,8 +5,8 @@
 export const soqlSyntaxStyles = `
 .soql-block {
   display: inline;
-  font-family: var(--vscode-editor-font-family, monospace);
-  font-size: var(--vscode-editor-font-size, 0.9em);
+  font-family: var(--lana-font-mono);
+  font-size: var(--lana-text-mono);
   white-space: pre-wrap;
   word-break: break-word;
 }

--- a/log-viewer/src/features/timeline/components/TimelineFlameChart.ts
+++ b/log-viewer/src/features/timeline/components/TimelineFlameChart.ts
@@ -50,11 +50,8 @@ export class TimelineFlameChart extends LitElement {
         background: var(--vscode-inputValidation-errorBackground, #ffebee);
         border: var(--lana-stroke) solid var(--vscode-inputValidation-errorBorder, #ef5350);
         border-radius: var(--lana-radius-sm);
-        color: var(
-          --vscode-inputValidation-errorForeground,
-          var(--vscode-errorForeground, #c62828)
-        );
-        font-family: monospace;
+        color: var(--vscode-inputValidation-errorForeground, var(--lana-severity-error));
+        font-family: var(--lana-font-mono);
         max-width: 80%;
         text-align: center;
       }
@@ -65,8 +62,8 @@ export class TimelineFlameChart extends LitElement {
         left: 50%;
         transform: translate(-50%, -50%);
         padding: var(--lana-space-lg);
-        color: var(--vscode-descriptionForeground, #999);
-        font-family: monospace;
+        color: var(--lana-fg-muted);
+        font-family: var(--lana-font-mono);
       }
     `,
   ];

--- a/log-viewer/src/features/timeline/components/TimelineKey.ts
+++ b/log-viewer/src/features/timeline/components/TimelineKey.ts
@@ -52,7 +52,7 @@ export class Timelinekey extends LitElement {
 
       /* The time is the data: mono like the header vitals, full foreground against the muted label. */
       .chip__time {
-        font-family: var(--vscode-editor-font-family, monospace);
+        font-family: var(--lana-font-mono);
         font-variant-numeric: tabular-nums;
         color: var(--lana-fg);
       }

--- a/log-viewer/src/features/timeline/components/TimelineLegacy.ts
+++ b/log-viewer/src/features/timeline/components/TimelineLegacy.ts
@@ -68,9 +68,9 @@ export class TimelineLegacy extends LitElement {
         padding: 5px;
         border-radius: var(--lana-radius-sm);
         border-left: 4px solid;
-        background-color: var(--vscode-editor-background);
-        color: var(--vscode-editor-foreground);
-        font-family: monospace;
+        background-color: var(--lana-editor-bg);
+        color: var(--lana-editor-fg);
+        font-family: var(--lana-font-mono);
         font-size: 0.92rem;
         pointer-events: none;
         transition: opacity 0.15s ease;
@@ -125,7 +125,7 @@ export class TimelineLegacy extends LitElement {
       }
 
       #timeline {
-        background-color: var(--vscode-editor-background);
+        background-color: var(--lana-editor-bg);
         z-index: 0;
         width: 100%;
         height: 100%;

--- a/log-viewer/src/features/timeline/components/TimelineView.ts
+++ b/log-viewer/src/features/timeline/components/TimelineView.ts
@@ -94,10 +94,9 @@ export class TimelineView extends LitElement {
     css`
       :host {
         /* Editor */
-        --tl-editor-background: var(--vscode-editor-background);
-        --tl-editor-foreground: var(--vscode-editor-foreground);
+        --tl-editor-foreground: var(--lana-editor-fg);
         --tl-cursor-foreground: var(--vscode-editorCursor-foreground, #fff);
-        --tl-focus-border: var(--vscode-focusBorder, #007fd4);
+        --tl-focus-border: var(--lana-focus-border);
         --tl-line-number-foreground: var(--vscode-editorLineNumber-foreground, #808080);
 
         /* Find/selection */
@@ -106,27 +105,18 @@ export class TimelineView extends LitElement {
         --tl-selection-highlight-border: var(--vscode-editor-selectionHighlightBorder, transparent);
 
         /* Widgets */
-        --tl-widget-background: var(--vscode-editorWidget-background, #252526);
-        --tl-widget-border: var(--vscode-editorWidget-border, #454545);
+        --tl-widget-background: var(--lana-popover-bg);
+        --tl-widget-border: var(--lana-surface-border);
         --tl-widget-foreground: var(--vscode-editorWidget-foreground, #cccccc);
 
         /* Hover/tooltip */
-        --tl-hover-background: var(
-          --vscode-editorHoverWidget-background,
-          var(--vscode-editorWidget-background, #252526)
-        );
-        --tl-hover-border: var(
-          --vscode-editorHoverWidget-border,
-          var(--vscode-editorWidget-border, #454545)
-        );
-        --tl-hover-foreground: var(
-          --vscode-editorHoverWidget-foreground,
-          var(--vscode-editorWidget-foreground, #cccccc)
-        );
+        --tl-hover-background: var(--lana-hover-bg);
+        --tl-hover-border: var(--lana-hover-border);
+        --tl-hover-foreground: var(--lana-hover-fg);
 
         /* Text */
-        --tl-description-foreground: var(--vscode-descriptionForeground, #999);
-        --tl-font-family: var(--vscode-font-family, sans-serif);
+        --tl-description-foreground: var(--lana-fg-muted);
+        --tl-font-family: var(--lana-font-ui);
 
         /* Buttons */
         --tl-button-secondary-background: var(--vscode-button-secondaryBackground, #3a3d41);
@@ -135,9 +125,6 @@ export class TimelineView extends LitElement {
           --vscode-button-secondaryHoverBackground,
           #45494e
         );
-
-        /* Toolbar */
-        --tl-toolbar-hover-background: var(--vscode-toolbar-hoverBackground);
 
         display: flex;
         flex-direction: column;

--- a/log-viewer/src/styles/global.styles.ts
+++ b/log-viewer/src/styles/global.styles.ts
@@ -20,12 +20,10 @@ export const globalStyles = [
       --filter-control-font-size: 11px;
       --filter-control-padding: 0 var(--lana-space-sm);
       --filter-control-radius: var(--lana-radius-sm);
-      --filter-control-border-color: var(--vscode-settings-dropdownBorder, #3c3c3c);
-      --filter-control-bg: var(--vscode-settings-dropdownBackground, #313131);
 
       /* Popover design tokens — facet/range/select/context-menu popovers all
        consume these so they render as one family. */
-      --filter-popover-bg: var(--vscode-menu-background, var(--vscode-editor-background));
+      --filter-popover-bg: var(--vscode-menu-background, var(--lana-editor-bg));
       --filter-popover-border-color: var(--vscode-menu-border, var(--lana-surface-border));
       --filter-popover-radius: var(--lana-radius-md);
       --filter-popover-shadow: var(--lana-shadow-popover);
@@ -38,18 +36,18 @@ export const globalStyles = [
     }
 
     a {
-      color: var(--vscode-textLink-foreground);
+      color: var(--lana-link-fg);
       text-decoration: none;
       cursor: pointer;
 
       &:hover {
-        color: var(--vscode-textLink-activeForeground);
+        color: var(--lana-link-fg-active);
         text-decoration: underline;
       }
 
       &:active {
         background: transparent;
-        color: var(--vscode-textLink-activeForeground);
+        color: var(--lana-link-fg-active);
         text-decoration: underline;
       }
     }
@@ -60,7 +58,7 @@ export const globalStyles = [
     }
 
     ::-webkit-scrollbar-corner {
-      background-color: var(--vscode-editor-background);
+      background-color: var(--lana-editor-bg);
     }
 
     ::-webkit-scrollbar-thumb {
@@ -104,10 +102,9 @@ export const globalStyles = [
       width: 16px;
       height: 16px;
       flex-shrink: 0;
-      border: var(--lana-stroke) solid
-        var(--vscode-checkbox-border, var(--vscode-settings-dropdownBorder, #6b6b6b));
+      border: var(--lana-stroke) solid var(--vscode-checkbox-border, var(--lana-control-border));
       border-radius: 3px;
-      background-color: var(--vscode-checkbox-background, #313131);
+      background-color: var(--vscode-checkbox-background, var(--lana-control-bg));
       cursor: pointer;
     }
 
@@ -128,7 +125,7 @@ export const globalStyles = [
     }
 
     .vs-checkbox:focus-visible {
-      outline: 1px solid var(--vscode-focusBorder);
+      outline: 1px solid var(--lana-focus-border);
       outline-offset: 1px;
     }
 
@@ -152,10 +149,10 @@ export const globalStyles = [
       align-items: center;
       gap: var(--lana-space-2xs);
       padding: var(--filter-control-padding);
-      border: var(--lana-stroke) solid var(--filter-control-border-color);
+      border: var(--lana-stroke) solid var(--lana-control-border);
       border-radius: var(--filter-control-radius);
-      background-color: var(--filter-control-bg);
-      color: var(--vscode-foreground);
+      background-color: var(--lana-control-bg);
+      color: var(--lana-fg);
       font: inherit;
       font-size: var(--filter-control-font-size);
       line-height: 1.4;
@@ -164,11 +161,11 @@ export const globalStyles = [
     }
 
     .filter-control:hover {
-      background-color: var(--vscode-list-hoverBackground);
+      background-color: var(--lana-row-hover-bg);
     }
 
     .filter-control:focus-visible {
-      outline: 1px solid var(--vscode-focusBorder);
+      outline: 1px solid var(--lana-focus-border);
       outline-offset: 1px;
     }
 
@@ -180,8 +177,8 @@ export const globalStyles = [
      value-carrying filter. */
     .pill-toggle[aria-pressed='true'] {
       background-color: var(--vscode-inputOption-activeBackground);
-      border-color: var(--vscode-inputOption-activeBorder, var(--vscode-focusBorder));
-      color: var(--vscode-inputOption-activeForeground, var(--vscode-foreground));
+      border-color: var(--vscode-inputOption-activeBorder, var(--lana-focus-border));
+      color: var(--vscode-inputOption-activeForeground, var(--lana-fg));
     }
 
     /* Value-filter controls (facet/range triggers with a value, single-select
@@ -189,8 +186,8 @@ export const globalStyles = [
      distinguishes "a filter is applied" from the binary toggle's ON state
      above, while still reading as accented against the plain pill. */
     .filter-control--active {
-      border-color: var(--vscode-inputOption-activeBorder, var(--vscode-focusBorder));
-      color: var(--vscode-inputOption-activeForeground, var(--vscode-foreground));
+      border-color: var(--vscode-inputOption-activeBorder, var(--lana-focus-border));
+      color: var(--vscode-inputOption-activeForeground, var(--lana-fg));
     }
 
     /* Shared base for every filter-bar popover (facet checklist, range inputs,
@@ -202,8 +199,8 @@ export const globalStyles = [
       border: var(--lana-stroke) solid var(--filter-popover-border-color);
       border-radius: var(--filter-popover-radius);
       box-shadow: var(--filter-popover-shadow);
-      color: var(--vscode-menu-foreground, var(--vscode-foreground));
-      font-family: var(--vscode-font-family);
+      color: var(--vscode-menu-foreground, var(--lana-fg));
+      font-family: var(--lana-font-ui);
     }
 
     .filter-popover-row {
@@ -214,7 +211,7 @@ export const globalStyles = [
     }
 
     .filter-popover-row:hover {
-      background-color: var(--vscode-list-hoverBackground);
+      background-color: var(--lana-row-hover-bg);
     }
   `,
 ];

--- a/log-viewer/src/styles/headerControl.styles.ts
+++ b/log-viewer/src/styles/headerControl.styles.ts
@@ -23,11 +23,11 @@ export const headerControlStyles = css`
     width: 26px;
     height: 22px;
     border-radius: 4px;
-    color: var(--vscode-foreground);
+    color: var(--lana-fg);
   }
 
   .header-control:hover {
-    background-color: var(--vscode-toolbar-hoverBackground);
+    background-color: var(--lana-toolbar-hover-bg);
   }
 
   /* Bottom-right, like the activity bar's — and clear of the header's top edge, which

--- a/log-viewer/src/styles/revealRow.styles.ts
+++ b/log-viewer/src/styles/revealRow.styles.ts
@@ -30,7 +30,7 @@ export const bleedRowStyles = css`
   }
 
   .bleed-row:focus-visible {
-    outline: var(--lana-stroke) solid var(--vscode-focusBorder);
+    outline: var(--lana-stroke) solid var(--lana-focus-border);
     outline-offset: calc(-1 * var(--lana-stroke));
   }
 `;

--- a/log-viewer/src/styles/tokens.css
+++ b/log-viewer/src/styles/tokens.css
@@ -55,8 +55,12 @@
   /* Header metadata (size · duration · identity) — just under the title size. */
   --lana-text-meta: 0.9rem;
 
-  /* Monospace, for text whose alignment carries meaning: stacks, code. */
+  /* Monospace, for text whose alignment carries meaning: stacks, code. The host
+     sets the editor's own size, which is not always its UI size. */
   --lana-font-mono: var(--vscode-editor-font-family, monospace);
+  --lana-text-mono: var(--vscode-editor-font-size, 0.9em);
+
+  --lana-font-ui: var(--vscode-font-family, sans-serif);
 
   /* Surfaces — the same registered colors VS Code's own chrome is built from.
      `surface-border` is absent before the size-token registry (stable 1.128 ships
@@ -65,10 +69,11 @@
     --vscode-surface-border,
     var(--vscode-widget-border, var(--vscode-sideBar-border, transparent))
   );
-  --lana-header-bg: var(
-    --vscode-tab-activeBackground,
-    var(--vscode-editor-background, transparent)
-  );
+  --lana-header-bg: var(--vscode-tab-activeBackground, var(--lana-editor-bg));
+
+  /* The editor's own ground and text, where `fg` is the host's UI text. */
+  --lana-editor-bg: var(--vscode-editor-background, #1f1f1f);
+  --lana-editor-fg: var(--vscode-editor-foreground, #cccccc);
 
   /* Code surface — the fill VS Code gives inline code blocks in its own markdown. */
   --lana-code-bg: var(--vscode-textCodeBlock-background, rgba(128, 128, 128, 0.12));
@@ -79,11 +84,31 @@
 
   /* Floating surfaces — tooltips and popovers, matching VS Code's widget chrome. */
   --lana-popover-bg: var(--vscode-editorWidget-background, #252526);
-  /* Divider inside a hover panel — the colour VS Code rules its own hover status bar with. */
+  /* Hover panels — VS Code gives these their own chrome, a shade off the widget set. */
+  --lana-hover-bg: var(--vscode-editorHoverWidget-background, var(--lana-popover-bg));
+  --lana-hover-fg: var(
+    --vscode-editorHoverWidget-foreground,
+    var(--vscode-editorWidget-foreground, #cccccc)
+  );
   --lana-hover-border: var(
     --vscode-editorHoverWidget-border,
     var(--vscode-editorWidget-border, rgba(128, 128, 128, 0.35))
   );
+
+  /* One ring app-wide, so focus never reads as a hover. */
+  --lana-focus-border: var(--vscode-focusBorder, #007fd4);
+
+  /* Icons that stand on their own, not beside the text they belong to. */
+  --lana-icon-fg: var(--vscode-icon-foreground, currentColor);
+
+  /* Hover for a toolbar action — a fill, where a list row gets `row-hover-bg`. */
+  --lana-toolbar-hover-bg: var(--vscode-toolbar-hoverBackground, rgba(90, 93, 94, 0.31));
+
+  --lana-link-fg: var(--vscode-textLink-foreground, #4daafc);
+  --lana-link-fg-active: var(--vscode-textLink-activeForeground, #4daafc);
+
+  --lana-control-border: var(--vscode-settings-dropdownBorder, #3c3c3c);
+  --lana-control-bg: var(--vscode-settings-dropdownBackground, #313131);
 
   --lana-shadow-popover: 0 4px 16px var(--vscode-widget-shadow, rgba(0, 0, 0, 0.36));
   --lana-shadow-overlay: 0 8px 24px var(--vscode-widget-shadow, rgba(0, 0, 0, 0.5));

--- a/log-viewer/src/tabulator/style/DataGrid.scss
+++ b/log-viewer/src/tabulator/style/DataGrid.scss
@@ -5,7 +5,7 @@
 
 // Row-hover colour is the only theme value also referenced by our own rules below, so it
 // stays a variable; every other tabulator theme value is inlined into the config map below.
-$rowHoverBackground: var(--vscode-list-hoverBackground);
+$rowHoverBackground: var(--lana-row-hover-bg);
 
 $codicon-chevron-right: '\eab6';
 $codicon-chevron-down: '\eab4';
@@ -32,46 +32,44 @@ $codicon-chevron-down: '\eab4';
   @include meta.load-css(
     'tabulator-tables/src/scss/tabulator',
     // resolved via sass loadPaths (node_modules)
+    // `header`/`footer`/`rowAltBackgroundColor` must stay Sass colour literals —
+    // tabulator.scss runs `color.adjust()` on those three, which no CSS var survives.
     $with: (
-        backgroundColor: var(--vscode-editor-background),
+        backgroundColor: var(--lana-editor-bg),
         borderColor: transparent,
-        textSize: var(--vscode-editor-font-size),
+        textSize: var(--lana-text-mono),
         // header
         headerBackgroundColor: transparent,
-        headerTextColor: var(--vscode-editor-foreground),
+        headerTextColor: var(--lana-editor-fg),
         headerBorderColor: transparent,
         headerSeparatorColor: transparent,
         headerMargin: 4px,
-        // column header sort arrows — upstream only ever uses these as plain colours
-        // (no color.adjust()), so CSS vars are safe here.
-        sortArrowHover: var(--vscode-icon-foreground, currentColor),
-        sortArrowActive: var(--vscode-icon-foreground, currentColor),
-        sortArrowInactive: var(--vscode-descriptionForeground, #999),
+        sortArrowHover: var(--lana-icon-fg),
+        sortArrowActive: var(--lana-icon-fg),
+        sortArrowInactive: var(--lana-fg-muted),
         // rows
-        rowBackgroundColor: var(--vscode-editor-background),
-        // Must stay a Sass colour literal — tabulator.scss runs color.adjust() on it
-        // for calc rows (so it can't be a CSS var).
+        rowBackgroundColor: var(--lana-editor-bg),
         rowAltBackgroundColor: transparent,
         rowBorderColor: transparent,
-        rowTextColor: var(--vscode-editor-foreground),
+        rowTextColor: var(--lana-editor-fg),
         rowHoverBackground: $rowHoverBackground,
         rowSelectedBackground: var(--vscode-list-activeSelectionBackground),
         rowSelectedBackgroundHover: var(--vscode-list-activeSelectionBackground),
-        editBoxColor: var(--vscode-focusBorder, #1d68cd),
-        errorColor: var(--vscode-errorForeground, #f14c4c),
+        editBoxColor: var(--lana-focus-border),
+        errorColor: var(--lana-severity-error),
         // footer
         footerBackgroundColor: transparent,
-        footerTextColor: var(--vscode-editor-foreground),
+        footerTextColor: var(--lana-editor-fg),
         footerBorderColor: transparent,
         footerSeparatorColor: transparent,
-        footerActiveColor: var(--vscode-textLink-activeForeground, #3794ff)
+        footerActiveColor: var(--lana-link-fg-active)
       )
   );
   @include meta.load-css('../format/Progress.css');
 
   .tabulator {
     .tabulator-header {
-      border-bottom: 1px solid var(--vscode-widget-border, var(--vscode-editorGroup-border));
+      border-bottom: 1px solid var(--lana-surface-border);
     }
 
     .tabulator-tableholder {
@@ -228,9 +226,9 @@ $codicon-chevron-down: '\eab4';
     }
 
     .datagrid-code-text {
-      font-family: monospace;
+      font-family: var(--lana-font-mono);
       font-weight: var(--vscode-font-weight, normal);
-      font-size: var(--vscode-editor-font-size, 0.9em);
+      font-size: var(--lana-text-mono);
     }
 
     .tabulator-row.tabulator-selected {
@@ -256,15 +254,15 @@ $codicon-chevron-down: '\eab4';
     }
 
     .sort-by--bottom {
-      color: var(--vscode-icon-foreground, currentColor);
+      color: var(--lana-icon-fg);
       border-bottom: none;
-      border-top: 6px solid var(--vscode-icon-foreground, currentColor);
+      border-top: 6px solid var(--lana-icon-fg);
       border-left: 6px solid transparent;
       border-right: 6px solid transparent;
     }
     .sort-by--top {
-      color: var(--vscode-icon-foreground, currentColor);
-      border-bottom: 6px solid var(--vscode-icon-foreground, currentColor);
+      color: var(--lana-icon-fg);
+      border-bottom: 6px solid var(--lana-icon-fg);
       border-top: none;
       border-left: 6px solid transparent;
       border-right: 6px solid transparent;
@@ -277,10 +275,10 @@ $codicon-chevron-down: '\eab4';
 
   .tabulator-tooltip {
     // Match timeline tooltip styling for consistency
-    background: var(--vscode-editorHoverWidget-background, var(--vscode-editorWidget-background));
-    color: var(--vscode-editorHoverWidget-foreground, var(--vscode-editor-foreground));
+    background: var(--lana-hover-bg);
+    color: var(--lana-hover-fg);
     overflow-wrap: anywhere;
-    font-family: monospace;
+    font-family: var(--lana-font-mono);
     font-size: 0.92rem;
     font-variant-numeric: tabular-nums;
     padding: 5px;
@@ -289,18 +287,18 @@ $codicon-chevron-down: '\eab4';
   }
 
   .tabulator-edit-list {
-    border-color: var(--vscode-focusBorder, default);
+    border-color: var(--lana-focus-border);
 
     .tabulator-edit-list-item {
-      color: var(--vscode-editor-foreground, 'white');
+      color: var(--lana-editor-fg);
       &.active {
         background-color: var(--vscode-list-activeSelectionBackground);
-        color: var(--vscode-editor-foreground, 'white');
+        color: var(--lana-editor-fg);
       }
 
       &:hover {
         background-color: var(--vscode-list-activeSelectionBackground);
-        color: var(--vscode-editor-foreground, 'white');
+        color: var(--lana-editor-fg);
       }
     }
   }


### PR DESCRIPTION
# 📝 PR Overview

The webview reached for `--vscode-*` vars in 267 places, and a role used in many files was spelled a different way in each one. The canvas tooltip border and the HTML tooltip border beside it resolved through different chains, so on a theme missing one var they did not match.

Names the 13 shared roles as `--lana-*` tokens and points every use at them. Direct `--vscode-*` uses fall from 267 to 87; every role left is used in fewer than three files, so it stays a direct var. No runtime cost: canvas colours are read once per theme change, not per frame.

## 🛠️ Changes made

- Adds 13 tokens — `font-ui`, `text-mono`, `editor-bg`, `editor-fg`, `focus-border`, `icon-fg`, `toolbar-hover-bg`, `hover-bg`, `hover-fg`, `link-fg`, `link-fg-active`, `control-border`, `control-bg` — so one role has one spelling.
- Collapses the timeline's `--tl-*` hover bridge onto the tokens, and drops two entries with no reader. The canvas tooltip border now matches the HTML one on every theme.
- Points the gauge tiers in `GovernorTrends`, `DatabaseMetricCard` and `GovernorSummary` at `--lana-severity-*`. They each held their own `charts-*`/`errorForeground` chain, so their resolved colour shifts slightly.
- Records the token test in `.claude/rules/log-viewer.md`: a token when the role spans three or more files, VS Code has no var, the value is a chain, or the var ships in no supported release.
- Records the one sanctioned `--vscode-*` override — skinning a `vscode-elements` component that reads its own var, scoped to that element. `vscode-tabs` reads `--vscode-panel-background` inside a closed shadow root, so no `--lana-*` name can reach it.
- Leaves `header`, `footer` and `rowAltBackgroundColor` in `DataGrid.scss` as Sass literals: `tabulator.scss` runs `color.adjust()` on those three, which no CSS var survives.

## 🧩 Type of change (check all applicable)

- [ ] 🐛 Bug fix - something not working as expected
- [ ] ✨ New feature – adds new functionality
- [x] ♻️ Refactor - internal changes with no user impact
- [ ] ⚡ Performance Improvement
- [ ] 📝 Documentation - README or documentation site changes
- [ ] 🔧 Chore - dev tooling, CI, config
- [ ] 💥 Breaking change

## 📷 Screenshots / gifs / video [optional]

N/A

## 🔗 Related Issues

N/A

## ✅ Tests added?

- [ ] 👍 yes
- [x] 🙅 no, not needed
- [ ] 🙋 no, I need help

## 📚 Docs updated?

- [ ] 🔖 README.md
- [ ] 🔖 CHANGELOG.md
- [ ] 📖 help site
- [ ] 🧪 Marked any pre-release-only features (README `🧪` badge — see [RELEASING.md](../RELEASING.md#-marking-pre-release-only-features))
- [x] 🙅 not needed

## Anything else we need to know? [optional]

**Test plan** — `pnpm test` (131 suites, 1771 tests) and `pnpm lint` pass; production `rolldown` build clean. Manual check in the dev host, in a light theme and a dark theme: Call Tree grid chrome, Database gauges, Timeline canvas and tooltip, Analysis links, Inspector sparklines, filter-bar popovers.

The commit subject carries `(#55)`, which is a wrong reference — no issue tracks this sweep. The squash merge takes this PR title, so it does not reach `main`.