### PR TITLE
fix(inspector): count each recursive call once, not once per enclosing call

### DIFF
--- a/log-viewer/src/components/EventVitals.ts
+++ b/log-viewer/src/components/EventVitals.ts
@@ -16,7 +16,9 @@ import { logContext } from '../core/log/logContext.js';
 import type { LogStore } from '../core/log/LogStore.js';
 import { DEFAULT_NAMESPACE, getCallerNamespace } from '../core/utility/CallerNamespace.js';
 import { formatMs } from '../core/utility/Duration.js';
+import { outermostEvents } from '../core/utility/EventTree.js';
 import { formatInteger } from '../core/utility/Util.js';
+import { sumDurationTotalForRootEvents } from '../features/analysis/services/CallStackSum.js';
 import { SOSL_ROWS_PER_QUERY_LIMIT } from '../features/database/limits.js';
 import { globalStyles } from '../styles/global.styles.js';
 
@@ -182,13 +184,14 @@ export class EventVitals extends LitElement {
       this._row(rows, 'Calls', formatInteger(events.length));
     }
 
-    // Aggregates sum their occurrences; a single frame reports its own timing.
-    // Total and self read together, so they share one row.
-    const total = events.reduce((sum, e) => sum + e.duration.total, 0);
+    // A recursive frame's outer call already holds its inner calls, so a total
+    // counts the outermost occurrences only.
+    const total = sumDurationTotalForRootEvents([events]);
     const self = events.reduce((sum, e) => sum + e.duration.self, 0);
     this._row(rows, 'Time', html`${this._ms(total)}${qualifier(`self ${this._ms(self)}`)}`);
     if (isAggregate) {
-      this._row(rows, 'Avg', this._ms(total / events.length));
+      // Self time never nests, so it and the call count cover the same calls.
+      this._row(rows, 'Avg self', this._ms(self / events.length));
     }
 
     this._metricRows(rows, events);
