### PR TITLE
fix: keep large logs off the argument limit, and state the speed and memory trade

### DIFF
--- a/.claude/rules/log-viewer.md
+++ b/.claude/rules/log-viewer.md
@@ -15,6 +15,9 @@ Webview UI.
 
 - Parse + render: `<5MB` in `<1s`, `10MB` in `<3s`, `20MB+` in `<5s`. Benchmark on `sample-app/` logs.
 - Nothing synchronous over 50ms. Show progress over 100ms.
+- Be fast and never block.
+- Keep memory low, even at the cost of speed.
+- Weigh that trade in every change, and measure it.
 
 ## Theme
 

--- a/lana-docs/docs/docs/features/inspector.md
+++ b/lana-docs/docs/docs/features/inspector.md
@@ -60,11 +60,11 @@ Right-click a row in the **Call stack** or **Call tree** for:
 
 Press `Escape` to clear the selection on the tab you're on; the inspector returns to its whole-log view.
 
-Clicking a row highlights the matching frame or row in the tab you're on, and never switches tab: the Timeline selects the frame and centers it when it's off screen, the Call Tree scrolls to it in **Time Order**, and the Database tab selects the statement. Rows in the Call tree's **Aggregated** and **Bottom-Up** views merge several occurrences, so there is no single frame to select; clicking one marks every occurrence instead, and nothing moves. Arrow keys move between rows, and `CMD / CTRL + c` copies the table.
+Clicking a row highlights the matching frame or row in the tab you're on, and never switches tab: the Timeline selects the frame and centers it when it's off screen, the Call Tree scrolls to it in every view, and the Database tab selects the statement. Rows in the Call tree's **Aggregated** and **Bottom-Up** views merge several occurrences, so clicking one marks every occurrence, goes to the first, and reads the details of the calls it counts. Focus stays in the inspector, so the arrow keys keep moving there. Arrow keys move between rows, and `CMD / CTRL + c` copies the table.
 
 Hovering works both ways and moves nothing — no selection, no scroll, no pan:
 
-- Hover an inspector row to pick out what it names in the tab you're on: the Timeline dims around the frame, and the Call Tree and Database tables mark the row. A row that merges several occurrences marks all of them.
+- Hover an inspector row to pick out what it names in the tab you're on: the Timeline dims around the frame, and the Call Tree, Analysis and Database tables mark the row. A row that merges several occurrences marks all of them.
 - Hover a frame, row or statement in the tab you're on to mark the inspector rows that name it, where they are already on screen. Analysis rows are method totals rather than single calls, so they mark nothing.
 
 What you clicked stays picked out as the pointer moves away, so you can read the Timeline or a table with it still marked. `Escape` clears it.

--- a/lana/src/symbols/RawLogSymbolProvider.ts
+++ b/lana/src/symbols/RawLogSymbolProvider.ts
@@ -81,7 +81,9 @@ class RawLogSymbolProvider implements DocumentSymbolProvider {
         symbols.push(symbol);
       } else {
         // No foldable range for this event; lift its descendants to this level.
-        symbols.push(...children);
+        for (const child of children) {
+          symbols.push(child);
+        }
       }
     }
 

