### PR TITLE
fix(log-viewer): keep pane hairlines visible on themes with no sideBar.border

### DIFF
--- a/lana-docs/docs/docs/features/find.mdx
+++ b/lana-docs/docs/docs/features/find.mdx
@@ -29,12 +29,15 @@ The Find feature in Apex Debug Log Analyzer for Salesforce quickly searches, hig
 - The tooltip is shown for the current matching event, making it easy to view the event details such as Total or Self time.
 
 <img
-src="https://raw.githubusercontent.com/certinia/debug-log-analyzer/main/lana/assets/1_20/timeline-find.png"
-alt="Timeline screenshot showing highlighted search results and tooltip with event details"
-style={{
-  width: '50%', height:'auto', maxWidth:'400px'
-}}
-loading="lazy"/>
+  src="https://raw.githubusercontent.com/certinia/debug-log-analyzer/main/lana/assets/1_20/timeline-find.png"
+  alt="Timeline screenshot showing highlighted search results and tooltip with event details"
+  style={{
+    width: '50%',
+    height: 'auto',
+    maxWidth: '400px',
+  }}
+  loading="lazy"
+/>
 
 ### Call Tree
 
@@ -42,12 +45,15 @@ loading="lazy"/>
 - The row with the current matching text will also be highlighted
 
 <img
-src="https://raw.githubusercontent.com/certinia/debug-log-analyzer/main/lana/assets/1_20/calltree-find.png"
-alt="Call Tree view screenshot showing expanded parent nodes and highlighted search result"
-style={{
-  width: '50%', height:'auto', maxWidth:'400px'
-}}
-loading="lazy"/>
+  src="https://raw.githubusercontent.com/certinia/debug-log-analyzer/main/lana/assets/1_20/calltree-find.png"
+  alt="Call Tree view screenshot showing expanded parent nodes and highlighted search result"
+  style={{
+    width: '50%',
+    height: 'auto',
+    maxWidth: '400px',
+  }}
+  loading="lazy"
+/>
 
 ### Analysis + Database
 
@@ -55,9 +61,12 @@ loading="lazy"/>
 - The row with the current matching text will also be highlighted
 
 <img
-src="https://raw.githubusercontent.com/certinia/debug-log-analyzer/main/lana/assets/1_20/analysis-find.png"
-alt="Analysis view screenshot showing expanded groups and highlighted search results"
-style={{
-  width: '50%', height:'auto', maxWidth:'400px'
-}}
-loading="lazy"/>
+  src="https://raw.githubusercontent.com/certinia/debug-log-analyzer/main/lana/assets/1_20/analysis-find.png"
+  alt="Analysis view screenshot showing expanded groups and highlighted search results"
+  style={{
+    width: '50%',
+    height: 'auto',
+    maxWidth: '400px',
+  }}
+  loading="lazy"
+/>

--- a/lana-docs/docs/docs/features/raw-log.mdx
+++ b/lana-docs/docs/docs/features/raw-log.mdx
@@ -27,12 +27,15 @@ Right-click any frame in the Timeline or Call Tree and select **Show in Log File
 | Show in Raw Log | Right-click frame → "Show in Log File" |
 
 <img
-src="https://raw.githubusercontent.com/certinia/debug-log-analyzer/main/lana/assets/1_20/timeline-goto-log.gif"
-alt="Jumping from a Timeline frame to the matching line in the raw .log file."
-style={{
-  width: '50%', height:'auto', maxWidth:'400px'
-}}
-loading="lazy"/>
+  src="https://raw.githubusercontent.com/certinia/debug-log-analyzer/main/lana/assets/1_20/timeline-goto-log.gif"
+  alt="Jumping from a Timeline frame to the matching line in the raw .log file."
+  style={{
+    width: '50%',
+    height: 'auto',
+    maxWidth: '400px',
+  }}
+  loading="lazy"
+/>
 
 ### Show in Log Analysis
 

--- a/lana-docs/docs/docs/gettingstarted.mdx
+++ b/lana-docs/docs/docs/gettingstarted.mdx
@@ -20,21 +20,25 @@ image: https://raw.githubusercontent.com/certinia/debug-log-analyzer/main/lana/a
 
 Install Apex Log Analyzer using whichever you prefer:
 
