### PR TITLE
feat(inspector): name where the hot path fans out instead of claiming a hot spot

### DIFF
--- a/log-viewer/src/components/HotPath.ts
+++ b/log-viewer/src/components/HotPath.ts
@@ -9,27 +9,41 @@ import { styleMap } from 'lit/directives/style-map.js';
 import '#vscode-elements/vscode-icon.js';
 import { logContext } from '../core/log/logContext.js';
 import type { LogStore } from '../core/log/LogStore.js';
-import { formatDuration } from '../core/utility/Util.js';
+import { formatDuration, sharePercent } from '../core/utility/Util.js';
 import {
   getExecutionHighlights,
   type ExecutionHighlights,
+  type HotPathEnd,
   type HotPathFrame,
 } from '../features/call-tree/utils/ExecutionHighlights.js';
 import { globalStyles } from '../styles/global.styles.js';
 import { inspectorSectionStyles } from '../styles/inspectorSection.styles.js';
 import { revealRowStyles } from '../styles/revealRow.styles.js';
-import { CategoryPaletteController, categorySwatch } from './categoryTime.js';
-import { dispatchInspectorReveal } from './inspectorReveal.js';
+import { CategoryPaletteController, categoryLabel } from './categoryTime.js';
+import { dispatchInspectorLocate, dispatchInspectorReveal } from './inspectorReveal.js';
+import { revealRowMeter, revealRowTitle } from './revealRowMeter.js';
 
-/** Frames shown, the terminus among them; the tail between them collapses into a "more" line. */
+/** Frames shown, the last one among them; the tail between them collapses into a "more" line. */
 const FRAME_CAP = 10;
+
+/** Branch rows shown under a fanned-out last frame; the rest are counted in a line. */
+const BRANCH_CAP = 3;
+
+/** A share below this rounds to 0.0%, so its clause earns no room. */
+const SHARE_FLOOR = 0.05;
 
 /**
  * The Call Tree tab's whole-log opener: the chain of calls holding most of the
  * log's time, entry point first — Visual Studio's Hot Path, Chrome's heaviest
- * stack. Each frame shows its total time and share of the log, and clicking it
- * selects that call in the tree. A truncated log heads the list with a warning,
- * because every timing below a cut-off call under-reports.
+ * stack.
+ *
+ * Each frame gives its total time and share of the log, then the split that says
+ * where the time went: the part it kept, and the part it shed to branches the
+ * path does not follow. Clicking a frame selects that call in the tree.
+ *
+ * Where the last frame keeps little of its own time it is no hot spot, so the
+ * calls the time fanned out to follow it. A truncated log heads the list with a
+ * warning: every timing below a cut-off call under-reports.
  */
 @customElement('hot-path')
 export class HotPath extends LitElement {
@@ -64,9 +78,16 @@ export class HotPath extends LitElement {
         flex: 0 0 auto;
       }
 
+      /* A pointer to where the last frame's time went, indented under it. */
+      .branch-row {
+        padding-left: var(--lana-space-md);
+      }
+
+      .summary,
       .more {
         padding: var(--lana-space-3xs) 0;
         color: var(--lana-fg-muted);
+        font-variant-numeric: tabular-nums;
       }
     `,
   ];
@@ -78,51 +99,130 @@ export class HotPath extends LitElement {
       return html`<p class="note">The log has no timed calls.</p>`;
     }
 
-    // The terminus is the frame the path exists to name, so a long path keeps it
-    // and drops the middle instead: the last row shown is always the terminus.
+    // The last frame is the one the path exists to name, so a long path keeps it
+    // and drops the middle instead. Rows read their neighbour from the whole
+    // path, never from the shown list, so a collapsed middle leaves the figures
+    // on either side of it true.
     const path = highlights.hotPath;
+    const last = path.length - 1;
     const shown =
-      path.length > FRAME_CAP ? [...path.slice(0, FRAME_CAP - 1), path[path.length - 1]!] : path;
-    const hidden = path.length - shown.length;
-    const rows = shown.map((frame, index) =>
-      this._frameRow(frame, highlights.totalTime, index === shown.length - 1),
+      path.length > FRAME_CAP
+        ? [...path.keys()].slice(0, FRAME_CAP - 1).concat(last)
+        : [...path.keys()];
+    const branches = highlights.hotPathBranches;
+    const rows = shown.map((index) =>
+      this._frameRow(
+        path[index]!,
+        path[index + 1],
+        highlights.totalTime,
+        index === last ? highlights.hotPathEnd : null,
+        branches.length,
+      ),
     );
+    const hidden = path.length - shown.length;
     if (hidden > 0) {
-      // The dropped frames are counted where they were: above the terminus.
+      // The dropped frames are counted where they were: above the last frame.
       rows.splice(rows.length - 1, 0, html`<div class="more">+ ${hidden} more frames</div>`);
     }
-    return html`${this._truncationCaveat(highlights)}${rows}`;
+    rows.push(
+      ...branches
+        .slice(0, BRANCH_CAP)
+        .map((branch) => this._branchRow(branch, highlights.totalTime)),
+    );
+    if (branches.length > BRANCH_CAP) {
+      rows.push(html`<div class="more">+ ${branches.length - BRANCH_CAP} more branches</div>`);
+    }
+    return html`${this._truncationCaveat(highlights)}${summary(path, highlights.totalTime)}${rows}`;
   }
 
   /**
-   * One frame: a swatch, name and figures, its share of the log as a meter
-   * beneath — the staircase of shrinking meters shows the descent, and the
-   * meter's solid head is the frame's own self time. The path's terminus is the
-   * hot spot, so it alone gets emphasis.
+   * One frame: the name and figures, the split of its time beneath, then
+   * the shared meter — length is the frame's share of the log, solid up to its
+   * self time, with a hover target per part — so a hot-path row and a hot-spot
+   * row read the same way. `end` is set on the last frame only, and says whether
+   * it is the hot spot, which is the one frame that earns emphasis.
    */
-  private _frameRow(frame: HotPathFrame, logTotal: number, isTerminus: boolean) {
-    const share = logTotal > 0 ? (frame.totalTime / logTotal) * 100 : 0;
-    const selfShare = frame.totalTime > 0 ? (frame.selfTime / frame.totalTime) * 100 : 0;
+  private _frameRow(
+    frame: HotPathFrame,
+    child: HotPathFrame | undefined,
+    logTotal: number,
+    end: HotPathEnd | null,
+    branchCount: number,
+  ) {
+    const total = sharePercent(frame.totalTime, logTotal);
+    const self = sharePercent(frame.selfTime, logTotal);
+    const offTime = branchTime(frame, child);
+    // The last frame sheds its time to nothing the path names, so it reads as
+    // held below the frame rather than off the path.
+    const offWhere = end !== null ? 'below this frame' : 'to branches';
+    const title = revealRowTitle(
+      frame,
+      child ? `${formatDuration(child.totalTime)} on the path` : '',
+      offTime > 0 ? `${formatDuration(offTime)} ${offWhere}` : '',
+    );
     return html`
       <button
-        class="bleed-row reveal-row ${isTerminus ? 'reveal-row--focus' : ''}"
+        class="bleed-row reveal-row ${end === 'hot-spot' ? 'reveal-row--focus' : ''}"
         type="button"
-        title="Show this call in the tree"
+        title=${title}
         style=${styleMap({
           '--row-hue': this._palette.colorFor(frame.category),
-          '--self-pct': `${selfShare}%`,
+          '--self-pct': `${sharePercent(frame.selfTime, frame.totalTime)}%`,
         })}
         @click=${() => dispatchInspectorReveal(this, frame.eventIndex)}
+        @pointerenter=${() => dispatchInspectorLocate(this, frame.eventIndexes)}
+        @pointerleave=${() => dispatchInspectorLocate(this, [])}
       >
-        ${categorySwatch(frame.category)}
+        ${categoryLabel(frame.category)}
         <span class="reveal-row__name" title=${frame.text}>${frame.text}</span>
         <span class="reveal-row__value"
           >${frame.count > 1 ? `${frame.count}× · ` : ''}${formatDuration(frame.totalTime)} ·
-          ${share.toFixed(1)}%</span
+          ${total.toFixed(1)}%</span
         >
-        <span class="reveal-row__meter"
-          ><span class="reveal-row__meter-fill" style="width: ${share}%"></span
-        ></span>
+        <span class="reveal-row__sub"
+          >${caption(frame, self, offTime, sharePercent(offTime, logTotal), offWhere, end, branchCount)}</span
+        >
+        ${revealRowMeter(
+          total,
+          [
+            { share: self, title: `self ${formatDuration(frame.selfTime)}` },
+            ...(child
+              ? [
+                  {
+                    share: sharePercent(child.totalTime, logTotal),
+                    title: `${formatDuration(child.totalTime)} on the path`,
+                  },
+                ]
+              : []),
+            {
+              share: sharePercent(offTime, logTotal),
+              title: `${formatDuration(offTime)} ${offWhere}`,
+            },
+          ],
+          title,
+        )}
+      </button>
+    `;
+  }
+
+  /** Where the last frame's time went: a pointer, so it gives no split of its own. */
+  private _branchRow(branch: HotPathFrame, logTotal: number) {
+    const churn = branch.count > 1 ? `${branch.count}× · ` : '';
+    return html`
+      <button
+        class="bleed-row reveal-row branch-row"
+        type="button"
+        title=${`${churn}total ${formatDuration(branch.totalTime)}`}
+        @click=${() => dispatchInspectorReveal(this, branch.eventIndex)}
+        @pointerenter=${() => dispatchInspectorLocate(this, branch.eventIndexes)}
+        @pointerleave=${() => dispatchInspectorLocate(this, [])}
+      >
+        ${categoryLabel(branch.category)}
+        <span class="reveal-row__name" title=${branch.text}>${branch.text}</span>
+        <span class="reveal-row__value"
+          >${churn}${formatDuration(branch.totalTime)} ·
+          ${sharePercent(branch.totalTime, logTotal).toFixed(1)}%</span
+        >
       </button>
     `;
   }
@@ -147,6 +247,50 @@ export class HotPath extends LitElement {
       <span>${text}</span>
     </button>`;
   }