--- a/lana/src/symbols/RawLogSymbolProvider.ts
+++ b/lana/src/symbols/RawLogSymbolProvider.ts
@@ -81,6 +81,7 @@ class RawLogSymbolProvider implements DocumentSymbolProvider {
         symbols.push(symbol);
       } else {
         // No foldable range for this event; lift its descendants to this level.
+        // Pushed one at a time: a spread would overrun the argument limit.
         for (const child of children) {
           symbols.push(child);
         }

--- a/log-viewer/src/components/CallTreeDetail.ts
+++ b/log-viewer/src/components/CallTreeDetail.ts
@@ -33,6 +33,7 @@ import { soqlSyntaxStyles } from '../features/soql/styles/soql-syntax.css.js';
 import { globalStyles } from '../styles/global.styles.js';
 import { progressColumnWidth } from '../tabulator/format/measureWidth.js';
 import type { ProgressParams } from '../tabulator/format/ProgressMS.js';
+import { tableHolder } from '../tabulator/module/tableHolder.js';
 import dataGridStyles from '../tabulator/style/DataGrid.scss';
 import './ContextMenu.js';
 import type { ContextMenu } from './ContextMenu.js';
@@ -352,14 +353,10 @@ export class CallTreeDetail extends LitElement {
     // Already where it belongs, which is the usual case: the row the walk
     // reports is the row the user just picked here. Selecting it again re-renders
     // it, and tabulator's row re-render takes the table's focus with it.
-    //
-    // `id` is read from the data, never `getIndex()`: that routes through
-    // Tabulator's accessor, which deep-clones the row data — and our rows hold
-    // the parsed log, so one call walks the whole graph.
     if (selected.length === 1 && rowId(selected[0]) === this.activeEventIndex) {
       return;
     }
-    const holder = this._tableHolder(this.viewMode);
+    const holder = tableHolder(this._tableHost(this.viewMode));
     const root = holder?.getRootNode();
     const hadFocus = root instanceof ShadowRoot && root.activeElement === holder;
     this._echoGuard.run(() => {
@@ -374,10 +371,6 @@ export class CallTreeDetail extends LitElement {
     if (hadFocus) {
       holder?.focus({ preventScroll: true });
     }
-  }
-
-  private _tableHolder(mode: ViewMode): HTMLElement | null {
-    return this._tableHost(mode)?.querySelector<HTMLElement>('.tabulator-tableholder') ?? null;
   }
 
   /**

--- a/log-viewer/src/components/CallTreeDetail.ts
+++ b/log-viewer/src/components/CallTreeDetail.ts
@@ -37,7 +37,12 @@ import dataGridStyles from '../tabulator/style/DataGrid.scss';
 import './ContextMenu.js';
 import type { ContextMenu } from './ContextMenu.js';
 import { dispatchInspectorLocate, dispatchInspectorReveal } from './inspectorReveal.js';
-import { LOCATED_ROW_CLASS, LocatedRowMarker, rowIndexStamper } from './locatedRow.js';
+import {
+  LOCATED_ROW_CLASS,
+  LocatedRowMarker,
+  rowId,
+  rowIndexStamper,
+} from './locatedRow.js';
 import { PANEL_ROW_MENU_ITEMS, runPanelRowAction } from './panelRowMenu.js';
 import {
   buildScopedCallTree,
@@ -338,26 +343,46 @@ export class CallTreeDetail extends LitElement {
   }
 
   /**
-   * Marks the active frame, without reporting it as a new pick. Only rows keyed by
-   * event can be selected by index, so the grouped views have nothing to mark.
+   * Marks the active frame, without reporting it as a new pick. Only rows keyed
+   * by event can be selected by index, so a view whose rows merge occurrences
+   * keeps the row the user picked: clearing it would take away the row the
+   * keyboard moves from.
    */
   private _markActive(): void {
     const table = this._tables[this.viewMode]?.table;
-    if (!table) {
+    if (!table || this.viewMode !== 'time-order' || this._scoped?.timeOrderMerged) {
       return;
     }
+    const selected = table.getSelectedRows();
+    // Already where it belongs, which is the usual case: the row the walk
+    // reports is the row the user just picked here. Selecting it again re-renders
+    // it, and tabulator's row re-render takes the table's focus with it.
+    //
+    // `id` is read from the data, never `getIndex()`: that routes through
+    // Tabulator's accessor, which deep-clones the row data — and our rows hold
+    // the parsed log, so one call walks the whole graph.
+    if (selected.length === 1 && rowId(selected[0]) === this.activeEventIndex) {
+      return;
+    }
+    const holder = this._tableHolder(this.viewMode);
+    const root = holder?.getRootNode();
+    const hadFocus = root instanceof ShadowRoot && root.activeElement === holder;
     this._echoGuard.run(() => {
-      for (const selected of table.getSelectedRows()) {
-        selected.deselect();
+      for (const row of selected) {
+        row.deselect();
       }
-      if (
-        this.viewMode === 'time-order' &&
-        !this._scoped?.timeOrderMerged &&
-        this.activeEventIndex >= 0
-      ) {
+      if (this.activeEventIndex >= 0) {
         table.selectRow([this.activeEventIndex]);
       }
     });
+    // The re-render above drops focus, so the keyboard keeps its place here.
+    if (hadFocus) {
+      holder?.focus({ preventScroll: true });
+    }
+  }
+
+  private _tableHolder(mode: ViewMode): HTMLElement | null {
+    return this._tableHost(mode)?.querySelector<HTMLElement>('.tabulator-tableholder') ?? null;
   }
 
   /**

--- a/log-viewer/src/components/CallTreeDetail.ts
+++ b/log-viewer/src/components/CallTreeDetail.ts
@@ -142,7 +142,13 @@ export class CallTreeDetail extends LitElement {
 
   /** A built table. `stale` means it holds a previous selection's rows, so it
    *  needs re-filling before it is shown again. */
-  private _tables: Record<ViewMode, { table: Tabulator; stale: boolean } | null> = {
+  private _tables: Record<
+    ViewMode,
+    /** `rows` is the data the table was filled with. Never read it back with
+     *  `getData()`: that runs Tabulator's accessors, which deep-clone the row
+     *  data, and our rows hold the parsed log. */
+    { table: Tabulator; stale: boolean; rows: ScopedRow[] } | null
+  > = {
     'time-order': null,
     aggregated: null,
     'bottom-up': null,
@@ -185,6 +191,9 @@ export class CallTreeDetail extends LitElement {
 
   /** Marks the row for the frame under the pointer in the tab's own view. */
   private _locatedRow = new LocatedRowMarker();
+  // The frames the tab on screen last reported under its pointer, so a table
+  // that finishes building after the report still marks them.
+  private _locatedEvents: readonly number[] = [];
   private _locateUnsubscribe?: () => void;
   private _selectionClearUnsubscribe?: () => void;
 
@@ -218,10 +227,8 @@ export class CallTreeDetail extends LitElement {
   connectedCallback(): void {
     super.connectedCallback();
     this._locateUnsubscribe = eventBus.on('detail:locate', ({ eventIndexes }) => {
-      this._locatedRow.mark(
-        this._tableHost(this.viewMode),
-        this._rowIdsFor(this.viewMode, eventIndexes),
-      );
+      this._locatedEvents = eventIndexes;
+      this._markLocated();
     });
     // Escape clears the selection of the tab on screen. A picked row here is no
     // selection of that view, so this table drops its own.
@@ -237,13 +244,24 @@ export class CallTreeDetail extends LitElement {
    * grouped row merges occurrences behind a synthetic id, so it is found by the
    * occurrences it carries — and one frame can name several rows in Bottom-Up.
    */
+  private _markLocated(): void {
+    this._locatedRow.mark(
+      this._tableHost(this.viewMode),
+      this._rowIdsFor(this.viewMode, this._locatedEvents),
+    );
+  }
+
   private _rowIdsFor(mode: ViewMode, eventIndexes: readonly number[]): number[] {
     if ((mode === 'time-order' && !this._scoped?.timeOrderMerged) || !eventIndexes.length) {
       return [...eventIndexes];
     }
-    const byEvent = (this._rowsByEvent[mode] ??= rowIdsByEvent(
-      (this._tables[mode]?.table.getData() ?? []) as ScopedRow[],
-    ));
+    const rows = this._tables[mode]?.rows ?? [];
+    if (!rows.length) {
+      // Still building. Caching the map now would hold an empty one for the life
+      // of the scope, since only a new scope clears it.
+      return [];
+    }
+    const byEvent = (this._rowsByEvent[mode] ??= rowIdsByEvent(rows));
     const ids = new Set<number>();
     for (const eventIndex of eventIndexes) {
       for (const id of byEvent.get(eventIndex) ?? []) {
@@ -473,6 +491,7 @@ export class CallTreeDetail extends LitElement {
       // Those rows belong to the previous selection and the build below spans
       // several frames — clear them rather than leave them standing under a
       // selection they don't describe.
+      built.rows = [];
       void built.table.setData([]);
     }
     const data = await this._rows(mode, { yieldFrame: waitForNextFrame, signal });
@@ -489,7 +508,12 @@ export class CallTreeDetail extends LitElement {
     const slot = this._tables[mode];
     if (slot) {
       slot.stale = false;
-      void slot.table.setData(data).then(() => this._markActive());
+      slot.rows = data;
+      this._rowsByEvent[mode] = null;
+      void slot.table.setData(data).then(() => {
+        this._markActive();
+        this._markLocated();
+      });
       return;
     }
     if (!scoped) {
@@ -591,8 +615,9 @@ export class CallTreeDetail extends LitElement {
     });
     table.on('tableBuilt', () => {
       this._markActive();
+      this._markLocated();
     });
-    this._tables[mode] = { table, stale: false };
+    this._tables[mode] = { table, stale: false, rows: data };
   }
 
   /** Row right-click menu: reveal in the Call Tree tab, or copy the frame. */

--- a/log-viewer/src/components/CallTreeDetail.ts
+++ b/log-viewer/src/components/CallTreeDetail.ts
@@ -37,12 +37,7 @@ import dataGridStyles from '../tabulator/style/DataGrid.scss';
 import './ContextMenu.js';
 import type { ContextMenu } from './ContextMenu.js';
 import { dispatchInspectorLocate, dispatchInspectorReveal } from './inspectorReveal.js';
-import {
-  LOCATED_ROW_CLASS,
-  LocatedRowMarker,
-  rowId,
-  rowIndexStamper,
-} from './locatedRow.js';
+import { LOCATED_ROW_CLASS, LocatedRowMarker, rowId, rowIndexStamper } from './locatedRow.js';
 import { PANEL_ROW_MENU_ITEMS, runPanelRowAction } from './panelRowMenu.js';
 import {
   buildScopedCallTree,
@@ -581,7 +576,15 @@ export class CallTreeDetail extends LitElement {
       if (eventIndex !== null) {
         dispatchInspectorReveal(this, eventIndex);
       } else {
-        dispatchInspectorLocate(this, locatableEventIndexes(data), true);
+        // The same aggregate a merged row in the tab itself reports, so Details
+        // reads the same either way. Built from the row: a scoped row carries no
+        // key, which is what the tab's own rows are read through.
+        const instances = locatableEventIndexes(data);
+        dispatchInspectorLocate(this, instances, true, {
+          kind: 'aggregate',
+          instances,
+          calledBy: this.viewMode === 'bottom-up' ? callerOfRow(rows[0]) : undefined,
+        });
       }
     });
     // Hovering a row marks it in the tab on screen, so the user can see where it
@@ -738,4 +741,22 @@ export class CallTreeDetail extends LitElement {
     this._locatedRow.clear();
     this.viewMode = mode;
   }
+}
+
+/**
+ * The frame that called a bottom-up row's own calls: the caller shown directly
+ * above the row's seed. A tree parent is the callee there, so the walk runs to
+ * the row one level below the top.
+ */
+function callerOfRow(row: RowComponent | undefined): string | undefined {
+  let node = row;
+  let parent = node?.getTreeParent();
+  if (!node || !parent) {
+    return undefined;
+  }
+  for (let above = parent.getTreeParent(); above; above = parent.getTreeParent()) {
+    node = parent;
+    parent = above;
+  }
+  return (node.getData() as Partial<ScopedRow>).text;
 }

--- a/log-viewer/src/components/LogInspector.ts
+++ b/log-viewer/src/components/LogInspector.ts
@@ -90,6 +90,7 @@ export class LogInspector extends LitElement {
     super();
     this._unsubscribe.push(
       eventBus.on('detail:select', (d) => this._onSelect(d)),
+      eventBus.on('detail:view', (d) => this._onView(d)),
       eventBus.on('detail:toggle', (d) => this._onToggle(d)),
     );
     getSettings()
@@ -210,6 +211,16 @@ export class LogInspector extends LitElement {
 
   private _setScope(scope: InspectorScope): void {
     this._scope = scope;
+    this._scheduleRebuild();
+  }
+
+  /** A tab turned its own tree around, so what the inspector should answer with
+   *  changed even though the selection did not. */
+  private _onView(detail: { source: DetailSource; view: SelectionView }): void {
+    if (this._sourceViews.get(detail.source) === detail.view) {
+      return;
+    }
+    this._sourceViews.set(detail.source, detail.view);
     this._scheduleRebuild();
   }
 

--- a/log-viewer/src/components/LogInspector.ts
+++ b/log-viewer/src/components/LogInspector.ts
@@ -59,13 +59,11 @@ export class LogInspector extends LitElement {
 
   // Latest selection per source; the bar renders the active tab's entry.
   private _selections = new Map<DetailSource, DetailSelection>();
-  // The frame walked to inside that selection's call stack, per source. Held
-  // apart from the selection so the call stack keeps its anchor while Details
-  // and the call tree follow the walk.
-  private _activeFrames = new Map<DetailSource, number>();
-  // What a picked inspector row stands for, where it merges occurrences and so
-  // names no single frame to walk to. Details describes this instead.
-  private _activeBuckets = new Map<DetailSource, DetailSelection>();
+  // What the inspector has walked to inside that selection, per source: one
+  // frame, or the calls a picked row counts where its rows merge occurrences.
+  // Held apart from the selection so the call stack keeps its anchor while
+  // Details and the call tree follow the walk.
+  private _active = new Map<DetailSource, DetailSelection>();
 
   /** The direction each tab is showing, so the inspector can open on the other. */
   private _sourceViews = new Map<DetailSource, SelectionView | undefined>();
@@ -233,8 +231,7 @@ export class LogInspector extends LitElement {
     view?: SelectionView;
   }): void {
     // A pick in the tab itself is a new anchor, so any walk down the old stack ends.
-    this._activeFrames.delete(detail.source);
-    this._activeBuckets.delete(detail.source);
+    this._active.delete(detail.source);
     this._sourceViews.set(detail.source, detail.view);
     if (detail.selection) {
       this._selections.set(detail.source, detail.selection);
@@ -270,8 +267,7 @@ export class LogInspector extends LitElement {
     // Without a selection the sections are the whole-log ones, which have no
     // frame to follow; the whole-log rows only reveal.
     if (this._scopedSelection(source)) {
-      this._activeFrames.set(source, e.detail.eventIndex);
-      this._activeBuckets.delete(source);
+      this._active.set(source, { kind: 'event', eventIndex: e.detail.eventIndex });
       this._scheduleRebuild();
     }
   };
@@ -291,11 +287,20 @@ export class LogInspector extends LitElement {
       eventIndexes: e.detail.eventIndexes,
       sticky: e.detail.sticky,
     });
-    // A picked row that merges occurrences has no frame to walk to, so what it
-    // counts is what Details answers about.
-    if (e.detail.sticky && e.detail.selection && this._scopedSelection(source)) {
-      this._activeFrames.delete(source);
-      this._activeBuckets.set(source, e.detail.selection);
+    if (!e.detail.sticky || !this._scopedSelection(source)) {
+      return;
+    }
+    if (!e.detail.eventIndexes.length) {
+      // The pick is being dropped, which hands Details back to the tab's own
+      // selection.
+      if (this._active.delete(source)) {
+        this._scheduleRebuild();
+      }
+    } else if (e.detail.selection) {
+      // A picked row that merges occurrences has no frame to walk to, so what it
+      // counts is what Details answers about. A sticky mark with no such row
+      // leaves the walk where it is.
+      this._active.set(source, e.detail.selection);
       this._scheduleRebuild();
     }
   };
@@ -342,9 +347,8 @@ export class LogInspector extends LitElement {
       ? await buildDetailSections(
           source,
           this._scopedSelection(source),
-          this._activeFrames.get(source) ?? null,
+          this._active.get(source) ?? null,
           this._sourceViews.get(source),
-          this._activeBuckets.get(source) ?? null,
         )
       : [];
     // Drop a slow build that a newer selection already superseded.

--- a/log-viewer/src/components/LogInspector.ts
+++ b/log-viewer/src/components/LogInspector.ts
@@ -63,6 +63,9 @@ export class LogInspector extends LitElement {
   // apart from the selection so the call stack keeps its anchor while Details
   // and the call tree follow the walk.
   private _activeFrames = new Map<DetailSource, number>();
+  // What a picked inspector row stands for, where it merges occurrences and so
+  // names no single frame to walk to. Details describes this instead.
+  private _activeBuckets = new Map<DetailSource, DetailSelection>();
 
   /** The direction each tab is showing, so the inspector can open on the other. */
   private _sourceViews = new Map<DetailSource, SelectionView | undefined>();
@@ -231,6 +234,7 @@ export class LogInspector extends LitElement {
   }): void {
     // A pick in the tab itself is a new anchor, so any walk down the old stack ends.
     this._activeFrames.delete(detail.source);
+    this._activeBuckets.delete(detail.source);
     this._sourceViews.set(detail.source, detail.view);
     if (detail.selection) {
       this._selections.set(detail.source, detail.selection);
@@ -267,6 +271,7 @@ export class LogInspector extends LitElement {
     // frame to follow; the whole-log rows only reveal.
     if (this._scopedSelection(source)) {
       this._activeFrames.set(source, e.detail.eventIndex);
+      this._activeBuckets.delete(source);
       this._scheduleRebuild();
     }
   };
@@ -286,6 +291,13 @@ export class LogInspector extends LitElement {
       eventIndexes: e.detail.eventIndexes,
       sticky: e.detail.sticky,
     });
+    // A picked row that merges occurrences has no frame to walk to, so what it
+    // counts is what Details answers about.
+    if (e.detail.sticky && e.detail.selection && this._scopedSelection(source)) {
+      this._activeFrames.delete(source);
+      this._activeBuckets.set(source, e.detail.selection);
+      this._scheduleRebuild();
+    }
   };
 
   /** Drops a mark left behind by a pointer that never left the row. Sticky, so a
@@ -332,6 +344,7 @@ export class LogInspector extends LitElement {
           this._scopedSelection(source),
           this._activeFrames.get(source) ?? null,
           this._sourceViews.get(source),
+          this._activeBuckets.get(source) ?? null,
         )
       : [];
     // Drop a slow build that a newer selection already superseded.

--- a/log-viewer/src/components/__tests__/CallTreeDetailScopedBuild.test.ts
+++ b/log-viewer/src/components/__tests__/CallTreeDetailScopedBuild.test.ts
@@ -60,6 +60,7 @@ interface StubTable {
   redraw: jest.Mock;
   destroy: jest.Mock;
   selectRow: jest.Mock;
+  getSelectedRows: jest.Mock;
 }
 
 /** The stub tables built so far, oldest first. */
@@ -108,9 +109,13 @@ async function frame(el: CallTreeDetail): Promise<void> {
   await settle(el);
 }
 
-async function mount(eventIndex: number): Promise<CallTreeDetail> {
+async function mount(
+  eventIndex: number,
+  sourceView?: 'callers' | 'callees',
+): Promise<CallTreeDetail> {
   const el = document.createElement('call-tree-detail') as CallTreeDetail;
   el.eventIndex = eventIndex;
+  el.sourceView = sourceView;
   document.body.appendChild(el);
   await el.updateComplete;
   return el;
@@ -179,6 +184,40 @@ describe('CallTreeDetail scoped build', () => {
     expect(table.selectRow).toHaveBeenCalledWith([9]);
     expect(build).not.toHaveBeenCalled();
     expect(table.setData).not.toHaveBeenCalled();
+  });
+
+  it('leaves the row alone when the mark is already on it', async () => {
+    build.mockImplementation((eventIndex) => Promise.resolve(tree(eventIndex * 1000)));
+    const el = await mount(5);
+    await frame(el);
+    const table = tables.instances[0]!;
+    const picked = { deselect: jest.fn(), getData: () => ({ id: 9 }) };
+    table.getSelectedRows.mockReturnValue([picked]);
+    table.selectRow.mockClear();
+
+    el.activeEventIndex = 9;
+    await frame(el);
+
+    // Re-selecting it would re-render the row, and tabulator's row re-render
+    // takes the table's focus with it.
+    expect(picked.deselect).not.toHaveBeenCalled();
+    expect(table.selectRow).not.toHaveBeenCalled();
+  });
+
+  it('keeps the picked row where a view merges occurrences', async () => {
+    build.mockImplementation((eventIndex) => Promise.resolve(tree(eventIndex * 1000)));
+    // A tab showing callees opens the inspector on bottom up, whose rows merge.
+    const el = await mount(5, 'callees');
+    await frame(el);
+    const table = tables.instances[0]!;
+    const picked = { deselect: jest.fn() };
+    table.getSelectedRows.mockReturnValue([picked]);
+
+    el.activeEventIndex = 9;
+    await frame(el);
+
+    expect(picked.deselect).not.toHaveBeenCalled();
+    expect(table.selectRow).not.toHaveBeenCalled();
   });
 
   it('retargets the percentage denominator without touching the bar width', async () => {

--- a/log-viewer/src/components/__tests__/CallTreeDetailScopedBuild.test.ts
+++ b/log-viewer/src/components/__tests__/CallTreeDetailScopedBuild.test.ts
@@ -38,15 +38,18 @@ jest.mock('../scopedCallTree.js', () => ({
   // Keep the real row readers: the hover test is about which rows name a frame.
   revealableEventIndex: jest.requireActual('../scopedCallTree.js').revealableEventIndex,
   locatableEventIndexes: jest.requireActual('../scopedCallTree.js').locatableEventIndexes,
+  rowIdsByEvent: jest.requireActual('../scopedCallTree.js').rowIdsByEvent,
 }));
 
 import { Tabulator } from 'tabulator-tables';
 
 import type { CallTreeDetail } from '../CallTreeDetail.js';
 import '../CallTreeDetail.js';
-import { buildScopedCallTree, type ScopedCallTree } from '../scopedCallTree.js';
+import { buildScopedCallTree, type ScopedCallTree, type ScopedRow } from '../scopedCallTree.js';
 import { INSPECTOR_LOCATE_EVENT, type InspectorLocateEvent } from '../inspectorReveal.js';
+import { eventBus } from '../../core/events/EventBus.js';
 import type { ProgressParams } from '../../tabulator/format/ProgressMS.js';
+import { LOCATED_ROW_CLASS } from '../locatedRow.js';
 
 const build = jest.mocked(buildScopedCallTree);
 
@@ -282,6 +285,38 @@ describe('CallTreeDetail scoped build', () => {
     expect(tables.instances).toHaveLength(1);
     expect(totalColumn(tables.instances[0]!).formatterParams.totalValue).toBe(6000);
   });
+  it('marks the rows a frame names once the merged view has its rows', async () => {
+    // A row that merges occurrences, so only the map from the rows can name it.
+    const merged = [{ id: -3, eventIndexes: [8, 12], _children: null }] as unknown as ScopedRow[];
+    const resolvers = deferBuilds();
+    const el = await mount(5, 'callees');
+    await frame(el);
+    const grid = el.shadowRoot!.querySelector('.table-host:not(.is-hidden) .grid')!;
+    const row = document.createElement('div');
+    row.classList.add('tabulator-row');
+    row.setAttribute('data-row-index', '-3');
+    grid.append(row);
+
+    // The pointer reports a frame while the walk is still running.
+    eventBus.emit('detail:locate', { source: 'timeline', eventIndexes: [8] });
+    expect(row.classList.contains(LOCATED_ROW_CLASS)).toBe(false);
+
+    resolvers[0]!({
+      ...tree(5000),
+      aggregated: () => Promise.resolve(merged),
+      bottomUp: () => Promise.resolve(merged),
+    });
+    await frame(el);
+    const tableBuilt = tables.instances[0]!.on.mock.calls.find(
+      (call) => call[0] === 'tableBuilt',
+    )?.[1] as (() => void) | undefined;
+
+    // The tree finished after the report, so the build marks what was reported.
+    tableBuilt?.();
+
+    expect(row.classList.contains(LOCATED_ROW_CLASS)).toBe(true);
+  });
+
   it('reports every occurrence the row under the pointer stands for', async () => {
     build.mockImplementation((eventIndex) => Promise.resolve(tree(eventIndex * 1000)));
     const el = await mount(5);

--- a/log-viewer/src/components/__tests__/LogInspector.test.ts
+++ b/log-viewer/src/components/__tests__/LogInspector.test.ts
@@ -43,6 +43,7 @@ jest.mock('../detailSections.js', () => ({
     _source: string,
     selection: { eventIndex?: number } | null,
     activeEventIndex: number | null,
+    sourceView?: string,
   ) => {
     // The markers carry the anchor and the active frame through to the rendered
     // content, so a stale build resolving late is distinguishable from the one
@@ -53,7 +54,8 @@ jest.mock('../detailSections.js', () => ({
             id: 'vitals',
             title: 'Details',
             content: html`<div class="marker">${selection.eventIndex}</div>
-              <div class="active">${activeEventIndex ?? '-'}</div>`,
+              <div class="active">${activeEventIndex ?? '-'}</div>
+              <div class="view">${sourceView ?? '-'}</div>`,
           },
           { id: 'callstack', title: 'Call stack', content: html`<div>c</div>` },
         ]
@@ -67,7 +69,7 @@ jest.mock('../detailSections.js', () => ({
   },
 }));
 
-import { eventBus } from '../../core/events/EventBus.js';
+import { eventBus, type DetailSource } from '../../core/events/EventBus.js';
 import type { LogInspector } from '../LogInspector.js';
 import type { PaneView } from '../PaneView.js';
 import type { ViewModeSwitch } from '../ViewModeSwitch.js';
@@ -131,7 +133,7 @@ function emptyText(el: LogInspector): string | null {
   return dock?.textContent?.trim() ?? null;
 }
 
-function select(source: 'timeline' | 'database', eventIndex: number): void {
+function select(source: DetailSource, eventIndex: number): void {
   eventBus.emit('detail:select', { source, selection: { kind: 'event', eventIndex } });
 }
 
@@ -142,6 +144,11 @@ function marker(el: LogInspector): string | null {
 /** The frame the sections follow, `-` while the anchor is what is shown. */
 function activeMarker(el: LogInspector): string | null {
   return paneView(el).shadowRoot?.querySelector('.active')?.textContent ?? null;
+}
+
+/** The direction the tab reported, `-` while it has reported none. */
+function viewMarker(el: LogInspector): string | null {
+  return paneView(el).shadowRoot?.querySelector('.view')?.textContent ?? null;
 }
 
 /** The scope switch is slotted into the dock, so it lives in the inspector's own root. */
@@ -304,6 +311,33 @@ describe('LogInspector', () => {
     await flush(el);
 
     expect([marker(el), activeMarker(el)]).toEqual(['7', '-']);
+  });
+
+  it('follows the direction a tab turns to, leaving its selection alone', async () => {
+    const el = await mount('tree-tab');
+    select('calltree', 1);
+    await flush(el);
+    expect(viewMarker(el)).toBe('-');
+
+    eventBus.emit('detail:view', { source: 'calltree', view: 'callers' });
+    await flush(el);
+
+    expect([marker(el), viewMarker(el)]).toEqual(['1', 'callers']);
+  });
+
+  it('ignores a tab reporting the direction it already showed', async () => {
+    const el = await mount('tree-tab');
+    select('calltree', 1);
+    eventBus.emit('detail:view', { source: 'calltree', view: 'callees' });
+    await flush(el);
+    dispatchInspectorReveal(dockLayout(el), 5);
+    await flush(el);
+
+    eventBus.emit('detail:view', { source: 'calltree', view: 'callees' });
+    await flush(el);
+
+    // No rebuild, so the walk down the stack is still where it was.
+    expect(activeMarker(el)).toBe('5');
   });
 
   it('keeps each tab walking its own stack', async () => {

--- a/log-viewer/src/components/__tests__/LogInspector.test.ts
+++ b/log-viewer/src/components/__tests__/LogInspector.test.ts
@@ -44,6 +44,7 @@ jest.mock('../detailSections.js', () => ({
     selection: { eventIndex?: number } | null,
     activeEventIndex: number | null,
     sourceView?: string,
+    activeBucket?: { instances: number[] } | null,
   ) => {
     // The markers carry the anchor and the active frame through to the rendered
     // content, so a stale build resolving late is distinguishable from the one
@@ -55,7 +56,8 @@ jest.mock('../detailSections.js', () => ({
             title: 'Details',
             content: html`<div class="marker">${selection.eventIndex}</div>
               <div class="active">${activeEventIndex ?? '-'}</div>
-              <div class="view">${sourceView ?? '-'}</div>`,
+              <div class="view">${sourceView ?? '-'}</div>
+              <div class="bucket">${activeBucket?.instances.join(',') ?? '-'}</div>`,
           },
           { id: 'callstack', title: 'Call stack', content: html`<div>c</div>` },
         ]
@@ -149,6 +151,11 @@ function activeMarker(el: LogInspector): string | null {
 /** The direction the tab reported, `-` while it has reported none. */
 function viewMarker(el: LogInspector): string | null {
   return paneView(el).shadowRoot?.querySelector('.view')?.textContent ?? null;
+}
+
+/** The calls a picked merged row counts, `-` while no such row is picked. */
+function bucketMarker(el: LogInspector): string | null {
+  return paneView(el).shadowRoot?.querySelector('.bucket')?.textContent ?? null;
 }
 
 /** The scope switch is slotted into the dock, so it lives in the inspector's own root. */
@@ -377,6 +384,36 @@ describe('LogInspector', () => {
     // A locate picks nothing, so neither the anchor nor the walk moves.
     await flush(el);
     expect([marker(el), activeMarker(el)]).toEqual(['1', '-']);
+  });
+
+  it('describes what a picked row counts when it names no single frame', async () => {
+    const el = await mount('timeline-tab');
+    select('timeline', 1);
+    await flush(el);
+
+    dispatchInspectorLocate(dockLayout(el), [5, 9], true, {
+      kind: 'aggregate',
+      instances: [5, 9],
+    });
+    await flush(el);
+
+    // The bucket answers instead of a walked frame, and the anchor is untouched.
+    expect([marker(el), activeMarker(el), bucketMarker(el)]).toEqual(['1', '-', '5,9']);
+  });
+
+  it('drops the picked row once a single frame is walked to', async () => {
+    const el = await mount('timeline-tab');
+    select('timeline', 1);
+    dispatchInspectorLocate(dockLayout(el), [5, 9], true, {
+      kind: 'aggregate',
+      instances: [5, 9],
+    });
+    await flush(el);
+
+    dispatchInspectorReveal(dockLayout(el), 5);
+    await flush(el);
+
+    expect([activeMarker(el), bucketMarker(el)]).toEqual(['5', '-']);
   });
 
   it('drops a mark the pointer never left when the tab changes', async () => {

--- a/log-viewer/src/components/__tests__/LogInspector.test.ts
+++ b/log-viewer/src/components/__tests__/LogInspector.test.ts
@@ -42,10 +42,11 @@ jest.mock('../detailSections.js', () => ({
   buildDetailSections: (
     _source: string,
     selection: { eventIndex?: number } | null,
-    activeEventIndex: number | null,
+    active: { kind: string; eventIndex?: number; instances?: number[] } | null,
     sourceView?: string,
-    activeBucket?: { instances: number[] } | null,
   ) => {
+    const walked = active?.kind === 'event' ? String(active.eventIndex) : '-';
+    const counted = active?.kind === 'aggregate' ? (active.instances?.join(',') ?? '-') : '-';
     // The markers carry the anchor and the active frame through to the rendered
     // content, so a stale build resolving late is distinguishable from the one
     // that supersedes it, and a walk is distinguishable from a new pick.
@@ -55,9 +56,9 @@ jest.mock('../detailSections.js', () => ({
             id: 'vitals',
             title: 'Details',
             content: html`<div class="marker">${selection.eventIndex}</div>
-              <div class="active">${activeEventIndex ?? '-'}</div>
+              <div class="active">${walked}</div>
               <div class="view">${sourceView ?? '-'}</div>
-              <div class="bucket">${activeBucket?.instances.join(',') ?? '-'}</div>`,
+              <div class="bucket">${counted}</div>`,
           },
           { id: 'callstack', title: 'Call stack', content: html`<div>c</div>` },
         ]
@@ -399,6 +400,34 @@ describe('LogInspector', () => {
 
     // The bucket answers instead of a walked frame, and the anchor is untouched.
     expect([marker(el), activeMarker(el), bucketMarker(el)]).toEqual(['1', '-', '5,9']);
+  });
+
+  it('leaves the walk alone for a sticky mark that names no picked row', async () => {
+    const el = await mount('timeline-tab');
+    select('timeline', 1);
+    dispatchInspectorReveal(dockLayout(el), 5);
+    await flush(el);
+
+    // A tree whose rows carry no aggregate marks stickily without picking one.
+    dispatchInspectorLocate(dockLayout(el), [7, 8], true);
+    await flush(el);
+
+    expect(activeMarker(el)).toBe('5');
+  });
+
+  it('drops the picked row when the pick itself is dropped', async () => {
+    const el = await mount('timeline-tab');
+    select('timeline', 1);
+    dispatchInspectorLocate(dockLayout(el), [5, 9], true, {
+      kind: 'aggregate',
+      instances: [5, 9],
+    });
+    await flush(el);
+
+    dispatchInspectorLocate(dockLayout(el), [], true);
+    await flush(el);
+
+    expect([marker(el), activeMarker(el), bucketMarker(el)]).toEqual(['1', '-', '-']);
   });
 
   it('drops the picked row once a single frame is walked to', async () => {

--- a/log-viewer/src/components/__tests__/detailSections.test.ts
+++ b/log-viewer/src/components/__tests__/detailSections.test.ts
@@ -208,6 +208,23 @@ describe('buildDetailSections', () => {
     expect(vitals.getAttribute('called-by')).toBe('');
   });
 
+  it('describes the calls a walked bucket counts, as a bucket picked in the tab is', async () => {
+    const sections = await buildDetailSections(
+      'analysis',
+      { kind: 'aggregate', instances: [11, 12, 13] },
+      null,
+      undefined,
+      { kind: 'aggregate', instances: [21, 22], calledBy: 'Trigger1' },
+    );
+
+    const vitals = rendered(sections, 'vitals', 'event-vitals') as HTMLElement & {
+      instances: number[] | null;
+    };
+    expect(vitals.instances).toEqual([21, 22]);
+    expect(vitals.getAttribute('eventIndex')).toBe('21');
+    expect(vitals.getAttribute('called-by')).toBe('Trigger1');
+  });
+
   it('adds the whole-log database figures for the database with nothing selected', async () => {
     const sections = await buildDetailSections('database', null);
     expect(sections.map((s) => s.id)).toEqual([

--- a/log-viewer/src/components/__tests__/detailSections.test.ts
+++ b/log-viewer/src/components/__tests__/detailSections.test.ts
@@ -82,13 +82,27 @@ describe('buildDetailSections', () => {
 
   it('passes the frame walked to on to the database sections', async () => {
     databaseCalls.length = 0;
-    await buildDetailSections('database', { kind: 'event', eventIndex: 9, type: 'soql' }, 4);
+    await buildDetailSections(
+      'database',
+      { kind: 'event', eventIndex: 9, type: 'soql' },
+      {
+        kind: 'event',
+        eventIndex: 4,
+      },
+    );
 
     expect(databaseCalls).toEqual([{ eventIndex: 9, type: 'soql', activeEventIndex: 4 }]);
   });
 
   it('anchors the stack and the tree to the selection, while Details follows the active frame', async () => {
-    const sections = await buildDetailSections('timeline', { kind: 'event', eventIndex: 4 }, 2);
+    const sections = await buildDetailSections(
+      'timeline',
+      { kind: 'event', eventIndex: 4 },
+      {
+        kind: 'event',
+        eventIndex: 2,
+      },
+    );
 
     expect(rendered(sections, 'callstack', 'call-stack-detail').getAttribute('eventIndex')).toBe(
       '4',
@@ -149,7 +163,7 @@ describe('buildDetailSections', () => {
     const sections = await buildDetailSections(
       'analysis',
       { kind: 'aggregate', instances: [11, 12, 13] },
-      8,
+      { kind: 'event', eventIndex: 8 },
     );
 
     const findings = rendered(sections, 'findings', 'log-diagnostics') as HTMLElement & {
@@ -169,7 +183,14 @@ describe('buildDetailSections', () => {
   });
 
   it('re-scopes the namespace split to the frame being followed', async () => {
-    const sections = await buildDetailSections('timeline', { kind: 'event', eventIndex: 4 }, 2);
+    const sections = await buildDetailSections(
+      'timeline',
+      { kind: 'event', eventIndex: 4 },
+      {
+        kind: 'event',
+        eventIndex: 2,
+      },
+    );
 
     expect(
       rendered(sections, 'namespace-time', 'namespace-time-bar').getAttribute('eventIndex'),
@@ -197,7 +218,7 @@ describe('buildDetailSections', () => {
     const sections = await buildDetailSections(
       'analysis',
       { kind: 'aggregate', instances: [11, 12, 13] },
-      8,
+      { kind: 'event', eventIndex: 8 },
     );
 
     const vitals = rendered(sections, 'vitals', 'event-vitals') as HTMLElement & {
@@ -212,8 +233,6 @@ describe('buildDetailSections', () => {
     const sections = await buildDetailSections(
       'analysis',
       { kind: 'aggregate', instances: [11, 12, 13] },
-      null,
-      undefined,
       { kind: 'aggregate', instances: [21, 22], calledBy: 'Trigger1' },
     );
 

--- a/log-viewer/src/components/__tests__/locatedRow.test.ts
+++ b/log-viewer/src/components/__tests__/locatedRow.test.ts
@@ -6,10 +6,11 @@
 import { describe, expect, it } from '@jest/globals';
 import type { RowComponent } from 'tabulator-tables';
 
-import type { LogEvent } from 'apex-log-parser';
+import type { ApexLog, LogEvent } from 'apex-log-parser';
 
 import {
   LOCATED_ROW_CLASS,
+  LocatedRowIds,
   LocatedRowMarker,
   eventKeyPaths,
   rowIndexStamper,
@@ -197,5 +198,39 @@ describe('LocatedRowMarker', () => {
     marker.mark(container, [7]);
 
     expect(rowFor(container, 0).classList.contains(LOCATED_ROW_CLASS)).toBe(false);
+  });
+});
+
+describe('LocatedRowIds', () => {
+  const root = ev('exec', null);
+  const outerFrame = ev('outer', root);
+  const frame = ev('inner', outerFrame);
+  const log = { eventsById: { 5: frame } } as unknown as ApexLog;
+
+  it('builds the paths of the rows the frames belong to', () => {
+    const ids = new LocatedRowIds().idsFor(log, [5], 'callers');
+
+    expect(ids).toEqual(eventKeyPaths(frame, 'callers'));
+  });
+
+  it('reuses what it built for the frames it was last asked about', () => {
+    // The view re-reports its picked frames whenever the pointer leaves a row.
+    const memo = new LocatedRowIds();
+    const picked = [5];
+
+    expect(memo.idsFor(log, picked, 'callers')).toBe(memo.idsFor(log, picked, 'callers'));
+  });
+
+  it('rebuilds for the same frames in the other direction', () => {
+    const memo = new LocatedRowIds();
+    const picked = [5];
+
+    expect(memo.idsFor(log, picked, 'callers')).not.toEqual(memo.idsFor(log, picked, 'callees'));
+  });
+
+  it('names the rows of a view keyed by event with the indexes themselves', () => {
+    const picked = [5];
+
+    expect(new LocatedRowIds().idsFor(log, picked, undefined)).toBe(picked);
   });
 });

--- a/log-viewer/src/components/__tests__/locatedRow.test.ts
+++ b/log-viewer/src/components/__tests__/locatedRow.test.ts
@@ -6,12 +6,43 @@
 import { describe, expect, it } from '@jest/globals';
 import type { RowComponent } from 'tabulator-tables';
 
-import { LOCATED_ROW_CLASS, LocatedRowMarker, rowIndexStamper } from '../locatedRow.js';
+import type { LogEvent } from 'apex-log-parser';
+
+import {
+  LOCATED_ROW_CLASS,
+  LocatedRowMarker,
+  eventKeyPaths,
+  rowIndexStamper,
+  rowKeyPath,
+  stampRowKeyPath,
+} from '../locatedRow.js';
 
 const stamp = rowIndexStamper('eventIndex');
 
-function rowComponent(element: HTMLElement, data: Record<string, unknown>): RowComponent {
-  return { getElement: () => element, getData: () => data } as unknown as RowComponent;
+function rowComponent(
+  element: HTMLElement,
+  data: Record<string, unknown>,
+  parent: RowComponent | false = false,
+): RowComponent {
+  return {
+    getElement: () => element,
+    getData: () => data,
+    getTreeParent: () => parent,
+  } as unknown as RowComponent;
+}
+
+/** A bucket row and its chain of parents, innermost last, as tabulator hands them
+ *  over: the tree parent of a bottom-up caller row is the frame it called. */
+function bucketRow(...keys: string[]): RowComponent {
+  let row: RowComponent | false = false;
+  for (const key of keys) {
+    row = rowComponent(document.createElement('div'), { key }, row);
+  }
+  return row as RowComponent;
+}
+
+function ev(text: string, parent: LogEvent | null): LogEvent {
+  return { type: 'METHOD_ENTRY', namespace: '', text, parent } as unknown as LogEvent;
 }
 
 /** A table host holding a rendered row element per index, as the stamp leaves them. */
@@ -30,6 +61,25 @@ function rowFor(container: HTMLElement, index: number): HTMLElement {
   return container.children[index] as HTMLElement;
 }
 
+describe('stampRowKeyPath', () => {
+  it('marks the row under one parent and not its namesake under another', () => {
+    const container = document.createElement('div');
+    const rows = [bucketRow('Trigger1', 'Util.log'), bucketRow('Trigger2', 'Util.log')];
+    for (const row of rows) {
+      const element = row.getElement();
+      element.classList.add('tabulator-row');
+      stampRowKeyPath(row);
+      container.append(element);
+    }
+    const marker = new LocatedRowMarker();
+
+    marker.mark(container, [rowKeyPath(rows[0]!)!]);
+
+    expect(rows[0]!.getElement().classList.contains(LOCATED_ROW_CLASS)).toBe(true);
+    expect(rows[1]!.getElement().classList.contains(LOCATED_ROW_CLASS)).toBe(false);
+  });
+});
+
 describe('rowIndexStamper', () => {
   it('leaves a row with no index alone, as a calc row is', () => {
     const element = document.createElement('div');
@@ -37,6 +87,56 @@ describe('rowIndexStamper', () => {
     stamp(rowComponent(element, { 'duration.total': 12 }));
 
     expect(element.attributes).toHaveLength(0);
+  });
+});
+
+describe('rowKeyPath', () => {
+  it('names a top-level row by its own key alone', () => {
+    expect(rowKeyPath(bucketRow('A'))).toBe('A');
+  });
+
+  it('tells two same-named rows apart by the parents that reach them', () => {
+    // One method holds a row under every caller it has, so the key alone cannot.
+    expect(rowKeyPath(bucketRow('Trigger1', 'Util.log'))).not.toBe(
+      rowKeyPath(bucketRow('Trigger2', 'Util.log')),
+    );
+  });
+
+  it('reads a deep row as the whole path, outermost first', () => {
+    const deep = rowKeyPath(bucketRow('A', 'B', 'C'));
+    expect(deep).toBe(rowKeyPath(bucketRow('A', 'B', 'C')));
+    expect(deep).not.toBe(rowKeyPath(bucketRow('A', 'B')));
+  });
+
+  it('leaves a row that stands for one frame unnamed, as its index names it', () => {
+    expect(rowKeyPath(rowComponent(document.createElement('div'), { id: 7 }))).toBeUndefined();
+  });
+});
+
+describe('eventKeyPaths', () => {
+  const root = ev('exec', null);
+  const outer = ev('outer', root);
+  const inner = ev('inner', outer);
+
+  it('names one row in a top-down view, at the depth the frame ran at', () => {
+    const paths = eventKeyPaths(inner, 'callees');
+
+    expect(paths).toHaveLength(1);
+    expect(paths[0]).toBe(rowKeyPath(bucketRow('METHOD_ENTRY||outer', 'METHOD_ENTRY||inner')));
+  });
+
+  it('names a row per caller depth in a bottom-up view', () => {
+    // The frame heads a row on its own, and one under each caller above it.
+    const paths = eventKeyPaths(inner, 'callers');
+
+    expect(paths).toEqual([
+      rowKeyPath(bucketRow('METHOD_ENTRY||inner')),
+      rowKeyPath(bucketRow('METHOD_ENTRY||inner', 'METHOD_ENTRY||outer')),
+    ]);
+  });
+
+  it('leaves the log root out, as it is a row in neither view', () => {
+    expect(eventKeyPaths(root, 'callers')).toEqual([]);
   });
 });
 

--- a/log-viewer/src/components/__tests__/scopedCallTree.test.ts
+++ b/log-viewer/src/components/__tests__/scopedCallTree.test.ts
@@ -360,8 +360,9 @@ describe('buildScopedCallTree', () => {
 
     const [bottomUp] = (await tree.bottomUp(options))!;
     expect(bottomUp?.eventIndexes).toEqual(instances);
-    // The caller stands for its own one frame, met once per occurrence beneath it.
-    expect(bottomUp?._children?.[0]?.eventIndexes).toEqual([300]);
+    // A caller row stands for the calls it conducted, which is what its time and
+    // its count are taken from, so it names those rather than its own frame.
+    expect(bottomUp?._children?.[0]?.eventIndexes).toEqual(instances);
   });
 
   it('a single-frame row carries no list — its one occurrence is the row itself', async () => {
@@ -495,14 +496,15 @@ describe('rowIdsByEvent', () => {
 
   it('names one frame in as many rows as stand for it', async () => {
     // Rebuilds the loop and its two calls; the loop itself is the selection.
-    loopOccurrences(2);
+    const instances = loopOccurrences(2);
     const tree = (await build(300))!;
     const rows = (await tree.bottomUp(options))!;
 
-    // Bottom-Up puts the caller under the leaf it called, so frame 300 is named
-    // by that nested row as well as by any row of its own.
-    const callerRows = rowIdsByEvent(rows).get(300) ?? [];
-    expect(callerRows).toEqual(expect.arrayContaining([rows[0]!._children![0]!.id]));
+    // Bottom-Up puts the caller under the leaf it called, and the caller row
+    // stands for the same calls, so one call names the leaf row and the caller
+    // row beneath it.
+    const named = rowIdsByEvent(rows).get(instances[0]!) ?? [];
+    expect(named).toEqual(expect.arrayContaining([rows[0]!.id, rows[0]!._children![0]!.id]));
   });
 
   it('leaves a frame no row names out of the lookup', async () => {

--- a/log-viewer/src/components/detailSections.ts
+++ b/log-viewer/src/components/detailSections.ts
@@ -40,20 +40,16 @@ import './NamespaceTimeBar.js';
  * ambient scope only applies when `selection` is `null`, so it belongs inside
  * the `!selection` branch — never above it.
  *
- * `activeEventIndex` is the frame the user walked to inside the selection's own
- * call stack. Details and the call tree follow it; the call stack stays anchored
- * to `selection`, so walking down a stack never puts a frame out of reach.
- *
- * `activeBucket` is the same walk onto a row that merges occurrences, which names
- * no single frame: Details describes the calls that row counts, exactly as it
- * does for a merged row picked in the tab itself.
+ * `active` is what the user walked to inside the selection's own call stack:
+ * one frame, or the calls a row counts where the view's rows merge occurrences.
+ * Details and the call tree follow it; the call stack stays anchored to
+ * `selection`, so walking down a stack never puts a frame out of reach.
  */
 export async function buildDetailSections(
   source: DetailSource,
   selection: DetailSelection | null,
-  activeEventIndex: number | null = null,
+  active: DetailSelection | null = null,
   sourceView?: SelectionView,
-  activeBucket: DetailSelection | null = null,
 ): Promise<PaneSection[]> {
   // Nothing selected: the whole log is the scope. `DetailDock`'s own empty
   // state still covers the moment before a tab id resolves.
@@ -171,28 +167,29 @@ export async function buildDetailSections(
     return buildDatabaseSections({
       eventIndex: selection.eventIndex,
       type: selection.type,
-      activeEventIndex,
+      activeEventIndex: active?.kind === 'event' ? active.eventIndex : null,
     });
   }
 
   const isAggregate = selection.kind === 'aggregate';
   // An aggregate scopes to all its occurrences; a single frame to itself.
   const anchorIndex = isAggregate ? (selection.instances[0] ?? -1) : selection.eventIndex;
-  // A walked bucket answers as its own aggregate, keyed on its first occurrence
-  // the way a bucket picked in the tab is.
-  const bucket = activeBucket?.kind === 'aggregate' ? activeBucket : null;
-  const active = bucket ? (bucket.instances[0] ?? anchorIndex) : (activeEventIndex ?? anchorIndex);
-  // One frame in the stack is being followed, so the aggregate no longer
-  // describes what Details and the call tree are showing.
-  const following = active !== anchorIndex;
-  const instances = bucket
-    ? bucket.instances
-    : isAggregate && !following
-      ? selection.instances
-      : null;
-  const calledBy = bucket
-    ? (bucket.calledBy ?? '')
-    : (isAggregate && !following && selection.calledBy) || '';
+  // A walked row that merges occurrences answers as its own aggregate, keyed on
+  // its first occurrence the way a bucket picked in the tab is.
+  const activeIndex =
+    active?.kind === 'aggregate'
+      ? (active.instances[0] ?? anchorIndex)
+      : (active?.eventIndex ?? anchorIndex);
+  // The aggregate Details describes, or none once the walk follows one frame
+  // inside it: the aggregate no longer describes what is shown.
+  const shown =
+    active?.kind === 'aggregate'
+      ? active
+      : isAggregate && activeIndex === anchorIndex
+        ? selection
+        : null;
+  const instances = shown?.instances ?? null;
+  const calledBy = shown?.calledBy ?? '';
 
   const sections: PaneSection[] = [
     {
@@ -200,7 +197,7 @@ export async function buildDetailSections(
       title: 'Details',
       fit: 'content',
       content: html`<event-vitals
-        eventIndex=${active}
+        eventIndex=${activeIndex}
         .instances=${instances}
         called-by=${calledBy}
       ></event-vitals>`,
@@ -212,7 +209,7 @@ export async function buildDetailSections(
     sections.push(
       namespaceTimeSection(
         html`<namespace-time-bar
-          eventIndex=${active}
+          eventIndex=${activeIndex}
           .instances=${instances}
         ></namespace-time-bar>`,
       ),
@@ -227,7 +224,7 @@ export async function buildDetailSections(
       // The verdict on the selected row, so it reads beside the tree rather than
       // being crowded down to its header by it.
       weight: 3,
-      content: html`<log-diagnostics .instances=${instances ?? [active]}></log-diagnostics>`,
+      content: html`<log-diagnostics .instances=${instances ?? [activeIndex]}></log-diagnostics>`,
     });
   }
   sections.push(
@@ -237,7 +234,7 @@ export async function buildDetailSections(
       weight: 3,
       content: html`<call-stack-detail
         eventIndex=${anchorIndex}
-        activeEventIndex=${active}
+        activeEventIndex=${activeIndex}
       ></call-stack-detail>`,
     },
     {
@@ -247,7 +244,7 @@ export async function buildDetailSections(
       content: html`<call-tree-detail
         eventIndex=${anchorIndex}
         .instances=${isAggregate ? selection.instances : null}
-        activeEventIndex=${active}
+        activeEventIndex=${activeIndex}
         .source=${source}
         .sourceView=${sourceView}
       ></call-tree-detail>`,

--- a/log-viewer/src/components/detailSections.ts
+++ b/log-viewer/src/components/detailSections.ts
@@ -43,12 +43,17 @@ import './NamespaceTimeBar.js';
  * `activeEventIndex` is the frame the user walked to inside the selection's own
  * call stack. Details and the call tree follow it; the call stack stays anchored
  * to `selection`, so walking down a stack never puts a frame out of reach.
+ *
+ * `activeBucket` is the same walk onto a row that merges occurrences, which names
+ * no single frame: Details describes the calls that row counts, exactly as it
+ * does for a merged row picked in the tab itself.
  */
 export async function buildDetailSections(
   source: DetailSource,
   selection: DetailSelection | null,
   activeEventIndex: number | null = null,
   sourceView?: SelectionView,
+  activeBucket: DetailSelection | null = null,
 ): Promise<PaneSection[]> {
   // Nothing selected: the whole log is the scope. `DetailDock`'s own empty
   // state still covers the moment before a tab id resolves.
@@ -173,12 +178,21 @@ export async function buildDetailSections(
   const isAggregate = selection.kind === 'aggregate';
   // An aggregate scopes to all its occurrences; a single frame to itself.
   const anchorIndex = isAggregate ? (selection.instances[0] ?? -1) : selection.eventIndex;
-  const active = activeEventIndex ?? anchorIndex;
+  // A walked bucket answers as its own aggregate, keyed on its first occurrence
+  // the way a bucket picked in the tab is.
+  const bucket = activeBucket?.kind === 'aggregate' ? activeBucket : null;
+  const active = bucket ? (bucket.instances[0] ?? anchorIndex) : (activeEventIndex ?? anchorIndex);
   // One frame in the stack is being followed, so the aggregate no longer
   // describes what Details and the call tree are showing.
   const following = active !== anchorIndex;
-  const instances = isAggregate && !following ? selection.instances : null;
-  const calledBy = (isAggregate && !following && selection.calledBy) || '';
+  const instances = bucket
+    ? bucket.instances
+    : isAggregate && !following
+      ? selection.instances
+      : null;
+  const calledBy = bucket
+    ? (bucket.calledBy ?? '')
+    : (isAggregate && !following && selection.calledBy) || '';
 
   const sections: PaneSection[] = [
     {

--- a/log-viewer/src/components/inspectorReveal.ts
+++ b/log-viewer/src/components/inspectorReveal.ts
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2026 Certinia Inc. All rights reserved.
  */
+import type { DetailSelection } from '../core/events/EventBus.js';
 
 /** Name of the DOM event an inspector section raises to reveal one of its rows. */
 export const INSPECTOR_REVEAL_EVENT = 'inspector-reveal';
@@ -28,6 +29,7 @@ export const INSPECTOR_LOCATE_EVENT = 'inspector-locate';
 export type InspectorLocateEvent = CustomEvent<{
   eventIndexes: readonly number[];
   sticky: boolean;
+  selection?: DetailSelection | null;
 }>;
 
 /**
@@ -37,15 +39,19 @@ export type InspectorLocateEvent = CustomEvent<{
  *
  * @param sticky - True when the row was picked, so the mark holds once the
  *   pointer leaves; false for the pointer itself.
+ * @param selection - What a picked row stands for, so Details can describe the
+ *   row rather than the selection it sits under. A merged row has no single
+ *   frame to walk to, which is why this rides here rather than on a reveal.
  */
 export function dispatchInspectorLocate(
   source: HTMLElement,
   eventIndexes: readonly number[],
   sticky = false,
+  selection: DetailSelection | null = null,
 ): void {
   source.dispatchEvent(
     new CustomEvent(INSPECTOR_LOCATE_EVENT, {
-      detail: { eventIndexes, sticky },
+      detail: { eventIndexes, sticky, selection },
       bubbles: true,
       composed: true,
     }),

--- a/log-viewer/src/components/locatedRow.ts
+++ b/log-viewer/src/components/locatedRow.ts
@@ -7,7 +7,7 @@ import type { RowComponent } from 'tabulator-tables';
 
 import type { DetailSelection, SelectionView } from '../core/events/EventBus.js';
 import { eventByEventIndex } from '../core/utility/EventSearch.js';
-import { getEventKey } from '../features/call-tree/utils/Aggregation.js';
+import { eventKeyChain } from '../features/call-tree/utils/Aggregation.js';
 import { occurrencesThrough } from '../features/call-tree/utils/bottomUpOccurrences.js';
 
 /** Class the marked row carries; each table styles it itself. */
@@ -99,6 +99,18 @@ function rowCallChain(row: RowComponent, data: CallRow): CallChain | null {
   return chain;
 }
 
+/**
+ * A row's own index value, read from the data.
+ *
+ * Never `RowComponent.getIndex()`: that routes through Tabulator's accessor,
+ * which deep-clones the row data. Our rows hold the parsed log, so one call
+ * walks the whole event graph and blocks the UI for minutes.
+ */
+export function rowId(row: RowComponent | undefined): number | undefined {
+  const id = (row?.getData() as { id?: unknown } | undefined)?.id;
+  return typeof id === 'number' ? id : undefined;
+}
+
 /** Joins a key path. A key holds arbitrary log text, so the separator is one
  *  that text cannot carry: two different paths can never join to one string. */
 const KEY_PATH_SEPARATOR = '\u0001';
@@ -113,18 +125,6 @@ const keyPaths = new WeakMap<CallRow, string>();
  *
  * Undefined on a row that stands for one frame, which its event index identifies.
  */
-/**
- * A row's own index value, read from the data.
- *
- * Never `RowComponent.getIndex()`: that routes through Tabulator's accessor,
- * which deep-clones the row data. Our rows hold the parsed log, so one call
- * walks the whole event graph and blocks the UI for minutes.
- */
-export function rowId(row: RowComponent | undefined): number | undefined {
-  const id = (row?.getData() as { id?: unknown } | undefined)?.id;
-  return typeof id === 'number' ? id : undefined;
-}
-
 export function rowKeyPath(row: RowComponent): string | undefined {
   const data = rowCallData(row);
   if (data.key === undefined) {
@@ -167,19 +167,19 @@ export function stampRowKeyPath(row: RowComponent): void {
  * The log root is not a row in either view, so the walk stops below it.
  */
 export function eventKeyPaths(event: LogEvent, direction: SelectionView): string[] {
-  const keys: string[] = [];
-  for (let node: LogEvent | null = event; node?.parent; node = node.parent) {
-    keys.push(getEventKey(node));
-  }
+  const keys = eventKeyChain(event);
   if (!keys.length) {
     return [];
   }
   if (direction === 'callees') {
     return [keys.reverse().join(KEY_PATH_SEPARATOR)];
   }
+  // Each path extends the one before it, so the characters are copied once.
   const paths: string[] = [];
-  for (let depth = 1; depth <= keys.length; depth++) {
-    paths.push(keys.slice(0, depth).join(KEY_PATH_SEPARATOR));
+  let path = '';
+  for (const key of keys) {
+    path = path ? path + KEY_PATH_SEPARATOR + key : key;
+    paths.push(path);
   }
   return paths;
 }
@@ -219,7 +219,7 @@ function rowCallOccurrences(row: RowComponent): LogEvent[] {
  * frames, so there is no cheaper set to walk, and only the paths they produce
  * repeat.
  */
-export function keyPathsForEvents(
+function keyPathsForEvents(
   root: ApexLog,
   eventIndexes: readonly number[],
   direction: SelectionView,
@@ -273,6 +273,46 @@ export function rowDetailSelection(row: RowComponent | undefined): DetailSelecti
     instances: rowOccurrences(row),
     calledBy: chain?.caller.text,
   };
+}
+
+/**
+ * The ids that mark a view's rows for a list of frames, memoised on the list.
+ *
+ * A view re-reports its picked frames every time the pointer leaves an inspector
+ * row, and translating a wide pick into bucket paths costs far more than the mark
+ * it feeds.
+ */
+export class LocatedRowIds {
+  private lastRoot: ApexLog | null = null;
+  private lastEvents: readonly number[] | undefined;
+  private lastDirection: SelectionView | undefined;
+  private lastIds: readonly (number | string)[] = [];
+
+  /**
+   * @param direction - The view's own direction, or undefined where its rows are
+   * keyed by event and so are named by the indexes themselves.
+   */
+  public idsFor(
+    root: ApexLog | null,
+    eventIndexes: readonly number[],
+    direction: SelectionView | undefined,
+  ): readonly (number | string)[] {
+    if (!direction || !root || !eventIndexes.length) {
+      return eventIndexes;
+    }
+    if (
+      this.lastEvents === eventIndexes &&
+      this.lastDirection === direction &&
+      this.lastRoot === root
+    ) {
+      return this.lastIds;
+    }
+    this.lastRoot = root;
+    this.lastEvents = eventIndexes;
+    this.lastDirection = direction;
+    this.lastIds = keyPathsForEvents(root, eventIndexes, direction);
+    return this.lastIds;
+  }
 }
 
 /**

--- a/log-viewer/src/components/locatedRow.ts
+++ b/log-viewer/src/components/locatedRow.ts
@@ -2,10 +2,11 @@
  * Copyright (c) 2026 Certinia Inc. All rights reserved.
  */
 
-import type { LogEvent } from 'apex-log-parser';
+import type { ApexLog, LogEvent } from 'apex-log-parser';
 import type { RowComponent } from 'tabulator-tables';
 
 import type { DetailSelection, SelectionView } from '../core/events/EventBus.js';
+import { eventByEventIndex } from '../core/utility/EventSearch.js';
 import { getEventKey } from '../features/call-tree/utils/Aggregation.js';
 import { occurrencesThrough } from '../features/call-tree/utils/bottomUpOccurrences.js';
 
@@ -199,6 +200,32 @@ function rowCallOccurrences(row: RowComponent): LogEvent[] {
 }
 
 /** The calls a row stands for, as the event indexes the mark works in. */
+/**
+ * The key paths that the frames `eventIndexes` name stand for, so a grid whose
+ * rows merge occurrences can mark them.
+ *
+ * Every occurrence is walked: occurrences of one frame sit under distinct parent
+ * frames, so there is no cheaper set to walk, and only the paths they produce
+ * repeat.
+ */
+export function keyPathsForEvents(
+  root: ApexLog,
+  eventIndexes: readonly number[],
+  direction: SelectionView,
+): string[] {
+  const paths = new Set<string>();
+  for (const eventIndex of eventIndexes) {
+    const event = eventByEventIndex(root, eventIndex);
+    if (!event) {
+      continue;
+    }
+    for (const path of eventKeyPaths(event, direction)) {
+      paths.add(path);
+    }
+  }
+  return [...paths];
+}
+
 export function rowOccurrences(row: RowComponent): number[] {
   const data = rowCallData(row);
   const cached = derivedIndexes.get(data);

--- a/log-viewer/src/components/locatedRow.ts
+++ b/log-viewer/src/components/locatedRow.ts
@@ -113,6 +113,18 @@ const keyPaths = new WeakMap<CallRow, string>();
  *
  * Undefined on a row that stands for one frame, which its event index identifies.
  */
+/**
+ * A row's own index value, read from the data.
+ *
+ * Never `RowComponent.getIndex()`: that routes through Tabulator's accessor,
+ * which deep-clones the row data. Our rows hold the parsed log, so one call
+ * walks the whole event graph and blocks the UI for minutes.
+ */
+export function rowId(row: RowComponent | undefined): number | undefined {
+  const id = (row?.getData() as { id?: unknown } | undefined)?.id;
+  return typeof id === 'number' ? id : undefined;
+}
+
 export function rowKeyPath(row: RowComponent): string | undefined {
   const data = rowCallData(row);
   if (data.key === undefined) {

--- a/log-viewer/src/components/locatedRow.ts
+++ b/log-viewer/src/components/locatedRow.ts
@@ -5,7 +5,8 @@
 import type { LogEvent } from 'apex-log-parser';
 import type { RowComponent } from 'tabulator-tables';
 
-import type { DetailSelection } from '../core/events/EventBus.js';
+import type { DetailSelection, SelectionView } from '../core/events/EventBus.js';
+import { getEventKey } from '../features/call-tree/utils/Aggregation.js';
 import { occurrencesThrough } from '../features/call-tree/utils/bottomUpOccurrences.js';
 
 /** Class the marked row carries; each table styles it itself. */
@@ -15,7 +16,8 @@ export const LOCATED_ROW_CLASS = 'located-row';
 const ROW_INDEX_ATTRIBUTE = 'data-row-index';
 
 /**
- * Builds a Tabulator `rowFormatter` that stamps the row's index on its element.
+ * Builds a Tabulator `rowFormatter` that stamps what identifies the row in its
+ * own table: an event index where every row is one frame.
  *
  * The mark then finds a row with one DOM query. Asking Tabulator instead
  * (`getRows('visible')`) wraps every row in the table in a component, which the
@@ -23,6 +25,9 @@ const ROW_INDEX_ATTRIBUTE = 'data-row-index';
  *
  * The index is read from the data rather than `getIndex()`: Tabulator runs the
  * formatter for its calc rows too, and those carry no index.
+ *
+ * A view whose rows merge occurrences stamps {@link stampRowKeyPath} instead, as
+ * a bucket has no event of its own.
  *
  * @param indexField - the table's `index` option
  */
@@ -91,6 +96,79 @@ function rowCallChain(row: RowComponent, data: CallRow): CallChain | null {
   const chain: CallChain = { root: node, keys: keys.reverse(), caller };
   derivedChains.set(data, chain);
   return chain;
+}
+
+/** Joins a key path. A key holds arbitrary log text, so the separator is one
+ *  that text cannot carry: two different paths can never join to one string. */
+const KEY_PATH_SEPARATOR = '\u0001';
+
+const keyPaths = new WeakMap<CallRow, string>();
+
+/**
+ * What tells a merged row apart from a same-named row under a different parent:
+ * the bucket keys from its top-level ancestor out to the row itself. A single
+ * key does not, because a bucket map is allocated per parent, so one method holds
+ * a row under every caller it has.
+ *
+ * Undefined on a row that stands for one frame, which its event index identifies.
+ */
+export function rowKeyPath(row: RowComponent): string | undefined {
+  const data = rowCallData(row);
+  if (data.key === undefined) {
+    return undefined;
+  }
+  const cached = keyPaths.get(data);
+  if (cached !== undefined) {
+    return cached;
+  }
+  const keys = [data.key];
+  for (let parent = row.getTreeParent(); parent; parent = parent.getTreeParent()) {
+    const parentKey = rowCallData(parent).key;
+    if (parentKey === undefined) {
+      break;
+    }
+    keys.push(parentKey);
+  }
+  const path = keys.reverse().join(KEY_PATH_SEPARATOR);
+  keyPaths.set(data, path);
+  return path;
+}
+
+/** A `rowFormatter` for a view whose rows merge occurrences, stamping the key
+ *  path so the mark finds the row with the same one DOM query. */
+export function stampRowKeyPath(row: RowComponent): void {
+  const path = rowKeyPath(row);
+  if (path !== undefined) {
+    row.getElement()?.setAttribute(ROW_INDEX_ATTRIBUTE, path);
+  }
+}
+
+/**
+ * The key paths naming the rows a frame belongs to in a merged view.
+ *
+ * A top-down row sits at the frame's own depth, so one path names it. A
+ * bottom-up row is the frame plus however many of its callers the chain shows, so
+ * every prefix names a row the frame heads — which is why one frame marks several
+ * rows there.
+ *
+ * The log root is not a row in either view, so the walk stops below it.
+ */
+export function eventKeyPaths(event: LogEvent, direction: SelectionView): string[] {
+  const keys: string[] = [];
+  for (let node: LogEvent | null = event; node?.parent; node = node.parent) {
+    keys.push(getEventKey(node));
+  }
+  if (!keys.length) {
+    return [];
+  }
+  if (direction === 'callees') {
+    return [keys.reverse().join(KEY_PATH_SEPARATOR)];
+  }
+  const paths: string[] = [];
+  for (let depth = 1; depth <= keys.length; depth++) {
+    paths.push(keys.slice(0, depth).join(KEY_PATH_SEPARATOR));
+  }
+  return paths;
 }
 
 /** True where the row holds no calls of its own, so its chain answers for it. */
@@ -167,25 +245,26 @@ export function rowDetailSelection(row: RowComponent | undefined): DetailSelecti
  * scrolls, expands or re-sorts. Rows the table has not rendered have no element
  * to mark, so they are left alone.
  *
- * The table must use {@link rowIndexStamper} to build its `rowFormatter`.
+ * The table must stamp its rows: {@link rowIndexStamper} where a row is one
+ * frame, {@link stampRowKeyPath} where rows merge occurrences.
  */
 export class LocatedRowMarker {
   private elements: HTMLElement[] = [];
 
   /**
-   * Move the mark to the rows for `eventIndexes`, or drop it with an empty list.
-   * Only the rendered rows are read, so the cost follows the viewport rather than
-   * the table; callers still only call this when the target changes.
+   * Move the mark to the rows `ids` name, or drop it with an empty list. Only the
+   * rendered rows are read, so the cost follows the viewport rather than the
+   * table; callers still only call this when the target changes.
    *
    * @param host - Element the table is mounted in
-   * @param eventIndexes - Events to mark, empty to clear
+   * @param ids - What the table stamps for the rows to mark, empty to clear
    */
-  public mark(host: HTMLElement | null, eventIndexes: readonly number[]): void {
+  public mark(host: HTMLElement | null, ids: readonly (number | string)[]): void {
     this.clear();
-    if (!host || !eventIndexes.length) {
+    if (!host || !ids.length) {
       return;
     }
-    const wanted = new Set(eventIndexes.map(String));
+    const wanted = new Set(ids.map(String));
     for (const element of host.querySelectorAll<HTMLElement>(
       `.tabulator-row[${ROW_INDEX_ATTRIBUTE}]`,
     )) {

--- a/log-viewer/src/components/locatedRow.ts
+++ b/log-viewer/src/components/locatedRow.ts
@@ -211,7 +211,6 @@ function rowCallOccurrences(row: RowComponent): LogEvent[] {
   return derived;
 }
 
-/** The calls a row stands for, as the event indexes the mark works in. */
 /**
  * The key paths that the frames `eventIndexes` name stand for, so a grid whose
  * rows merge occurrences can mark them.
@@ -238,6 +237,7 @@ export function keyPathsForEvents(
   return [...paths];
 }
 
+/** The calls a row stands for, as the event indexes the mark works in. */
 export function rowOccurrences(row: RowComponent): number[] {
   const data = rowCallData(row);
   const cached = derivedIndexes.get(data);

--- a/log-viewer/src/components/scopedCallTree.ts
+++ b/log-viewer/src/components/scopedCallTree.ts
@@ -634,14 +634,19 @@ async function buildBottomUp(
       seed.duration.total += attributed;
       seed.duration.self += row.duration.self;
       seed.callCount += 1;
-      for (const index of locatableEventIndexes(row)) {
+      const seedIndexes = locatableEventIndexes(row);
+      for (const index of seedIndexes) {
         seed._indexes.add(index);
       }
       let map = seed._map;
       for (let link = callers; link; link = link.caller) {
         const node = ensure(map, null, link.row, link.key);
         node.duration.total += attributed;
-        for (const index of locatableEventIndexes(link.row)) {
+        // A caller row stands for the calls it conducted, not for the caller
+        // frame, so it holds the same frames its time and count are taken from.
+        // That is what the grids send for their own caller rows, so the two sides
+        // point at the same calls.
+        for (const index of seedIndexes) {
           node._indexes.add(index);
         }
         // Callers count the call they contributed too, matching the Call Tree

--- a/log-viewer/src/components/scopedCallTree.ts
+++ b/log-viewer/src/components/scopedCallTree.ts
@@ -83,7 +83,11 @@ export function rowIdsByEvent(rows: readonly ScopedRow[]): Map<number, number[]>
       }
     }
     if (row._children) {
-      stack.push(...row._children);
+      // Pushed one at a time: a spread (and `push.apply`) passes each element as
+      // an argument, and a wide level would overrun the argument limit.
+      for (const child of row._children) {
+        stack.push(child);
+      }
     }
   }
   return byEvent;
@@ -465,7 +469,10 @@ async function aggregate(
         seen.add(index);
       }
       if (row._children) {
-        (group._children as ScopedRow[]).push(...row._children);
+        const kids = group._children as ScopedRow[];
+        for (const child of row._children) {
+          kids.push(child);
+        }
       }
     }
 

--- a/log-viewer/src/core/events/EventBus.ts
+++ b/log-viewer/src/core/events/EventBus.ts
@@ -67,6 +67,10 @@ interface EventMap {
     view?: SelectionView;
   };
 
+  // A tab changed the direction it shows, with its selection untouched. The
+  // inspector opens on the view a tab is not showing, so it has to be told.
+  'detail:view': { source: DetailSource; view: SelectionView };
+
   // App-level request to show/hide (or force a state on) the inspector.
   'detail:toggle': { visible?: boolean };
 

--- a/log-viewer/src/core/utility/EventSearch.ts
+++ b/log-viewer/src/core/utility/EventSearch.ts
@@ -60,6 +60,16 @@ export function findEventByTimestamp(
 }
 
 /**
+ * The event an index names, without its depth.
+ *
+ * {@link findEventByEventIndex} walks the whole ancestor chain to report a depth,
+ * which costs one walk per event: use this wherever the depth is not read.
+ */
+export function eventByEventIndex(apexLog: ApexLog, eventIndex: number): LogEvent | null {
+  return apexLog.eventsById[eventIndex] ?? null;
+}
+
+/**
  * Resolve an event directly by its parser-assigned eventIndex.
  * This is stable and unique within a single parse.
  */

--- a/log-viewer/src/features/analysis/components/AnalysisView.ts
+++ b/log-viewer/src/features/analysis/components/AnalysisView.ts
@@ -14,7 +14,16 @@ import type { ApexLog } from 'apex-log-parser';
 import '../../../components/ContextMenu.js';
 import type { ContextMenu } from '../../../components/ContextMenu.js';
 import { eventBus } from '../../../core/events/EventBus.js';
-import { rowDetailSelection, rowOccurrences } from '../../../components/locatedRow.js';
+import {
+  LOCATED_ROW_CLASS,
+  LocatedRowMarker,
+  eventKeyPaths,
+  rowDetailSelection,
+  rowOccurrences,
+  stampRowKeyPath,
+} from '../../../components/locatedRow.js';
+import { InspectorEmphasis } from '../../../components/inspectorEmphasis.js';
+import { findEventByEventIndex } from '../../../core/utility/EventSearch.js';
 import { SelectionEchoGuard } from '../../../core/events/SelectionEchoGuard.js';
 import { isVisible } from '../../../core/utility/Util.js';
 import { getSettings, updateSetting } from '../../settings/Settings.js';
@@ -64,6 +73,11 @@ export class AnalysisView extends LitElement {
         /* inset previously provided by the tab panel's padding */
         padding: 10px 6px;
         box-sizing: border-box;
+      }
+
+      /* The frame under the pointer in the inspector. */
+      .tabulator-row.${unsafeCSS(LOCATED_ROW_CLASS)} {
+        background-color: var(--lana-row-hover-bg);
       }
 
       .analysis-view {
@@ -145,6 +159,9 @@ export class AnalysisView extends LitElement {
   /** Guards the programmatic select made on the inspector's behalf. */
   private _echoGuard = new SelectionEchoGuard();
   private _inspectorRevealUnsubscribe: (() => void) | null = null;
+  private _inspectorLocateUnsubscribe: (() => void) | null = null;
+  private _locatedRow = new LocatedRowMarker();
+  private _emphasis = new InspectorEmphasis();
 
   constructor() {
     super();
@@ -156,14 +173,24 @@ export class AnalysisView extends LitElement {
         void this._revealEventIndex(detail.eventIndex);
       }
     });
+    // Mark the buckets the inspector points at. A row is a method bucket rather
+    // than one event, so a frame is translated into the paths of the rows it heads.
+    this._inspectorLocateUnsubscribe = eventBus.on('inspector:locate', (detail) => {
+      if (detail.source === 'analysis') {
+        this._markLocated(this._emphasis.report(detail.eventIndexes, detail.sticky));
+      }
+    });
     document.addEventListener('lv-find', this._findEvt);
     document.addEventListener('lv-find-match', this._findEvt);
     document.addEventListener('lv-find-close', this._findEvt);
 
-    // Escape (app-wide) deselects here; the table reports the clear itself.
+    // Escape (app-wide) deselects here; the table reports the clear itself. It
+    // also drops a mark held by a picked inspector row, which is no selection of
+    // this table's own.
     this._selectionClearUnsubscribe = eventBus.on('selection:clear', (detail) => {
       if (detail.source === 'analysis') {
         this.analysisTable?.deselectRow();
+        this._markLocated(this._emphasis.pick([]));
       }
     });
   }
@@ -184,6 +211,31 @@ export class AnalysisView extends LitElement {
     this._selectionClearUnsubscribe = null;
     this._inspectorRevealUnsubscribe?.();
     this._inspectorRevealUnsubscribe = null;
+    this._inspectorLocateUnsubscribe?.();
+    this._inspectorLocateUnsubscribe = null;
+    this._locatedRow.clear();
+  }
+
+  /**
+   * Mark the buckets that hold `eventIndexes`. The grid ranks methods and expands
+   * to their callers, so one frame heads a row at every caller depth it sits in.
+   */
+  private _markLocated(eventIndexes: readonly number[]): void {
+    const table = this.analysisTable;
+    if (!table || !eventIndexes.length || !this.timelineRoot) {
+      this._locatedRow.clear();
+      return;
+    }
+    const paths = new Set<string>();
+    for (const eventIndex of eventIndexes) {
+      const found = findEventByEventIndex(this.timelineRoot, eventIndex);
+      if (found) {
+        for (const path of eventKeyPaths(found.event, 'callers')) {
+          paths.add(path);
+        }
+      }
+    }
+    this._locatedRow.mark(table.element, [...paths]);
   }
 
   /**
@@ -598,7 +650,10 @@ export class AnalysisView extends LitElement {
             this._clearSearchHighlights();
           }
         },
-        rowFormatter: categoryRowFormatter,
+        rowFormatter: (row) => {
+          categoryRowFormatter(row);
+          stampRowKeyPath(row);
+        },
       },
       {
         placeholder: 'No Analysis Available',
@@ -640,8 +695,6 @@ export class AnalysisView extends LitElement {
 
     // Tell the inspector which calls the pointer is over, so it can mark the rows
     // that stand for them; a bucket merges calls, so it names every call it counts.
-    // The other direction has nothing to land on here: a row is a method bucket,
-    // not one event, so the inspector's pointer marks no row in this grid.
     this.analysisTable.on('rowMouseEnter', (_e, row) => {
       eventBus.emit('detail:locate', {
         source: 'analysis',

--- a/log-viewer/src/features/analysis/components/AnalysisView.ts
+++ b/log-viewer/src/features/analysis/components/AnalysisView.ts
@@ -16,14 +16,12 @@ import type { ContextMenu } from '../../../components/ContextMenu.js';
 import { eventBus } from '../../../core/events/EventBus.js';
 import {
   LOCATED_ROW_CLASS,
+  LocatedRowIds,
   LocatedRowMarker,
-  keyPathsForEvents,
   rowDetailSelection,
   rowOccurrences,
-  stampRowKeyPath,
 } from '../../../components/locatedRow.js';
 import { InspectorEmphasis } from '../../../components/inspectorEmphasis.js';
-import { findEventByEventIndex } from '../../../core/utility/EventSearch.js';
 import { SelectionEchoGuard } from '../../../core/events/SelectionEchoGuard.js';
 import { isVisible } from '../../../core/utility/Util.js';
 import { getSettings, updateSetting } from '../../settings/Settings.js';
@@ -40,7 +38,7 @@ import {
 import type { BottomUpRow } from '../../call-tree/utils/Aggregation.js';
 import {
   categoryColoringStyles,
-  categoryRowFormatter,
+  groupedRowFormatter,
   wireCategoryColoring,
 } from '../../call-tree/utils/CategoryColoring.js';
 import { expandCollapseAll } from '../../call-tree/utils/ExpandCollapse.js';
@@ -161,6 +159,7 @@ export class AnalysisView extends LitElement {
   private _inspectorRevealUnsubscribe: (() => void) | null = null;
   private _inspectorLocateUnsubscribe: (() => void) | null = null;
   private _locatedRow = new LocatedRowMarker();
+  private _locateIds = new LocatedRowIds();
   private _emphasis = new InspectorEmphasis();
 
   constructor() {
@@ -221,14 +220,9 @@ export class AnalysisView extends LitElement {
    * to their callers, so one frame heads a row at every caller depth it sits in.
    */
   private _markLocated(eventIndexes: readonly number[]): void {
-    const table = this.analysisTable;
-    if (!table || !eventIndexes.length || !this.timelineRoot) {
-      this._locatedRow.clear();
-      return;
-    }
     this._locatedRow.mark(
-      table.element,
-      keyPathsForEvents(this.timelineRoot, eventIndexes, 'callers'),
+      this.analysisTable?.element ?? null,
+      this._locateIds.idsFor(this.timelineRoot, eventIndexes, 'callers'),
     );
   }
 
@@ -644,10 +638,7 @@ export class AnalysisView extends LitElement {
             this._clearSearchHighlights();
           }
         },
-        rowFormatter: (row) => {
-          categoryRowFormatter(row);
-          stampRowKeyPath(row);
-        },
+        rowFormatter: groupedRowFormatter,
       },
       {
         placeholder: 'No Analysis Available',

--- a/log-viewer/src/features/analysis/components/AnalysisView.ts
+++ b/log-viewer/src/features/analysis/components/AnalysisView.ts
@@ -17,7 +17,7 @@ import { eventBus } from '../../../core/events/EventBus.js';
 import {
   LOCATED_ROW_CLASS,
   LocatedRowMarker,
-  eventKeyPaths,
+  keyPathsForEvents,
   rowDetailSelection,
   rowOccurrences,
   stampRowKeyPath,
@@ -226,16 +226,10 @@ export class AnalysisView extends LitElement {
       this._locatedRow.clear();
       return;
     }
-    const paths = new Set<string>();
-    for (const eventIndex of eventIndexes) {
-      const found = findEventByEventIndex(this.timelineRoot, eventIndex);
-      if (found) {
-        for (const path of eventKeyPaths(found.event, 'callers')) {
-          paths.add(path);
-        }
-      }
-    }
-    this._locatedRow.mark(table.element, [...paths]);
+    this._locatedRow.mark(
+      table.element,
+      keyPathsForEvents(this.timelineRoot, eventIndexes, 'callers'),
+    );
   }
 
   /**

--- a/log-viewer/src/features/call-tree/components/CalltreeView.ts
+++ b/log-viewer/src/features/call-tree/components/CalltreeView.ts
@@ -19,6 +19,7 @@ import { isVisible } from '../../../core/utility/Util.js';
 import { getSettings, updateSetting } from '../../settings/Settings.js';
 import { CALLTREE_GO_TO_ROW } from '../navigation.js';
 import type { AggregatedRow, BottomUpRow } from '../utils/Aggregation.js';
+import { findBucketRow } from '../utils/bucketRows.js';
 import {
   categoryColoringStyles,
   categoryRowFormatter,
@@ -192,6 +193,11 @@ export class CalltreeView extends LitElement {
     this._inspectorLocateUnsubscribe = eventBus.on('inspector:locate', (detail) => {
       if (detail.source === 'calltree') {
         this._markLocated(this._emphasis.report(detail.eventIndexes, detail.sticky));
+        if (detail.sticky && detail.eventIndexes.length) {
+          // A picked inspector row merges calls, so the mark shows all of them
+          // while the view moves to the first, as a pick of one frame does.
+          void this._revealEventIndex(detail.eventIndexes[0]!);
+        }
       }
     });
 
@@ -931,23 +937,45 @@ export class CalltreeView extends LitElement {
   }
 
   /**
-   * Select the row for `eventIndex` in place: no tab switch, no view-mode change
-   * and no focus steal, unlike {@link _goToRow}. Only Time Order has a row per
-   * event, so the grouped modes are left alone.
+   * Select the row for `eventIndex` in the view on screen, in place: no tab
+   * switch, no view-mode change and no focus steal, unlike {@link _goToRow}.
+   * Focus stays where the click was, which is the inspector.
    */
   private async _revealEventIndex(eventIndex: number): Promise<void> {
-    if (this.viewMode !== 'time-order' || !this.calltreeTable) {
+    const table = this._getActiveTable();
+    if (!table) {
       return;
     }
 
-    const treeRow = await this._findByEventIndex(this.calltreeTable.getRows(), eventIndex);
+    const treeRow = await this._findRowFor(table, eventIndex);
     if (!treeRow) {
       return;
     }
 
     await this._echoGuard.runAsync(() =>
       //@ts-expect-error This is a custom function added in by RowNavigation custom module
-      this.calltreeTable.goToRow(treeRow, { scrollIfVisible: false, focusRow: false }),
+      table.goToRow(treeRow, { scrollIfVisible: false, focusRow: false }),
+    );
+  }
+
+  /**
+   * The row holding `eventIndex` in the view on screen, with the path to it
+   * materialised. Time Order has a row per event; the grouped views find the
+   * bucket instead.
+   */
+  private async _findRowFor(table: Tabulator, eventIndex: number): Promise<RowComponent | null> {
+    if (this.viewMode === 'time-order') {
+      return this._findByEventIndex(table.getRows(), eventIndex);
+    }
+    if (!this.rootMethod) {
+      return null;
+    }
+    const found = findEventByEventIndex(this.rootMethod, eventIndex);
+    if (!found) {
+      return null;
+    }
+    return findBucketRow(table.getRows(), found.event, directionOf(this.viewMode), () =>
+      this._waitForTableRender(),
     );
   }
 

--- a/log-viewer/src/features/call-tree/components/CalltreeView.ts
+++ b/log-viewer/src/features/call-tree/components/CalltreeView.ts
@@ -14,7 +14,7 @@ import type { ApexLog, LogEvent } from 'apex-log-parser';
 import { eventBus, type DetailSource } from '../../../core/events/EventBus.js';
 import { SelectionEchoGuard } from '../../../core/events/SelectionEchoGuard.js';
 import { vscodeMessenger } from '../../../core/messaging/VSCodeExtensionMessenger.js';
-import { findEventByEventIndex } from '../../../core/utility/EventSearch.js';
+import { eventByEventIndex } from '../../../core/utility/EventSearch.js';
 import { isVisible } from '../../../core/utility/Util.js';
 import { getSettings, updateSetting } from '../../settings/Settings.js';
 import { CALLTREE_GO_TO_ROW } from '../navigation.js';
@@ -23,6 +23,7 @@ import { findBucketRow } from '../utils/bucketRows.js';
 import {
   categoryColoringStyles,
   categoryRowFormatter,
+  groupedRowFormatter,
   wireCategoryColoring,
 } from '../utils/CategoryColoring.js';
 import { deepFilter } from '../utils/DetailsFilter.js';
@@ -64,12 +65,11 @@ import {
 } from '../../../tabulator/ColumnViews.js';
 import {
   LOCATED_ROW_CLASS,
+  LocatedRowIds,
   LocatedRowMarker,
-  keyPathsForEvents,
   rowDetailSelection,
   rowIndexStamper,
   rowOccurrences,
-  stampRowKeyPath,
 } from '../../../components/locatedRow.js';
 import { InspectorEmphasis } from '../../../components/inspectorEmphasis.js';
 import { createTimeOrderTable } from './TimeOrderTable.js';
@@ -81,10 +81,6 @@ const stampTimeOrderIndex = rowIndexStamper('id');
 const timeOrderRowFormatter = (row: RowComponent): void => {
   categoryRowFormatter(row);
   stampTimeOrderIndex(row);
-};
-const groupedRowFormatter = (row: RowComponent): void => {
-  categoryRowFormatter(row);
-  stampRowKeyPath(row);
 };
 
 /** The Name column is always shown in the call-tree tables. */
@@ -175,6 +171,7 @@ export class CalltreeView extends LitElement {
   private _inspectorLocateUnsubscribe: (() => void) | null = null;
   private _selectionClearUnsubscribe: (() => void) | null = null;
   private _locatedRow = new LocatedRowMarker();
+  private _locateIds = new LocatedRowIds();
   /** Which of the inspector's reports the mark follows. */
   private _emphasis = new InspectorEmphasis();
 
@@ -193,11 +190,15 @@ export class CalltreeView extends LitElement {
     // inspector is showing.
     this._inspectorLocateUnsubscribe = eventBus.on('inspector:locate', (detail) => {
       if (detail.source === 'calltree') {
-        this._markLocated(this._emphasis.report(detail.eventIndexes, detail.sticky));
+        const ids = this._emphasis.report(detail.eventIndexes, detail.sticky);
         if (detail.sticky && detail.eventIndexes.length) {
           // A picked inspector row merges calls, so the mark shows all of them
-          // while the view moves to the first, as a pick of one frame does.
-          void this._revealEventIndex(detail.eventIndexes[0]!);
+          // while the view moves to the first, as a pick of one frame does. The
+          // reveal expands and scrolls, which re-renders the rows the mark lands
+          // on, so it goes on after.
+          void this._revealEventIndex(detail.eventIndexes[0]!).then(() => this._markLocated(ids));
+        } else {
+          this._markLocated(ids);
         }
       }
     });
@@ -840,19 +841,11 @@ export class CalltreeView extends LitElement {
    * per caller depth in Bottom-Up.
    */
   private _markLocated(eventIndexes: readonly number[]): void {
-    const table = this._getActiveTable();
-    if (!table) {
-      this._locatedRow.clear();
-      return;
-    }
-    this._locatedRow.mark(table.element, this._locateIdsFor(eventIndexes));
-  }
-
-  private _locateIdsFor(eventIndexes: readonly number[]): readonly (number | string)[] {
-    if (this.viewMode === 'time-order' || !eventIndexes.length || !this.rootMethod) {
-      return eventIndexes;
-    }
-    return keyPathsForEvents(this.rootMethod, eventIndexes, directionOf(this.viewMode));
+    const direction = this.viewMode === 'time-order' ? undefined : directionOf(this.viewMode);
+    this._locatedRow.mark(
+      this._getActiveTable()?.element ?? null,
+      this._locateIds.idsFor(this.rootMethod, eventIndexes, direction),
+    );
   }
 
   private _getActiveTable(): Tabulator | null {
@@ -909,8 +902,8 @@ export class CalltreeView extends LitElement {
     document.dispatchEvent(new CustomEvent('show-tab', { detail: { tabid: 'tree-tab' } }));
 
     if (this.viewMode !== 'time-order') {
-      this.viewMode = 'time-order';
-      await this.updateComplete;
+      // Through the switch, so the inspector hears the direction change too.
+      await this._setViewMode('time-order');
     }
 
     if (!this._callTreeTableWrapper) {
@@ -965,11 +958,11 @@ export class CalltreeView extends LitElement {
     if (!this.rootMethod) {
       return null;
     }
-    const found = findEventByEventIndex(this.rootMethod, eventIndex);
-    if (!found) {
+    const event = eventByEventIndex(this.rootMethod, eventIndex);
+    if (!event) {
       return null;
     }
-    return findBucketRow(table.getRows(), found.event, directionOf(this.viewMode), () =>
+    return findBucketRow(table.getRows(), event, directionOf(this.viewMode), () =>
       this._waitForTableRender(),
     );
   }
@@ -1224,7 +1217,7 @@ export class CalltreeView extends LitElement {
   // redraw. A single rAF can race the virtual renderer and leave getTreeChildren
   // empty mid-descent.
   private _waitForTableRender(): Promise<void> {
-    const table = this.calltreeTable;
+    const table = this._getActiveTable();
     if (!table) {
       return waitForNextFrame();
     }
@@ -1348,12 +1341,12 @@ export class CalltreeView extends LitElement {
       return null;
     }
 
-    const result = findEventByEventIndex(this.rootMethod, eventIndex);
-    if (!result) {
+    const event = eventByEventIndex(this.rootMethod, eventIndex);
+    if (!event) {
       return null;
     }
 
-    return this._materializeRowPath(rows, result.event);
+    return this._materializeRowPath(rows, event);
   }
 
   private async _materializeRowPath(

--- a/log-viewer/src/features/call-tree/components/CalltreeView.ts
+++ b/log-viewer/src/features/call-tree/components/CalltreeView.ts
@@ -597,6 +597,10 @@ export class CalltreeView extends LitElement {
     if (switchEpoch !== this.viewSwitchEpoch) {
       return;
     }
+
+    // The selection is untouched, but the direction this tab shows is not, and
+    // that is what the inspector opens on the other side of.
+    eventBus.emit('detail:view', { source: 'calltree', view: directionOf(this.viewMode) });
   }
 
   private _destroyCurrentTable(): void {

--- a/log-viewer/src/features/call-tree/components/CalltreeView.ts
+++ b/log-viewer/src/features/call-tree/components/CalltreeView.ts
@@ -31,6 +31,7 @@ import type { TimeOrderRow } from '../utils/TimeOrderTree.js';
 import { waitForNextFrame } from '../../../core/utility/FrameBudget.js';
 
 import { inMsRange, type FilterRange } from '../../../tabulator/filters/MinMax.js';
+import { withCodeDrivenExpand } from '../../../tabulator/module/expandOrigin.js';
 
 import dataGridStyles from '../../../tabulator/style/DataGrid.scss';
 
@@ -1404,7 +1405,8 @@ export class CalltreeView extends LitElement {
       let children = matchedRow.getTreeChildren() ?? [];
       const rowData = matchedRow.getData() as TimeOrderRow;
       if (!children.length && rowData._children?.length && !matchedRow.isTreeExpanded()) {
-        matchedRow.treeExpand();
+        const rowToExpand = matchedRow;
+        withCodeDrivenExpand(() => rowToExpand.treeExpand());
         await this._waitForTableRender();
         children = matchedRow.getTreeChildren() ?? [];
       }

--- a/log-viewer/src/features/call-tree/components/CalltreeView.ts
+++ b/log-viewer/src/features/call-tree/components/CalltreeView.ts
@@ -63,19 +63,26 @@ import {
 import {
   LOCATED_ROW_CLASS,
   LocatedRowMarker,
+  eventKeyPaths,
   rowDetailSelection,
   rowIndexStamper,
   rowOccurrences,
+  stampRowKeyPath,
 } from '../../../components/locatedRow.js';
 import { InspectorEmphasis } from '../../../components/inspectorEmphasis.js';
 import { createTimeOrderTable } from './TimeOrderTable.js';
 
-/** Time Order keys its rows by event index, so the inspector can mark them; the
- *  grouped views key theirs by group, so they carry no index to mark. */
+/** Time Order keys its rows by event index; the grouped views key theirs by the
+ *  path of buckets that reaches them, since one method holds a row under every
+ *  caller it has. Either way the inspector can mark them. */
 const stampTimeOrderIndex = rowIndexStamper('id');
 const timeOrderRowFormatter = (row: RowComponent): void => {
   categoryRowFormatter(row);
   stampTimeOrderIndex(row);
+};
+const groupedRowFormatter = (row: RowComponent): void => {
+  categoryRowFormatter(row);
+  stampRowKeyPath(row);
 };
 
 /** The Name column is always shown in the call-tree tables. */
@@ -181,14 +188,10 @@ export class CalltreeView extends LitElement {
     });
 
     // Mark the frames the inspector points at, while the Call Tree is the tab the
-    // inspector is showing. Only Time Order keys its rows by event, so the grouped
-    // views have nothing to mark and are left alone.
+    // inspector is showing.
     this._inspectorLocateUnsubscribe = eventBus.on('inspector:locate', (detail) => {
       if (detail.source === 'calltree') {
-        this._locatedRow.mark(
-          this.calltreeTable?.element ?? null,
-          this._emphasis.report(detail.eventIndexes, detail.sticky),
-        );
+        this._markLocated(this._emphasis.report(detail.eventIndexes, detail.sticky));
       }
     });
 
@@ -200,7 +203,7 @@ export class CalltreeView extends LitElement {
         for (const table of this._tables) {
           table.deselectRow();
         }
-        this._locatedRow.mark(this.calltreeTable?.element ?? null, this._emphasis.pick([]));
+        this._markLocated(this._emphasis.pick([]));
       }
     });
     document.addEventListener(CALLTREE_GO_TO_ROW, this._goToRowEvt);
@@ -819,6 +822,38 @@ export class CalltreeView extends LitElement {
     activeTable.restoreRedraw();
   }
 
+  /**
+   * Mark the rows of the view on screen for `eventIndexes`. Time Order stamps the
+   * event index itself; a grouped view stamps the bucket path, so a frame is
+   * translated into the paths of the rows it belongs to — one in Aggregated, one
+   * per caller depth in Bottom-Up.
+   */
+  private _markLocated(eventIndexes: readonly number[]): void {
+    const table = this._getActiveTable();
+    if (!table) {
+      this._locatedRow.clear();
+      return;
+    }
+    this._locatedRow.mark(table.element, this._locateIdsFor(eventIndexes));
+  }
+
+  private _locateIdsFor(eventIndexes: readonly number[]): readonly (number | string)[] {
+    if (this.viewMode === 'time-order' || !eventIndexes.length || !this.rootMethod) {
+      return eventIndexes;
+    }
+    const direction = directionOf(this.viewMode);
+    const paths = new Set<string>();
+    for (const eventIndex of eventIndexes) {
+      const found = findEventByEventIndex(this.rootMethod, eventIndex);
+      if (found) {
+        for (const path of eventKeyPaths(found.event, direction)) {
+          paths.add(path);
+        }
+      }
+    }
+    return [...paths];
+  }
+
   private _getActiveTable(): Tabulator | null {
     switch (this.viewMode) {
       case 'time-order':
@@ -1079,7 +1114,7 @@ export class CalltreeView extends LitElement {
           this._clearSearchHighlights();
         }
       },
-      rowFormatter: categoryRowFormatter,
+      rowFormatter: groupedRowFormatter,
     });
     this.aggregatedTreeTable = table;
     await tableBuilt;
@@ -1105,7 +1140,7 @@ export class CalltreeView extends LitElement {
             this._clearSearchHighlights();
           }
         },
-        rowFormatter: categoryRowFormatter,
+        rowFormatter: groupedRowFormatter,
       },
       {
         selectableRows: 'highlight',
@@ -1134,7 +1169,7 @@ export class CalltreeView extends LitElement {
       if (!selection) {
         // The selection went with it, and so does a mark a picked inspector row
         // left here — it was never a selection of this table.
-        this._locatedRow.mark(this.calltreeTable?.element ?? null, this._emphasis.pick([]));
+        this._markLocated(this._emphasis.pick([]));
       }
       eventBus.emit('detail:select', {
         source,

--- a/log-viewer/src/features/call-tree/components/CalltreeView.ts
+++ b/log-viewer/src/features/call-tree/components/CalltreeView.ts
@@ -65,7 +65,7 @@ import {
 import {
   LOCATED_ROW_CLASS,
   LocatedRowMarker,
-  eventKeyPaths,
+  keyPathsForEvents,
   rowDetailSelection,
   rowIndexStamper,
   rowOccurrences,
@@ -852,17 +852,7 @@ export class CalltreeView extends LitElement {
     if (this.viewMode === 'time-order' || !eventIndexes.length || !this.rootMethod) {
       return eventIndexes;
     }
-    const direction = directionOf(this.viewMode);
-    const paths = new Set<string>();
-    for (const eventIndex of eventIndexes) {
-      const found = findEventByEventIndex(this.rootMethod, eventIndex);
-      if (found) {
-        for (const path of eventKeyPaths(found.event, direction)) {
-          paths.add(path);
-        }
-      }
-    }
-    return [...paths];
+    return keyPathsForEvents(this.rootMethod, eventIndexes, directionOf(this.viewMode));
   }
 
   private _getActiveTable(): Tabulator | null {

--- a/log-viewer/src/features/call-tree/utils/Aggregation.ts
+++ b/log-viewer/src/features/call-tree/utils/Aggregation.ts
@@ -144,6 +144,18 @@ export function getEventKey(event: LogEvent): string {
 }
 
 /**
+ * The bucket keys from `event` out to its outermost frame, innermost first. The
+ * log root heads no row in any view, so the walk stops below it.
+ */
+export function eventKeyChain(event: LogEvent): string[] {
+  const keys: string[] = [];
+  for (let node: LogEvent | null = event; node?.parent; node = node.parent) {
+    keys.push(getEventKey(node));
+  }
+  return keys;
+}
+
+/**
  * Generates a key for call-stack tracking to detect recursive calls.
  * Excludes event type so the same method is recognised regardless of entry type
  * (e.g. CODE_UNIT_STARTED at the top level, METHOD_ENTRY for recursive calls).

--- a/log-viewer/src/features/call-tree/utils/CategoryColoring.ts
+++ b/log-viewer/src/features/call-tree/utils/CategoryColoring.ts
@@ -4,6 +4,7 @@
 import { css } from 'lit';
 import type { RowComponent } from 'tabulator-tables';
 
+import { stampRowKeyPath } from '../../../components/locatedRow.js';
 import { VSCodeExtensionMessenger } from '../../../core/messaging/VSCodeExtensionMessenger.js';
 import { subscribeSettings, type LanaSettings } from '../../settings/Settings.js';
 import { CATEGORY_THEME_KEY, DEFAULT_THEME_NAME } from '../../timeline/themes/Themes.js';
@@ -39,6 +40,13 @@ export const categoryRowFormatter = (row: RowComponent): void => {
   if (themeKey) {
     row.getElement().style.setProperty('--row-cat-color', `var(--ct-color-${themeKey})`);
   }
+};
+
+/** The `rowFormatter` for a view whose rows merge occurrences: the colour strip,
+ *  plus the key path the inspector's mark finds the row by. */
+export const groupedRowFormatter = (row: RowComponent): void => {
+  categoryRowFormatter(row);
+  stampRowKeyPath(row);
 };
 
 function applyCategoryTheme(host: HTMLElement, themeName: string): void {

--- a/log-viewer/src/features/call-tree/utils/ExpandCollapse.ts
+++ b/log-viewer/src/features/call-tree/utils/ExpandCollapse.ts
@@ -6,21 +6,19 @@ import type { RowComponent } from 'tabulator-tables';
 import { withCodeDrivenExpand } from '../../../tabulator/module/expandOrigin.js';
 
 export function expandCollapseAll(rows: RowComponent[], expand: boolean): void {
-  withCodeDrivenExpand(() => walk(rows, expand));
-}
+  withCodeDrivenExpand(() => {
+    for (const row of rows) {
+      const children = row.getTreeChildren();
+      if (!children || children.length === 0) {
+        continue;
+      }
 
-function walk(rows: RowComponent[], expand: boolean): void {
-  for (const row of rows) {
-    const children = row.getTreeChildren();
-    if (!children || children.length === 0) {
-      continue;
+      if (expand) {
+        row.treeExpand();
+      } else {
+        row.treeCollapse();
+      }
+      expandCollapseAll(children, expand);
     }
-
-    if (expand) {
-      row.treeExpand();
-    } else {
-      row.treeCollapse();
-    }
-    walk(children, expand);
-  }
+  });
 }

--- a/log-viewer/src/features/call-tree/utils/ExpandCollapse.ts
+++ b/log-viewer/src/features/call-tree/utils/ExpandCollapse.ts
@@ -3,7 +3,13 @@
  */
 import type { RowComponent } from 'tabulator-tables';
 
+import { withCodeDrivenExpand } from '../../../tabulator/module/expandOrigin.js';
+
 export function expandCollapseAll(rows: RowComponent[], expand: boolean): void {
+  withCodeDrivenExpand(() => walk(rows, expand));
+}
+
+function walk(rows: RowComponent[], expand: boolean): void {
   for (const row of rows) {
     const children = row.getTreeChildren();
     if (!children || children.length === 0) {
@@ -15,6 +21,6 @@ export function expandCollapseAll(rows: RowComponent[], expand: boolean): void {
     } else {
       row.treeCollapse();
     }
-    expandCollapseAll(children, expand);
+    walk(children, expand);
   }
 }

--- a/log-viewer/src/features/call-tree/utils/__tests__/bucketRows.test.ts
+++ b/log-viewer/src/features/call-tree/utils/__tests__/bucketRows.test.ts
@@ -1,0 +1,103 @@
+/*
+ * Copyright (c) 2026 Certinia Inc. All rights reserved.
+ */
+import { describe, expect, it } from '@jest/globals';
+import type { LogEvent } from 'apex-log-parser';
+import type { RowComponent } from 'tabulator-tables';
+
+import { findBucketRow } from '../bucketRows.js';
+
+function ev(text: string, parent: LogEvent | null): LogEvent {
+  return { type: 'METHOD_ENTRY', namespace: '', text, parent } as unknown as LogEvent;
+}
+
+const key = (text: string) => `METHOD_ENTRY||${text}`;
+
+interface FakeRow {
+  key: string;
+  children: FakeRow[];
+  expanded: boolean;
+  /** Set once the row is asked to expand, so a test can prove it was. */
+  expandedByWalk?: boolean;
+}
+
+function row(text: string, ...children: FakeRow[]): FakeRow {
+  return { key: key(text), children, expanded: false };
+}
+
+/** Wraps the fakes as tabulator hands rows over: children exist only once open. */
+function asRows(rows: FakeRow[]): RowComponent[] {
+  return rows.map(
+    (data) =>
+      ({
+        getData: () => ({ key: data.key, _children: data.children }),
+        getTreeChildren: () => (data.expanded ? asRows(data.children) : []),
+        isTreeExpanded: () => data.expanded,
+        treeExpand: () => {
+          data.expanded = true;
+          data.expandedByWalk = true;
+        },
+      }) as unknown as RowComponent,
+  );
+}
+
+const settled = () => Promise.resolve();
+
+describe('findBucketRow', () => {
+  describe('a bottom-up view', () => {
+    it('heads the frame with a top-level row, so its own key finds it', async () => {
+      const rows = [row('other'), row('target')];
+
+      const found = await findBucketRow(asRows(rows), ev('target', null), 'callers', settled);
+
+      expect(found && (found.getData() as { key: string }).key).toBe(key('target'));
+    });
+
+    it('finds nothing where no row heads the frame', async () => {
+      const found = await findBucketRow(
+        asRows([row('other')]),
+        ev('gone', null),
+        'callers',
+        settled,
+      );
+
+      expect(found).toBeNull();
+    });
+  });
+
+  describe('a top-down view', () => {
+    // exec -> a -> target, and a second exec branch holding the same method.
+    const root = ev('LOG_ROOT', null);
+    const exec = ev('exec', root);
+    const outer = ev('a', exec);
+    const target = ev('target', outer);
+
+    it('descends the call path and expands what it walks through', async () => {
+      const deep = row('target');
+      const mid = row('a', deep);
+      const rows = [row('other', row('target')), row('exec', mid)];
+
+      const found = await findBucketRow(asRows(rows), target, 'callees', settled);
+
+      expect(found && (found.getData() as { key: string }).key).toBe(key('target'));
+      // The row under `other` shares the key, so only the path can tell them apart.
+      expect(mid.expandedByWalk).toBe(true);
+      expect(rows[0]!.expandedByWalk).toBeUndefined();
+    });
+
+    it('lands on the deepest row it resolved when a level is filtered out', async () => {
+      // `a` is missing, so the walk stops at `exec` rather than giving up.
+      const rows = [row('exec')];
+
+      const found = await findBucketRow(asRows(rows), target, 'callees', settled);
+
+      expect(found && (found.getData() as { key: string }).key).toBe(key('exec'));
+    });
+
+    it('finds nothing where the outermost frame has no row', async () => {
+      const found = await findBucketRow(asRows([row('elsewhere')]), target, 'callees', settled);
+
+      expect(found).toBeNull();
+    });
+  });
+});

--- a/log-viewer/src/features/call-tree/utils/bucketRows.ts
+++ b/log-viewer/src/features/call-tree/utils/bucketRows.ts
@@ -7,7 +7,7 @@ import type { RowComponent } from 'tabulator-tables';
 
 import type { SelectionView } from '../../../core/events/EventBus.js';
 import { withCodeDrivenExpand } from '../../../tabulator/module/expandOrigin.js';
-import { getEventKey } from './Aggregation.js';
+import { eventKeyChain, getEventKey } from './Aggregation.js';
 
 interface BucketRow {
   key?: string;
@@ -39,17 +39,12 @@ export async function findBucketRow(
     return rows.find((row) => bucketOf(row).key === key) ?? null;
   }
 
-  // The log root is not a row, so the path starts at the outermost frame below it.
-  const path: LogEvent[] = [];
-  for (let node: LogEvent | null = event; node?.parent; node = node.parent) {
-    path.push(node);
-  }
-  path.reverse();
+  const path = eventKeyChain(event).reverse();
 
   let currentRows = rows;
   let matched: RowComponent | null = null;
   for (let depth = 0; depth < path.length; depth++) {
-    const key = getEventKey(path[depth]!);
+    const key = path[depth]!;
     const next = currentRows.find((row) => bucketOf(row).key === key);
     if (!next) {
       break;

--- a/log-viewer/src/features/call-tree/utils/bucketRows.ts
+++ b/log-viewer/src/features/call-tree/utils/bucketRows.ts
@@ -6,6 +6,7 @@ import type { LogEvent } from 'apex-log-parser';
 import type { RowComponent } from 'tabulator-tables';
 
 import type { SelectionView } from '../../../core/events/EventBus.js';
+import { withCodeDrivenExpand } from '../../../tabulator/module/expandOrigin.js';
 import { getEventKey } from './Aggregation.js';
 
 interface BucketRow {
@@ -57,11 +58,11 @@ export async function findBucketRow(
     if (depth === path.length - 1) {
       break;
     }
-    let children = matched.getTreeChildren() ?? [];
-    if (!children.length && bucketOf(matched)._children?.length && !matched.isTreeExpanded()) {
-      matched.treeExpand();
+    let children = next.getTreeChildren() ?? [];
+    if (!children.length && bucketOf(next)._children?.length && !next.isTreeExpanded()) {
+      withCodeDrivenExpand(() => next.treeExpand());
       await waitForRender();
-      children = matched.getTreeChildren() ?? [];
+      children = next.getTreeChildren() ?? [];
     }
     currentRows = children;
   }

--- a/log-viewer/src/features/call-tree/utils/bucketRows.ts
+++ b/log-viewer/src/features/call-tree/utils/bucketRows.ts
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2026 Certinia Inc. All rights reserved.
+ */
+
+import type { LogEvent } from 'apex-log-parser';
+import type { RowComponent } from 'tabulator-tables';
+
+import type { SelectionView } from '../../../core/events/EventBus.js';
+import { getEventKey } from './Aggregation.js';
+
+interface BucketRow {
+  key?: string;
+  _children?: unknown[];
+}
+
+const bucketOf = (row: RowComponent): BucketRow => row.getData() as BucketRow;
+
+/**
+ * The row a frame belongs to in a view whose rows merge occurrences.
+ *
+ * A bottom-up view heads the frame with a top-level row, so its own key finds it.
+ * A top-down view mirrors the call path, so the walk descends the frame's
+ * ancestors, matching each level by bucket and expanding as it goes. It falls
+ * back to the deepest bucket it did resolve, so a level hidden by a filter lands
+ * on the nearest visible ancestor rather than nothing.
+ *
+ * @param rows - the view's top-level rows
+ * @param waitForRender - resolves once an expanded row's children exist
+ */
+export async function findBucketRow(
+  rows: RowComponent[],
+  event: LogEvent,
+  direction: SelectionView,
+  waitForRender: () => Promise<void>,
+): Promise<RowComponent | null> {
+  if (direction === 'callers') {
+    const key = getEventKey(event);
+    return rows.find((row) => bucketOf(row).key === key) ?? null;
+  }
+
+  // The log root is not a row, so the path starts at the outermost frame below it.
+  const path: LogEvent[] = [];
+  for (let node: LogEvent | null = event; node?.parent; node = node.parent) {
+    path.push(node);
+  }
+  path.reverse();
+
+  let currentRows = rows;
+  let matched: RowComponent | null = null;
+  for (let depth = 0; depth < path.length; depth++) {
+    const key = getEventKey(path[depth]!);
+    const next = currentRows.find((row) => bucketOf(row).key === key);
+    if (!next) {
+      break;
+    }
+    matched = next;
+    if (depth === path.length - 1) {
+      break;
+    }
+    let children = matched.getTreeChildren() ?? [];
+    if (!children.length && bucketOf(matched)._children?.length && !matched.isTreeExpanded()) {
+      matched.treeExpand();
+      await waitForRender();
+      children = matched.getTreeChildren() ?? [];
+    }
+    currentRows = children;
+  }
+  return matched;
+}

--- a/log-viewer/src/features/database/components/DatabaseTimeTree.ts
+++ b/log-viewer/src/features/database/components/DatabaseTimeTree.ts
@@ -156,6 +156,9 @@ export class DatabaseTime extends LitElement {
 
   /** eventIndex to the ids of the rows that name it, built on the first mark. */
   private _rowsByEvent: Map<number, number[]> | null = null;
+  /** The rows the table was filled with. Never read them back with `getData()`:
+   *  that runs Tabulator's accessors, which deep-clone every row. */
+  private _rows: readonly DatabaseTreeRow[] = [];
 
   /** The build in flight; a newer one aborts it, and so does a disconnect. */
   private _building: AbortController | null = null;
@@ -221,6 +224,7 @@ export class DatabaseTime extends LitElement {
     this._table?.destroy();
     this._table = null;
     this._rowsByEvent = null;
+    this._rows = [];
   }
 
   firstUpdated(): void {
@@ -249,12 +253,10 @@ export class DatabaseTime extends LitElement {
 
   /** The ids of the rows that name `eventIndexes`; one frame names several. */
   private _rowIdsFor(eventIndexes: readonly number[]): number[] {
-    if (!eventIndexes.length || !this._table) {
+    if (!eventIndexes.length || !this._rows.length) {
       return [];
     }
-    const byEvent = (this._rowsByEvent ??= rowIdsByEventIndex(
-      this._table.getData() as DatabaseTreeRow[],
-    ));
+    const byEvent = (this._rowsByEvent ??= rowIdsByEventIndex(this._rows));
     const ids = new Set<number>();
     for (const eventIndex of eventIndexes) {
       for (const id of byEvent.get(eventIndex) ?? []) {
@@ -298,6 +300,7 @@ export class DatabaseTime extends LitElement {
     this._timeBarParams.totalValue = overview?.time.timeNs ?? 0;
     this._selfBarParams.totalValue = this._ownCodeTotalNs;
     this._rowsByEvent = null;
+    this._rows = rows;
 
     if (this._table) {
       void this._table.setData(rows);

--- a/log-viewer/src/features/timeline/optimised/FlameChart.ts
+++ b/log-viewer/src/features/timeline/optimised/FlameChart.ts
@@ -252,7 +252,7 @@ export class FlameChart<E extends EventNode = EventNode> {
     this.options = options;
     this.callbacks = callbacks;
 
-    // Store truncation markers for rendering
+    // Pushed one at a time: a spread would overrun the argument limit.
     for (const marker of markers) {
       this.markers.push(marker);
     }

--- a/log-viewer/src/features/timeline/optimised/FlameChart.ts
+++ b/log-viewer/src/features/timeline/optimised/FlameChart.ts
@@ -253,7 +253,9 @@ export class FlameChart<E extends EventNode = EventNode> {
     this.callbacks = callbacks;
 
     // Store truncation markers for rendering
-    this.markers.push(...markers);
+    for (const marker of markers) {
+      this.markers.push(marker);
+    }
 
     const { width, height } = await this.awaitContainerSize(container);
 

--- a/log-viewer/src/tabulator/module/RowKeyboardNavigation.ts
+++ b/log-viewer/src/tabulator/module/RowKeyboardNavigation.ts
@@ -10,6 +10,7 @@ import {
 } from 'tabulator-tables';
 
 import { isCodeDrivenExpand, withCodeDrivenExpand } from './expandOrigin.js';
+import { tableHolder } from './tableHolder.js';
 
 // todo: make this generic and support opening grouped rows too then use on DB view.
 // todo: remove the '@ts-expect-error' + fix the types file
@@ -35,7 +36,6 @@ export class RowKeyboardNavigation extends Module {
   static moduleExtensions = this.getModuleExtensions();
 
   private localTable: Tabulator;
-  private tableHolder: HTMLElement | null = null;
 
   constructor(table: Tabulator) {
     super(table);
@@ -61,8 +61,7 @@ export class RowKeyboardNavigation extends Module {
 
     row.select();
     // The key bindings only fire while the holder itself holds focus.
-    this.tableHolder ??= this.localTable.element.querySelector('.tabulator-tableholder');
-    this.tableHolder?.focus({ preventScroll: true });
+    tableHolder(this.localTable.element)?.focus({ preventScroll: true });
   }
 
   rowClick(event: UIEvent, row: RowComponent) {

--- a/log-viewer/src/tabulator/module/RowKeyboardNavigation.ts
+++ b/log-viewer/src/tabulator/module/RowKeyboardNavigation.ts
@@ -9,6 +9,8 @@ import {
   type RowComponent,
 } from 'tabulator-tables';
 
+import { isCodeDrivenExpand, withCodeDrivenExpand } from './expandOrigin.js';
+
 // todo: make this generic and support opening grouped rows too then use on DB view.
 // todo: remove the '@ts-expect-error' + fix the types file
 
@@ -44,22 +46,23 @@ export class RowKeyboardNavigation extends Module {
   initialize() {
     this.setOption('selectableRows', 'highlight');
     this.localTable.on('dataTreeRowExpanded', (row, _level) => {
-      this.rowExpandedToggled(row, _level);
-    });
-    this.localTable.on('dataTreeRowCollapsed', (row, _level) => {
-      this.rowExpandedToggled(row, _level);
+      this.rowExpanded(row);
     });
     this.localTable.on('rowClick', (event, row) => {
       this.rowClick(event, row);
     });
   }
 
-  rowExpandedToggled(row: RowComponent, _level: number) {
-    const table = row.getTable();
-    const selectedRows = table.getSelectedRows();
-    if (!selectedRows.length) {
-      row.select();
+  /** The user's first expansion gives the keyboard a row to move from. */
+  rowExpanded(row: RowComponent) {
+    if (isCodeDrivenExpand() || this.localTable.getSelectedRows().length) {
+      return;
     }
+
+    row.select();
+    // The key bindings only fire while the holder itself holds focus.
+    this.tableHolder ??= this.localTable.element.querySelector('.tabulator-tableholder');
+    this.tableHolder?.focus({ preventScroll: true });
   }
 
   rowClick(event: UIEvent, row: RowComponent) {
@@ -152,7 +155,7 @@ export class RowKeyboardNavigation extends Module {
                 nextRow.getElement().scrollIntoView({ block: 'nearest' });
               }
             } else {
-              row.treeExpand();
+              withCodeDrivenExpand(() => row.treeExpand());
             }
           },
           collapseRow: function (e: KeyboardEvent) {

--- a/log-viewer/src/tabulator/module/RowNavigation.ts
+++ b/log-viewer/src/tabulator/module/RowNavigation.ts
@@ -3,6 +3,8 @@
  */
 import type { Tabulator } from 'tabulator-tables';
 import { Module, type RowComponent } from 'tabulator-tables';
+
+import { withCodeDrivenExpand } from './expandOrigin.js';
 type GoToRowOptions = { scrollIfVisible: boolean; focusRow: boolean };
 export class RowNavigation extends Module {
   static moduleName = 'rowNavigation';
@@ -50,7 +52,7 @@ export class RowNavigation extends Module {
       grp.show();
     }
 
-    const rowsToExpand = [];
+    const rowsToExpand: RowComponent[] = [];
     //@ts-expect-error This is private to tabulator, but we have no other choice atm.
     let parent = row._getSelf().modules.dataTree ? row.getTreeParent() : false;
     while (parent) {
@@ -60,9 +62,11 @@ export class RowNavigation extends Module {
       parent = parent.getTreeParent();
     }
 
-    for (const row of rowsToExpand) {
-      row.treeExpand();
-    }
+    withCodeDrivenExpand(() => {
+      for (const row of rowsToExpand) {
+        row.treeExpand();
+      }
+    });
 
     for (const row of table.getSelectedRows()) {
       row.deselect();

--- a/log-viewer/src/tabulator/module/__tests__/RowKeyboardNavigation.test.ts
+++ b/log-viewer/src/tabulator/module/__tests__/RowKeyboardNavigation.test.ts
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) 2026 Certinia Inc. All rights reserved.
+ */
+import { beforeEach, describe, expect, it } from '@jest/globals';
+import type { RowComponent } from 'tabulator-tables';
+
+// The tabulator ESM build doesn't load under jest, and the module registers
+// itself on import.
+jest.mock('tabulator-tables', () => ({
+  Module: class {
+    constructor(_table: unknown) {}
+    registerTableOption() {}
+    setOption() {}
+  },
+  Tabulator: { registerModule: () => {} },
+  KeybindingsModule: {},
+  SelectRowModule: {},
+}));
+
+import { withCodeDrivenExpand } from '../expandOrigin.js';
+import { RowKeyboardNavigation } from '../RowKeyboardNavigation.js';
+
+function setup(selected: RowComponent[] = []) {
+  const handlers: Record<string, ((...args: unknown[]) => void)[]> = {};
+  const holder = { focus: jest.fn() };
+  const table = {
+    options: {},
+    on: (evt: string, fn: (...args: unknown[]) => void) => {
+      (handlers[evt] ??= []).push(fn);
+    },
+    element: { querySelector: () => holder },
+    getSelectedRows: () => selected,
+  };
+  const plugin = new RowKeyboardNavigation(table as never);
+  plugin.initialize();
+
+  const row = { select: jest.fn() } as unknown as RowComponent;
+  const expand = () => handlers['dataTreeRowExpanded']?.forEach((fn) => fn(row, 0));
+  return { handlers, holder, row, expand };
+}
+
+describe('RowKeyboardNavigation', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('selects and focuses the row the user expanded first', () => {
+    const { row, holder, expand } = setup();
+
+    expand();
+
+    expect(row.select).toHaveBeenCalled();
+    expect(holder.focus).toHaveBeenCalled();
+  });
+
+  it('leaves an existing selection where it is', () => {
+    const selected = { select: jest.fn() } as unknown as RowComponent;
+    const { row, holder, expand } = setup([selected]);
+
+    expand();
+
+    expect(row.select).not.toHaveBeenCalled();
+    expect(holder.focus).not.toHaveBeenCalled();
+  });
+
+  it('does not answer a collapse at all', () => {
+    const { handlers } = setup();
+
+    expect(handlers['dataTreeRowCollapsed']).toBeUndefined();
+  });
+
+  it('ignores an expansion the code drove', () => {
+    const { row, holder, expand } = setup();
+
+    withCodeDrivenExpand(expand);
+
+    expect(row.select).not.toHaveBeenCalled();
+    expect(holder.focus).not.toHaveBeenCalled();
+  });
+});

--- a/log-viewer/src/tabulator/module/expandOrigin.ts
+++ b/log-viewer/src/tabulator/module/expandOrigin.ts
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2026 Certinia Inc. All rights reserved.
+ */
+
+/**
+ * Whether the code or the user opened a row.
+ *
+ * Tabulator's `dataTreeRowExpanded` event carries no origin, and `expandRow`'s
+ * `silent` flag is ignored, so a twisty click and a `treeExpand()` call are
+ * otherwise indistinguishable. The code that opens rows declares itself here.
+ */
+
+let depth = 0;
+
+export function isCodeDrivenExpand(): boolean {
+  return depth > 0;
+}
+
+/** Marks any row `body` opens as the code's own, not the user's. */
+export function withCodeDrivenExpand<T>(body: () => T): T {
+  depth += 1;
+  try {
+    return body();
+  } finally {
+    depth -= 1;
+  }
+}

--- a/log-viewer/src/tabulator/module/tableHolder.ts
+++ b/log-viewer/src/tabulator/module/tableHolder.ts
@@ -1,0 +1,8 @@
+/*
+ * Copyright (c) 2026 Certinia Inc. All rights reserved.
+ */
+
+/** A table's scrolling body: what holds focus while the key bindings are live. */
+export function tableHolder(host: HTMLElement | null | undefined): HTMLElement | null {
+  return host?.querySelector<HTMLElement>('.tabulator-tableholder') ?? null;
+}


### PR DESCRIPTION
# 📝 PR Overview

> **Stacked on #965.** This branch is #965 plus the last three commits. Review those three; the diff collapses once #965 merges, and this comes out of draft then. A fork branch cannot be a PR base, which is why the base is `main`.

Three unrelated pieces of hardening found while measuring the inspector on a 100 MB log.

`push(...array)` passes each element as an argument, so an array whose length follows the log — a truncation-marker list, a wide tree level, a lifted symbol list — overruns the engine's argument limit and throws. Each site now pushes in a loop.

## 🛠️ Changes made

- Build the log-scale arrays with a loop, not a spread: `scopedCallTree` (twice), `FlameChart` markers, `RawLogSymbolProvider` lifted children. The bounded ones, such as a single query's clause tokens, are left alone.
- One recursion behind Expand All. It was split in two so the code-driven expand wrapper was not re-entered, but the wrapper counts its depth, so re-entry is safe.
- State speed and memory as a trade in the `log-viewer` rules, so it is weighed and measured in every change.

## 🧩 Type of change (check all applicable)

- [x] 🐛 Bug fix - something not working as expected
- [x] ♻️ Refactor - internal changes with no user impact
- [ ] ✨ New feature – adds new functionality
- [ ] ⚡ Performance Improvement
- [x] 📝 Documentation - README or documentation site changes
- [ ] 🔧 Chore - dev tooling, CI, config
- [ ] 💥 Breaking change

## 📷 Screenshots / gifs / video [optional]

N/A

## 🔗 Related Issues

related #373
related #405

## ✅ Tests added?

- [x] 🙅 no, not needed

`jest --runInBand` stays green: 145 suites, 1968 tests. The push loops and the recursion are the same work in a different shape, and the third change is a rules document.

## 📚 Docs updated?

- [x] 🙅 not needed

No user-visible behaviour changes.

## Anything else we need to know? [optional]

The argument limit is the same ceiling for a spread and for `push.apply`, so only a loop fixes it.