### PR TITLE
fix(inspector): stop tall sections shrinking the table to a sliver

### DIFF
--- a/log-viewer/src/components/PaneView.ts
+++ b/log-viewer/src/components/PaneView.ts
@@ -19,9 +19,10 @@ export interface PaneSection {
   weight?: number;
   /**
    * How the open pane takes space (default `'fill'`). A `'content'` pane sizes
-   * to its content and shrinks — scrolling inside — when space runs out, and it
-   * never stretches to soak up leftovers; dragging its sash pins it to a size
-   * instead, which a double-click hands back to the content.
+   * to its content and shrinks — scrolling inside — when space runs out, it
+   * never stretches to soak up leftovers, and it leaves the open fill panes a
+   * share of the space. Dragging its sash pins it to a size instead, which a
+   * double-click hands back to the content.
    * A `'fill'` pane shares the remaining space by weight.
    */
   fit?: 'content' | 'fill';
@@ -212,9 +213,10 @@ export class PaneView extends LitElement {
 
   render() {
     const weights = this._flexWeights();
+    const basis = this._fillBasis();
     const items: TemplateResult[] = [];
     this.sections.forEach((section, index) => {
-      items.push(this._renderPane(section, weights.get(section.id) ?? 1));
+      items.push(this._renderPane(section, weights.get(section.id) ?? 1, basis));
       const next = this.sections[index + 1];
       // A sash trades space between the two panes beside it, so it exists
       // wherever both neighbours are open. A content pane starts at its
@@ -258,18 +260,35 @@ export class PaneView extends LitElement {
     );
   }
 
-  private _renderPane(section: PaneSection, weight: number) {
+  /**
+   * A fill pane's flex basis: an equal share of the panel, so a stack of
+   * sized-to-content panes cannot squeeze it to `--lana-pane-min`. From a basis
+   * of zero it can only grow into free space, and once the content panes fill
+   * the panel there is none; from a share it shrinks alongside them instead, and
+   * keeps its natural size while the panel is roomy. Zero while every open pane
+   * fills, where a share each would take the whole panel and flatten the
+   * weights.
+   */
+  private _fillBasis(): string {
+    const open = this.sections.filter((section) => this._isOpen(section.id));
+    const content = open.filter((section) => !this._isFill(section)).length;
+    return this.orientation === 'vertical' && content > 0 ? `calc(100% / ${open.length})` : '0';
+  }
+
+  private _renderPane(section: PaneSection, weight: number, basis: string) {
     const open = this._isOpen(section.id);
     const collapsible = this._collapsible;
-    // An open content pane sizes to its content — or to the size it was dragged
-    // to — but stays shrinkable, so when space runs out it scrolls instead of
+    // An open content pane sizes to its content, or to the size it was dragged
+    // to, but stays shrinkable, so when space runs out it scrolls instead of
     // pushing the fill panes off screen.
     const dragged = this._weights[section.id];
     const style = !open
       ? 'flex: 0 0 auto'
       : this._isFill(section)
-        ? `flex: ${weight} 1 0`
-        : `flex: 0 1 ${dragged === undefined ? 'auto' : `${dragged}px`}`;
+        ? `flex: ${weight} 1 ${basis}`
+        : dragged !== undefined
+          ? `flex: 0 1 ${dragged}px`
+          : 'flex: 0 1 auto';
 
     return html`<div class="pane" data-id=${section.id} ?data-open=${open} style=${style}>
       <div

--- a/log-viewer/src/components/__tests__/PaneView.test.ts
+++ b/log-viewer/src/components/__tests__/PaneView.test.ts
@@ -50,6 +50,10 @@ function sash(el: PaneView): HTMLElement {
   return found as HTMLElement;
 }
 
+function paneStyle(el: PaneView, id: string): string {
+  return el.shadowRoot?.querySelector(`.pane[data-id="${id}"]`)?.getAttribute('style') ?? '';
+}
+
 // jsdom has no PointerEvent; the handlers only read the coordinate and pointerId.
 function pointer(type: string, clientY: number): Event {
   return Object.assign(new MouseEvent(type, { clientY, bubbles: true, cancelable: true }), {
@@ -286,7 +290,7 @@ describe('PaneView', () => {
 
     const pane = (id: string) => el.shadowRoot?.querySelector(`.pane[data-id="${id}"]`);
     expect(pane('a')?.getAttribute('style')).toContain('flex: 0 1 auto');
-    expect(pane('b')?.getAttribute('style')).toContain('flex: 1 1 0');
+    expect(pane('b')?.getAttribute('style')).toContain('flex: 1 1 calc(100% / 2)');
   });
 
   it('renders a sash beside a content pane too', async () => {
@@ -319,9 +323,9 @@ describe('PaneView', () => {
     const pane = (id: string) => el.shadowRoot?.querySelector(`.pane[data-id="${id}"]`);
     // A basis, not a weight: it never stretches, and it still shrinks to scroll.
     expect(pane('a')?.getAttribute('style')).toContain('flex: 0 1 500px');
-    // The content pane's size is no part of the fill panes' shares.
-    expect(pane('b')?.getAttribute('style')).toContain('flex: 1.5 1 0');
-    expect(pane('c')?.getAttribute('style')).toContain('flex: 0.5 1 0');
+    // The content pane's size is no part of the fill panes' weights.
+    expect(pane('b')?.getAttribute('style')).toContain('flex: 1.5 1 calc(100% / 3)');
+    expect(pane('c')?.getAttribute('style')).toContain('flex: 0.5 1 calc(100% / 3)');
   });
 
   it('hands a content pane back to its content on a double-click', async () => {
@@ -347,5 +351,60 @@ describe('PaneView', () => {
     // The size is gone rather than zeroed, so the consumer replaces the axis.
     expect(detail?.sizes['vertical:a']).toBeUndefined();
     expect(detail?.orientation).toBe('vertical');
+  });
+
+  describe('fill pane share', () => {
+    const mixed: PaneSection[] = [
+      { id: 'a', title: 'A', content: html`<div>A</div>`, fit: 'content' },
+      { id: 'b', title: 'B', content: html`<div>B</div>`, fit: 'content' },
+      { id: 'c', title: 'C', content: html`<div>C</div>` },
+    ];
+
+    async function mountMixed(
+      orientation: PaneOrientation,
+      props: Partial<PaneView> = {},
+    ): Promise<PaneView> {
+      const el = document.createElement('pane-view') as PaneView;
+      Object.assign(el, { orientation, sections: mixed }, props);
+      document.body.appendChild(el);
+      await el.updateComplete;
+      return el;
+    }
+
+    it('gives the fill pane a share to shrink from, and leaves the content panes alone', async () => {
+      const el = await mountMixed('vertical');
+
+      // Three open panes, so the fill pane starts from a third and grows.
+      expect(paneStyle(el, 'c')).toContain('flex: 1 1 calc(100% / 3)');
+      expect(paneStyle(el, 'a')).toContain('flex: 0 1 auto');
+      expect(paneStyle(el, 'b')).toContain('flex: 0 1 auto');
+    });
+
+    it('widens the share as sections collapse', async () => {
+      const el = await mountMixed('vertical', { collapsed: { b: true } });
+
+      expect(paneStyle(el, 'c')).toContain('flex: 1 1 calc(100% / 2)');
+    });
+
+    it('shares by weight alone once no content pane is open', async () => {
+      const el = await mountMixed('vertical', { collapsed: { a: true, b: true } });
+
+      // One section read on its own gets the whole panel either way, and with
+      // several fill panes a share each would flatten their weights.
+      expect(paneStyle(el, 'c')).toContain('flex: 1 1 0');
+    });
+
+    it('leaves a dragged content pane at the size it was given', async () => {
+      const el = await mountMixed('vertical', { paneSizes: { 'vertical:a': 500 } });
+
+      expect(paneStyle(el, 'a')).toContain('flex: 0 1 500px');
+      expect(paneStyle(el, 'c')).toContain('flex: 1 1 calc(100% / 3)');
+    });
+
+    it('shares nothing side by side, where the axis is the width', async () => {
+      const el = await mountMixed('horizontal');
+
+      expect(paneStyle(el, 'c')).toContain('flex: 1 1 0');
+    });
   });
 });


### PR DESCRIPTION
# 📝 PR Overview

In the Inspector, a fill pane renders with a flex basis of zero, so it can only take space that is left over. Once the sized-to-content sections filled the panel there was none left, and the pane resolved at its `--lana-pane-min` floor: the Call Tree grid dropped to a header and a sliver whenever the sections above it were tall, which is most of the time in a narrow dock.

A fill pane now starts from its equal share of the panel. While the panel is roomy the content sections keep their natural height and the grid grows into the rest; once they fill it every pane shrinks in proportion, so the grid keeps its share and a tall section scrolls inside itself.

## 🛠️ Changes made

- `PaneView` gives an open fill pane a percentage flex basis, its share of the open panes — the grid no longer competes for leftovers that do not exist.
- The basis is zero while every open pane fills, where a share each would take the whole panel and flatten the weights.
- Shrinking, not arithmetic, absorbs the sashes and the collapsed headers, so nothing has to track the panel's fixed chrome.
- A pane dragged to a size still holds it, and the horizontal dock is unchanged: its axis is the width.
- Applies in `PaneView`, so every Inspector tab gets it.

## 🧩 Type of change (check all applicable)

- [x] 🐛 Bug fix - something not working as expected
- [ ] ✨ New feature – adds new functionality
- [ ] ♻️ Refactor - internal changes with no user impact
- [ ] ⚡ Performance Improvement
- [ ] 📝 Documentation - README or documentation site changes
- [ ] 🔧 Chore - dev tooling, CI, config
- [ ] 💥 Breaking change

## 📷 Screenshots / gifs / video [optional]

N/A

## 🔗 Related Issues

related #63

## ✅ Tests added?

- [x] 👍 yes

`PaneView.test.ts`: the share and its widening as sections collapse, weight-only sharing with no content pane open, a dragged pane keeping its size, and no share in the horizontal dock.

## 📚 Docs updated?

- [x] 🙅 not needed

The unreleased Inspector entry already says the sections resize.

## Anything else we need to know? [optional]

Two pre-existing defects found next door, left alone: `_startSash` snapshots every open pane rather than the two beside the sash, so one drag pins the whole stack; and the horizontal dock has no `min-width` counterpart to `--lana-pane-min`.