-- **Extensions sidebar** — search for `Apex Log Analyzer` and click **Install
+- **Extensions sidebar** — search for `Apex Log Analyzer` and click \*\*Install
 - **Marketplace** — open the [VS Code Marketplace: Apex Log Analyzer](https://marketplace.visualstudio.com/items?itemName=financialforce.lana) and click **Install**.
 - **Command Palette** — press `Cmd/Ctrl+Shift+P` and run `ext install financialforce.lana`.
 - **Command line** — run from a terminal:
+
 ```sh
   code --install-extension financialforce.lana
 ```
 
 <img
-src="https://raw.githubusercontent.com/certinia/debug-log-analyzer/main/lana/assets/1_20/vscode/install.png"
-alt="The Apex Log Analyzer listing in the VS Code Extensions view with the Install button"
-style={{
-    width: '50%', height:'auto', maxWidth:'400px'
+  src="https://raw.githubusercontent.com/certinia/debug-log-analyzer/main/lana/assets/1_20/vscode/install.png"
+  alt="The Apex Log Analyzer listing in the VS Code Extensions view with the Install button"
+  style={{
+    width: '50%',
+    height: 'auto',
+    maxWidth: '400px',
   }}
-loading="lazy"/>
+  loading="lazy"
+/>
 
 ### Pre-Release
 
@@ -53,13 +57,16 @@ With the `.log` file open in VSCode.
    or
 1. Click the 'Log: Show Apex Log Analysis' code lens at the top of the file\
    <img
-   src="https://raw.githubusercontent.com/certinia/debug-log-analyzer/main/lana/assets/1_20/vscode/show-analysis-lens.webp"
-   alt="Screenshot showing the Log: Show Apex Log Analysis code lense in a log file"
-   style={{
-       width: '50%', height:'auto', maxWidth:'400px'
+     src="https://raw.githubusercontent.com/certinia/debug-log-analyzer/main/lana/assets/1_20/vscode/show-analysis-lens.webp"
+     alt="Screenshot showing the Log: Show Apex Log Analysis code lense in a log file"
+     style={{
+       width: '50%',
+       height: 'auto',
+       maxWidth: '400px',
      }}
-   loading="lazy"/>\
-   or
+     loading="lazy"
+   />
+   \ or
 1. Right click -> 'Log: Show Apex Log Analysis'
    or
 1. Click editor 'Log: Show Apex Log Analysis' icon button at top of editor

--- a/log-viewer/src/styles/tokens.css
+++ b/log-viewer/src/styles/tokens.css
@@ -163,8 +163,9 @@
   /* Primary text, for promoting muted text back to full strength. */
   --lana-fg: var(--vscode-foreground, #cccccc);
 
-  /* The hairline between panes, and around a docked one. */
-  --lana-panel-divider: var(--vscode-sideBar-border, transparent);
+  /* The hairline between panes, and around a docked one. Themes that set no
+     `sideBar.border` fall through to the app's own hairline, never to nothing. */
+  --lana-panel-divider: var(--vscode-sideBar-border, var(--lana-surface-border));
 
   /* Resize handles. `inset` pulls the handle over its neighbours so no gap shows,
      leaving the divider hairline as the only seam. */

--- a/package.json
+++ b/package.json
@@ -43,13 +43,13 @@
     "copy:package-docs": "node ./scripts/copy-package-docs.mjs",
     "typecheck": "tsc -b",
     "typecheck:tsc6": "tsc6 -b",
-    "lint": "concurrently -r -g 'eslint . --cache --cache-location node_modules/.cache/eslint/' 'prettier --cache **/*.{ts,css,md,scss} --check --experimental-cli' 'pnpm run typecheck'",
+    "lint": "concurrently -r -g 'eslint . --cache --cache-location node_modules/.cache/eslint/' 'prettier --cache **/*.{ts,css,md,mdx,scss} --check --experimental-cli' 'pnpm run typecheck'",
     "test": "jest",
     "test:ci": "jest --runInBand",
     "ci:install": "pnpm install --frozen-lockfile --prefer-offline --ignore-scripts",
     "prettier-format": "prettier '**/*.ts' --cache --write --experimental-cli"
   },
   "lint-staged": {
-    "*.{ts,css,md,scss}": "prettier --cache --write --experimental-cli"
+    "*.{ts,css,md,mdx,scss}": "prettier --cache --write --experimental-cli"
   }
 }


### PR DESCRIPTION
## What

Two small fixes: the pane divider no longer disappears on some themes, and prettier now checks the docs' `.mdx` files.

## Why

`--lana-panel-divider` ended its fallback chain in `transparent`. A theme that sets no `sideBar.border` therefore got a token that was defined but invisible, and because it was defined, no consumer fallback behind it could fire — the pane borders and the docked panel's top and bottom edges lost their line.

The lint and lint-staged globs covered `ts`, `css`, `md` and `scss` but not `mdx`, so three docs pages had drifted out of format with nothing to catch it.

## Changes

- `--lana-panel-divider` falls through to `--lana-surface-border`, the app's own hairline, so the seam is always drawn — same fix as `--lana-surface-border` got.
- `mdx` added to the `lint` and `lint-staged` globs, and the three drifted pages formatted.

## Testing

- `prettier --check '**/*.{ts,css,md,mdx,scss}'` clean, `tsc -b` clean, `jest` 1775 tests / 131 suites pass.
- `docusaurus build` succeeds, so the reformatted MDX still compiles.
- Divider checked in a light and a dark theme.