### PR TITLE
feat(inspector): fit the Database section in a narrow dock

### DIFF
--- a/lana-docs/docs/docs/features/inspector.md
+++ b/lana-docs/docs/docs/features/inspector.md
@@ -25,7 +25,7 @@ It docks to the **right**, **left** or **bottom**, resizes by dragging its edge,
 ### Sections
 
 - **Details** – timing, plus every governor metric the selection consumed as `used / limit`. For SOQL also selectivity, query plan and cardinality, with the query text highlighted and copyable.
-- **Self time by namespace** – Timeline only: the self time under the selection split by the namespace whose code ran it, so you can see whose package burned it.
+- **Self time by namespace** – Timeline only: the self time under the selection split by the namespace whose code ran it, so you can see whose package burned it. Every namespace bar colours the six biggest and gathers the rest into one **others** segment, which names them on hover.
 - **Findings** – Analysis only: which of the log's findings name the selected method or anything it called, so you can tell whether the row you picked is one of the log's problems.
 - **Call stack** – the parent frames that led to the selection, outermost first, with total and self time.
 - **Call tree** – the selection's own execution in **Time Order**, **Aggregated** or **Bottom-Up**, scoped to the selection rather than the whole log like the [Call Tree](./calltree.mdx) tab.
@@ -45,7 +45,7 @@ With nothing selected the inspector reads the whole log. Every tab opens with an
 - **Analysis** – **Findings**: what is slow or wrong in the log, and what to do about it, led by the findings by severity — press any number of them to hold the list to those. A finding whose events the log times also shows how long they took and what that is of the log. Each finding lists the statements behind it, most repeated first; click one to reveal its row in the grid.
   **Self time spread**: how few signatures hold 80% of the log’s self time, then a histogram of per-call self time for each of the busiest repeated signatures, with the median and the 95th call marked. The grid gives an average, which reads the same whether every call is slow or one call is; the shape tells them apart. Move the pointer across a lane to read how many calls a bucket holds. A call the log made once has no shape, so the costliest of them are named under **Ran once**. Only calls the log timed count. Click any row to select its worst call.
 
-Every figure comes from the log itself, so a truncated log, a log without `Rows:` or one without `CUMULATIVE_LIMIT_USAGE` reports less rather than guessing, and says so. Ranked sections list their top eight and account for the rest in a final row. Select a row and every section re-scopes to it.
+Every figure comes from the log itself, so a truncated log, a log without `Rows:` or one without `CUMULATIVE_LIMIT_USAGE` reports less rather than guessing, and says so. Ranked sections list only the top few and account for the rest in a final row. Select a row and every section re-scopes to it.
 
 ### Row actions
 

--- a/log-viewer/src/components/NamespaceTimeBar.ts
+++ b/log-viewer/src/components/NamespaceTimeBar.ts
@@ -20,10 +20,6 @@ import {
   type NamespaceTime,
 } from './namespaceTime.js';
 
-/** A dock-width bar cannot show more segments wide enough to read or hover, so
- *  the rest go to the tail however many colours there are. */
-export const MAX_SEGMENTS = 12;
-
 /** No scope resolved yet, so the first null scope still reads as a change. */
 const UNRESOLVED = Symbol('unresolved scope');
 
