### PR TITLE
fix: keep large logs off the argument limit, and state the speed and memory trade

### DIFF
--- a/.claude/rules/log-viewer.md
+++ b/.claude/rules/log-viewer.md
@@ -15,6 +15,9 @@ Webview UI.
 
 - Parse + render: `<5MB` in `<1s`, `10MB` in `<3s`, `20MB+` in `<5s`. Benchmark on `sample-app/` logs.
 - Nothing synchronous over 50ms. Show progress over 100ms.
+- Be fast and never block.
+- Keep memory low, even at the cost of speed.
+- Weigh that trade in every change, and measure it.
 
 ## Theme
 

--- a/lana/src/symbols/RawLogSymbolProvider.ts
+++ b/lana/src/symbols/RawLogSymbolProvider.ts
@@ -81,7 +81,9 @@ class RawLogSymbolProvider implements DocumentSymbolProvider {
         symbols.push(symbol);
       } else {
         // No foldable range for this event; lift its descendants to this level.
-        symbols.push(...children);
+        for (const child of children) {
+          symbols.push(child);
+        }
       }
     }
 

--- a/lana/src/symbols/RawLogSymbolProvider.ts
+++ b/lana/src/symbols/RawLogSymbolProvider.ts
@@ -81,6 +81,7 @@ class RawLogSymbolProvider implements DocumentSymbolProvider {
         symbols.push(symbol);
       } else {
         // No foldable range for this event; lift its descendants to this level.
+        // Pushed one at a time: a spread would overrun the argument limit.
         for (const child of children) {
           symbols.push(child);
         }

--- a/log-viewer/src/components/scopedCallTree.ts
+++ b/log-viewer/src/components/scopedCallTree.ts
@@ -83,7 +83,11 @@ export function rowIdsByEvent(rows: readonly ScopedRow[]): Map<number, number[]>
       }
     }
     if (row._children) {
-      stack.push(...row._children);
+      // Pushed one at a time: a spread (and `push.apply`) passes each element as
+      // an argument, and a wide level would overrun the argument limit.
+      for (const child of row._children) {
+        stack.push(child);
+      }
     }
   }
   return byEvent;
@@ -465,7 +469,10 @@ async function aggregate(
         seen.add(index);
       }
       if (row._children) {
-        (group._children as ScopedRow[]).push(...row._children);
+        const kids = group._children as ScopedRow[];
+        for (const child of row._children) {
+          kids.push(child);
+        }
       }
     }
 