@@ -255,21 +258,25 @@ export class EventVitals extends LitElement {
    */
   private _metricRows(rows: TemplateResult[], events: LogEvent[]): void {
     const limits = this.logStore?.log.governorLimits;
-    // Aggregates sum their occurrences, matching how the grids aggregate a row.
-    const sum = (pick: (e: LogEvent) => SelfTotal, part: 'total' | 'self') =>
-      events.reduce((acc, e) => acc + pick(e)[part], 0);
+    // A total nests and a self reading does not, so each sums the set that holds
+    // it once.
+    const outer = outermostEvents(events);
+    const sumTotal = (pick: (e: LogEvent) => SelfTotal) =>
+      outer.reduce((acc, e) => acc + pick(e).total, 0);
+    const sumSelf = (pick: (e: LogEvent) => SelfTotal) =>
+      events.reduce((acc, e) => acc + pick(e).self, 0);
 
     // A statement's own row count is its headline number, so it shows even at
     // zero ("returned nothing" is a result); other zero metrics stay hidden.
     const alwaysShow = this.type ? `${this.type.toUpperCase()} Rows` : '';
 
     for (const metric of METRICS) {
-      const total = sum(metric.pick, 'total');
+      const total = sumTotal(metric.pick);
       if (!total && metric.label !== alwaysShow) {
         continue;
       }
       const limit = limits ? metric.limit(limits, this.type) : 0;
-      const self = metric.hasSelf === false ? 0 : sum(metric.pick, 'self');
+      const self = metric.hasSelf === false ? 0 : sumSelf(metric.pick);
       const format = metric.bytes ? formatBytes : formatInteger;
       this._row(
         rows,

--- a/log-viewer/src/components/__tests__/EventVitals.test.ts
+++ b/log-viewer/src/components/__tests__/EventVitals.test.ts
@@ -128,11 +128,11 @@ describe('EventVitals', () => {
     expect(labels(el)).not.toContain('Throws');
   });
 
-  it('sums across occurrences and reports Calls/Avg for an aggregate', async () => {
+  it('sums across occurrences and reports Calls/Avg self for an aggregate', async () => {
     const el = await mount(store, { instances: [soqlIndex, soslIndex] });
     const shown = labels(el);
     expect(shown).toContain('Calls');
-    expect(shown).toContain('Avg');
+    expect(shown).toContain('Avg self');
     expect(valueFor(el, 'Calls')).toBe('2');
   });
 
@@ -164,5 +164,32 @@ describe('EventVitals across namespaces', () => {
     expect(valueFor(el, 'Namespace')).toBe('c2g');
     expect(labels(el)).toContain('Caller namespace');
     expect(valueFor(el, 'Caller namespace')).not.toBe('c2g');
+  });
+});
+
+// Its own log: a method that calls itself, so a total and a self reading no
+// longer sum over the same set of calls.
+describe('EventVitals over a recursive frame', () => {
+  const recursiveLog =
+    '09:18:22.6 (0)|EXECUTION_STARTED\n' +
+    '09:18:22.6 (1000000)|CODE_UNIT_STARTED|[EXTERNAL]|066d0000002m8ij|apex://pkg.Entry\n' +
+    '09:18:22.6 (2000000)|METHOD_ENTRY|[1]|01p000000000001|Rec.walk()\n' +
+    '09:18:22.6 (3000000)|METHOD_ENTRY|[1]|01p000000000001|Rec.walk()\n' +
+    '09:18:22.6 (4000000)|METHOD_EXIT|[1]|01p000000000001|Rec.walk()\n' +
+    '09:18:22.6 (6000000)|METHOD_EXIT|[1]|01p000000000001|Rec.walk()\n' +
+    '09:18:22.6 (7000000)|CODE_UNIT_FINISHED|apex://pkg.Entry\n' +
+    '09:18:22.6 (8000000)|EXECUTION_FINISHED\n';
+
+  it('totals the outermost calls, and averages the self time of every call', async () => {
+    const apexLog = parse(recursiveLog);
+    const store = logStoreFor(apexLog);
+    const calls = apexLog.eventsById.filter((e) => e.type === 'METHOD_ENTRY');
+    const el = await mount(store, { instances: calls.map((e) => e.eventIndex) });
+
+    expect(valueFor(el, 'Calls')).toBe('2');
+    // The outer call is 4ms and holds the 1ms inner call, so summing both totals
+    // would read 5ms.
+    expect(valueFor(el, 'Time')).toBe('4.000 ms (self 4.000 ms)');
+    expect(valueFor(el, 'Avg self')).toBe('2.000 ms');
   });
 });

--- a/log-viewer/src/components/__tests__/scopedCallTree.test.ts
+++ b/log-viewer/src/components/__tests__/scopedCallTree.test.ts
@@ -211,6 +211,26 @@ describe('buildScopedCallTree', () => {
     expect(bottomUp?.duration.self).toBe(OCCURRENCES);
   });
 
+  it('an aggregate of nested occurrences counts each one once', async () => {
+    // A recursive frame: the outer call already holds the inner one, so taking
+    // both as roots would walk the inner call twice.
+    const outer = ev(400, 'METHOD_ENTRY', 'rec', { total: 10, self: 4 });
+    const inner = ev(401, 'METHOD_ENTRY', 'rec', { total: 6, self: 6 });
+    outer.parent = root;
+    outer.children = [inner];
+    inner.parent = outer;
+    byId.set(outer.eventIndex, outer);
+    byId.set(inner.eventIndex, inner);
+
+    const tree = (await build(outer.eventIndex, [outer.eventIndex, inner.eventIndex]))!;
+    // The outer call's 10, not 16.
+    expect(tree.rootTotal).toBe(10);
+
+    const [bottomUp] = (await tree.bottomUp(options))!;
+    expect(bottomUp?.callCount).toBe(2);
+    expect(bottomUp?.duration.self).toBe(10);
+  });
+
   it('a merged row names every occurrence behind it, so all of them can be marked', async () => {
     const instances = loopOccurrences(3);
     const tree = (await build(instances[0]!, instances))!;

--- a/log-viewer/src/components/scopedCallTree.ts
+++ b/log-viewer/src/components/scopedCallTree.ts
@@ -4,6 +4,7 @@
 import type { LogEvent } from 'apex-log-parser';
 
 import { currentLogStore } from '../core/log/LogStore.js';
+import { outermostEvents } from '../core/utility/EventTree.js';
 import { EXCLUDED_DETAIL_TYPES } from '../features/call-tree/utils/DetailsFilter.js';
 import {
   CHECK_EVERY,
@@ -89,9 +90,7 @@ export interface ScopedCallTree {
   /** The selected node's total time (ns) — the % denominator for the bars. */
   rootTotal: number;
   /** The whole log's total time (ns). It sizes the bar columns once for the log
-   *  instead of per selection, so the widths stay put as the selection changes.
-   *  An aggregate `rootTotal` sums nested occurrences, so it can read wider than
-   *  this; the column carries enough padding to absorb that. */
+   *  instead of per selection, so the widths stay put as the selection changes. */
   logTotal: number;
   /** The three views, built on first call and cached (only one is on screen).
    *  Each hands the frame back as it works, and returns null when abandoned. */
@@ -188,9 +187,11 @@ export async function buildScopedCallTree(
   // An aggregate selection scopes to every occurrence of the frame; a single
   // selection to just itself.
   const indexes = instances?.length ? instances : eventIndex >= 0 ? [eventIndex] : [];
-  const selectedEvents = indexes
+  const resolved = indexes
     .map((i) => store.eventByIndex(i))
     .filter((e): e is LogEvent => e !== null);
+  // An occurrence inside another would otherwise be walked once per enclosing call.
+  const selectedEvents = outermostEvents(resolved);
   if (!selectedEvents.length) {
     return null;
   }


### PR DESCRIPTION
The inspector inflated every figure for a recursive method. Selecting a method the Analysis grid counts 1,998 times gave a Bottom Up call count of 12,781, with the times raised in step, so the panel disagreed with the grid the user had just clicked.

An aggregate selection took each occurrence as a root and walked its whole subtree. For a recursive frame an occurrence sits inside another, so it was walked once per enclosing call. The fix sums the outermost occurrences only, which is how the grids already sum theirs. Self time never nests, so it and the call count still cover every occurrence.

## Changes

- `scopedCallTree` drops occurrences that sit inside another selected one, so a frame is walked once. This also fixes the Bottom Up call count, which the same root set feeds.
- `EventVitals` takes its Time total from `sumDurationTotalForRootEvents`, the helper the bottom-up grid uses for the same figure, so the two agree.
- Each governor metric total now sums the outermost occurrences and each self reading every occurrence, through two named summers rather than one that switched on a string.
- The former `Avg` row becomes `Avg self`: total self time over the call count. Both count the same calls, so the figure is a true per-call reading, and it matches the grids' existing Avg Self Time columns.

## Test plan

- `pnpm test`
- New case in `scopedCallTree.test.ts`: an aggregate of nested occurrences totals the outer call alone, and counts both calls once.
- New case in `EventVitals.test.ts`: a self-calling method totals the outermost call and averages the self time of every call.
- Manual, Analysis tab on a log with a recursive method: the row's Calls and the inspector's Bottom Up Calls agree.