@@ -86,16 +82,11 @@ export class NamespaceTimeBar extends LitElement {
     if (!slices.length || !color) {
       return html`<p class="note">No time was recorded here.</p>`;
     }
-    const segments = segmentsWithTail(
-      slices,
-      MAX_SEGMENTS,
-      (slice) => ({
-        label: slice.namespace,
-        value: slice.selfTime,
-        color: color(slice.namespace),
-      }),
-      (slice) => slice.selfTime,
-    );
+    const segments = segmentsWithTail(slices, (slice) => ({
+      label: slice.namespace,
+      value: slice.selfTime,
+      color: color(slice.namespace),
+    }));
 
     return html`<stacked-time-bar
       legend

--- a/log-viewer/src/components/StackedTimeBar.ts
+++ b/log-viewer/src/components/StackedTimeBar.ts
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2026 Certinia Inc. All rights reserved.
  */
-import { LitElement, css, html, svg, type TemplateResult } from 'lit';
+import { LitElement, css, html, svg, type PropertyValues, type TemplateResult } from 'lit';
 import { customElement, property, state } from 'lit/decorators.js';
 import { classMap } from 'lit/directives/class-map.js';
 import { styleMap } from 'lit/directives/style-map.js';
@@ -16,34 +16,43 @@ export interface StackedSegment {
   color: string;
   /** What the segment is made of. Shown in the tip. */
   detail?: string;
+  /** The segments this one stands for. A tail lists them in its tip. */
+  parts?: readonly StackedSegment[];
 }
 
+/** How many of a tail's parts its tip names before it counts the rest. */
+const TIP_PARTS = 5;
+
 /**
- * The first `max` rows as segments, with everything past them gathered into one
- * muted tail, so a bar with more rows than it can colour still totals the whole.
- *
- * The tail reads its size through `sizeOf`, so a row past `max` never pays for a
- * segment that is thrown away.
+ * How many segments a bar colours before the rest go to its tail. Six reads as
+ * two rows of legend in a narrow dock, and a narrower segment is too thin to hit.
+ */
+export const DEFAULT_MAX_SEGMENTS = 6;
+
+/**
+ * Every row as a segment, with those past `max` gathered into one muted tail, so
+ * a bar with more rows than it can colour still totals the whole. The tail
+ * carries the segments it stands for, which its tip names.
  */
 export function segmentsWithTail<T>(
   rows: readonly T[],
-  max: number,
   toSegment: (row: T, index: number) => StackedSegment,
-  sizeOf: (row: T) => number,
+  max: number = DEFAULT_MAX_SEGMENTS,
 ): StackedSegment[] {
-  const segments = rows.slice(0, max).map(toSegment);
-  if (rows.length > max) {
-    let tail = 0;
-    for (let index = max; index < rows.length; index++) {
-      tail += sizeOf(rows[index]!); // in range: below rows.length
-    }
-    segments.push({
-      label: `${formatInteger(rows.length - max)} others`,
-      value: tail,
-      color: 'var(--lana-fg-muted)',
-    });
+  const segments = rows.map(toSegment);
+  if (segments.length <= max) {
+    return segments;
   }
-  return segments;
+  const rest = segments.slice(max);
+  return [
+    ...segments.slice(0, max),
+    {
+      label: `${formatInteger(rest.length)} others`,
+      value: rest.reduce((running, segment) => running + segment.value, 0),
+      color: 'var(--lana-fg-muted)',
+      parts: rest,
+    },
+  ];
 }
 
 /**
@@ -91,6 +100,9 @@ export class StackedTimeBar extends LitElement {
   @state()
   private _pointerPercent: number | null = null;
 
+  /** Lit drops the tip element with the hover, which takes its open state too. */
+  private _tipShown = false;
+
   static styles = [
     globalStyles,
     css`
@@ -118,16 +130,35 @@ export class StackedTimeBar extends LitElement {
         background: var(--lana-fg);
       }
 
-      /* The readout. The legend carries the same figures, but a narrow or
-       scrolled panel can push it out of view, so the bar answers too. It follows
-       the pointer along the bar, and sits below it because above it the section
-       title covers it. */
-      .tip {
+      /* What the tip points at: the pointer's place on the bar, given a box the
+       top-layer tip can anchor to. */
+      .tip-anchor {
         position: absolute;
-        top: calc(100% + var(--lana-space-3xs));
-        z-index: 1;
         pointer-events: none;
-        white-space: nowrap;
+        inset-block: 0;
+        width: var(--lana-stroke);
+        anchor-name: --stacked-bar-tip;
+      }
+
+      /* The readout. The legend carries the same figures, but a narrow or
+       scrolled panel can push it out of view, so the bar answers too. In the top
+       layer, so no pane clips or covers it. */
+      .tip {
+        position: fixed;
+        position-anchor: --stacked-bar-tip;
+        /* Out from the pointer, flipping rather than leaving the window. */
+        position-area: block-end span-inline-end;
+        position-try-fallbacks:
+          flip-block,
+          flip-inline,
+          flip-block flip-inline;
+        /* Rather than strand at stale coordinates once the bar scrolls away. */
+        position-visibility: anchors-visible;
+        inset: auto;
+        margin-block: var(--lana-space-2xs);
+        pointer-events: none;
+        width: max-content;
+        max-width: min(40ch, 90vw);
         font-size: var(--lana-text-sm);
         color: var(--lana-fg);
         padding: var(--lana-space-3xs) var(--lana-space-xs);
@@ -161,10 +192,25 @@ export class StackedTimeBar extends LitElement {
         flex: none;
       }
 
-      .legend__value {
+      .legend__value,
+      .tip__part-value {
         font-family: var(--lana-font-mono);
         font-variant-numeric: tabular-nums;
         color: var(--lana-fg-muted);
+      }
+
+      /* What a tail stands for, one name a line under its own readout. */
+      .tip__parts {
+        display: grid;
+        grid-template-columns: 1fr auto;
+        gap: 0 var(--lana-space-sm);
+        padding-top: var(--lana-space-3xs);
+        color: var(--lana-fg-muted);
+      }
+
+      /* The count of what the tip had no room to name spans both columns. */
+      .tip__parts-rest {
+        grid-column: 1 / -1;
       }
 
       /* Hovering a segment or a legend item singles it out: the others recede and
@@ -213,7 +259,7 @@ export class StackedTimeBar extends LitElement {
     // A bar hover always gets the readout; a legend hover only when the segment
     // has a detail, which the legend itself does not carry. Without that the
     // detail of a sub-pixel segment could not be reached at all.
-    const tipSlice = hover?.onBar || hovered?.detail ? hovered : undefined;
+    const tipSlice = hover?.onBar || hovered?.detail || hovered?.parts ? hovered : undefined;
     // The pointer where we have it, the segment's centre until the first move.
     const tipCenter = this._pointerPercent ?? (tipSlice ? tipSlice.start + tipSlice.width / 2 : 0);
 
@@ -226,7 +272,7 @@ export class StackedTimeBar extends LitElement {
           role="img"
           aria-label=${this.label}
           @pointermove=${this._trackPointer}
-          @pointerleave=${() => (this._pointerPercent = null)}
+          @pointerleave=${this._clearHover}
         >
           ${laid.map(
             (segment) => svg`<rect
@@ -253,25 +299,63 @@ export class StackedTimeBar extends LitElement {
         }
         ${
           tipSlice
-            ? html`<div
-                class="tip"
-                style=${styleMap(
-                  tipCenter <= 50
-                    ? { left: `${tipCenter.toFixed(1)}%` }
-                    : { right: `${(100 - tipCenter).toFixed(1)}%` },
-                )}
-              >
-                ${tipSlice.label} ·
-                ${readout(tipSlice.value, denominator, this.format)}${
-                  tipSlice.detail ? ` · ${tipSlice.detail}` : ''
-                }
-              </div>`
+            ? html`<span
+                  class="tip-anchor"
+                  style=${styleMap({ left: `${tipCenter.toFixed(1)}%` })}
+                ></span>
+                <div class="tip" popover="manual">
+                  ${tipSlice.label} ·
+                  ${readout(tipSlice.value, denominator, this.format)}${
+                    tipSlice.detail ? ` · ${tipSlice.detail}` : ''
+                  }
+                  ${tipSlice.parts ? this._parts(tipSlice.parts, denominator) : ''}
+                </div>`
             : ''
         }
       </div>
       ${this.legend ? this._legend(laid, denominator) : ''}
     `;
   }
+
+  /** The names a tail stands for, biggest first, then a count for any past the list. */
+  private _parts(parts: readonly StackedSegment[], denominator: number): TemplateResult {
+    const rest = parts.length - TIP_PARTS;
+    return html`<span class="tip__parts">
+      ${parts
+        .slice(0, TIP_PARTS)
+        .map(
+          (part) =>
+            html`<span>${part.label}</span>
+              <span class="tip__part-value"
+                >${readout(part.value, denominator, this.format)}</span
+              >`,
+        )}
+      ${rest > 0 ? html`<span class="tip__parts-rest">+${formatInteger(rest)} more</span>` : ''}
+    </span>`;
+  }
+
+  /** A tip in the top layer would outlive the segments it read, so it goes with them. */
+  protected willUpdate(changed: PropertyValues<this>): void {
+    if (changed.has('segments')) {
+      this._clearHover();
+    }
+  }
+
+  /** The tip only reaches the top layer, past every pane's clipping, once shown. */
+  protected updated(): void {
+    const tip = this.renderRoot.querySelector<HTMLElement>('.tip');
+    if (!tip) {
+      this._tipShown = false;
+    } else if (!this._tipShown && typeof tip.showPopover === 'function') {
+      tip.showPopover();
+      this._tipShown = true;
+    }
+  }
+
+  private _clearHover = () => {
+    this._hover = null;
+    this._pointerPercent = null;
+  };
 
   private _trackPointer(event: PointerEvent) {
     const bar = event.currentTarget as SVGElement;

--- a/log-viewer/src/components/__tests__/NamespaceTimeBar.test.ts
+++ b/log-viewer/src/components/__tests__/NamespaceTimeBar.test.ts
@@ -9,7 +9,8 @@ import type { ApexLog } from 'apex-log-parser';
 let apexLog: ApexLog | null = null;
 
 import type { LogStore } from '../../core/log/LogStore.js';
-import { MAX_SEGMENTS, type NamespaceTimeBar } from '../NamespaceTimeBar.js';
+import type { NamespaceTimeBar } from '../NamespaceTimeBar.js';
+import { DEFAULT_MAX_SEGMENTS } from '../StackedTimeBar.js';
 import '../NamespaceTimeBar.js';
 import { logNamespacePalette } from '../namespacePalette.js';
 import { ev, eventByIndex, log, resetEvents, type FakeEvent } from './fixtures/logEvents.js';
@@ -82,10 +83,10 @@ describe('namespace-time-bar', () => {
   });
 
   it('gathers the namespaces past the cap into one tail segment', async () => {
-    const namespaces = Array.from({ length: MAX_SEGMENTS }, (_, index) => `ns${index}`).concat(
-      'nsA',
-      'nsB',
-    );
+    const namespaces = Array.from(
+      { length: DEFAULT_MAX_SEGMENTS },
+      (_, index) => `ns${index}`,
+    ).concat('nsA', 'nsB');
     // Descending self time, so the two smallest fall past the palette.
     logOf(
       namespaces.map((namespace, index) => ev(namespace, (namespaces.length - index) * 10)),
@@ -94,7 +95,7 @@ describe('namespace-time-bar', () => {
 
     const shown = segments(await mount());
 
-    expect(shown).toHaveLength(MAX_SEGMENTS + 1);
+    expect(shown).toHaveLength(DEFAULT_MAX_SEGMENTS + 1);
     // nsA at 20 and nsB at 10.
     expect(shown.at(-1)).toMatchObject({ label: '2 others', value: 30 });
   });

--- a/log-viewer/src/components/__tests__/StackedTimeBar.test.ts
+++ b/log-viewer/src/components/__tests__/StackedTimeBar.test.ts
@@ -76,16 +76,16 @@ describe('stacked-time-bar', () => {
   it('follows the pointer along the bar', async () => {
     const element = await mount(SEGMENTS);
     const bar = element.shadowRoot?.querySelector('svg') as SVGElement;
-    // jsdom lays nothing out, so the bar is given a width to measure against.
-    bar.getBoundingClientRect = () => ({ left: 100, width: 200 }) as DOMRect;
+    // jsdom lays nothing out, so the bar is given a box to measure against.
+    bar.getBoundingClientRect = () => ({ left: 100, width: 200, top: 0, bottom: 10 }) as DOMRect;
 
     element.shadowRoot?.querySelector('rect')?.dispatchEvent(new Event('pointerenter'));
     // jsdom has no PointerEvent, and only clientX is read.
     bar.dispatchEvent(Object.assign(new Event('pointermove'), { clientX: 130 }));
     await element.updateComplete;
 
-    // 30px into 200px: the tip sits at 15%, not the segment's 33% centre.
-    expect(element.shadowRoot?.querySelector('.tip')?.getAttribute('style')).toContain(
+    // 30px into 200px: the tip anchors at 15%, not the segment's 33% centre.
+    expect(element.shadowRoot?.querySelector('.tip-anchor')?.getAttribute('style')).toContain(
       'left:15.0%',
     );
   });
@@ -118,5 +118,68 @@ describe('stacked-time-bar', () => {
     await element.updateComplete;
 
     expect(element.shadowRoot?.querySelector('.tip')?.textContent).toContain('SOQL 200 ms');
+  });
+
+  it('names what a tail stands for when it is hovered', async () => {
+    const element = await mount(
+      [
+        SEGMENTS[0]!,
+        {
+          label: '2 others',
+          value: 100_000_000,
+          color: 'grey',
+          parts: [
+            { label: 'pkgA', value: 60_000_000, color: 'grey' },
+            { label: 'pkgB', value: 40_000_000, color: 'grey' },
+          ],
+        },
+      ],
+      0,
+      true,
+    );
+
+    const items = element.shadowRoot?.querySelectorAll('.legend__item') ?? [];
+    items[1]?.dispatchEvent(new Event('pointerenter'));
+    await element.updateComplete;
+
+    const tip = element.shadowRoot?.querySelector('.tip')?.textContent ?? '';
+    expect(tip).toContain('2 others');
+    expect(tip).toContain('pkgA');
+    expect(tip).toContain('pkgB');
+  });
+
+  it('counts the parts a tip has no room to name', async () => {
+    const parts = Array.from({ length: 7 }, (_, index) => ({
+      label: `pkg${index}`,
+      value: 10_000_000,
+      color: 'grey',
+    }));
+    const element = await mount(
+      [SEGMENTS[0]!, { label: '7 others', value: 70_000_000, color: 'grey', parts }],
+      0,
+      true,
+    );
+
+    const items = element.shadowRoot?.querySelectorAll('.legend__item') ?? [];
+    items[1]?.dispatchEvent(new Event('pointerenter'));
+    await element.updateComplete;
+
+    const tip = element.shadowRoot?.querySelector('.tip')?.textContent ?? '';
+    expect(tip).toContain('pkg4');
+    expect(tip).not.toContain('pkg5');
+    expect(tip).toContain('+2 more');
+  });
+
+  it('drops the tip when the segments change under it', async () => {
+    const element = await mount(SEGMENTS, 1_000_000_000);
+    element.shadowRoot?.querySelector('rect')?.dispatchEvent(new Event('pointerenter'));
+    await element.updateComplete;
+    expect(element.shadowRoot?.querySelector('.tip')).not.toBeNull();
+
+    // A re-scoped section: the hovered segment is gone, and pointerleave never fires.
+    element.segments = [{ label: 'SOSL', value: 50_000_000, color: 'green' }];
+    await element.updateComplete;
+
+    expect(element.shadowRoot?.querySelector('.tip')).toBeNull();
   });
 });

--- a/log-viewer/src/features/database/components/DatabaseOverview.ts
+++ b/log-viewer/src/features/database/components/DatabaseOverview.ts
@@ -36,7 +36,7 @@ import {
  * How many rows a ranked section shows before it defers to the grids beside it.
  * These sections are a springboard: the sortable, complete view is the tab.
  */
-const MAX_ROWS = 8;
+const MAX_ROWS = 5;
 
 /**
  * The room a statement label has. Lines are clauses, not display lines: the row
@@ -167,7 +167,7 @@ export class DatabaseConcentration extends LitElement {
     if (!overview?.ranked.length) {
       return html`<p class="note">${NO_STATEMENTS}</p>`;
     }
-    const { count, percent, total } = concentration(overview);
+    const { count, percent } = concentration(overview);
     const { shown, rest } = topRows(overview.ranked);
     const colors = kindColors(this._palette);
     const databaseNs = overview.time.timeNs;
@@ -176,9 +176,7 @@ export class DatabaseConcentration extends LitElement {
     return html`
       <p class="headline">
         <span class="headline__figure">${formatInteger(count)}</span>
-        of
-        <span class="headline__figure">${formatInteger(total)}</span>
-        statement${total === 1 ? '' : 's'} ·
+        ${count === 1 ? 'statement holds' : 'statements hold'}
         <span class="headline__figure">${shareText(percent)}</span>
         of DB time ·
         <span class="headline__figure">${shareText(overview.time.percentOfLog)}</span>
@@ -188,7 +186,13 @@ export class DatabaseConcentration extends LitElement {
       ${
         rest.length > 0
           ? html`<p class="tail">
-              <span>the other ${formatInteger(rest.length)} statements</span>
+              <span
+                >${
+                  rest.length === 1
+                    ? 'the other statement'
+                    : `the other ${formatInteger(rest.length)} statements`
+                }</span
+              >
               <span class="tail__value"
                 >${shareText(sharePercent(databaseNs - shownNs, databaseNs))}</span
               >
@@ -295,17 +299,12 @@ export class DatabaseNamespaces extends LitElement {
     namespaces: DatabaseBreakdown[],
     color: (namespace: string) => string,
   ) {
-    const segments = segmentsWithTail(
-      namespaces,
-      MAX_ROWS,
-      (row) => ({
-        label: row.key,
-        value: row.timeNs,
-        color: color(row.key),
-        detail: kindSplit(row),
-      }),
-      (row) => row.timeNs,
-    );
+    const segments = segmentsWithTail(namespaces, (row) => ({
+      label: row.key,
+      value: row.timeNs,
+      color: color(row.key),
+      detail: kindSplit(row),
+    }));
 
     return html`
       <div class="bar">

--- a/log-viewer/src/features/database/components/DatabaseRowBudget.ts
+++ b/log-viewer/src/features/database/components/DatabaseRowBudget.ts
@@ -28,7 +28,7 @@ import {
 import { kindColors } from './DatabaseOverview.js';
 import { governorTier } from './GovernorSummary.js';
 
-/** SObjects a bar names before the rest become one tail segment. */
+/** More than a namespace bar: single-hue shades in a wide card, not a dock legend. */
 const MAX_OBJECTS = 8;
 
 const KIND_LABEL: Record<RowBudgetKind, string> = { SOQL: 'Query rows', DML: 'DML rows' };
@@ -197,14 +197,13 @@ function caveat(budgets: readonly RowBudget[]): string {
 function objectSegments(groups: readonly RowGroup[], hue: string): StackedSegment[] {
   return segmentsWithTail(
     groups,
-    MAX_OBJECTS,
     (group, index) => ({
       label: group.sObject,
       value: group.rows,
       color: shade(hue, index),
       detail: `${formatInteger(group.statements)} statement${group.statements === 1 ? '' : 's'}`,
     }),
-    (group) => group.rows,
+    MAX_OBJECTS,
   );
 }
 

--- a/log-viewer/src/features/database/components/__tests__/DatabaseOverview.test.ts
+++ b/log-viewer/src/features/database/components/__tests__/DatabaseOverview.test.ts
@@ -277,7 +277,7 @@ describe('database-concentration', () => {
     const shown = texts(await mount('database-concentration'), '.headline');
 
     // 150ms then 100ms of self time in 300ms crosses 75%.
-    expect(shown).toEqual(['2 of 3 statements · 83.3% of DB time · 30.0% of log']);
+    expect(shown).toEqual(['2 statements hold 83.3% of DB time · 30.0% of log']);
   });
 
   it('gives each row its total, its share, its cost per row and its repeats', async () => {
@@ -354,8 +354,8 @@ describe('database-concentration', () => {
     overview = many;
     const element = await mount('database-concentration');
 
-    expect(texts(element, '.reveal-row')).toHaveLength(8);
-    expect(texts(element, '.tail')[0]).toBe('the other 2 statements 20.0%');
+    expect(texts(element, '.reveal-row')).toHaveLength(5);
+    expect(texts(element, '.tail')[0]).toBe('the other 5 statements 50.0%');
   });
 
   it('renders a query as highlighted SOQL, and a DML as its own text', async () => {
@@ -470,7 +470,7 @@ describe('database-namespaces', () => {
     expect(shown[1]?.segments.map((segment) => segment.label)).toEqual(['pkg', 'trigPkg']);
   });
 
-  it('collapses the namespaces past the eighth into one segment', async () => {
+  it('gathers the namespaces past the sixth into one tail that carries them', async () => {
     const many = fullOverview();
     many.askedBy = Array.from({ length: 10 }, (_ignored, index) => ({
       key: `ns${index}`,
@@ -485,8 +485,11 @@ describe('database-namespaces', () => {
     overview = many;
     const chart = bar(await mount('database-namespaces'));
 
-    expect(chart.segments).toHaveLength(9);
-    expect(chart.segments[8]).toMatchObject({ label: '2 others', value: 30_000_000 });
+    expect(chart.segments).toHaveLength(7);
+    const tail = chart.segments[6]!;
+    expect(tail.label).toBe('4 others');
+    expect(tail.value).toBe(100_000_000);
+    expect(tail.parts?.map((part) => part.label)).toEqual(['ns6', 'ns7', 'ns8', 'ns9']);
   });
 
   it('says so when the log records no statements', async () => {

--- a/log-viewer/src/features/database/services/__tests__/databaseOverview.test.ts
+++ b/log-viewer/src/features/database/services/__tests__/databaseOverview.test.ts
@@ -336,7 +336,7 @@ describe('concentration', () => {
         dml(47_000_000, 52_000_000, 'Insert', 'Case', 1),
     );
 
-    expect(concentration(overview)).toEqual({ count: 1, percent: 75, total: 3 });
+    expect(concentration(overview)).toEqual({ count: 1, percent: 75 });
   });
 
   it('walks on when no single statement dominates', () => {
@@ -345,7 +345,7 @@ describe('concentration', () => {
         soql(21_000_000, 31_000_000, 1, 'SELECT Id FROM Contact'),
     );
 
-    expect(concentration(overview)).toEqual({ count: 2, percent: 100, total: 2 });
+    expect(concentration(overview)).toEqual({ count: 2, percent: 100 });
   });
 
   it('takes a target of its own', () => {
@@ -358,7 +358,7 @@ describe('concentration', () => {
   });
 
   it('reports nothing held for a log with no statements', () => {
-    expect(concentration(overviewOf(''))).toEqual({ count: 0, percent: 0, total: 0 });
+    expect(concentration(overviewOf(''))).toEqual({ count: 0, percent: 0 });
   });
 });
 

--- a/log-viewer/src/features/database/services/databaseOverview.ts
+++ b/log-viewer/src/features/database/services/databaseOverview.ts
@@ -110,7 +110,6 @@ export interface Concentration {
   count: number;
   /** The share those statements hold, 0-100. */
   percent: number;
-  total: number;
 }
 
 /**
@@ -189,10 +188,9 @@ export function concentration(
   overview: DatabaseOverview,
   target = CONCENTRATION_SHARE,
 ): Concentration {
-  const total = overview.ranked.length;
   const databaseNs = overview.time.timeNs;
-  if (!total || databaseNs <= 0) {
-    return { count: 0, percent: 0, total };
+  if (!overview.ranked.length || databaseNs <= 0) {
+    return { count: 0, percent: 0 };
   }
   let held = 0;
   let count = 0;
@@ -203,7 +201,7 @@ export function concentration(
       break;
     }
   }
-  return { count, percent: (held / databaseNs) * 100, total };
+  return { count, percent: (held / databaseNs) * 100 };
 }
 
 /** The kind's own figures on {@link DatabaseTime}. */


### PR DESCRIPTION
# 📝 PR Overview

The Inspector's Database section outgrew a side dock. Eight ranked statements and a headline of four figures made it tall enough to push the panes below it out of view, and a log with many namespaces spent its bar on segments too thin to hit, with a legend that ran to three or four rows.

Five ranked statements now, a headline of two figures, and every namespace bar colours the six biggest and gathers the rest into one muted tail. The tail names what it stands for on hover, with times and shares, so nothing is lost to the cap. The full sortable list is still one click away on the tab's grid.

## 🛠️ Changes made

- One cap for every bar: `DEFAULT_MAX_SEGMENTS` sits beside `segmentsWithTail`, so the bar and its legend cannot disagree. The Row budget's wider card is the single documented override.
- A tail carries the segments it stands for as `parts`, and its tip lists them — the `N others` chip was the segment most likely to be asked about and the only one that answered nothing.
- The tip moves to the top layer with CSS anchor positioning, the pattern `AnchoredPopover` and the grid filters already use. A pane can no longer clip it, it flips rather than leave the window, and it follows the bar when the panel scrolls.
- The hover clears when the segments change, so a tip in the top layer cannot outlive the segment it read.
- The headline reads `N statements hold X% of DB time · Y% of log`, and `Concentration.total` goes with the figure it fed.

## 🧩 Type of change (check all applicable)

- [ ] 🐛 Bug fix - something not working as expected
- [x] ✨ New feature – adds new functionality
- [ ] ♻️ Refactor - internal changes with no user impact
- [ ] ⚡ Performance Improvement
- [ ] 📝 Documentation - README or documentation site changes
- [ ] 🔧 Chore - dev tooling, CI, config
- [ ] 💥 Breaking change

## 📷 Screenshots / gifs / video [optional]

To follow.

## 🔗 Related Issues

related #63

## ✅ Tests added?

- [x] 👍 yes

`StackedTimeBar.test.ts`: the tail's parts in its tip, the cut at five names, the tip following the pointer, and the tip dropping when the segments change under it. `DatabaseOverview.test.ts`: ten namespaces reaching the bar as six plus a tail that carries them.

## 📚 Docs updated?

- [ ] 🔖 README.md
- [ ] 🔖 CHANGELOG.md
- [x] 📖 help site
- [ ] 🧪 Marked any pre-release-only features (README `🧪` badge — see [RELEASING.md](../RELEASING.md#-marking-pre-release-only-features))
- [ ] 🙅 not needed

The Inspector CHANGELOG entry is unreleased and already says "with hover for more details", so it needs no edit.

## Anything else we need to know? [optional]

Needs a look in a light and a dark theme, in the side dock and the bottom dock, before merge.
