### PR TITLE
fix(inspector): make the scoped call tree agree with the grid it was opened from

### DIFF
--- a/log-viewer/src/components/CallTreeDetail.ts
+++ b/log-viewer/src/components/CallTreeDetail.ts
@@ -154,6 +154,10 @@ export class CallTreeDetail extends LitElement {
     showPercentageText: true,
   };
 
+  /** The scope's own call count, read by the Calls total. Retargeted per
+   *  selection for the same reason `_barParams` is. */
+  private _scopeCalls = 0;
+
   // The scoped tree (all three representations) for the current eventIndex,
   // computed once per selection and shared across the mode tables.
   private _scoped: ScopedCallTree | null = null;
@@ -458,6 +462,7 @@ export class CallTreeDetail extends LitElement {
     // the formatters read rather than rebuilding the columns around a new total.
     const scoped = this._scoped;
     this._barParams.totalValue = scoped?.rootTotal ?? 0;
+    this._scopeCalls = scoped?.calls ?? 0;
 
     const slot = this._tables[mode];
     if (slot) {
@@ -607,7 +612,11 @@ export class CallTreeDetail extends LitElement {
         field: 'duration.total',
         barWidth,
         barParams,
-        bottomCalc: 'sum',
+        // Tabulator sums the top level only, which is the whole scope in the
+        // grouped modes and overlapping rows in Bottom-Up. The scope's own total
+        // answers in every mode, through `barParams`, which is retargeted per
+        // selection.
+        bottomCalc: () => barParams.totalValue,
         tooltip: (_e, cell: CellComponent) => formatDuration(cell.getValue()),
       }),
       createDurationBarColumn({
@@ -620,7 +629,8 @@ export class CallTreeDetail extends LitElement {
     ];
 
     // Time Order rows are single calls, so a count only makes sense once frames
-    // are grouped (aggregated / bottom-up).
+    // are grouped (aggregated / bottom-up). The column set is built once per mode
+    // and re-filled per selection, so it cannot depend on the selection.
     if (!isTimeOrder) {
       columns.push({
         title: 'Calls',
@@ -634,7 +644,9 @@ export class CallTreeDetail extends LitElement {
         widthShrink: 0,
         cssClass: 'number-cell',
         formatter: (cell: CellComponent) => formatInteger(cell.getValue()),
-        bottomCalc: 'sum',
+        // Aggregated counts a call at its own depth and Bottom-Up counts it in
+        // its leaf row, so neither top level holds them all. The scope does.
+        bottomCalc: () => this._scopeCalls,
       });
     }
 

--- a/log-viewer/src/components/__tests__/CallTreeDetailScopedBuild.test.ts
+++ b/log-viewer/src/components/__tests__/CallTreeDetailScopedBuild.test.ts
@@ -69,6 +69,7 @@ const tables = Tabulator as unknown as { instances: StubTable[] };
 function tree(rootTotal: number): ScopedCallTree {
   return {
     rootTotal,
+    calls: 1,
     logTotal: 5_000_000,
     timeOrder: () => Promise.resolve([]),
     aggregated: () => Promise.resolve([]),

--- a/log-viewer/src/components/__tests__/scopedCallTree.test.ts
+++ b/log-viewer/src/components/__tests__/scopedCallTree.test.ts
@@ -90,54 +90,55 @@ describe('buildScopedCallTree', () => {
     expect(await build(-1)).toBeNull();
   });
 
-  it('time-order: ancestors attributed to the selection, leaf keeps its real duration', async () => {
-    selectedIndex = 4;
+  it('time-order: the selection roots the tree, its callers left out', async () => {
+    selectedIndex = 3;
     const tree = (await build(selectedIndex))!;
-    expect(tree.rootTotal).toBe(200);
+    expect(tree.rootTotal).toBe(500);
 
-    // Single chain root→leaf: exec → m1 → m2 → soql.
+    // m2 down, not exec → m1 → m2 down.
     const chain: ScopedRow[] = [];
     let node: ScopedRow | undefined = (await tree.timeOrder(options))![0];
     while (node) {
       chain.push(node);
       node = node._children?.[0];
     }
-    expect(chain.map((r) => r.text)).toEqual(['exec', 'm1', 'm2', 'SELECT Id FROM Account']);
-    // Ancestors: total = selection total, self 0.
-    for (const ancestor of chain.slice(0, 3)) {
-      expect(ancestor.duration).toEqual({ total: 200, self: 0 });
-    }
-    // The selected leaf keeps its real duration.
-    expect(chain[3]?.duration).toEqual({ total: 200, self: 200 });
+    expect(chain.map((r) => r.text)).toEqual(['m2', 'SELECT Id FROM Account']);
+    // Every duration is the frame's own — nothing is attributed to a caller.
+    expect(chain[0]?.duration).toEqual({ total: 500, self: 0 });
+    expect(chain[1]?.duration).toEqual({ total: 200, self: 200 });
   });
 
-  it('bottom-up: the selected leaf is the top row with callers nested in reverse', async () => {
+  it('bottom-up: a selected leaf is the whole view, with nothing above it', async () => {
     const tree = (await build(4))!;
     const rows = (await tree.bottomUp(options))!;
-    expect(rows.map((r) => r.text)).toEqual(['SELECT Id FROM Account']);
-    const top = rows[0]!;
-    expect(top.duration.self).toBe(200);
 
-    // Callers unwind back up to the root: soql → m2 → m1 → exec.
-    const callers: string[] = [];
-    let node: ScopedRow | undefined = top._children?.[0];
-    while (node) {
-      callers.push(node.text);
-      node = node._children?.[0];
-    }
-    expect(callers).toEqual(['m2', 'm1', 'exec']);
+    expect(rows.map((r) => r.text)).toEqual(['SELECT Id FROM Account']);
+    expect(rows[0]?.duration.self).toBe(200);
+    // Its real callers are outside the scope, so the row stands alone.
+    expect(rows[0]?._children).toBeNull();
+  });
+
+  it('bottom-up: the hottest frame inside the selection heads the view', async () => {
+    // m2 spends none of its time itself; the statement it holds spends all of it.
+    // So the statement heads the view and m2 reads as its caller.
+    const tree = (await build(3))!;
+    const rows = (await tree.bottomUp(options))!;
+
+    expect(rows.map((row) => row.text)).toEqual(['SELECT Id FROM Account']);
+    expect(rows[0]?.duration).toEqual({ total: 200, self: 200 });
+    expect(rows[0]?._children?.map((row) => row.text)).toEqual(['m2']);
   });
 
   it('bottom-up: every caller counts the call it contributed, never zero', async () => {
-    const tree = (await build(4))!;
+    const tree = (await build(3))!;
     const counts: number[] = [];
     let node: ScopedRow | undefined = (await tree.bottomUp(options))![0];
     while (node) {
       counts.push(node.callCount);
       node = node._children?.[0];
     }
-    // soql + its three callers, each crediting the one call.
-    expect(counts).toEqual([1, 1, 1, 1]);
+    // The statement plus m2, its caller inside the scope, each crediting the one call.
+    expect(counts).toEqual([1, 1]);
   });
 
   it('drops zero-duration bookkeeping rows, keeping those with timed descendants', async () => {
@@ -159,6 +160,32 @@ describe('buildScopedCallTree', () => {
     // only way to reach `timed`.
     expect(selected._children!.map((row) => row.text)).toEqual(['[12]']);
     expect(selected._children![0]!._children!.map((row) => row.text)).toEqual(['timed']);
+    // The dropped row is not counted either, so the Calls total matches the rows.
+    expect(tree.calls).toBe(3);
+  });
+
+  it('counts every call the scope holds, so each view totals the same', async () => {
+    const tree = (await build(3))!;
+    const calls = (rows: ScopedRow[]): number => {
+      let total = 0;
+      const stack = [...rows];
+      while (stack.length) {
+        const row = stack.pop()!;
+        total += row.callCount;
+        if (row._children) {
+          stack.push(...row._children);
+        }
+      }
+      return total;
+    };
+
+    // m2 and the statement it holds.
+    expect(tree.calls).toBe(2);
+    expect(calls((await tree.timeOrder(options))!)).toBe(tree.calls);
+    expect(calls((await tree.aggregated(options))!)).toBe(tree.calls);
+    // Bottom-Up heads a row with a frame that spends time, and m2 spends none, so
+    // its own rows fall short of the scope. Hence the total comes from the scope.
+    expect((await tree.bottomUp(options))!.reduce((sum, row) => sum + row.callCount, 0)).toBe(1);
   });
 
   it('keeps the selection itself even when it has no duration', async () => {
@@ -171,7 +198,7 @@ describe('buildScopedCallTree', () => {
   });
 
   it('aggregated: linear path stays one node per frame', async () => {
-    const tree = (await build(4))!;
+    const tree = (await build(3))!;
     const texts: string[] = [];
     let node: ScopedRow | undefined = (await tree.aggregated(options))![0];
     while (node) {
@@ -179,7 +206,7 @@ describe('buildScopedCallTree', () => {
       expect(node.callCount).toBe(1);
       node = node._children?.[0];
     }
-    expect(texts).toEqual(['exec', 'm1', 'm2', 'SELECT Id FROM Account']);
+    expect(texts).toEqual(['m2', 'SELECT Id FROM Account']);
   });
 
   it('builds each view only on first read, then caches it', async () => {
@@ -226,18 +253,66 @@ describe('buildScopedCallTree', () => {
     // The outer call's 10, not 16.
     expect(tree.rootTotal).toBe(10);
 
+    // Both frames spend time, so both seed the one row, and its total is the
+    // outer call's whole cost — the inner call is inside it, not added to it.
     const [bottomUp] = (await tree.bottomUp(options))!;
     expect(bottomUp?.callCount).toBe(2);
-    expect(bottomUp?.duration.self).toBe(10);
+    expect(bottomUp?.duration).toEqual({ total: 10, self: 10 });
+  });
+
+  it('bottom-up: a recursive frame counts the time it shares with itself once', async () => {
+    // rec → work → rec. The outer call's 10 already holds the inner call's 6, so
+    // the row reads 10 and not 16, while both calls' self time is its own.
+    const outer = ev(500, 'METHOD_ENTRY', 'rec', { total: 10, self: 1 });
+    const work = ev(501, 'METHOD_ENTRY', 'work', { total: 9, self: 3 });
+    const inner = ev(502, 'METHOD_ENTRY', 'rec', { total: 6, self: 6 });
+    outer.parent = root;
+    outer.children = [work];
+    work.parent = outer;
+    work.children = [inner];
+    inner.parent = work;
+    byId.set(outer.eventIndex, outer);
+
+    const rows = (await (await build(outer.eventIndex))!.bottomUp(options))!;
+
+    expect(
+      rows.map((row) => [row.text, row.duration.total, row.duration.self, row.callCount]),
+    ).toEqual([
+      ['rec', 10, 7, 2],
+      ['work', 9, 3, 1],
+    ]);
+  });
+
+  it('bottom-up: recursion is the same method, whatever entry the log gave it', async () => {
+    // A code unit that calls itself as a method entry: the Call Tree tab treats
+    // the two as one method, so the inner call's 6 comes off the outer call's 10
+    // here too, leaving 4 + 6 rather than 10 + 6.
+    const outer = ev(510, 'CODE_UNIT_STARTED', 'rec', { total: 10, self: 1 });
+    const inner = ev(511, 'METHOD_ENTRY', 'rec', { total: 6, self: 6 });
+    outer.parent = root;
+    outer.children = [inner];
+    inner.parent = outer;
+    byId.set(outer.eventIndex, outer);
+
+    const tree = (await build(outer.eventIndex))!;
+    const rows = (await tree.bottomUp(options))!;
+
+    expect(rows.map((row) => [row.type, row.duration.total, row.duration.self])).toEqual([
+      ['METHOD_ENTRY', 6, 6],
+      ['CODE_UNIT_STARTED', 4, 1],
+    ]);
+    // The two rows hold the outer call's time once between them.
+    expect(rows.reduce((sum, row) => sum + row.duration.total, 0)).toBe(tree.rootTotal);
   });
 
   it('a merged row names every occurrence behind it, so all of them can be marked', async () => {
     const instances = loopOccurrences(3);
-    const tree = (await build(instances[0]!, instances))!;
+    // The loop, so its three calls merge into one row inside the scope.
+    const tree = (await build(300))!;
 
     const [aggregated] = (await tree.aggregated(options))!;
-    // The instances share one ancestor, so its group names that one frame; the
-    // group beneath it merges all three occurrences.
+    // The selection names its own one frame; the group beneath it merges all
+    // three occurrences.
     expect(aggregated?.eventIndexes).toEqual([300]);
     expect(aggregated?._children?.[0]?.eventIndexes).toEqual(instances);
 
@@ -361,15 +436,15 @@ describe('buildWholeLogCallTree', () => {
 describe('rowIdsByEvent', () => {
   it('finds the merged rows a frame is named by, at every depth', async () => {
     const instances = loopOccurrences(3);
-    const tree = (await build(instances[0]!, instances))!;
+    const tree = (await build(300))!;
     const rows = (await tree.aggregated(options))!;
 
     const byEvent = rowIdsByEvent(rows);
     const groupId = rows[0]!.id;
     const occurrenceId = rows[0]!._children![0]!.id;
 
-    // The caller's own frame names the group above; each occurrence names the
-    // group that merges all three.
+    // The selection names the row above; each occurrence names the group that
+    // merges all three.
     expect(byEvent.get(300)).toEqual([groupId]);
     for (const eventIndex of instances) {
       expect(byEvent.get(eventIndex)).toEqual([occurrenceId]);
@@ -377,8 +452,9 @@ describe('rowIdsByEvent', () => {
   });
 
   it('names one frame in as many rows as stand for it', async () => {
-    const instances = loopOccurrences(2);
-    const tree = (await build(instances[0]!, instances))!;
+    // Rebuilds the loop and its two calls; the loop itself is the selection.
+    loopOccurrences(2);
+    const tree = (await build(300))!;
     const rows = (await tree.bottomUp(options))!;
 
     // Bottom-Up puts the caller under the leaf it called, so frame 300 is named

--- a/log-viewer/src/components/locatedRow.ts
+++ b/log-viewer/src/components/locatedRow.ts
@@ -2,7 +2,11 @@
  * Copyright (c) 2026 Certinia Inc. All rights reserved.
  */
 
+import type { LogEvent } from 'apex-log-parser';
 import type { RowComponent } from 'tabulator-tables';
+
+import type { DetailSelection } from '../core/events/EventBus.js';
+import { occurrencesThrough } from '../features/call-tree/utils/bottomUpOccurrences.js';
 
 /** Class the marked row carries; each table styles it itself. */
 export const LOCATED_ROW_CLASS = 'located-row';
@@ -31,21 +35,89 @@ export function rowIndexStamper(indexField: string): (row: RowComponent) => void
   };
 }
 
-/** A row standing for one call, or for every occurrence of a merged one. */
-interface OccurrenceRow {
-  originalData?: { eventIndex: number };
-  instances?: { eventIndex: number }[];
+/** A row of a merged view: `key` is the bucket it stands for, `instances` the
+ *  occurrences it holds, which a bottom-up caller bucket has none of. */
+interface CallRow {
+  key?: string;
+  text?: string;
+  instances?: LogEvent[];
+  originalData?: LogEvent;
+}
+
+const rowCallData = (row: RowComponent): CallRow => row.getData() as CallRow;
+
+/** Derived calls, held per row: a pointer sweep re-enters rows, and the click
+ *  that follows a hover asks again. Both answers are cached, because deriving
+ *  them reads every occurrence the root bucket holds. */
+const derivedCalls = new WeakMap<CallRow, LogEvent[]>();
+const derivedIndexes = new WeakMap<CallRow, number[]>();
+
+const NO_CALLS: LogEvent[] = [];
+
+/**
+ * The calls a row stands for. A bottom-up caller row holds none of its own, so it
+ * is derived from its root bucket and the chain that reaches it.
+ */
+function rowCallOccurrences(row: RowComponent): LogEvent[] {
+  const data = rowCallData(row);
+  if (data.instances?.length) {
+    return data.instances;
+  }
+  if (data.key === undefined) {
+    return data.originalData ? [data.originalData] : NO_CALLS;
+  }
+  const cached = derivedCalls.get(data);
+  if (cached) {
+    return cached;
+  }
+
+  const chain = [data.key];
+  let root = data;
+  for (let parent = row.getTreeParent(); parent; parent = parent.getTreeParent()) {
+    root = rowCallData(parent);
+    if (root.key === undefined) {
+      derivedCalls.set(data, NO_CALLS);
+      return NO_CALLS;
+    }
+    chain.push(root.key);
+  }
+  // The tree parent is the callee, so the walk runs inwards; the path runs out.
+  const derived = occurrencesThrough(root.instances ?? [], chain.reverse());
+  derivedCalls.set(data, derived);
+  return derived;
+}
+
+/** The calls a row stands for, as the event indexes the mark works in. */
+export function rowOccurrences(row: RowComponent): number[] {
+  const data = rowCallData(row);
+  const cached = derivedIndexes.get(data);
+  if (cached) {
+    return cached;
+  }
+  const indexes = rowCallOccurrences(row).map((event) => event.eventIndex);
+  derivedIndexes.set(data, indexes);
+  return indexes;
 }
 
 /**
- * The events a row stands for: every occurrence of a merged row, the single call
- * of a plain one, and none for a row that holds no event.
+ * What a selected row tells the inspector: a merged row names every call it
+ * counts, a Time Order row the one call it is, and no row nothing.
  */
-export function rowOccurrences(data: OccurrenceRow | undefined): number[] {
-  if (data?.instances?.length) {
-    return data.instances.map((event) => event.eventIndex);
+export function rowDetailSelection(row: RowComponent | undefined): DetailSelection | null {
+  if (!row) {
+    return null;
   }
-  return data?.originalData ? [data.originalData.eventIndex] : [];
+  const data = rowCallData(row);
+  const event = data.originalData;
+  if (!event) {
+    return null;
+  }
+  if (data.key === undefined) {
+    return { kind: 'event', eventIndex: event.eventIndex };
+  }
+  // A bucket stands for its calls even where none derive: `originalData` is the
+  // caller frame, which is the mis-scoping this scoping exists to avoid.
+  return { kind: 'aggregate', instances: rowOccurrences(row), label: data.text ?? event.text };
 }
 
 /**

--- a/log-viewer/src/components/scopedCallTree.ts
+++ b/log-viewer/src/components/scopedCallTree.ts
@@ -6,6 +6,7 @@ import type { LogEvent } from 'apex-log-parser';
 import { currentLogStore } from '../core/log/LogStore.js';
 import { outermostEvents } from '../core/utility/EventTree.js';
 import { EXCLUDED_DETAIL_TYPES } from '../features/call-tree/utils/DetailsFilter.js';
+import { getEventKey, getStackKey } from '../features/call-tree/utils/Aggregation.js';
 import {
   CHECK_EVERY,
   frameBudget,
@@ -13,15 +14,10 @@ import {
   type Tick,
 } from '../core/utility/FrameBudget.js';
 
-/** Frame grouping key — same shape as the call-tree aggregation. */
-function frameKey(event: LogEvent): string {
-  return `${event.type ?? ''}|${event.namespace}|${event.text}`;
-}
-
 /**
- * A row in the scoped call tree. `duration` is attributed to the selection (see
- * {@link buildScopedCallTree}); `originalData` is the real event (used by the
- * name formatter / navigation), so its own duration may differ.
+ * A row in the scoped call tree. `duration` is the frame's own, summed across
+ * the occurrences a merged row stands for; `originalData` is the first of them,
+ * used by the name formatter and navigation.
  */
 export interface ScopedRow {
   id: number;
@@ -89,6 +85,9 @@ export function rowIdsByEvent(rows: readonly ScopedRow[]): Map<number, number[]>
 export interface ScopedCallTree {
   /** The selected node's total time (ns) — the % denominator for the bars. */
   rootTotal: number;
+  /** Every call the scope holds, the selection's own included. Counted once, so
+   *  each view's Calls total answers the same question however it groups. */
+  calls: number;
   /** The whole log's total time (ns). It sizes the bar columns once for the log
    *  instead of per selection, so the widths stay put as the selection changes. */
   logTotal: number;
@@ -97,6 +96,13 @@ export interface ScopedCallTree {
   timeOrder(options: FrameBudgetOptions): Promise<ScopedRow[] | null>;
   aggregated(options: FrameBudgetOptions): Promise<ScopedRow[] | null>;
   bottomUp(options: FrameBudgetOptions): Promise<ScopedRow[] | null>;
+}
+
+/** A built subtree and the frames it kept, so the scope can be counted without a
+ *  second walk. */
+interface Subtree {
+  row: ScopedRow;
+  calls: number;
 }
 
 /**
@@ -109,7 +115,7 @@ export interface ScopedCallTree {
  * Iterative rather than recursive: subtree size is the second unbounded
  * dimension (the occurrence count is the first), and both have to be sliceable.
  */
-async function realSubtree(event: LogEvent, tick: Tick): Promise<ScopedRow | null> {
+async function realSubtree(event: LogEvent, tick: Tick): Promise<Subtree | null> {
   // Pre-order, so a node always precedes its descendants and the prune below
   // can walk it backwards to reach every child before its parent.
   const rows: ScopedRow[] = [];
@@ -138,6 +144,7 @@ async function realSubtree(event: LogEvent, tick: Tick): Promise<ScopedRow | nul
     }
   }
 
+  let calls = 1; // the selection itself
   for (let i = rows.length - 1; i >= 0; i--) {
     if (i % CHECK_EVERY === 0 && !(await tick())) {
       return null;
@@ -154,18 +161,37 @@ async function realSubtree(event: LogEvent, tick: Tick): Promise<ScopedRow | nul
     if (row.duration.total > 0 || row._children || EXCLUDED_DETAIL_TYPES.has(row.type)) {
       const parent = parents[i]!;
       (parent._children ??= []).push(row);
+      calls += 1;
     }
   }
-  return rows[0]!;
+  return { row: rows[0]!, calls };
+}
+
+/** Each event's real subtree as a root row, with the frames they hold between
+ *  them; null when the walk is abandoned. */
+async function subtreeRoots(
+  events: readonly LogEvent[],
+  tick: Tick,
+): Promise<{ roots: ScopedRow[]; calls: number } | null> {
+  const roots: ScopedRow[] = [];
+  let calls = 0;
+  for (const event of events) {
+    const subtree = await realSubtree(event, tick);
+    if (!subtree) {
+      return null;
+    }
+    roots.push(subtree.row);
+    calls += subtree.calls;
+  }
+  return { roots, calls };
 }
 
 /**
- * The call tree filtered to the selected statement: its ancestor path
- * (root→selected) + the selected node + its real subtree, with sibling branches
- * pruned. Ancestors are attributed to the selection (`total = selected.total`,
- * `self = 0`) so the selection's cost reads "all the way down"; the selected
- * node and its descendants keep their real durations. Returns the three views
- * (time-order / aggregated / bottom-up) or null when nothing is selected.
+ * The call tree filtered to the selection: the selected node and its real
+ * subtree, every duration the frame's own. Callers are left out, so each view
+ * answers where the selection's own time went — the same scope a profiler gives
+ * a focused frame. Returns the three views (time-order / aggregated /
+ * bottom-up) or null when nothing is selected.
  *
  * An aggregate selection scopes to every occurrence, and a frame can occur tens
  * of thousands of times, so the walk is sliced: it hands the frame back through
@@ -199,54 +225,35 @@ export async function buildScopedCallTree(
   // Percentages are relative to the whole selection (summed across occurrences).
   const rootTotal = selectedEvents.reduce((sum, e) => sum + e.duration.total, 0);
 
-  // Wrap each occurrence in its ancestor chain, innermost first, attributing that
-  // occurrence's total up its path with no self time. Aggregation then merges
-  // paths that share frames.
   const tick = frameBudget(options);
-  const roots: ScopedRow[] = [];
-  for (let i = 0; i < selectedEvents.length; i++) {
-    if (i % CHECK_EVERY === 0 && !(await tick())) {
-      return null;
-    }
-    const selected = selectedEvents[i]!;
-    const subtree = await realSubtree(selected, tick);
-    if (!subtree) {
-      return null;
-    }
-    let node = subtree;
-    let parent = selected.parent;
-    while (parent && parent !== apexLog) {
-      node = {
-        id: parent.eventIndex,
-        originalData: parent,
-        text: parent.text,
-        type: parent.type ?? '',
-        duration: { total: selected.duration.total, self: 0 },
-        callCount: 1,
-        eventIndexes: null,
-        _children: [node],
-      };
-      parent = parent.parent;
-    }
-    roots.push(node);
+  const scope = await subtreeRoots(selectedEvents, tick);
+  if (!scope) {
+    return null;
   }
 
-  // Many occurrences usually share ancestors, so merge the paths for a
-  // readable tree; a single occurrence keeps its exact chain.
-  return lazyCallTree(roots, rootTotal, apexLog.duration.total, roots.length > 1);
+  // Occurrences of one frame are the same call made again, so merge them into a
+  // single root; a single occurrence is already that.
+  return lazyCallTree(
+    scope.roots,
+    rootTotal,
+    apexLog.duration.total,
+    scope.calls,
+    scope.roots.length > 1,
+  );
 }
 
 /**
  * The three lazy views over a built set of roots. Only one view is on screen,
  * so each is built on first read and cached — aggregate()/buildBottomUp() are
- * full walks of every retained subtree. `mergeTimeOrder` folds occurrences that
- * share ancestors (a scoped aggregate); the whole-log tree and a single
- * occurrence keep their exact order.
+ * full walks of every retained subtree. `mergeTimeOrder` folds the occurrences of
+ * one frame into a single root (a scoped aggregate); the whole-log tree and a
+ * single occurrence keep their exact order.
  */
 function lazyCallTree(
   roots: ScopedRow[],
   rootTotal: number,
   logTotal: number,
+  calls: number,
   mergeTimeOrder: boolean,
 ): ScopedCallTree {
   let timeOrderRows: ScopedRow[] | null = null;
@@ -254,6 +261,7 @@ function lazyCallTree(
   let bottomUpRows: ScopedRow[] | null = null;
   return {
     rootTotal,
+    calls,
     logTotal,
     async timeOrder(viewOptions) {
       timeOrderRows ??= mergeTimeOrder ? await aggregate(roots, viewOptions) : roots;
@@ -272,9 +280,8 @@ function lazyCallTree(
 
 /**
  * The whole log's call tree — every root event with its real subtree and real
- * durations, nothing clamped or attributed. The scoped builder cannot answer
- * this: it exists to model a selection, so it rewrites ancestor durations. Here
- * there is no selection and no ancestors, so every figure is the event's own.
+ * durations. The scoped builder cannot answer this: it starts at a selection,
+ * so it never reaches the roots above one.
  *
  * Same three views, same slicing, same zero-duration-detail pruning as the
  * scoped tree; `rootTotal` and `logTotal` are both the log's total, so bars are
@@ -289,17 +296,19 @@ export async function buildWholeLogCallTree(
   }
 
   const tick = frameBudget(options);
-  const roots: ScopedRow[] = [];
-  for (const event of apexLog.children) {
-    const subtree = await realSubtree(event, tick);
-    if (!subtree) {
-      return null;
-    }
-    roots.push(subtree);
+  const scope = await subtreeRoots(apexLog.children, tick);
+  if (!scope) {
+    return null;
   }
 
   // Already the log's own event order, with real durations — no merging.
-  return lazyCallTree(roots, apexLog.duration.total, apexLog.duration.total, false);
+  return lazyCallTree(
+    scope.roots,
+    apexLog.duration.total,
+    apexLog.duration.total,
+    scope.calls,
+    false,
+  );
 }
 
 /** Top-down aggregation: merge sibling frames sharing a key, summing metrics. */
@@ -316,15 +325,15 @@ async function aggregate(
   async function merge(input: ScopedRow[]): Promise<ScopedRow[] | null> {
     const groups = new Map<string, ScopedRow>();
     const order: string[] = [];
-    // The occurrences behind each group. A set, because the ancestors of the
-    // instances of one frame are the same frame, met once per instance.
+    // The occurrences behind each group — a set, so one frame cannot be listed
+    // twice.
     const indexes = new Map<string, Set<number>>();
     for (let i = 0; i < input.length; i++) {
       if (i % CHECK_EVERY === 0 && !(await tick())) {
         return null;
       }
       const row = input[i]!;
-      const key = frameKey(row.originalData);
+      const key = getEventKey(row.originalData);
       let group = groups.get(key);
       if (!group) {
         group = {
@@ -387,13 +396,37 @@ interface BottomUpNode extends ScopedRow {
  *  walk carries a link per node instead of a copy of the path. */
 interface CallerChain {
   row: ScopedRow;
+  key: string;
   caller: CallerChain | null;
 }
 
+/** A frame on the walk. Both visits share it, so each key is built once and the
+ *  time the frame keeps survives from the first visit to the second. */
+interface WalkEntry {
+  row: ScopedRow;
+  callers: CallerChain | null;
+  key: string;
+  stackKey: string;
+  leaving: boolean;
+  /** The frame's time, less every call of the same frame inside it. */
+  attributed: number;
+  /** The enclosing call of the same frame, restored on the way out. */
+  outer: WalkEntry | null;
+}
+
 /**
- * Bottom-up: each frame with self time seeds a top-level row (ranked by self),
- * and its callers nest beneath it up to the root — the reverse of the call
- * path, with the seed's self time attributed to every caller as `total`.
+ * Bottom-up: a seed frame heads a top-level row and its callers nest beneath it
+ * up to the root — the reverse of the call path, with the seed's time attributed
+ * to every caller as `total`.
+ *
+ * Every frame with self time seeds a row, ranked by self, so the view answers
+ * where the time went inside whatever the rows cover: the selection when they
+ * are scoped to one, else the whole log.
+ *
+ * A row's `total` is its frames' time with recursion counted once: a call of the
+ * same frame inside another comes off the outer call, so the two never both
+ * claim the time they share. This is the attribution the Call Tree tab's
+ * bottom-up uses, so the two agree on a recursive frame.
  */
 async function buildBottomUp(
   rows: ScopedRow[],
@@ -406,8 +439,12 @@ async function buildBottomUp(
   const topOrder: BottomUpNode[] = [];
   const everyNode: BottomUpNode[] = [];
 
-  const ensure = (map: Map<string, BottomUpNode>, order: BottomUpNode[] | null, src: ScopedRow) => {
-    const key = frameKey(src.originalData);
+  const ensure = (
+    map: Map<string, BottomUpNode>,
+    order: BottomUpNode[] | null,
+    src: ScopedRow,
+    key: string,
+  ) => {
     let node = map.get(key);
     if (!node) {
       node = {
@@ -429,23 +466,66 @@ async function buildBottomUp(
     return node;
   };
 
+  // The innermost call of each frame still open on the walk's current path. A
+  // frame's own time is only final once every call of it inside has come off, so
+  // a row is filled in on the way out rather than on the way in. Keyed as the
+  // Call Tree tab keys recursion, without the event type, so a code unit that
+  // recurses as a method entry is the same frame to both.
+  const open = new Map<string, WalkEntry | null>();
+
+  const entryFor = (row: ScopedRow, callers: CallerChain | null): WalkEntry => ({
+    row,
+    callers,
+    key: getEventKey(row.originalData),
+    stackKey: getStackKey(row.originalData),
+    leaving: false,
+    attributed: 0,
+    outer: null,
+  });
+
   // Iterative pre-order over every occurrence's subtree: both the occurrence
   // count and the subtree size grow, so one flat sliceable loop covers both.
-  const stack: Array<{ row: ScopedRow; callers: CallerChain | null }> = [];
+  const stack: WalkEntry[] = [];
   for (let i = rows.length - 1; i >= 0; i--) {
-    stack.push({ row: rows[i]!, callers: null });
+    stack.push(entryFor(rows[i]!, null));
   }
   let steps = 0;
   while (stack.length) {
     if (steps++ % CHECK_EVERY === 0 && !(await tick())) {
       return null;
     }
-    const { row, callers } = stack.pop()!;
+    const entry = stack.pop()!;
+    const { row, callers } = entry;
+    if (!entry.leaving) {
+      const outer = open.get(entry.stackKey) ?? null;
+      if (outer) {
+        // Inside a call of the same frame, so this call's time is already part
+        // of that one's.
+        outer.attributed -= row.duration.total;
+      }
+      entry.outer = outer;
+      entry.attributed = row.duration.total;
+      open.set(entry.stackKey, entry);
+      entry.leaving = true;
+      stack.push(entry);
+      if (row._children) {
+        // Shared by every child, so the ancestor path costs one link per node
+        // rather than a copy of the whole path.
+        const childCallers: CallerChain = { row, key: entry.key, caller: callers };
+        for (let i = row._children.length - 1; i >= 0; i--) {
+          stack.push(entryFor(row._children[i]!, childCallers));
+        }
+      }
+      continue;
+    }
+
+    open.set(entry.stackKey, entry.outer);
+    const attributed = entry.attributed;
     if (row.duration.self > 0) {
       // The seed row, then its callers up to the root. The chain is already in
       // that order, so it is walked in place rather than copied and reversed.
-      const seed = ensure(topMap, topOrder, row);
-      seed.duration.total += row.duration.self;
+      const seed = ensure(topMap, topOrder, row, entry.key);
+      seed.duration.total += attributed;
       seed.duration.self += row.duration.self;
       seed.callCount += 1;
       for (const index of locatableEventIndexes(row)) {
@@ -453,8 +533,8 @@ async function buildBottomUp(
       }
       let map = seed._map;
       for (let link = callers; link; link = link.caller) {
-        const node = ensure(map, null, link.row);
-        node.duration.total += row.duration.self;
+        const node = ensure(map, null, link.row, link.key);
+        node.duration.total += attributed;
         for (const index of locatableEventIndexes(link.row)) {
           node._indexes.add(index);
         }
@@ -463,14 +543,6 @@ async function buildBottomUp(
         // only the seed left every caller row reading "Calls 0".
         node.callCount += 1;
         map = node._map;
-      }
-    }
-    if (row._children) {
-      // Shared by every child, so the ancestor path costs one link per node
-      // rather than a copy of the whole path.
-      const childCallers: CallerChain = { row, caller: callers };
-      for (let i = row._children.length - 1; i >= 0; i--) {
-        stack.push({ row: row._children[i]!, callers: childCallers });
       }
     }
   }

--- a/log-viewer/src/features/analysis/components/AnalysisView.ts
+++ b/log-viewer/src/features/analysis/components/AnalysisView.ts
@@ -14,7 +14,7 @@ import type { ApexLog } from 'apex-log-parser';
 import '../../../components/ContextMenu.js';
 import type { ContextMenu } from '../../../components/ContextMenu.js';
 import { eventBus } from '../../../core/events/EventBus.js';
-import { rowOccurrences } from '../../../components/locatedRow.js';
+import { rowDetailSelection, rowOccurrences } from '../../../components/locatedRow.js';
 import { SelectionEchoGuard } from '../../../core/events/SelectionEchoGuard.js';
 import { isVisible } from '../../../core/utility/Util.js';
 import { getSettings, updateSetting } from '../../settings/Settings.js';
@@ -624,38 +624,25 @@ export class AnalysisView extends LitElement {
     });
 
     // Feed the inspector. Analysis rows merge many calls, so they
-    // scope to every occurrence of the method.
+    // scope to every call they count.
     this.analysisTable.on('rowSelectionChanged', (_data, rows) => {
       if (this._echoGuard.suppressed) {
         return;
       }
-      const data = rows[0]?.getData() as BottomUpRow | undefined;
-      const event = data?.originalData;
-      if (!event) {
-        eventBus.emit('detail:select', { source: 'analysis', selection: null });
-        return;
-      }
-      const occurrences = data.instances?.length ? data.instances : null;
       eventBus.emit('detail:select', {
         source: 'analysis',
-        selection: occurrences
-          ? {
-              kind: 'aggregate',
-              instances: occurrences.map((e) => e.eventIndex),
-              label: data.text ?? event.text,
-            }
-          : { kind: 'event', eventIndex: event.eventIndex },
+        selection: rowDetailSelection(rows[0]),
       });
     });
 
     // Tell the inspector which calls the pointer is over, so it can mark the rows
-    // that stand for them; a bucket merges calls, so it names every occurrence.
+    // that stand for them; a bucket merges calls, so it names every call it counts.
     // The other direction has nothing to land on here: a row is a method bucket,
     // not one event, so the inspector's pointer marks no row in this grid.
     this.analysisTable.on('rowMouseEnter', (_e, row) => {
       eventBus.emit('detail:locate', {
         source: 'analysis',
-        eventIndexes: rowOccurrences(row.getData() as BottomUpRow),
+        eventIndexes: rowOccurrences(row),
       });
     });
     this.analysisTable.on('rowMouseLeave', () => {

--- a/log-viewer/src/features/analysis/components/__tests__/AnalysisView.test.ts
+++ b/log-viewer/src/features/analysis/components/__tests__/AnalysisView.test.ts
@@ -1,0 +1,166 @@
+/*
+ * Copyright (c) 2026 Certinia Inc. All rights reserved.
+ *
+ * @jest-environment jsdom
+ */
+import { afterEach, beforeEach, describe, expect, it } from '@jest/globals';
+import type { ApexLog, LogEvent } from 'apex-log-parser';
+import type { RowComponent, Tabulator } from 'tabulator-tables';
+
+// The grid brings tabulator and its module registrations, which don't load under
+// jest; this suite drives only the selection the view reports to the inspector.
+jest.mock('../../../call-tree/components/BottomUpTable.js', () => ({
+  createBottomUpTable: () => ({
+    table: { on: (name: string, handler: unknown) => handlers.set(name, handler) },
+    // Left pending: the columns are applied on build, and none are set up here.
+    tableBuilt: new Promise<Tabulator>(() => {}),
+  }),
+}));
+// vscode-button needs ElementInternals.setFormValue (absent in jsdom).
+jest.mock('#vscode-elements/vscode-button.js', () => ({}));
+jest.mock('#vscode-elements/vscode-option.js', () => ({}));
+jest.mock('#vscode-elements/vscode-toolbar-button.js', () => ({}));
+
+import {
+  eventBus,
+  type DetailSelection,
+  type DetailSource,
+} from '../../../../core/events/EventBus.js';
+import { toBottomUpTree, type BottomUpRow } from '../../../call-tree/utils/Aggregation.js';
+import { AnalysisView } from '../AnalysisView.js';
+
+const handlers = new Map<string, unknown>();
+
+let nextEventIndex = 0;
+
+function frame(text: string, self: number, total: number, parent: LogEvent | null): LogEvent {
+  const event = {
+    eventIndex: nextEventIndex++,
+    type: 'METHOD_ENTRY',
+    namespace: 'default',
+    text,
+    parent,
+    children: [],
+    duration: { self, total },
+    dmlCount: { self: 0, total: 0 },
+    soqlCount: { self: 0, total: 0 },
+    soslCount: { self: 0, total: 0 },
+    dmlRowCount: { self: 0, total: 0 },
+    soqlRowCount: { self: 0, total: 0 },
+    soslRowCount: { self: 0, total: 0 },
+    thrownCount: { self: 0, total: 0 },
+    heapAllocated: { self: 0, total: 0 },
+    heapGross: { self: 0, total: 0 },
+    heapPeak: 0,
+  } as unknown as LogEvent;
+  parent?.children.push(event);
+  return event;
+}
+
+/** A -> B -> A on one branch, A -> C -> A on the other. */
+function recursiveRoots(): LogEvent[] {
+  const outer1 = frame('A', 10, 100, null);
+  const b1 = frame('B', 20, 90, outer1);
+  frame('A', 70, 70, b1);
+  const outer2 = frame('A', 5, 50, null);
+  const c1 = frame('C', 15, 45, outer2);
+  frame('A', 30, 30, c1);
+  return [outer1, outer2];
+}
+
+function rowComponent(data: BottomUpRow, treeParent?: RowComponent): RowComponent {
+  return {
+    getData: () => data,
+    getTreeParent: () => treeParent ?? false,
+  } as unknown as RowComponent;
+}
+
+function findRow(rows: BottomUpRow[], text: string): BottomUpRow {
+  const row = rows.find((candidate) => candidate.text === text);
+  if (!row) {
+    throw new Error(`Unable to find row for ${text}`);
+  }
+  return row;
+}
+
+describe('analysis-view selection', () => {
+  let view: AnalysisView;
+  let roots: BottomUpRow[];
+  let seen: Array<{ source: DetailSource; selection: DetailSelection | null }>;
+  let off: () => void;
+
+  beforeEach(() => {
+    nextEventIndex = 0;
+    handlers.clear();
+    roots = toBottomUpTree(recursiveRoots());
+    view = new AnalysisView();
+    // The table mounts in a wrapper the view finds in its render root; it has
+    // none until it is updated, so stand one in.
+    view.tableContainer = document.createElement('div');
+    void view._renderAnalysis({} as ApexLog);
+    seen = [];
+    off = eventBus.on('detail:select', (detail) => seen.push(detail));
+  });
+
+  afterEach(() => {
+    off();
+    view.disconnectedCallback();
+  });
+
+  function select(row: RowComponent): void {
+    (handlers.get('rowSelectionChanged') as (data: unknown, rows: RowComponent[]) => void)(null, [
+      row,
+    ]);
+  }
+
+  it('scopes a root row to every call it counts', () => {
+    const rootRow = findRow(roots, 'A');
+
+    select(rowComponent(rootRow));
+
+    expect(seen).toEqual([
+      {
+        source: 'analysis',
+        selection: {
+          kind: 'aggregate',
+          instances: rootRow.instances.map((event) => event.eventIndex),
+          label: 'A',
+        },
+      },
+    ]);
+  });
+
+  it('scopes a caller row to the calls it holds, not the caller frame', () => {
+    const rootRow = findRow(roots, 'A');
+    const throughB = findRow(rootRow._children ?? [], 'B');
+    const throughBA = findRow(throughB._children ?? [], 'A');
+    const throughBComponent = rowComponent(throughB, rowComponent(rootRow));
+
+    select(throughBComponent);
+    select(rowComponent(throughBA, throughBComponent));
+
+    const derived = rootRow.instances.filter((event) => event.parent?.text === 'B');
+    expect(derived).toHaveLength(1);
+    expect(seen.map((detail) => detail.selection)).toEqual([
+      {
+        kind: 'aggregate',
+        instances: derived.map((event) => event.eventIndex),
+        label: 'B',
+      },
+      {
+        kind: 'aggregate',
+        instances: derived.map((event) => event.eventIndex),
+        label: 'A',
+      },
+    ]);
+  });
+
+  it('clears the inspector when the selection goes', () => {
+    (handlers.get('rowSelectionChanged') as (data: unknown, rows: RowComponent[]) => void)(
+      null,
+      [],
+    );
+
+    expect(seen).toEqual([{ source: 'analysis', selection: null }]);
+  });
+});

--- a/log-viewer/src/features/call-tree/components/CalltreeView.ts
+++ b/log-viewer/src/features/call-tree/components/CalltreeView.ts
@@ -63,6 +63,7 @@ import {
 import {
   LOCATED_ROW_CLASS,
   LocatedRowMarker,
+  rowDetailSelection,
   rowIndexStamper,
   rowOccurrences,
 } from '../../../components/locatedRow.js';
@@ -1129,48 +1130,34 @@ export class CalltreeView extends LitElement {
 
   /**
    * Feed the inspector off row selection. A Time Order row is a
-   * single event; Aggregated/Bottom-Up rows merge many calls, so they scope to
-   * every occurrence (`instances`).
+   * single event; an Aggregated/Bottom-Up row merges many calls, so it scopes to
+   * every call it counts.
    */
   private _emitDetailSelection(table: Tabulator, source: DetailSource = 'calltree'): void {
     table.on('rowSelectionChanged', (_data, rows) => {
       if (this._echoGuard.suppressed) {
         return;
       }
-      const data = rows[0]?.getData() as
-        { originalData?: LogEvent; instances?: LogEvent[]; text?: string } | undefined;
-      const event = data?.originalData;
-      if (!event) {
+      const selection = rowDetailSelection(rows[0]);
+      if (!selection) {
         // The selection went with it, and so does a mark a picked inspector row
         // left here — it was never a selection of this table.
         this._locatedRow.mark(this.calltreeTable?.element ?? null, this._emphasis.pick([]));
-        eventBus.emit('detail:select', { source, selection: null });
-        return;
       }
-      const occurrences = data.instances?.length ? data.instances : null;
-      eventBus.emit('detail:select', {
-        source,
-        selection: occurrences
-          ? {
-              kind: 'aggregate',
-              instances: occurrences.map((e) => e.eventIndex),
-              label: data.text ?? event.text,
-            }
-          : { kind: 'event', eventIndex: event.eventIndex },
-      });
+      eventBus.emit('detail:select', { source, selection });
     });
   }
 
   /**
    * Tell the inspector which frames the pointer is over, so it can mark the rows
    * that stand for them. Nothing is picked and nothing moves. An
-   * Aggregated/Bottom-Up row merges many calls, so it names every occurrence.
+   * Aggregated/Bottom-Up row merges many calls, so it names every call it counts.
    */
   private _emitDetailLocate(table: Tabulator, source: DetailSource = 'calltree'): void {
     table.on('rowMouseEnter', (_e, row) => {
       eventBus.emit('detail:locate', {
         source,
-        eventIndexes: rowOccurrences(row.getData() as { originalData?: LogEvent }),
+        eventIndexes: rowOccurrences(row),
       });
     });
     table.on('rowMouseLeave', () => {

--- a/log-viewer/src/features/call-tree/utils/Aggregation.ts
+++ b/log-viewer/src/features/call-tree/utils/Aggregation.ts
@@ -149,7 +149,7 @@ export function getEventKey(event: LogEvent): string {
  * (e.g. CODE_UNIT_STARTED at the top level, METHOD_ENTRY for recursive calls).
  * Matches the approach used by the analysis view's RowGrouper.
  */
-function getStackKey(event: LogEvent): string {
+export function getStackKey(event: LogEvent): string {
   return `${event.namespace}|${event.text}`;
 }
 

--- a/log-viewer/src/features/call-tree/utils/__tests__/Aggregation.test.ts
+++ b/log-viewer/src/features/call-tree/utils/__tests__/Aggregation.test.ts
@@ -4,7 +4,9 @@
 import { beforeEach, describe, expect, it } from '@jest/globals';
 import type { LogEvent } from 'apex-log-parser';
 
-import { toAggregatedCallTree, toBottomUpTree } from '../Aggregation.js';
+import { outermostEvents } from '../../../../core/utility/EventTree.js';
+import { toAggregatedCallTree, toBottomUpTree, type BottomUpRow } from '../Aggregation.js';
+import { occurrencesThrough } from '../bottomUpOccurrences.js';
 
 type EventOptions = {
   text: string;
@@ -1011,6 +1013,78 @@ describe('toBottomUpTree', () => {
     };
 
     assertRowsDoNotExceedGlobalTotals(rows, globalRoot);
+  });
+});
+
+describe('bottom-up caller row scope', () => {
+  beforeEach(() => {
+    nextTimestamp = 1;
+  });
+
+  /** A -> B -> A on one branch, A -> C -> A on the other, so a caller bucket
+   *  reaches a strict subset of the root bucket's occurrences. */
+  function recursiveRoot(): LogEvent {
+    const root = createEvent({ text: 'LOG_ROOT', self: 0, total: 150, type: 'EXECUTION_STARTED' });
+    const outer1 = createEvent({ text: 'A', self: 10, total: 100, parent: root });
+    const b1 = createEvent({ text: 'B', self: 20, total: 90, parent: outer1 });
+    createEvent({ text: 'A', self: 70, total: 70, parent: b1 });
+    const outer2 = createEvent({ text: 'A', self: 5, total: 50, parent: root });
+    const c1 = createEvent({ text: 'C', self: 15, total: 45, parent: outer2 });
+    createEvent({ text: 'A', self: 30, total: 30, parent: c1 });
+    return root;
+  }
+
+  /** Every bucket with the chain that reaches it, root bucket key first. */
+  function bucketsWithPaths(
+    rows: BottomUpRow[],
+    parentPath: string[] = [],
+  ): Array<{ row: BottomUpRow; keyPath: string[] }> {
+    return rows.flatMap((row) => {
+      const keyPath = [...parentPath, row.key];
+      return [{ row, keyPath }, ...bucketsWithPaths(row._children ?? [], keyPath)];
+    });
+  }
+
+  function derivedFor(roots: BottomUpRow[], keyPath: string[]): LogEvent[] {
+    const root = roots.find((candidate) => candidate.key === keyPath[0]);
+    return occurrencesThrough(root?.instances ?? [], keyPath);
+  }
+
+  it('counts one call per occurrence the row derives', () => {
+    const roots = toBottomUpTree(recursiveRoot().children);
+
+    const buckets = bucketsWithPaths(roots);
+    expect(buckets.length).toBeGreaterThan(roots.length);
+    for (const { row, keyPath } of buckets) {
+      expect(derivedFor(roots, keyPath)).toHaveLength(row.callCount);
+    }
+  });
+
+  it('scopes a caller row to the calls made through it, not to every call', () => {
+    const roots = toBottomUpTree(recursiveRoot().children);
+
+    const recursive = findRowByText(roots, 'A');
+    const throughB = findRowByText(recursive._children ?? [], 'B');
+    expect(recursive.callCount).toBe(4);
+    expect(throughB.callCount).toBe(1);
+    expect(derivedFor(roots, [recursive.key, throughB.key])).toEqual([
+      recursive.instances.find((event) => event.parent?.text === 'B'),
+    ]);
+  });
+
+  it('agrees with the row totals the grid shows', () => {
+    const roots = toBottomUpTree(recursiveRoot().children);
+
+    for (const { row, keyPath } of bucketsWithPaths(roots)) {
+      const derived = derivedFor(roots, keyPath);
+      const totalTime = outermostEvents(derived).reduce(
+        (sum, event) => sum + event.duration.total,
+        0,
+      );
+      const selfTime = derived.reduce((sum, event) => sum + event.duration.self, 0);
+      expect(row.totalTime).toBeCloseTo(totalTime, 6);
+      expect(row.totalSelfTime).toBeCloseTo(selfTime, 6);
+    }
   });
 });
 

--- a/log-viewer/src/features/call-tree/utils/__tests__/bottomUpOccurrences.test.ts
+++ b/log-viewer/src/features/call-tree/utils/__tests__/bottomUpOccurrences.test.ts
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2026 Certinia Inc. All rights reserved.
+ */
+import { describe, expect, it } from '@jest/globals';
+import type { LogEvent } from 'apex-log-parser';
+
+import { getEventKey as keyOf } from '../Aggregation.js';
+import { occurrencesThrough } from '../bottomUpOccurrences.js';
+
+let nextEventIndex = 0;
+
+/** A frame carrying only what a bucket key and an ancestor walk read. */
+function frame(text: string, parent: LogEvent | null): LogEvent {
+  const event = {
+    eventIndex: nextEventIndex++,
+    type: 'METHOD_ENTRY',
+    namespace: 'default',
+    text,
+    parent,
+    children: [],
+  } as unknown as LogEvent;
+  parent?.children.push(event);
+  return event;
+}
+
+// A -> B -> A on one branch, A -> C -> A on the other: the two-level recursion
+// the bottom-up root bucket for A holds every occurrence of.
+const outer1 = frame('A', null);
+const b1 = frame('B', outer1);
+const a2 = frame('A', b1);
+const outer2 = frame('A', null);
+const c1 = frame('C', outer2);
+const a3 = frame('A', c1);
+
+const rootInstances = [a2, a3, outer1, outer2];
+
+describe('occurrencesThrough', () => {
+  it('reaches every occurrence for a root row', () => {
+    expect(occurrencesThrough(rootInstances, [keyOf(outer1)])).toEqual(rootInstances);
+  });
+
+  it('reaches the subset a caller row stands for', () => {
+    expect(occurrencesThrough(rootInstances, [keyOf(a2), keyOf(b1)])).toEqual([a2]);
+    expect(occurrencesThrough(rootInstances, [keyOf(a3), keyOf(c1)])).toEqual([a3]);
+  });
+
+  it('follows a two-level recursion up to the outer call', () => {
+    expect(occurrencesThrough(rootInstances, [keyOf(a2), keyOf(b1), keyOf(outer1)])).toEqual([a2]);
+  });
+
+  it('reaches nothing through a chain no occurrence took', () => {
+    expect(occurrencesThrough(rootInstances, [keyOf(a2), keyOf(b1), keyOf(c1)])).toEqual([]);
+    // Past the outermost call there is no ancestor left to match.
+    expect(
+      occurrencesThrough(rootInstances, [keyOf(a2), keyOf(b1), keyOf(outer1), keyOf(b1)]),
+    ).toEqual([]);
+    expect(occurrencesThrough(rootInstances, ['no such key'])).toEqual([]);
+  });
+
+  it('reaches nothing without a path', () => {
+    expect(occurrencesThrough(rootInstances, [])).toEqual([]);
+  });
+});

--- a/log-viewer/src/features/call-tree/utils/bottomUpOccurrences.ts
+++ b/log-viewer/src/features/call-tree/utils/bottomUpOccurrences.ts
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2026 Certinia Inc. All rights reserved.
+ */
+
+import type { LogEvent } from 'apex-log-parser';
+
+/**
+ * Occurrences reached through `keyPath`: `keyPath[0]` is the occurrence itself, so
+ * the root bucket's own key, and the last entry is the bucket being scoped.
+ *
+ * A bottom-up caller bucket stores no occurrences of its own, so they are derived
+ * from the root bucket, which holds every one of them. Storing them per bucket
+ * would cost the sum of all chain depths.
+ *
+ * @param rootInstances - every occurrence the root bucket holds
+ * @param keyPath - the chain that reaches the bucket, the occurrence first
+ */
+export function occurrencesThrough(
+  rootInstances: readonly LogEvent[],
+  keyPath: readonly string[],
+): LogEvent[] {
+  if (!keyPath.length) {
+    return [];
+  }
+  // Split once per call rather than rebuilding a key per frame per level: the
+  // filter runs over every occurrence the root holds, on a pointer move.
+  const path = keyPath.map(splitKey);
+  return rootInstances.filter((instance) => reachedThrough(instance, path));
+}
+
+/** A bucket key's three parts. `text` can itself hold a separator, so only the
+ *  first two are cut. */
+interface KeyParts {
+  type: string;
+  namespace: string;
+  text: string;
+}
+
+function splitKey(key: string): KeyParts {
+  const type = key.indexOf('|');
+  const namespace = key.indexOf('|', type + 1);
+  return {
+    type: key.slice(0, type),
+    namespace: key.slice(type + 1, namespace),
+    text: key.slice(namespace + 1),
+  };
+}
+
+function reachedThrough(instance: LogEvent, path: readonly KeyParts[]): boolean {
+  let frame: LogEvent | null = instance;
+  for (const part of path) {
+    if (
+      !frame ||
+      (frame.type ?? '') !== part.type ||
+      frame.namespace !== part.namespace ||
+      frame.text !== part.text
+    ) {
+      return false;
+    }
+    frame = frame.parent;
+  }
+  return true;
+}


### PR DESCRIPTION
# 📝 PR Overview

Selecting a row in a bottom-up call tree gave the inspector the wrong calls, then reported them wrongly. A row there is labelled by its caller but counts calls of the callee, and the inspector was handed the caller frame. The scoped tree also prepended the whole path from the log root, burying the selection's own work behind several expand arrows, and Bottom Up credited each row its self time as its total, so the Total column repeated Self.

The inspector now scopes to the calls the selected row counts, roots every view at the selection, and counts recursion once. A recursive method reads 11578.276 ms total against 11330.879 ms self, matching the Analysis grid exactly, where before it read the same figure in both columns.

## 🛠️ Changes made

- Derive a caller row's occurrences from its root bucket and the key chain that reaches it. Caller buckets hold none of their own, and storing them per bucket would cost the sum of all chain depths.
- Root Time Order, Aggregated and Bottom Up at the selection and show its subtree, dropping the ancestor path. This is what a focused frame gives in Chrome DevTools and the Firefox Profiler, and the callers are already on screen in the tab the selection came from.
- Give a bottom-up row its frames' time with recursion counted once, keyed as the Call Tree tab keys recursion, so a code unit that recurses as a method entry is one method to both.
- Take both footer totals from the scope. Tabulator sums a data tree's top level only, which holds every call in one mode and overlapping rows in another, so no sum of rows is right in every mode.
- Share one bucket-key helper with the call-tree aggregation, so the two bottom-up builders cannot drift.
- Compare frame fields in the occurrence derivation instead of rebuilding a key per frame per level. It runs on a pointer move, over every occurrence the root bucket holds.

## 🧩 Type of change (check all applicable)

- [x] 🐛 Bug fix - something not working as expected
- [ ] ✨ New feature – adds new functionality
- [ ] ♻️ Refactor - internal changes with no user impact
- [x] ⚡ Performance Improvement
- [ ] 📝 Documentation - README or documentation site changes
- [ ] 🔧 Chore - dev tooling, CI, config
- [ ] 💥 Breaking change

## 📷 Screenshots / gifs / video [optional]

N/A

## 🔗 Related Issues

related #373
related #405

## ✅ Tests added?

- [x] 👍 yes

Unit tests cover the caller-row derivation, the subtree scope, recursion counted once including the type-less case, and the scope's call count. `pnpm test` gives 139 suites and 1879 tests.

Checked by hand on `sample-app/debug-logs/sample-log.log`: selecting `RecursiveSearcher.search(RecursiveSearcher.SimTree)` on the Analysis tab, Bottom Up reads 11578.28 total, 11330.88 self, 1998 calls, matching the grid's first row, and expanding it reads 11479.95 and 1964, matching the second. All three views start at the selection. Light and dark themes, side dock and bottom dock.

## 📚 Docs updated?

- [x] 🙅 not needed

The help site already describes the inspector's call tree as scoped to the selection rather than the whole log, which this makes more true. No CHANGELOG entry: the Inspector is unreleased and its existing entry covers it.

## Anything else we need to know? [optional]

Four items in the same area are still open and are not in this PR: naming the panel by the frame it describes rather than the row's caller label, defaulting the inspector's view mode per source view, labelling the grid's recursion-corrected cell against the inspector's inclusive total, and two-way highlight and navigation across all three views.