--- a/log-viewer/src/features/call-tree/utils/ExpandCollapse.ts
+++ b/log-viewer/src/features/call-tree/utils/ExpandCollapse.ts
@@ -6,21 +6,19 @@ import type { RowComponent } from 'tabulator-tables';
 import { withCodeDrivenExpand } from '../../../tabulator/module/expandOrigin.js';
 
 export function expandCollapseAll(rows: RowComponent[], expand: boolean): void {
-  withCodeDrivenExpand(() => walk(rows, expand));
-}
+  withCodeDrivenExpand(() => {
+    for (const row of rows) {
+      const children = row.getTreeChildren();
+      if (!children || children.length === 0) {
+        continue;
+      }
 
-function walk(rows: RowComponent[], expand: boolean): void {
-  for (const row of rows) {
-    const children = row.getTreeChildren();
-    if (!children || children.length === 0) {
-      continue;
+      if (expand) {
+        row.treeExpand();
+      } else {
+        row.treeCollapse();
+      }
+      expandCollapseAll(children, expand);
     }
-
-    if (expand) {
-      row.treeExpand();
-    } else {
-      row.treeCollapse();
-    }
-    walk(children, expand);
-  }
+  });
 }

--- a/log-viewer/src/features/timeline/optimised/FlameChart.ts
+++ b/log-viewer/src/features/timeline/optimised/FlameChart.ts
@@ -252,7 +252,7 @@ export class FlameChart<E extends EventNode = EventNode> {
     this.options = options;
     this.callbacks = callbacks;
 
-    // Store truncation markers for rendering
+    // Pushed one at a time: a spread would overrun the argument limit.
     for (const marker of markers) {
       this.markers.push(marker);
     }

--- a/log-viewer/src/features/timeline/optimised/FlameChart.ts
+++ b/log-viewer/src/features/timeline/optimised/FlameChart.ts
@@ -253,7 +253,9 @@ export class FlameChart<E extends EventNode = EventNode> {
     this.callbacks = callbacks;
 
     // Store truncation markers for rendering
-    this.markers.push(...markers);
+    for (const marker of markers) {
+      this.markers.push(marker);
+    }
 
     const { width, height } = await this.awaitContainerSize(container);
 

--- a/log-viewer/src/tabulator/module/RowKeyboardNavigation.ts
+++ b/log-viewer/src/tabulator/module/RowKeyboardNavigation.ts
@@ -10,6 +10,7 @@ import {
 } from 'tabulator-tables';
 
 import { isCodeDrivenExpand, withCodeDrivenExpand } from './expandOrigin.js';
+import { tableHolder } from './tableHolder.js';
 
 // todo: make this generic and support opening grouped rows too then use on DB view.
 // todo: remove the '@ts-expect-error' + fix the types file
@@ -35,7 +36,6 @@ export class RowKeyboardNavigation extends Module {
   static moduleExtensions = this.getModuleExtensions();
 
   private localTable: Tabulator;
-  private tableHolder: HTMLElement | null = null;
 
   constructor(table: Tabulator) {
     super(table);
@@ -61,8 +61,7 @@ export class RowKeyboardNavigation extends Module {
 
     row.select();
     // The key bindings only fire while the holder itself holds focus.
-    this.tableHolder ??= this.localTable.element.querySelector('.tabulator-tableholder');
-    this.tableHolder?.focus({ preventScroll: true });
+    tableHolder(this.localTable.element)?.focus({ preventScroll: true });
   }
 
   rowClick(event: UIEvent, row: RowComponent) {


### PR DESCRIPTION
# 📝 PR Overview

Three pieces of hardening found while measuring the inspector on a 100 MB log. Replaces #966, which conflicted once #965 was squash-merged.

`push(...array)` passes each element as an argument, so an array whose length follows the log — a truncation-marker list, a wide tree level, a lifted symbol list — overruns the engine's argument limit and throws. Each site now pushes in a loop.

## 🛠️ Changes made

- Build the log-scale arrays with a loop, not a spread: `scopedCallTree` (twice), `FlameChart` markers, `RawLogSymbolProvider` lifted children. The bounded ones, such as a single query's clause tokens, are left alone.
- One recursion behind Expand All. It was split in two so the code-driven expand wrapper was not re-entered, but the wrapper counts its depth, so re-entry is safe.
- State speed and memory as a trade in the `log-viewer` rules, so it is weighed and measured in every change.

## 🧩 Type of change (check all applicable)

- [x] 🐛 Bug fix - something not working as expected
- [x] ♻️ Refactor - internal changes with no user impact
- [ ] ✨ New feature – adds new functionality
- [ ] ⚡ Performance Improvement
- [x] 📝 Documentation - README or documentation site changes
- [ ] 🔧 Chore - dev tooling, CI, config
- [ ] 💥 Breaking change

## 📷 Screenshots / gifs / video [optional]

N/A

## 🔗 Related Issues

related #373
related #405

## ✅ Tests added?

- [x] 🙅 no, not needed

`jest --runInBand` stays green: 145 suites, 1969 tests. The push loops and the recursion are the same work in a different shape, and the third change is a rules document.

## 📚 Docs updated?

- [x] 🙅 not needed

No user-visible behaviour changes.

## Anything else we need to know? [optional]

The argument limit is the same ceiling for a spread and for `push.apply`, so only a loop fixes it.