+}
+
+/** The frame's time that went to children the path does not follow. */
+function branchTime(frame: HotPathFrame, child: HotPathFrame | undefined): number {
+  return Math.max(frame.totalTime - frame.selfTime - (child?.totalTime ?? 0), 0);
+}
+
+/** The reading in one line: how far the path runs, and what it holds at each end. */
+function summary(path: HotPathFrame[], logTotal: number) {
+  const first = path[0]!;
+  const last = path[path.length - 1]!;
+  const frames = `${path.length} ${path.length === 1 ? 'frame' : 'frames'}`;
+  const tail = `${formatDuration(last.totalTime)} (${sharePercent(last.totalTime, logTotal).toFixed(1)}%)`;
+  return html`<div class="summary">
+    ${
+      path.length === 1
+        ? `${frames} · ${tail}`
+        : `${frames} · ${formatDuration(first.totalTime)} at entry → ${tail} at the last frame`
+    }
+  </div>`;
+}
+
+/** Where the row's own time went, in time and as a share of the log. */
+function caption(
+  frame: HotPathFrame,
+  self: number,
+  offTime: number,
+  offPath: number,
+  offWhere: string,
+  end: HotPathEnd | null,
+  branchCount: number,
+): string {
+  const parts = [`self ${formatDuration(frame.selfTime)} (${self.toFixed(1)}%)`];
+  if (offPath >= SHARE_FLOOR) {
+    parts.push(`${formatDuration(offTime)} (${offPath.toFixed(1)}%) ${offWhere}`);
+  }
+  if (end === 'hot-spot') {
+    parts.push('the hot spot');
+  } else if (end === 'fan-out') {
+    // A frame keeping little of its own time only splits the time up; the rows
+    // below name the ways, so say how many there are.
+    parts.push(branchCount > 1 ? `fans out ${branchCount} ways` : 'fans out below');
+  }
+  return parts.join(' · ');
 }
 
 declare global {

--- a/log-viewer/src/components/HotSpots.ts
+++ b/log-viewer/src/components/HotSpots.ts
@@ -8,7 +8,7 @@ import { styleMap } from 'lit/directives/style-map.js';
 
 import { logContext } from '../core/log/logContext.js';
 import type { LogStore } from '../core/log/LogStore.js';
-import { formatDuration } from '../core/utility/Util.js';
+import { formatDuration, sharePercent } from '../core/utility/Util.js';
 import {
   getExecutionHighlights,
   type HotSpotRow,
@@ -16,8 +16,9 @@ import {
 import { globalStyles } from '../styles/global.styles.js';
 import { inspectorSectionStyles } from '../styles/inspectorSection.styles.js';
 import { revealRowStyles } from '../styles/revealRow.styles.js';
-import { CategoryPaletteController, categorySwatch } from './categoryTime.js';
+import { CategoryPaletteController, categoryLabel } from './categoryTime.js';
 import { dispatchInspectorReveal } from './inspectorReveal.js';
+import { revealRowMeter, revealRowTitle } from './revealRowMeter.js';
 
 /**
  * The signatures with the most self time across the whole log — the ranked
@@ -47,39 +48,50 @@ export class HotSpots extends LitElement {
   }
 
   /**
-   * One signature: a swatch, the name and its self time, then the churn read
-   * beneath — calls, self time each, share of the log. The meter runs to the
-   * total share and its solid head is the self share the sub line names; one
-   * denominator, the log, across every row.
+   * One signature: the name and its self time, then the churn read
+   * beneath — calls, self time each, share of the log, and the time in the calls
+   * below it, which nothing else on the row gives in text. The meter runs to the
+   * total share and its solid head is the self share the sub line names, with a
+   * hover target per part; one denominator, the log, across every row.
    */
   private _spotRow(spot: HotSpotRow, logTotal: number) {
-    const share = logTotal > 0 ? (spot.selfTime / logTotal) * 100 : 0;
-    const meterShare = logTotal > 0 ? (spot.totalTime / logTotal) * 100 : 0;
-    const selfPct = spot.totalTime > 0 ? (spot.selfTime / spot.totalTime) * 100 : 0;
+    const share = sharePercent(spot.selfTime, logTotal);
+    const meterShare = sharePercent(spot.totalTime, logTotal);
+    const below = spot.totalTime - spot.selfTime;
+    const title = revealRowTitle(
+      spot,
+      below > 0 ? `${formatDuration(below)} in the calls below` : '',
+    );
     const churn =
       spot.count > 1
         ? `${spot.count}× · ${formatDuration(spot.selfTime / spot.count)} self avg · `
         : '';
+    const sub = `${churn}${share.toFixed(1)}% of log${below > 0 ? ` · ${formatDuration(below)} below` : ''}`;
     return html`
       <button
         class="bleed-row reveal-row"
         type="button"
-        title="Show the most expensive call in the tree"
+        title=${title}
         style=${styleMap({
           '--row-hue': this._palette.colorFor(spot.category),
-          '--self-pct': `${selfPct}%`,
+          '--self-pct': `${sharePercent(spot.selfTime, spot.totalTime)}%`,
         })}
         @click=${() => dispatchInspectorReveal(this, spot.eventIndex)}
       >
-        ${categorySwatch(spot.category)}
+        ${categoryLabel(spot.category)}
         <span class="reveal-row__name" title=${spot.text}>${spot.text}</span>
         <span class="reveal-row__value reveal-row__value--primary"
           >${formatDuration(spot.selfTime)}</span
         >
-        <span class="reveal-row__sub">${churn}${share.toFixed(1)}% of log</span>
-        <span class="reveal-row__meter"
-          ><span class="reveal-row__meter-fill" style="width: ${meterShare}%"></span
-        ></span>
+        <span class="reveal-row__sub">${sub}</span>
+        ${revealRowMeter(
+          meterShare,
+          [
+            { share, title: `self ${formatDuration(spot.selfTime)}` },
+            { share: meterShare - share, title: `${formatDuration(below)} in the calls below` },
+          ],
+          title,
+        )}
       </button>
     `;
   }

--- a/log-viewer/src/components/__tests__/HotPath.test.ts
+++ b/log-viewer/src/components/__tests__/HotPath.test.ts
@@ -21,6 +21,7 @@ const framesFor = (count: number) =>
   Array.from({ length: count }, (_unused, index) => ({
     text: `Frame${index}`,
     eventIndex: index,
+    eventIndexes: [index],
     totalTime: 1_000 - index,
     selfTime: (1_000 - index) / 2,
     count: 1,
@@ -30,6 +31,8 @@ const framesFor = (count: number) =>
 const pathOf = (frameCount: number): ExecutionHighlights => ({
   totalTime: 1_000,
   hotPath: framesFor(frameCount),
+  hotPathEnd: 'hot-spot',
+  hotPathBranches: [],
   hotSpots: [],
   truncation: null,
 });
@@ -44,6 +47,17 @@ const hotPath = async () => {
 
 const rowNames = (element: Element) =>
   [...element.shadowRoot!.querySelectorAll('.reveal-row__name')].map((name) => name.textContent);
+
+const meterWidth = (row: Element) =>
+  row.querySelector<HTMLElement>('.reveal-row__meter-fill')!.style.width;
+
+const branchNames = (element: Element) =>
+  [...element.shadowRoot!.querySelectorAll('.branch-row .reveal-row__name')].map(
+    (name) => name.textContent,
+  );
+
+const rowCaptions = (element: Element) =>
+  [...element.shadowRoot!.querySelectorAll('.reveal-row__sub')].map((sub) => sub.textContent);
 
 describe('hot-path', () => {
   beforeEach(() => {
@@ -63,27 +77,32 @@ describe('hot-path', () => {
     expect(focused?.[0]?.textContent).toContain('Frame2');
   });
 
-  it('colours each row by category and splits the meter at its self time', async () => {
+  it('colours each row by category and splits the bar at its self time', async () => {
     highlights = pathOf(1);
 
     const element = await hotPath();
 
     const row = element.shadowRoot?.querySelector<HTMLElement>('.reveal-row');
     expect(row?.style.getPropertyValue('--row-hue')).not.toBe('');
-    // Half the frame's total time is its own, so the solid head is half the bar.
+    // The bar runs to the frame's share of the log and is solid up to its self
+    // time; half the frame's total time is its own, and the path stops here, so
+    // the other half sits below it off the path.
+    expect(meterWidth(row!)).toBe('100%');
     expect(row?.style.getPropertyValue('--self-pct')).toBe('50%');
-    expect(row?.querySelector('.reveal-row__swatch')?.getAttribute('title')).toBe('Apex');
+    expect(row?.querySelector('.reveal-row__sub')?.textContent).toBe(
+      'self 0.001 ms (50.0%) \u00b7 0.001 ms (50.0%) below this frame \u00b7 the hot spot',
+    );
     // The hue is decorative, so the category is named in text a reader can hear.
-    expect(row?.querySelector('.reveal-row__swatch')?.getAttribute('aria-hidden')).toBe('true');
+    expect(row?.querySelector('.reveal-row__swatch')).toBeNull();
     expect(row?.querySelector('.reveal-row__sr')?.textContent).toBe('Apex');
   });
 
-  it('keeps the terminus and collapses the middle of a longer path', async () => {
+  it('keeps the last frame and collapses the middle of a longer path', async () => {
     highlights = pathOf(14);
 
     const element = await hotPath();
 
-    // Nine frames from the entry point, then the terminus, with the dropped
+    // Nine frames from the entry point, then the last frame, with the dropped
     // frames counted between them.
     expect(rowNames(element)).toEqual([
       'Frame0',
@@ -101,5 +120,189 @@ describe('hot-path', () => {
     const focused = element.shadowRoot?.querySelectorAll('.reveal-row--focus');
     expect(focused).toHaveLength(1);
     expect(focused?.[0]?.textContent).toContain('Frame13');
+  });
+
+  it('sums the path in one line above the rows', async () => {
+    highlights = pathOf(3);
+
+    const element = await hotPath();
+
+    expect(element.shadowRoot?.querySelector('.summary')?.textContent?.trim()).toBe(
+      '3 frames \u00b7 0.001 ms at entry \u2192 0.001 ms (99.8%) at the last frame',
+    );
+  });
+
+  it('splits each row into what it kept, passed on and shed', async () => {
+    highlights = {
+      totalTime: 1_000,
+      hotPath: [
+        { ...framesFor(1)[0]!, text: 'Parent', totalTime: 1_000, selfTime: 100 },
+        { ...framesFor(1)[0]!, text: 'Child', totalTime: 700, selfTime: 700 },
+      ],
+      hotPathEnd: 'hot-spot',
+      hotPathBranches: [],
+      hotSpots: [],
+      truncation: null,
+    };
+
+    const element = await hotPath();
+
+    const rows = element.shadowRoot!.querySelectorAll<HTMLElement>('.reveal-row');
+    // The parent kept 100ns, passed 700ns down, so 200ns went to branches.
+    expect(meterWidth(rows[0]!)).toBe('100%');
+    expect(rows[0]!.style.getPropertyValue('--self-pct')).toBe('10%');
+    expect(meterWidth(rows[1]!)).toBe('70%');
+    expect(rowCaptions(element)).toEqual([
+      'self 0 ms (10.0%) \u00b7 0 ms (20.0%) to branches',
+      'self 0.001 ms (70.0%) \u00b7 the hot spot',
+    ]);
+  });
+
+  it('names the ways the last frame fans out, and lists them', async () => {
+    highlights = {
+      totalTime: 1_000,
+      hotPath: [{ ...framesFor(1)[0]!, text: 'Parent', totalTime: 1_000, selfTime: 100 }],
+      hotPathEnd: 'fan-out',
+      hotPathBranches: [
+        {
+          text: 'Alpha',
+          eventIndex: 7,
+          eventIndexes: [7],
+          totalTime: 400,
+          selfTime: 0,
+          count: 1,
+          category: 'Apex',
+        },
+        {
+          text: 'Beta',
+          eventIndex: 8,
+          eventIndexes: [8, 11],
+          totalTime: 300,
+          selfTime: 0,
+          count: 2,
+          category: 'Apex',
+        },
+      ],
+      hotSpots: [],
+      truncation: null,
+    };
+
+    const element = await hotPath();
+
+    expect(rowCaptions(element)).toEqual([
+      'self 0 ms (10.0%) \u00b7 0.001 ms (90.0%) below this frame \u00b7 fans out 2 ways',
+    ]);
+    expect(branchNames(element)).toEqual(['Alpha', 'Beta']);
+    // A branch is a pointer, so it gives a time and a share and no split.
+    const branch = element.shadowRoot!.querySelectorAll('.branch-row')[1]!;
+    expect(
+      branch.querySelector('.reveal-row__value')?.textContent?.replace(/\s+/g, ' ').trim(),
+    ).toBe('2\u00d7 \u00b7 0 ms \u00b7 30.0%');
+    expect(branch.querySelector('.reveal-row__meter')).toBeNull();
+    // The last frame only splits the time up, so nothing is emphasised.
+    expect(element.shadowRoot?.querySelectorAll('.reveal-row--focus')).toHaveLength(0);
+  });
+
+  it('counts the branches past the third in a line', async () => {
+    highlights = {
+      totalTime: 1_000,
+      hotPath: [{ ...framesFor(1)[0]!, text: 'Parent', totalTime: 1_000, selfTime: 100 }],
+      hotPathEnd: 'fan-out',
+      hotPathBranches: ['A', 'B', 'C', 'D', 'E'].map((text, index) => ({
+        text,
+        eventIndex: index,
+        eventIndexes: [index],
+        totalTime: 100 - index,
+        selfTime: 0,
+        count: 1,
+        category: 'Apex' as const,
+      })),
+      hotSpots: [],
+      truncation: null,
+    };
+
+    const element = await hotPath();
+
+    expect(branchNames(element)).toEqual(['A', 'B', 'C']);
+    expect(element.shadowRoot?.querySelector('.more')?.textContent).toContain('2 more branches');
+    // The caption counts every way the time went, not the rows that fit.
+    expect(rowCaptions(element)[0]).toContain('fans out 5 ways');
+  });
+
+  it('marks every merged instance of a branch under the pointer', async () => {
+    highlights = {
+      totalTime: 1_000,
+      hotPath: [{ ...framesFor(1)[0]!, text: 'Parent', totalTime: 1_000, selfTime: 100 }],
+      hotPathEnd: 'fan-out',
+      hotPathBranches: [
+        {
+          text: 'Beta',
+          eventIndex: 8,
+          eventIndexes: [8, 11],
+          totalTime: 300,
+          selfTime: 0,
+          count: 2,
+          category: 'Apex',
+        },
+      ],
+      hotSpots: [],
+      truncation: null,
+    };
+    const element = await hotPath();
+    const marks: (readonly number[])[] = [];
+    element.addEventListener('inspector-locate', (event) => {
+      marks.push((event as CustomEvent<{ eventIndexes: readonly number[] }>).detail.eventIndexes);
+    });
+
+    const branch = element.shadowRoot!.querySelector('.branch-row')!;
+    branch.dispatchEvent(new Event('pointerenter'));
+    branch.dispatchEvent(new Event('pointerleave'));
+
+    expect(marks).toEqual([[8, 11], []]);
+    // One branch is no fan, so the caption says only that the time is below.
+    expect(rowCaptions(element)[0]).toContain('fans out below');
+  });
+
+  it('names each part of the bar for the pointer', async () => {
+    highlights = {
+      totalTime: 1_000,
+      hotPath: [
+        { ...framesFor(1)[0]!, text: 'Parent', totalTime: 1_000, selfTime: 100 },
+        { ...framesFor(1)[0]!, text: 'Child', totalTime: 700, selfTime: 700 },
+      ],
+      hotPathEnd: 'hot-spot',
+      hotPathBranches: [],
+      hotSpots: [],
+      truncation: null,
+    };
+
+    const element = await hotPath();
+
+    const hits = [
+      ...element
+        .shadowRoot!.querySelectorAll<HTMLElement>('.reveal-row')[0]!
+        .querySelectorAll<HTMLElement>('.reveal-row__meter-hit'),
+    ];
+    expect(hits.map((hit) => [hit.style.width, hit.title])).toEqual([
+      ['10%', 'self 0 ms'],
+      ['70%', '0.001 ms on the path'],
+      ['20%', '0 ms to branches'],
+    ]);
+  });
+
+  it('marks every merged instance of the row under the pointer', async () => {
+    highlights = pathOf(1);
+    highlights.hotPath[0]!.eventIndexes = [4, 9];
+    const element = await hotPath();
+    const marks: (readonly number[])[] = [];
+    element.addEventListener('inspector-locate', (event) => {
+      marks.push((event as CustomEvent<{ eventIndexes: readonly number[] }>).detail.eventIndexes);
+    });
+
+    const row = element.shadowRoot!.querySelector('.reveal-row')!;
+    row.dispatchEvent(new Event('pointerenter'));
+    row.dispatchEvent(new Event('pointerleave'));
+
+    expect(marks).toEqual([[4, 9], []]);
   });
 });

--- a/log-viewer/src/components/__tests__/HotSpots.test.ts
+++ b/log-viewer/src/components/__tests__/HotSpots.test.ts
@@ -18,6 +18,8 @@ import '../HotSpots.js';
 const spotsOf = (): ExecutionHighlights => ({
   totalTime: 1_000_000_000,
   hotPath: [],
+  hotPathEnd: 'hot-spot',
+  hotPathBranches: [],
   hotSpots: [
     {
       text: 'MyClass.run()',
@@ -52,7 +54,7 @@ describe('hot-spots', () => {
 
     // 200 ms of self time over 4 calls is 50 ms each, a fifth of a 1 s log.
     expect(element.shadowRoot?.querySelector('.reveal-row__sub')?.textContent).toBe(
-      '4× · 50 ms self avg · 20.0% of log',
+      '4× · 50 ms self avg · 20.0% of log · 200 ms below',
     );
   });
 
@@ -65,17 +67,49 @@ describe('hot-spots', () => {
     expect(row?.style.getPropertyValue('--row-hue')).not.toBe('');
     // The bar runs to the 40% total share; half of it — the 20% self share — is solid.
     expect(row?.style.getPropertyValue('--self-pct')).toBe('50%');
-    expect(row?.querySelector('.reveal-row__swatch')?.getAttribute('title')).toBe('Apex');
     // The hue is decorative, so the category is named in text a reader can hear.
-    expect(row?.querySelector('.reveal-row__swatch')?.getAttribute('aria-hidden')).toBe('true');
+    expect(row?.querySelector('.reveal-row__swatch')).toBeNull();
     expect(row?.querySelector('.reveal-row__sr')?.textContent).toBe('Apex');
     expect(
       element.shadowRoot?.querySelector<HTMLElement>('.reveal-row__meter-fill')?.style.width,
     ).toBe('40%');
   });
 
+  it('names the two parts of the bar for the pointer', async () => {
+    highlights = spotsOf();
+
+    const element = await hotSpots();
+
+    const hits = [...element.shadowRoot!.querySelectorAll<HTMLElement>('.reveal-row__meter-hit')];
+    // The parts are shares of the log, so they add up to the bar's own length.
+    expect(hits.map((hit) => [hit.style.width, hit.title])).toEqual([
+      ['20%', 'self 200 ms'],
+      ['20%', '200 ms in the calls below'],
+    ]);
+  });
+
+  it('gives the whole split as the row title, where the bar has no part', async () => {
+    highlights = spotsOf();
+
+    const element = await hotSpots();
+
+    const split = '4 calls merged · total 400 ms · self 200 ms · 200 ms in the calls below';
+    expect(element.shadowRoot?.querySelector<HTMLElement>('.reveal-row')?.title).toBe(split);
+    // The band carries it too, so the space past the bar is a titled element.
+    expect(element.shadowRoot?.querySelector<HTMLElement>('.reveal-row__meter-hits')?.title).toBe(
+      split,
+    );
+  });
+
   it('notes a log with no timed calls', async () => {
-    highlights = { totalTime: 0, hotPath: [], hotSpots: [], truncation: null };
+    highlights = {
+      totalTime: 0,
+      hotPath: [],
+      hotPathEnd: 'hot-spot',
+      hotPathBranches: [],
+      hotSpots: [],
+      truncation: null,
+    };
 
     const element = await hotSpots();
 

--- a/log-viewer/src/components/categoryTime.ts
+++ b/log-viewer/src/components/categoryTime.ts
@@ -23,14 +23,12 @@ export function categoryName(category: string): string {
 }
 
 /**
- * The category as a reveal row shows it: the colour chip `--row-hue` paints,
- * plus the same name in text a screen reader can hear, because the hue alone
- * carries no meaning. For a host that adopts `revealRowStyles`.
+ * The row's category in text a screen reader can hear: the row shows it as the
+ * meter's hue, which carries no meaning on its own. For a host that adopts
+ * `revealRowStyles`.
  */
-export function categorySwatch(category: string): TemplateResult {
-  const name = categoryName(category);
-  return html`<span class="reveal-row__swatch" title=${name} aria-hidden="true"></span>
-    <span class="reveal-row__sr">${name}</span>`;
+export function categoryLabel(category: string): TemplateResult {
+  return html`<span class="reveal-row__sr">${categoryName(category)}</span>`;
 }
 
 /** Neutral literal for {@link OTHER_CATEGORY} — no theme names it, and the

--- a/log-viewer/src/components/revealRowMeter.ts
+++ b/log-viewer/src/components/revealRowMeter.ts
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2026 Certinia Inc. All rights reserved.
+ */
+import { html } from 'lit';
+
+import { formatDuration } from '../core/utility/Util.js';
+
+/** One named part of a row's bar: its share of the log, and what it stands for. */
+export interface MeterPart {
+  /** Share of the log, in percent, so the parts add up to the bar's own length. */
+  share: number;
+  title: string;
+}
+
+/**
+ * The shared magnitude bar with a hover target per part. The track is a hairline
+ * and clips its children, so the targets sit over it instead: transparent, tall
+ * enough to aim at, and each carrying its own tooltip. A child's `title` wins
+ * over the row's, which keeps the whole split for the keyboard. `title` is the
+ * row's own, on the band itself: the space past the bar is then a titled element
+ * like every part, so the tooltip swaps there instead of restarting its timer.
+ */
+export function revealRowMeter(total: number, parts: MeterPart[], title: string) {
+  return html`<span class="reveal-row__meter-wrap">
+    <span class="reveal-row__meter"
+      ><span class="reveal-row__meter-fill" style="width: ${total}%"></span
+    ></span>
+    <span class="reveal-row__meter-hits" aria-hidden="true" title=${title}
+      >${parts
+        .filter((part) => part.share > 0)
+        .map(
+          (part) =>
+            html`<span
+              class="reveal-row__meter-hit"
+              style="width: ${part.share}%"
+              title=${part.title}
+            ></span>`,
+        )}</span
+    >
+  </span>`;
+}
+
+/** What a row merges and how its time splits, in absolute times: the reading a
+ *  truncated row and the keyboard would otherwise lose. Empty tails drop out. */
+export function revealRowTitle(
+  row: { count: number; totalTime: number; selfTime: number },
+  ...tail: string[]
+): string {
+  const parts = row.count > 1 ? [`${row.count} calls merged`] : [];
+  parts.push(`total ${formatDuration(row.totalTime)}`, `self ${formatDuration(row.selfTime)}`);
+  return parts.concat(tail.filter(Boolean)).join(' · ');
+}

--- a/log-viewer/src/core/utility/Util.ts
+++ b/log-viewer/src/core/utility/Util.ts
@@ -90,6 +90,11 @@ export function formatTimeRange(startTimeNs: number, endTimeNs: number): string 
   return `${formatDuration(startTimeNs)} → ${formatDuration(endTimeNs)}`;
 }
 
+/** `part` as a percentage of `whole`, or zero when there is no whole. */
+export function sharePercent(part: number, whole: number): number {
+  return whole > 0 ? (part / whole) * 100 : 0;
+}
+
 /** Integer → thousand-separated string (e.g. 1572864 → "1,572,864"), for heap/byte values. */
 export function formatInteger(value: number): string {
   return Math.round(value).toLocaleString();

--- a/log-viewer/src/features/call-tree/utils/ExecutionHighlights.ts
+++ b/log-viewer/src/features/call-tree/utils/ExecutionHighlights.ts
@@ -10,6 +10,8 @@ export interface HotPathFrame {
   text: string;
   /** The instance with the most total time, so a click lands on the worst one. */
   eventIndex: number;
+  /** Every merged instance, so a hover marks all of them, not just the worst. */
+  eventIndexes: number[];
   /** Total time summed across every merged sibling; its share of the log is `totalTime / totalTime(log)`. */
   totalTime: number;
   /** Self time summed across the same instances — the part of `totalTime` this
@@ -20,6 +22,9 @@ export interface HotPathFrame {
   /** The largest instance's category, so the row takes the flame chart's own colour. */
   category: LogCategory;
 }
+
+/** What the last hot path frame is: it does the work itself, or it only splits the time up. */
+export type HotPathEnd = 'hot-spot' | 'fan-out';
 
 /** One signature in the top-self-time list. */
 export interface HotSpotRow {
@@ -43,6 +48,11 @@ export interface ExecutionHighlights {
   /** The log's own total time, the denominator for every share shown. */
   totalTime: number;
   hotPath: HotPathFrame[];
+  /** What the last frame of the path is, which decides how the row reads. */
+  hotPathEnd: HotPathEnd;
+  /** The last frame's own children, biggest first; empty unless the path fans
+   *  out. A branch is a frame the path did not follow, so it reads the same. */
+  hotPathBranches: HotPathFrame[];
   hotSpots: HotSpotRow[];
   /** Calls the log's size cap cut off; their subtrees under-report every timing. */
   truncation: { regionCount: number; firstEventIndex: number } | null;
@@ -53,6 +63,16 @@ export interface ExecutionHighlights {
  * time; below it the time has spread out, and the last frame is the hot spot.
  */
 const HOT_PATH_FOLLOW_SHARE = 0.4;
+
+/**
+ * A last frame keeping this much of its own time does the work itself, so it is
+ * the hot spot; below it the frame only splits the time up, and its children are
+ * the reading. The stop reason does not decide this, the measured share does.
+ */
+const SELF_DOMINANT_SHARE = 0.5;
+
+/** A child under this share of the fanned-out frame is noise, not a branch. */
+const BRANCH_SHARE_FLOOR = 0.05;
 
 /** How many signatures the hot-spot list names. */
 const HOT_SPOT_COUNT = 5;
@@ -67,7 +87,7 @@ const HOT_SPOT_COUNT = 5;
 export function computeExecutionHighlights(apexLog: ApexLog): ExecutionHighlights {
   return {
     totalTime: apexLog.duration.total,
-    hotPath: computeHotPath(apexLog.children),
+    ...computeHotPath(apexLog.children),
     ...scanEvents(apexLog.eventsById),
   };
 }
@@ -86,30 +106,53 @@ interface FrameGroup {
  * siblings merge into one frame (a loop's 200 calls read as one line), the walk
  * follows the largest merged group, and it stops where the time spreads out —
  * either no child group holds the follow share, or the current frame's own self
- * time beats the largest child group, which makes this frame the hot spot.
+ * time beats the largest child group. Where the last frame keeps little of its
+ * own time it is no hot spot, so its children come back as the branches the time
+ * fanned out to.
  */
-function computeHotPath(roots: LogEvent[]): HotPathFrame[] {
-  const frames: HotPathFrame[] = [];
-  let current = largestGroup(roots);
+function computeHotPath(
+  roots: LogEvent[],
+): Pick<ExecutionHighlights, 'hotPath' | 'hotPathEnd' | 'hotPathBranches'> {
+  const hotPath: HotPathFrame[] = [];
+  let current = sortedGroups(roots)[0];
+  let children: FrameGroup[] = [];
   while (current && current.total > 0) {
-    const worst = largestInstance(current.instances);
-    frames.push({
-      text: worst.text,
-      eventIndex: worst.eventIndex,
-      totalTime: current.total,
-      // An instance reporting a negative self can drag the group's sum outside
-      // its total; the frame's own share of itself cannot sit outside it.
-      selfTime: Math.min(Math.max(current.self, 0), current.total),
-      count: current.instances.length,
-      category: worst.category,
-    });
-    const next = largestGroup(childrenOf(current.instances));
+    hotPath.push(frameOf(current));
+    children = sortedGroups(childrenOf(current.instances));
+    const next = children[0];
     if (!next || next.total < HOT_PATH_FOLLOW_SHARE * current.total || current.self > next.total) {
       break;
     }
     current = next;
   }
-  return frames;
+  const last = hotPath[hotPath.length - 1];
+  const branches =
+    last && last.selfTime < SELF_DOMINANT_SHARE * last.totalTime
+      ? children.filter((group) => group.total >= BRANCH_SHARE_FLOOR * last.totalTime).map(frameOf)
+      : [];
+  // A fan-out with no branch above the floor would point at rows that do not
+  // exist: the time stops at the frame after all, so it reads as the hot spot.
+  return {
+    hotPath,
+    hotPathEnd: branches.length > 0 ? 'fan-out' : 'hot-spot',
+    hotPathBranches: branches,
+  };
+}
+
+/** The frame the walk landed on, in the shape the rows read. */
+function frameOf(group: FrameGroup): HotPathFrame {
+  const worst = largestInstance(group.instances);
+  return {
+    text: worst.text,
+    eventIndex: worst.eventIndex,
+    eventIndexes: group.instances.map((instance) => instance.eventIndex),
+    totalTime: group.total,
+    // An instance reporting a negative self can drag the group's sum outside
+    // its total; the frame's own share of itself cannot sit outside it.
+    selfTime: Math.min(Math.max(group.self, 0), group.total),
+    count: group.instances.length,
+    category: worst.category,
+  };
 }
 
 /** Every child of every instance, without materialising a flattened array per level. */
@@ -119,8 +162,8 @@ function* childrenOf(parents: LogEvent[]): Generator<LogEvent> {
   }
 }
 
-/** Merge the events by signature and return the group holding the most total time. */
-function largestGroup(events: Iterable<LogEvent>): FrameGroup | null {
+/** Merge the events by signature, biggest total time first. */
+function sortedGroups(events: Iterable<LogEvent>): FrameGroup[] {
   const groups = new Map<string, FrameGroup>();
   for (const event of events) {
     const key = getEventKey(event);
@@ -137,13 +180,7 @@ function largestGroup(events: Iterable<LogEvent>): FrameGroup | null {
       });
     }
   }
-  let largest: FrameGroup | null = null;
-  for (const group of groups.values()) {
-    if (!largest || group.total > largest.total) {
-      largest = group;
-    }
-  }
-  return largest;
+  return [...groups.values()].sort((a, b) => b.total - a.total);
 }
 
 function largestInstance(instances: LogEvent[]): LogEvent {

--- a/log-viewer/src/features/call-tree/utils/__tests__/ExecutionHighlights.test.ts
+++ b/log-viewer/src/features/call-tree/utils/__tests__/ExecutionHighlights.test.ts
@@ -77,6 +77,7 @@ describe('computeExecutionHighlights hot path', () => {
     expect(hotPath[0]).toEqual({
       text: 'Root',
       eventIndex: root.eventIndex,
+      eventIndexes: [root.eventIndex],
       totalTime: 900,
       selfTime: 0,
       count: 1,
@@ -100,6 +101,7 @@ describe('computeExecutionHighlights hot path', () => {
       {
         text: 'Root',
         eventIndex: root.eventIndex,
+        eventIndexes: [root.eventIndex],
         totalTime: 1000,
         selfTime: 0,
         count: 1,
@@ -108,6 +110,8 @@ describe('computeExecutionHighlights hot path', () => {
       {
         text: 'Repeat',
         eventIndex: worst.eventIndex,
+        // Every instance the frame merges, so a hover marks all of them.
+        eventIndexes: [worst.eventIndex - 1, worst.eventIndex],
         totalTime: 600,
         selfTime: 0,
         count: 2,
@@ -180,6 +184,105 @@ describe('computeExecutionHighlights hot path', () => {
     expect(highlights.hotPath).toEqual([]);
     expect(highlights.hotSpots).toEqual([]);
     expect(highlights.truncation).toBeNull();
+  });
+});
+
+describe('computeExecutionHighlights hot path end', () => {
+  it('names a last frame that keeps its own time as the hot spot', () => {
+    const log = createLog(1000);
+    const root = createEvent({ text: 'Root', total: 1000 });
+    log.children.push(root);
+    const big = createEvent({ text: 'Big', total: 900, self: 800, parent: root });
+    createEvent({ text: 'Small', total: 100, parent: big });
+
+    const { hotPath, hotPathEnd, hotPathBranches } = computeExecutionHighlights(log);
+
+    expect(hotPath.map((frame) => frame.text)).toEqual(['Root', 'Big']);
+    expect(hotPathEnd).toBe('hot-spot');
+    // The frame does the work itself, so its children are no reading.
+    expect(hotPathBranches).toEqual([]);
+  });
+
+  it('hands back the branches where the time fans out instead', () => {
+    const log = createLog(1000);
+    const root = createEvent({ text: 'Root', total: 1000, self: 100 });
+    log.children.push(root);
+    // No child holds the follow share, and the frame kept a tenth of its own
+    // time, so the time fanned out here.
+    const alpha = createEvent({ text: 'Alpha', total: 380, parent: root });
+    createEvent({ text: 'Beta', total: 300, parent: root });
+    createEvent({ text: 'Gamma', total: 280, parent: root });
+    createEvent({ text: 'Tiny', total: 20, parent: root });
+
+    const { hotPath, hotPathEnd, hotPathBranches } = computeExecutionHighlights(log);
+
+    expect(hotPath.map((frame) => frame.text)).toEqual(['Root']);
+    expect(hotPathEnd).toBe('fan-out');
+    // Biggest first, and the child under a twentieth of the frame is noise.
+    expect(hotPathBranches.map((branch) => branch.text)).toEqual(['Alpha', 'Beta', 'Gamma']);
+    expect(hotPathBranches[0]).toEqual({
+      text: 'Alpha',
+      eventIndex: alpha.eventIndex,
+      eventIndexes: [alpha.eventIndex],
+      totalTime: 380,
+      selfTime: 0,
+      count: 1,
+      category: '',
+    });
+  });
+
+  it('names no fan-out where the frame has no branch worth a row', () => {
+    const log = createLog(1000);
+    const root = createEvent({ text: 'Root', total: 1000, self: 100 });
+    log.children.push(root);
+    // The frame kept a tenth of its own time, but its one child is noise, so
+    // there is nothing for a fan-out reading to point at.
+    createEvent({ text: 'Tiny', total: 20, parent: root });
+
+    const { hotPathEnd, hotPathBranches } = computeExecutionHighlights(log);
+
+    expect(hotPathEnd).toBe('hot-spot');
+    expect(hotPathBranches).toEqual([]);
+  });
+
+  it('merges same-signature branches, and points at the worst instance', () => {
+    const log = createLog(1000);
+    const root = createEvent({ text: 'Root', total: 1000, self: 100 });
+    log.children.push(root);
+    const first = createEvent({ text: 'Repeat', total: 100, parent: root });
+    createEvent({ text: 'Other', total: 300, parent: root });
+    const worst = createEvent({ text: 'Repeat', total: 200, parent: root });
+
+    const { hotPathEnd, hotPathBranches } = computeExecutionHighlights(log);
+
+    expect(hotPathEnd).toBe('fan-out');
+    expect(hotPathBranches).toEqual([
+      {
+        text: 'Repeat',
+        eventIndex: worst.eventIndex,
+        eventIndexes: [first.eventIndex, worst.eventIndex],
+        totalTime: 300,
+        selfTime: 0,
+        count: 2,
+        category: '',
+      },
+      {
+        text: 'Other',
+        eventIndex: first.eventIndex + 1,
+        eventIndexes: [first.eventIndex + 1],
+        totalTime: 300,
+        selfTime: 0,
+        count: 1,
+        category: '',
+      },
+    ]);
+  });
+
+  it('has no end to name in a log with no timed calls', () => {
+    const highlights = computeExecutionHighlights(createLog(0));
+
+    expect(highlights.hotPathEnd).toBe('hot-spot');
+    expect(highlights.hotPathBranches).toEqual([]);
   });
 });
 

--- a/log-viewer/src/features/database/components/DatabaseOverview.ts
+++ b/log-viewer/src/features/database/components/DatabaseOverview.ts
@@ -16,7 +16,7 @@ import '../../../components/StackedTimeBar.js';
 import { segmentsWithTail } from '../../../components/StackedTimeBar.js';
 import { logContext } from '../../../core/log/logContext.js';
 import type { LogStore } from '../../../core/log/LogStore.js';
-import { formatDuration, formatInteger } from '../../../core/utility/Util.js';
+import { formatDuration, formatInteger, sharePercent } from '../../../core/utility/Util.js';
 import { globalStyles } from '../../../styles/global.styles.js';
 import { inspectorSectionStyles } from '../../../styles/inspectorSection.styles.js';
 import { revealRowStyles } from '../../../styles/revealRow.styles.js';
@@ -207,7 +207,7 @@ export class DatabaseConcentration extends LitElement {
     const own = sharePercent(statement.netNs, databaseNs);
     return html`
       <button
-        class="bleed-row reveal-row reveal-row--no-swatch"
+        class="bleed-row reveal-row"
         type="button"
         title=${rowTitle(statement)}
         style=${styleMap({
@@ -323,11 +323,6 @@ function sameSplit(left: DatabaseBreakdown[], right: DatabaseBreakdown[]): boole
     left.length === right.length &&
     left.every((row, index) => row.key === right[index]?.key && row.timeNs === right[index]?.timeNs)
   );
-}
-
-/** `part` as a percentage of `whole`, or zero when there is no whole. */
-function sharePercent(part: number, whole: number): number {
-  return whole > 0 ? (part / whole) * 100 : 0;
 }
 
 /**

--- a/log-viewer/src/styles/revealRow.styles.ts
+++ b/log-viewer/src/styles/revealRow.styles.ts
@@ -37,13 +37,9 @@ export const bleedRowStyles = css`
 
 /**
  * A clickable line in an inspector section that reveals one event in the tab on
- * screen: a category swatch and the code's name on the left, its figures held to
- * the right edge, an optional full-width sub line and magnitude meter beneath
- * them. Layout only — the markup pairs it with the bleed-row shell.
- *
- * The swatch is optional: a section whose rows carry none adds
- * `.reveal-row--no-swatch`, or the name would take the swatch's fixed track and
- * push the figures off the row.
+ * screen: the code's name on the left, its figures held to the right edge, an
+ * optional full-width sub line and magnitude meter beneath them. Layout only —
+ * the markup pairs it with the bleed-row shell.
  *
  * The row's category hue arrives as `--row-hue` and the self-time share of its
  * own bar as `--self-pct`, both set inline on the row, so these rules stay
@@ -57,27 +53,13 @@ export const revealRowStyles = [
       --row-hue: var(--lana-meter-fill);
       --self-pct: 100%;
       display: grid;
-      grid-template-columns: auto minmax(0, 1fr) auto;
+      grid-template-columns: minmax(0, 1fr) auto;
       align-items: baseline;
       column-gap: var(--lana-space-sm);
       row-gap: var(--lana-space-3xs);
     }
 
-    .reveal-row--no-swatch {
-      grid-template-columns: minmax(0, 1fr) auto;
-    }
-
-    /* Identity, never magnitude: the same hue the flame chart gives the category. */
-    .reveal-row__swatch {
-      display: block;
-      align-self: center;
-      width: var(--lana-space-sm);
-      height: var(--lana-space-sm);
-      border-radius: var(--lana-radius-sm);
-      background: var(--row-hue);
-    }
-
-    /* The swatch's hue is decorative, so the category it stands for is spoken
+    /* The meter's hue is decorative, so the category it stands for is spoken
        here instead: hidden from view, part of the button's accessible name. */
     .reveal-row__sr {
       position: absolute;
@@ -124,14 +106,39 @@ export const revealRowStyles = [
       font-variant-numeric: tabular-nums;
     }
 
+    /* Holds the track and the hover targets over it, so a target can be taller
+       than the track without the track clipping it. */
+    .reveal-row__meter-wrap {
+      display: block;
+      grid-column: 1 / -1;
+      position: relative;
+    }
+
+    /* Transparent targets across the wrapper, each part sized as its share of
+       the log, so hovering the bar names the part under the pointer. */
+    .reveal-row__meter-hits {
+      display: flex;
+      position: absolute;
+      inset-inline: 0;
+      /* Grown past the track to a target a pointer can hit, no further than the
+         row's own padding, so it never covers the row below. */
+      inset-block: calc(-1 * var(--lana-space-3xs));
+    }
+
+    .reveal-row__meter-hit {
+      flex: 0 0 auto;
+    }
+
     /* Magnitude strip: length carries the share of the log, one denominator per
        section. The hue is identity only, over a track mixed from it so the track
        reads as this row's own in either theme. */
     .reveal-row__meter {
       display: block;
+      /* Spans the row on its own: a section may place the track straight in the
+         grid, without the hover targets the wrapper carries. */
       grid-column: 1 / -1;
       overflow: hidden;
-      height: var(--lana-space-3xs);
+      height: var(--lana-space-2xs);
       border-radius: var(--lana-radius-sm);
       background: color-mix(in srgb, var(--row-hue) 15%, transparent);
     }


### PR DESCRIPTION
# 📝 PR Overview

The last row of the Call Tree hot path always ended with "the hot spot", whatever the
measurement said. On `sample-app/debug-logs/sample-log.log` that row keeps 0.3% self time and
splits its time three ways, so the label named a hot spot that does not exist and hid the only
useful fact. The row bars also had no way to name their parts.

The verdict now follows the measurement: a frame that keeps at least half its own time is the
hot spot, and any other frame fans out, with its biggest children listed below it as branch
rows. Every bar names its parts on hover.

## 🛠️ Changes made

- Derive the last frame's verdict from its self share and its branch list, so a fan-out with no
  branch worth a row still reads as the hot spot.
- List up to three branch rows under a fanned-out frame, biggest first; each one selects and
  marks that call like a frame row.
- Give each bar a hover target per part (self, on the path, held below the frame), because the
  2px track is too thin to aim at.
- Carry the whole split in the row title, so the keyboard and a truncated row lose nothing.
- Share one `sharePercent` helper and one row-title builder across the hot path, hot spots and
  database rows.

## 🧩 Type of change (check all applicable)

- [x] 🐛 Bug fix - something not working as expected
- [x] ✨ New feature – adds new functionality
- [ ] ♻️ Refactor - internal changes with no user impact
- [ ] ⚡ Performance Improvement
- [ ] 📝 Documentation - README or documentation site changes
- [ ] 🔧 Chore - dev tooling, CI, config
- [ ] 💥 Breaking change

## 📷 Screenshots / gifs / video [optional]

N/A

## 🔗 Related Issues

related #373
related #405

## ✅ Tests added?

- [x] 👍 yes

`pnpm lint` and `pnpm test` pass (1789 tests, 131 suites). Manual check in the dev host on
`sample-log.log`: the last row reads `fans out 3 ways` with three branch rows, and
`261631_IO_Log1.log` keeps "the hot spot" with none. Both themes.

## 📚 Docs updated?

- [x] 🔖 CHANGELOG.md

The unreleased Inspector entry already covers the hot path and hot spots section.