### PR TITLE
perf(log-viewer): cut the inspector's Bottom-Up build from 2,253ms to 551ms on a 100MB log

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ build/
 out/
 coverage/
 *.tsbuildinfo
+scripts/measure/out/

--- a/log-viewer/src/components/CallTreeDetail.ts
+++ b/log-viewer/src/components/CallTreeDetail.ts
@@ -494,7 +494,7 @@ export class CallTreeDetail extends LitElement {
       built.rows = [];
       void built.table.setData([]);
     }
-    const data = await this._rows(mode, { yieldFrame: waitForNextFrame, signal });
+    const data = await this._rows(mode, { signal });
     if (!data || signal.aborted) {
       return;
     }

--- a/log-viewer/src/components/CallTreeDetail.ts
+++ b/log-viewer/src/components/CallTreeDetail.ts
@@ -38,14 +38,20 @@ import dataGridStyles from '../tabulator/style/DataGrid.scss';
 import './ContextMenu.js';
 import type { ContextMenu } from './ContextMenu.js';
 import { dispatchInspectorLocate, dispatchInspectorReveal } from './inspectorReveal.js';
-import { LOCATED_ROW_CLASS, LocatedRowMarker, rowId, rowIndexStamper } from './locatedRow.js';
+import {
+  LOCATED_ROW_CLASS,
+  LocatedRowIds,
+  LocatedRowMarker,
+  rowId,
+  rowIndexStamper,
+} from './locatedRow.js';
 import { PANEL_ROW_MENU_ITEMS, runPanelRowAction } from './panelRowMenu.js';
 import {
   buildScopedCallTree,
   buildWholeLogCallTree,
   locatableEventIndexes,
   revealableEventIndex,
-  rowIdsByEvent,
+  rowIdsByPath,
   type ScopedCallTree,
   type ScopedRow,
 } from './scopedCallTree.js';
@@ -191,6 +197,13 @@ export class CallTreeDetail extends LitElement {
 
   /** Marks the row for the frame under the pointer in the tab's own view. */
   private _locatedRow = new LocatedRowMarker();
+  /** Translates the reported frames into bucket paths, memoised on the report:
+   *  the tab re-reports the same list every time the pointer leaves a row. */
+  private _locateIds = new LocatedRowIds();
+  // The last report and the frames of it this scope stands for, so the filter
+  // runs once per report rather than once per pointer move.
+  private _reported: readonly number[] = [];
+  private _reportedInScope: readonly number[] = [];
   // The frames the tab on screen last reported under its pointer, so a table
   // that finishes building after the report still marks them.
   private _locatedEvents: readonly number[] = [];
@@ -198,11 +211,11 @@ export class CallTreeDetail extends LitElement {
   private _selectionClearUnsubscribe?: () => void;
 
   /**
-   * eventIndex to the ids of the rows that name it, per grouped mode. Built on
-   * the first mark of a scope, since only a pointer in the tab's own view needs
-   * it, and dropped with the rows it describes.
+   * Bucket path to the ids of the rows that stand for it, per grouped mode. Built
+   * on the first mark of a scope, since only a pointer in the tab's own view
+   * needs it, and dropped with the rows it describes.
    */
-  private _rowsByEvent: Record<ViewMode, Map<number, number[]> | null> = {
+  private _rowsByPath: Record<ViewMode, Map<number, number> | null> = {
     'time-order': null,
     aggregated: null,
     'bottom-up': null,
@@ -242,7 +255,7 @@ export class CallTreeDetail extends LitElement {
    * rows by event, so there the ids are the indexes themselves — unless it merged
    * a selection's occurrences, when its rows are grouped like the other views'. A
    * grouped row merges occurrences behind a synthetic id, so it is found by the
-   * occurrences it carries — and one frame can name several rows in Bottom-Up.
+   * bucket path it stands for.
    */
   private _markLocated(): void {
     this._locatedRow.mark(
@@ -251,9 +264,9 @@ export class CallTreeDetail extends LitElement {
     );
   }
 
-  private _rowIdsFor(mode: ViewMode, eventIndexes: readonly number[]): number[] {
+  private _rowIdsFor(mode: ViewMode, eventIndexes: readonly number[]): readonly number[] {
     if ((mode === 'time-order' && !this._scoped?.timeOrderMerged) || !eventIndexes.length) {
-      return [...eventIndexes];
+      return eventIndexes;
     }
     const rows = this._tables[mode]?.rows ?? [];
     if (!rows.length) {
@@ -261,14 +274,37 @@ export class CallTreeDetail extends LitElement {
       // of the scope, since only a new scope clears it.
       return [];
     }
-    const byEvent = (this._rowsByEvent[mode] ??= rowIdsByEvent(rows));
-    const ids = new Set<number>();
-    for (const eventIndex of eventIndexes) {
-      for (const id of byEvent.get(eventIndex) ?? []) {
-        ids.add(id);
+    const byPath = (this._rowsByPath[mode] ??= rowIdsByPath(rows));
+    const pathIds = this._locateIds.idsFor(
+      this.logStore?.log ?? null,
+      this._inScope(eventIndexes),
+      mode === 'bottom-up' ? 'callers' : 'callees',
+    );
+    const ids: number[] = [];
+    for (const pathId of pathIds) {
+      const id = byPath.get(pathId);
+      if (id !== undefined) {
+        ids.push(id);
       }
     }
-    return [...ids];
+    return ids;
+  }
+
+  /**
+   * The reported frames this scope stands for. A merged row is named by its
+   * bucket path, so without this a frame at the same path elsewhere in the log
+   * would mark a row that holds a different call.
+   */
+  private _inScope(eventIndexes: readonly number[]): readonly number[] {
+    const holds = this._scoped?.holds;
+    if (!holds) {
+      return eventIndexes;
+    }
+    if (this._reported !== eventIndexes) {
+      this._reported = eventIndexes;
+      this._reportedInScope = eventIndexes.filter(holds);
+    }
+    return this._reportedInScope;
   }
 
   /**
@@ -404,7 +440,7 @@ export class CallTreeDetail extends LitElement {
       if (slot) {
         slot.stale = true;
       }
-      this._rowsByEvent[mode] = null;
+      this._rowsByPath[mode] = null;
     }
   }
 
@@ -428,7 +464,7 @@ export class CallTreeDetail extends LitElement {
     for (const mode of Object.keys(this._tables) as ViewMode[]) {
       this._tables[mode]?.table.destroy();
       this._tables[mode] = null;
-      this._rowsByEvent[mode] = null;
+      this._rowsByPath[mode] = null;
     }
   }
 
@@ -509,7 +545,7 @@ export class CallTreeDetail extends LitElement {
     if (slot) {
       slot.stale = false;
       slot.rows = data;
-      this._rowsByEvent[mode] = null;
+      this._rowsByPath[mode] = null;
       void slot.table.setData(data).then(() => {
         this._markActive();
         this._markLocated();

--- a/log-viewer/src/components/NamespaceTimeBar.ts
+++ b/log-viewer/src/components/NamespaceTimeBar.ts
@@ -8,7 +8,6 @@ import { customElement, property, state } from 'lit/decorators.js';
 
 import { logContext } from '../core/log/logContext.js';
 import type { LogStore } from '../core/log/LogStore.js';
-import { waitForNextFrame } from '../core/utility/FrameBudget.js';
 import { globalStyles } from '../styles/global.styles.js';
 import { inspectorSectionStyles } from '../styles/inspectorSection.styles.js';
 import { segmentsWithTail } from './StackedTimeBar.js';
@@ -138,7 +137,6 @@ export class NamespaceTimeBar extends LitElement {
       return;
     }
     const slices = await scopedNamespaceSelfTimes(scope.key, scope.roots, {
-      yieldFrame: waitForNextFrame,
       signal: walk.signal,
     });
     if (this._walk !== walk) {

--- a/log-viewer/src/components/__tests__/CallTreeDetailScopedBuild.test.ts
+++ b/log-viewer/src/components/__tests__/CallTreeDetailScopedBuild.test.ts
@@ -38,7 +38,7 @@ jest.mock('../scopedCallTree.js', () => ({
   // Keep the real row readers: the hover test is about which rows name a frame.
   revealableEventIndex: jest.requireActual('../scopedCallTree.js').revealableEventIndex,
   locatableEventIndexes: jest.requireActual('../scopedCallTree.js').locatableEventIndexes,
-  rowIdsByEvent: jest.requireActual('../scopedCallTree.js').rowIdsByEvent,
+  rowIdsByPath: jest.requireActual('../scopedCallTree.js').rowIdsByPath,
 }));
 
 import { Tabulator } from 'tabulator-tables';
@@ -50,6 +50,10 @@ import { INSPECTOR_LOCATE_EVENT, type InspectorLocateEvent } from '../inspectorR
 import { eventBus } from '../../core/events/EventBus.js';
 import type { ProgressParams } from '../../tabulator/format/ProgressMS.js';
 import { LOCATED_ROW_CLASS } from '../locatedRow.js';
+import type { ApexLog } from 'apex-log-parser';
+
+import { logStoreFor, type LogStore } from '../../core/log/LogStore.js';
+import { ROOT_PATH_ID } from '../../core/log/keyPathIds.js';
 
 const build = jest.mocked(buildScopedCallTree);
 
@@ -286,10 +290,20 @@ describe('CallTreeDetail scoped build', () => {
     expect(totalColumn(tables.instances[0]!).formatterParams.totalValue).toBe(6000);
   });
   it('marks the rows a frame names once the merged view has its rows', async () => {
-    // A row that merges occurrences, so only the map from the rows can name it.
-    const merged = [{ id: -3, eventIndexes: [8, 12], _children: null }] as unknown as ScopedRow[];
+    // A merged row is named by the bucket path it stands for, so the frame the
+    // pointer reports has to be reachable through the log to be translated.
+    const event = { eventIndex: 8, type: 'METHOD_ENTRY', namespace: '', text: 'm' };
+    const log = { eventsById: [] as unknown[], children: [] };
+    log.eventsById[8] = { ...event, parent: log, children: [] };
+    const pathId = logStoreFor(log as unknown as ApexLog)
+      .keyPathIds()
+      .pathId(ROOT_PATH_ID, 'METHOD_ENTRY||m');
+    const merged = [
+      { id: -3, eventIndexes: [8, 12], _pathId: pathId, _children: null },
+    ] as unknown as ScopedRow[];
     const resolvers = deferBuilds();
     const el = await mount(5, 'callees');
+    el.logStore = { log } as unknown as LogStore;
     await frame(el);
     const grid = el.shadowRoot!.querySelector('.table-host:not(.is-hidden) .grid')!;
     const row = document.createElement('div');
@@ -314,6 +328,43 @@ describe('CallTreeDetail scoped build', () => {
     // The tree finished after the report, so the build marks what was reported.
     tableBuilt?.();
 
+    expect(row.classList.contains(LOCATED_ROW_CLASS)).toBe(true);
+  });
+
+  it('leaves a frame the scope does not hold unmarked, path or no path', async () => {
+    // The scoped views hold only the selection's own calls, but a merged row is
+    // named by its bucket path — which a second call of the same method
+    // elsewhere in the log shares.
+    const event = { eventIndex: 8, type: 'METHOD_ENTRY', namespace: '', text: 'm' };
+    const log = { eventsById: [] as unknown[], children: [] };
+    log.eventsById[8] = { ...event, parent: log, children: [] };
+    log.eventsById[12] = { ...event, eventIndex: 12, parent: log, children: [] };
+    const pathId = logStoreFor(log as unknown as ApexLog)
+      .keyPathIds()
+      .pathId(ROOT_PATH_ID, 'METHOD_ENTRY||m');
+    const merged = [
+      { id: -3, eventIndexes: [8], _pathId: pathId, _children: null },
+    ] as unknown as ScopedRow[];
+    build.mockResolvedValue({
+      ...tree(5000),
+      holds: (eventIndex: number) => eventIndex === 8,
+      aggregated: () => Promise.resolve(merged),
+      bottomUp: () => Promise.resolve(merged),
+    });
+    const el = await mount(5, 'callees');
+    el.logStore = { log } as unknown as LogStore;
+    await frame(el);
+    const grid = el.shadowRoot!.querySelector('.table-host:not(.is-hidden) .grid')!;
+    const row = document.createElement('div');
+    row.classList.add('tabulator-row');
+    row.setAttribute('data-row-index', '-3');
+    grid.append(row);
+
+    // Frame 12 sits at the same path as the row, but the scope never held it.
+    eventBus.emit('detail:locate', { source: 'timeline', eventIndexes: [12] });
+    expect(row.classList.contains(LOCATED_ROW_CLASS)).toBe(false);
+
+    eventBus.emit('detail:locate', { source: 'timeline', eventIndexes: [8] });
     expect(row.classList.contains(LOCATED_ROW_CLASS)).toBe(true);
   });
 

--- a/log-viewer/src/components/__tests__/locatedRow.test.ts
+++ b/log-viewer/src/components/__tests__/locatedRow.test.ts
@@ -3,19 +3,21 @@
  *
  * @jest-environment jsdom
  */
-import { describe, expect, it } from '@jest/globals';
+import { beforeEach, describe, expect, it } from '@jest/globals';
 import type { RowComponent } from 'tabulator-tables';
 
 import type { ApexLog, LogEvent } from 'apex-log-parser';
 
+import { logStoreFor } from '../../core/log/LogStore.js';
+import { ROOT_PATH_ID, KeyPathIds } from '../../core/log/keyPathIds.js';
 import {
   LOCATED_ROW_CLASS,
   LocatedRowIds,
   LocatedRowMarker,
-  eventKeyPaths,
+  eventPathIds,
   rowIndexStamper,
-  rowKeyPath,
-  stampRowKeyPath,
+  rowPathId,
+  rowPathStamper,
 } from '../locatedRow.js';
 
 const stamp = rowIndexStamper('eventIndex');
@@ -62,19 +64,21 @@ function rowFor(container: HTMLElement, index: number): HTMLElement {
   return container.children[index] as HTMLElement;
 }
 
-describe('stampRowKeyPath', () => {
+describe('rowPathStamper', () => {
   it('marks the row under one parent and not its namesake under another', () => {
+    const ids = new KeyPathIds();
+    const stampPath = rowPathStamper(ids);
     const container = document.createElement('div');
     const rows = [bucketRow('Trigger1', 'Util.log'), bucketRow('Trigger2', 'Util.log')];
     for (const row of rows) {
       const element = row.getElement();
       element.classList.add('tabulator-row');
-      stampRowKeyPath(row);
+      stampPath(row);
       container.append(element);
     }
     const marker = new LocatedRowMarker();
 
-    marker.mark(container, [rowKeyPath(rows[0]!)!]);
+    marker.mark(container, [rowPathId(rows[0]!, ids)!]);
 
     expect(rows[0]!.getElement().classList.contains(LOCATED_ROW_CLASS)).toBe(true);
     expect(rows[1]!.getElement().classList.contains(LOCATED_ROW_CLASS)).toBe(false);
@@ -91,53 +95,62 @@ describe('rowIndexStamper', () => {
   });
 });
 
-describe('rowKeyPath', () => {
+describe('rowPathId', () => {
+  let ids: KeyPathIds;
+  beforeEach(() => {
+    ids = new KeyPathIds();
+  });
+
   it('names a top-level row by its own key alone', () => {
-    expect(rowKeyPath(bucketRow('A'))).toBe('A');
+    expect(rowPathId(bucketRow('A'), ids)).toBe(ids.pathId(ROOT_PATH_ID, 'A'));
   });
 
   it('tells two same-named rows apart by the parents that reach them', () => {
     // One method holds a row under every caller it has, so the key alone cannot.
-    expect(rowKeyPath(bucketRow('Trigger1', 'Util.log'))).not.toBe(
-      rowKeyPath(bucketRow('Trigger2', 'Util.log')),
+    expect(rowPathId(bucketRow('Trigger1', 'Util.log'), ids)).not.toBe(
+      rowPathId(bucketRow('Trigger2', 'Util.log'), ids),
     );
   });
 
-  it('reads a deep row as the whole path, outermost first', () => {
-    const deep = rowKeyPath(bucketRow('A', 'B', 'C'));
-    expect(deep).toBe(rowKeyPath(bucketRow('A', 'B', 'C')));
-    expect(deep).not.toBe(rowKeyPath(bucketRow('A', 'B')));
+  it('gives one id to the whole path, so two rows on it agree', () => {
+    const deep = rowPathId(bucketRow('A', 'B', 'C'), ids);
+    expect(deep).toBe(rowPathId(bucketRow('A', 'B', 'C'), ids));
+    expect(deep).not.toBe(rowPathId(bucketRow('A', 'B'), ids));
   });
 
   it('leaves a row that stands for one frame unnamed, as its index names it', () => {
-    expect(rowKeyPath(rowComponent(document.createElement('div'), { id: 7 }))).toBeUndefined();
+    expect(rowPathId(rowComponent(document.createElement('div'), { id: 7 }), ids)).toBeUndefined();
   });
 });
 
-describe('eventKeyPaths', () => {
+describe('eventPathIds', () => {
   const root = ev('exec', null);
   const outer = ev('outer', root);
   const inner = ev('inner', outer);
+  let ids: KeyPathIds;
+  beforeEach(() => {
+    ids = new KeyPathIds();
+  });
 
   it('names one row in a top-down view, at the depth the frame ran at', () => {
-    const paths = eventKeyPaths(inner, 'callees');
+    const found = eventPathIds(inner, 'callees', ids);
 
-    expect(paths).toHaveLength(1);
-    expect(paths[0]).toBe(rowKeyPath(bucketRow('METHOD_ENTRY||outer', 'METHOD_ENTRY||inner')));
+    expect(found).toHaveLength(1);
+    expect(found[0]).toBe(rowPathId(bucketRow('METHOD_ENTRY||outer', 'METHOD_ENTRY||inner'), ids));
   });
 
   it('names a row per caller depth in a bottom-up view', () => {
     // The frame heads a row on its own, and one under each caller above it.
-    const paths = eventKeyPaths(inner, 'callers');
+    const found = eventPathIds(inner, 'callers', ids);
 
-    expect(paths).toEqual([
-      rowKeyPath(bucketRow('METHOD_ENTRY||inner')),
-      rowKeyPath(bucketRow('METHOD_ENTRY||inner', 'METHOD_ENTRY||outer')),
+    expect(found).toEqual([
+      rowPathId(bucketRow('METHOD_ENTRY||inner'), ids),
+      rowPathId(bucketRow('METHOD_ENTRY||inner', 'METHOD_ENTRY||outer'), ids),
     ]);
   });
 
   it('leaves the log root out, as it is a row in neither view', () => {
-    expect(eventKeyPaths(root, 'callers')).toEqual([]);
+    expect(eventPathIds(root, 'callers', ids)).toEqual([]);
   });
 });
 
@@ -208,9 +221,10 @@ describe('LocatedRowIds', () => {
   const log = { eventsById: { 5: frame } } as unknown as ApexLog;
 
   it('builds the paths of the rows the frames belong to', () => {
-    const ids = new LocatedRowIds().idsFor(log, [5], 'callers');
+    const found = new LocatedRowIds().idsFor(log, [5], 'callers');
 
-    expect(ids).toEqual(eventKeyPaths(frame, 'callers'));
+    // The log's own table, so a row stamped from it reaches the same ids.
+    expect(found).toEqual(eventPathIds(frame, 'callers', logStoreFor(log).keyPathIds()));
   });
 
   it('reuses what it built for the frames it was last asked about', () => {

--- a/log-viewer/src/components/__tests__/namespaceTime.test.ts
+++ b/log-viewer/src/components/__tests__/namespaceTime.test.ts
@@ -7,7 +7,7 @@ import type { FrameBudgetOptions } from '../../core/utility/FrameBudget.js';
 import { cachedNamespaceSelfTimes, scopedNamespaceSelfTimes } from '../namespaceTime.js';
 import { ev, log, roots, type FakeEvent } from './fixtures/logEvents.js';
 
-const options: FrameBudgetOptions = { yieldFrame: () => Promise.resolve() };
+const options: FrameBudgetOptions = { yieldSlice: () => Promise.resolve() };
 // A fresh scope per call, so each case walks rather than answering from the memo.
 const selfTimes = (events: FakeEvent[]) => scopedNamespaceSelfTimes({}, roots(events), options);
 

--- a/log-viewer/src/components/__tests__/scopedCallTree.test.ts
+++ b/log-viewer/src/components/__tests__/scopedCallTree.test.ts
@@ -76,9 +76,9 @@ import {
 } from '../scopedCallTree.js';
 import type { FrameBudgetOptions } from '../../core/utility/FrameBudget.js';
 
-/** These fixtures are small enough to never hit a slice deadline, so `yieldFrame`
+/** These fixtures are small enough to never hit a slice deadline, so `yieldSlice`
  *  is only there to satisfy the contract. */
-const options: FrameBudgetOptions = { yieldFrame: () => Promise.resolve() };
+const options: FrameBudgetOptions = { yieldSlice: () => Promise.resolve() };
 
 function build(eventIndex: number, instances?: number[]) {
   return buildScopedCallTree(eventIndex, instances ?? null, options);
@@ -376,7 +376,7 @@ describe('buildScopedCallTree', () => {
     const instances = loopOccurrences(OCCURRENCES);
     let yields = 0;
     const sliced: FrameBudgetOptions = {
-      yieldFrame: () => {
+      yieldSlice: () => {
         yields += 1;
         return Promise.resolve();
       },
@@ -406,7 +406,7 @@ describe('buildScopedCallTree', () => {
     try {
       // The first yield is the first chance to notice; nothing is returned after it.
       const tree = await buildScopedCallTree(instances[0]!, instances, {
-        yieldFrame: () => Promise.resolve(),
+        yieldSlice: () => Promise.resolve(),
         signal: AbortSignal.abort(),
       });
       expect(tree).toBeNull();
@@ -466,7 +466,7 @@ describe('buildWholeLogCallTree', () => {
     clock.mockImplementation(() => (time += 100));
     try {
       const tree = await buildWholeLogCallTree({
-        yieldFrame: () => Promise.resolve(),
+        yieldSlice: () => Promise.resolve(),
         signal: AbortSignal.abort(),
       });
       expect(tree).toBeNull();

--- a/log-viewer/src/components/__tests__/scopedCallTree.test.ts
+++ b/log-viewer/src/components/__tests__/scopedCallTree.test.ts
@@ -51,9 +51,14 @@ soql.parent = m2;
 const byId = new Map<number, FakeEvent>([exec, m1, m2, soql].map((e) => [e.eventIndex, e]));
 
 let selectedIndex = 4;
+const { KeyPathIds } = jest.requireActual<typeof import('../../core/log/keyPathIds.js')>(
+  '../../core/log/keyPathIds.js',
+);
+const paths = new KeyPathIds();
 jest.mock('../../core/log/LogStore.js', () => ({
   currentLogStore: () => ({
     log: root,
+    keyPathIds: () => paths,
     eventByIndex: (i: number) => byId.get(i) ?? null,
     // Mirrors LogStore.stackByEventIndex over the fixture's own index.
     stackByEventIndex: (i: number) => {
@@ -71,7 +76,8 @@ jest.mock('../../core/log/LogStore.js', () => ({
 import {
   buildScopedCallTree,
   buildWholeLogCallTree,
-  rowIdsByEvent,
+  locatableEventIndexes,
+  rowIdsByPath,
   type ScopedRow,
 } from '../scopedCallTree.js';
 import type { FrameBudgetOptions } from '../../core/utility/FrameBudget.js';
@@ -362,7 +368,7 @@ describe('buildScopedCallTree', () => {
     expect(bottomUp?.eventIndexes).toEqual(instances);
     // A caller row stands for the calls it conducted, which is what its time and
     // its count are taken from, so it names those rather than its own frame.
-    expect(bottomUp?._children?.[0]?.eventIndexes).toEqual(instances);
+    expect(locatableEventIndexes(bottomUp?._children?.[0])).toEqual(instances);
   });
 
   it('a single-frame row carries no list — its one occurrence is the row itself', async () => {
@@ -476,40 +482,81 @@ describe('buildWholeLogCallTree', () => {
   });
 });
 
-describe('rowIdsByEvent', () => {
-  it('finds the merged rows a frame is named by, at every depth', async () => {
-    const instances = loopOccurrences(3);
-    const tree = (await build(300))!;
-    const rows = (await tree.aggregated(options))!;
+describe('holds', () => {
+  it('stands for the selection, what it called, and the callers above it', async () => {
+    const tree = (await build(3))!;
 
-    const byEvent = rowIdsByEvent(rows);
-    const groupId = rows[0]!.id;
-    const occurrenceId = rows[0]!._children![0]!.id;
+    // m2 is the selection, soql runs inside it, m1 and exec are rows above it.
+    expect(tree.holds!(3)).toBe(true);
+    expect(tree.holds!(4)).toBe(true);
+    expect(tree.holds!(2)).toBe(true);
+    expect(tree.holds!(1)).toBe(true);
+  });
 
-    // The selection names the row above; each occurrence names the group that
-    // merges all three.
-    expect(byEvent.get(300)).toEqual([groupId]);
-    for (const eventIndex of instances) {
-      expect(byEvent.get(eventIndex)).toEqual([occurrenceId]);
+  it('leaves out a frame at the same bucket path elsewhere in the log', async () => {
+    // A second call of the same method, which a loop or a trigger makes common:
+    // its rows would be named by the same path as the selection's.
+    const twin = ev(500, 'METHOD_ENTRY', 'm2', { total: 200, self: 0 });
+    const twinLeaf = ev(501, 'SOQL_EXECUTE_BEGIN', 'SELECT Id FROM Account', {
+      total: 200,
+      self: 200,
+    });
+    twin.parent = m1;
+    twinLeaf.parent = twin;
+    twin.children = [twinLeaf];
+    m1.children = [m2, twin];
+    byId.set(500, twin);
+    byId.set(501, twinLeaf);
+    try {
+      const tree = (await build(3))!;
+
+      expect(tree.holds!(501)).toBe(false);
+    } finally {
+      m1.children = [m2];
+      byId.delete(500);
+      byId.delete(501);
     }
   });
 
-  it('names one frame in as many rows as stand for it', async () => {
+  it('stands for every frame where it covers the whole log', async () => {
+    expect((await buildWholeLogCallTree(options))!.holds).toBeUndefined();
+  });
+});
+
+describe('rowIdsByPath', () => {
+  it('finds a merged row by the bucket path it stands for, at every depth', async () => {
+    loopOccurrences(3);
+    const tree = (await build(300))!;
+    const rows = (await tree.aggregated(options))!;
+    const group = rows[0]!;
+    const occurrences = group._children![0]!;
+
+    const byPath = rowIdsByPath(rows);
+
+    expect(byPath.get(group._pathId!)).toBe(group.id);
+    expect(byPath.get(occurrences._pathId!)).toBe(occurrences.id);
+  });
+
+  it('leaves a path no row stands for out of the lookup', async () => {
+    const tree = (await build(4))!;
+
+    expect(rowIdsByPath((await tree.timeOrder(options))!).get(99999)).toBeUndefined();
+  });
+});
+
+describe('bottom-up occurrences', () => {
+  it('derives a caller row from the top-level row, holding no calls itself', async () => {
     // Rebuilds the loop and its two calls; the loop itself is the selection.
     const instances = loopOccurrences(2);
     const tree = (await build(300))!;
     const rows = (await tree.bottomUp(options))!;
+    const seed = rows[0]!;
+    const caller = seed._children![0]!;
 
-    // Bottom-Up puts the caller under the leaf it called, and the caller row
-    // stands for the same calls, so one call names the leaf row and the caller
-    // row beneath it.
-    const named = rowIdsByEvent(rows).get(instances[0]!) ?? [];
-    expect(named).toEqual(expect.arrayContaining([rows[0]!.id, rows[0]!._children![0]!.id]));
-  });
-
-  it('leaves a frame no row names out of the lookup', async () => {
-    const tree = (await build(4))!;
-
-    expect(rowIdsByEvent((await tree.timeOrder(options))!).get(999)).toBeUndefined();
+    // The top-level row owns the occurrences; the caller row stands for the same
+    // calls, and reads them back through the chain that reached them.
+    expect(seed.eventIndexes).toEqual(instances);
+    expect(caller.eventIndexes).toBeNull();
+    expect(locatableEventIndexes(caller)).toEqual(instances);
   });
 });

--- a/log-viewer/src/components/locatedRow.ts
+++ b/log-viewer/src/components/locatedRow.ts
@@ -6,6 +6,8 @@ import type { ApexLog, LogEvent } from 'apex-log-parser';
 import type { RowComponent } from 'tabulator-tables';
 
 import type { DetailSelection, SelectionView } from '../core/events/EventBus.js';
+import { logStoreFor } from '../core/log/LogStore.js';
+import type { KeyPathIds } from '../core/log/keyPathIds.js';
 import { eventByEventIndex } from '../core/utility/EventSearch.js';
 import { eventKeyChain } from '../features/call-tree/utils/Aggregation.js';
 import { occurrencesThrough } from '../features/call-tree/utils/bottomUpOccurrences.js';
@@ -27,7 +29,7 @@ const ROW_INDEX_ATTRIBUTE = 'data-row-index';
  * The index is read from the data rather than `getIndex()`: Tabulator runs the
  * formatter for its calc rows too, and those carry no index.
  *
- * A view whose rows merge occurrences stamps {@link stampRowKeyPath} instead, as
+ * A view whose rows merge occurrences stamps {@link rowPathStamper} instead, as
  * a bucket has no event of its own.
  *
  * @param indexField - the table's `index` option
@@ -111,26 +113,22 @@ export function rowId(row: RowComponent | undefined): number | undefined {
   return typeof id === 'number' ? id : undefined;
 }
 
-/** Joins a key path. A key holds arbitrary log text, so the separator is one
- *  that text cannot carry: two different paths can never join to one string. */
-const KEY_PATH_SEPARATOR = '\u0001';
-
-const keyPaths = new WeakMap<CallRow, string>();
+const pathIds = new WeakMap<CallRow, number>();
 
 /**
  * What tells a merged row apart from a same-named row under a different parent:
- * the bucket keys from its top-level ancestor out to the row itself. A single
- * key does not, because a bucket map is allocated per parent, so one method holds
- * a row under every caller it has.
+ * the bucket keys from its top-level ancestor out to the row itself, interned to
+ * one integer. A single key does not, because a bucket map is allocated per
+ * parent, so one method holds a row under every caller it has.
  *
  * Undefined on a row that stands for one frame, which its event index identifies.
  */
-export function rowKeyPath(row: RowComponent): string | undefined {
+export function rowPathId(row: RowComponent, ids: KeyPathIds): number | undefined {
   const data = rowCallData(row);
   if (data.key === undefined) {
     return undefined;
   }
-  const cached = keyPaths.get(data);
+  const cached = pathIds.get(data);
   if (cached !== undefined) {
     return cached;
   }
@@ -142,46 +140,38 @@ export function rowKeyPath(row: RowComponent): string | undefined {
     }
     keys.push(parentKey);
   }
-  const path = keys.reverse().join(KEY_PATH_SEPARATOR);
-  keyPaths.set(data, path);
-  return path;
+  const id = ids.pathOf(keys);
+  pathIds.set(data, id);
+  return id;
 }
 
-/** A `rowFormatter` for a view whose rows merge occurrences, stamping the key
- *  path so the mark finds the row with the same one DOM query. */
-export function stampRowKeyPath(row: RowComponent): void {
-  const path = rowKeyPath(row);
-  if (path !== undefined) {
-    row.getElement()?.setAttribute(ROW_INDEX_ATTRIBUTE, path);
-  }
+/** A `rowFormatter` for a view whose rows merge occurrences, stamping the path id
+ *  so the mark finds the row with the same one DOM query. */
+export function rowPathStamper(ids: KeyPathIds): (row: RowComponent) => void {
+  return (row) => {
+    const id = rowPathId(row, ids);
+    if (id !== undefined) {
+      row.getElement()?.setAttribute(ROW_INDEX_ATTRIBUTE, String(id));
+    }
+  };
 }
 
 /**
- * The key paths naming the rows a frame belongs to in a merged view.
+ * The path ids naming the rows a frame belongs to in a merged view.
  *
- * A top-down row sits at the frame's own depth, so one path names it. A
- * bottom-up row is the frame plus however many of its callers the chain shows, so
- * every prefix names a row the frame heads — which is why one frame marks several
- * rows there.
+ * A top-down row sits at the frame's own depth, so one id names it. A bottom-up
+ * row is the frame plus however many of its callers the chain shows, so every
+ * prefix names a row the frame heads — which is why one frame marks several rows
+ * there, and why each prefix is interned as it is reached.
  *
  * The log root is not a row in either view, so the walk stops below it.
  */
-export function eventKeyPaths(event: LogEvent, direction: SelectionView): string[] {
+export function eventPathIds(event: LogEvent, direction: SelectionView, ids: KeyPathIds): number[] {
   const keys = eventKeyChain(event);
   if (!keys.length) {
     return [];
   }
-  if (direction === 'callees') {
-    return [keys.reverse().join(KEY_PATH_SEPARATOR)];
-  }
-  // Each path extends the one before it, so the characters are copied once.
-  const paths: string[] = [];
-  let path = '';
-  for (const key of keys) {
-    path = path ? path + KEY_PATH_SEPARATOR + key : key;
-    paths.push(path);
-  }
-  return paths;
+  return direction === 'callees' ? [ids.pathOf(keys)] : ids.prefixesOf(keys);
 }
 
 /** True where the row holds no calls of its own, so its chain answers for it. */
@@ -212,29 +202,30 @@ function rowCallOccurrences(row: RowComponent): LogEvent[] {
 }
 
 /**
- * The key paths that the frames `eventIndexes` name stand for, so a grid whose
+ * The path ids that the frames `eventIndexes` name stand for, so a grid whose
  * rows merge occurrences can mark them.
  *
  * Every occurrence is walked: occurrences of one frame sit under distinct parent
  * frames, so there is no cheaper set to walk, and only the paths they produce
  * repeat.
  */
-function keyPathsForEvents(
+function pathIdsForEvents(
   root: ApexLog,
   eventIndexes: readonly number[],
   direction: SelectionView,
-): string[] {
-  const paths = new Set<string>();
+): number[] {
+  const ids = logStoreFor(root).keyPathIds();
+  const found = new Set<number>();
   for (const eventIndex of eventIndexes) {
     const event = eventByEventIndex(root, eventIndex);
     if (!event) {
       continue;
     }
-    for (const path of eventKeyPaths(event, direction)) {
-      paths.add(path);
+    for (const id of eventPathIds(event, direction, ids)) {
+      found.add(id);
     }
   }
-  return [...paths];
+  return [...found];
 }
 
 /** The calls a row stands for, as the event indexes the mark works in. */
@@ -286,19 +277,35 @@ export class LocatedRowIds {
   private lastRoot: ApexLog | null = null;
   private lastEvents: readonly number[] | undefined;
   private lastDirection: SelectionView | undefined;
-  private lastIds: readonly (number | string)[] = [];
+  private lastIds: readonly number[] = [];
 
   /**
    * @param direction - The view's own direction, or undefined where its rows are
    * keyed by event and so are named by the indexes themselves.
    */
   public idsFor(
+    root: ApexLog,
+    eventIndexes: readonly number[],
+    direction: SelectionView,
+  ): readonly number[];
+  public idsFor(
     root: ApexLog | null,
     eventIndexes: readonly number[],
     direction: SelectionView | undefined,
-  ): readonly (number | string)[] {
-    if (!direction || !root || !eventIndexes.length) {
+  ): readonly number[];
+  public idsFor(
+    root: ApexLog | null,
+    eventIndexes: readonly number[],
+    direction: SelectionView | undefined,
+  ): readonly number[] {
+    if (!direction) {
+      // The view's rows are keyed by event, so the indexes name them as they are.
       return eventIndexes;
+    }
+    if (!root || !eventIndexes.length) {
+      // A path id and an event index are both small integers, so passing the
+      // indexes on would mark whichever rows happened to share their numbers.
+      return [];
     }
     if (
       this.lastEvents === eventIndexes &&
@@ -310,7 +317,7 @@ export class LocatedRowIds {
     this.lastRoot = root;
     this.lastEvents = eventIndexes;
     this.lastDirection = direction;
-    this.lastIds = keyPathsForEvents(root, eventIndexes, direction);
+    this.lastIds = pathIdsForEvents(root, eventIndexes, direction);
     return this.lastIds;
   }
 }
@@ -325,7 +332,7 @@ export class LocatedRowIds {
  * to mark, so they are left alone.
  *
  * The table must stamp its rows: {@link rowIndexStamper} where a row is one
- * frame, {@link stampRowKeyPath} where rows merge occurrences.
+ * frame, {@link rowPathStamper} where rows merge occurrences.
  */
 export class LocatedRowMarker {
   private elements: HTMLElement[] = [];

--- a/log-viewer/src/components/scopedCallTree.ts
+++ b/log-viewer/src/components/scopedCallTree.ts
@@ -279,8 +279,8 @@ async function subtreeRoots(
  * (time-order / aggregated / bottom-up) or null when nothing is selected.
  *
  * An aggregate selection scopes to every occurrence, and a frame can occur tens
- * of thousands of times, so the walk is sliced: it hands the frame back through
- * `options.yieldFrame` rather than blocking on the whole selection at once.
+ * of thousands of times, so the walk is sliced: it hands the thread back through
+ * `options.yieldSlice` rather than blocking on the whole selection at once.
  * Nothing is capped or sampled — every occurrence is counted, just not all in
  * one frame.
  */

--- a/log-viewer/src/components/scopedCallTree.ts
+++ b/log-viewer/src/components/scopedCallTree.ts
@@ -4,6 +4,7 @@
 import type { LogEvent } from 'apex-log-parser';
 
 import { currentLogStore, type LogStore } from '../core/log/LogStore.js';
+import { ROOT_PATH_ID, type KeyPathIds } from '../core/log/keyPathIds.js';
 import { outermostEvents } from '../core/utility/EventTree.js';
 import { EXCLUDED_DETAIL_TYPES } from '../features/call-tree/utils/DetailsFilter.js';
 import { getEventKey, getStackKey } from '../features/call-tree/utils/Aggregation.js';
@@ -37,7 +38,25 @@ export interface ScopedRow {
    *  and it is outside `ScopedCallTree.calls`. The tree opens these rows so the
    *  selection is on screen, and leaves what ran inside it closed. */
   onPath?: boolean;
+  /** The interned bucket path of a row in a view whose rows merge occurrences:
+   *  what tells it apart from a same-named row under another parent. Absent
+   *  where a row is one frame, which its event index names. */
+  _pathId?: number;
+  /** Where a bottom-up row reads its occurrences. A caller row stands for the
+   *  calls its chain conducted, so it derives them from the top-level row rather
+   *  than holding a copy of the list. */
+  _seed?: OccurrenceSeed;
   _children: ScopedRow[] | null;
+}
+
+/** The occurrences of one top-level bottom-up row, shared by every caller row
+ *  under it. */
+export interface OccurrenceSeed {
+  eventIndexes: number[];
+  /** The interned caller chain that reached each one, in the same order. */
+  chains: number[];
+  /** The table those ids were minted from. */
+  paths: KeyPathIds;
 }
 
 /**
@@ -59,28 +78,50 @@ export function locatableEventIndexes(row: Partial<ScopedRow> | undefined): numb
   if (row?.eventIndexes) {
     return row.eventIndexes;
   }
+  const seed = row?._seed;
+  if (seed) {
+    // `_seed` is only ever set alongside `_pathId`.
+    const pathId = row._pathId!;
+    const { chains, eventIndexes, paths } = seed;
+    // A hot bucket has thousands of occurrences but few distinct chains, so the
+    // verdict is answered per chain and the walk runs once each.
+    const through = new Map<number, boolean>();
+    const derived: number[] = [];
+    for (let i = 0; i < chains.length; i++) {
+      const chain = chains[i]!;
+      let hit = through.get(chain);
+      if (hit === undefined) {
+        hit = paths.reaches(chain, pathId);
+        through.set(chain, hit);
+      }
+      if (hit) {
+        derived.push(eventIndexes[i]!);
+      }
+    }
+    // Kept once derived: a pointer sweep re-enters a row, and the click that
+    // follows asks again.
+    row.eventIndexes = derived;
+    return derived;
+  }
   const single = revealableEventIndex(row);
   return single === null ? [] : [single];
 }
 
 /**
- * The rows of one view keyed by each occurrence they stand for, so a frame named
- * elsewhere can be found in a view whose rows merge occurrences behind a
- * synthetic id. One frame can name several rows — in bottom-up it appears once
- * per caller chain it sits in.
+ * The rows of one view keyed by the bucket path each stands for, so a frame
+ * named elsewhere can be found behind the synthetic id of a row that merges
+ * occurrences. Keyed by path rather than by occurrence: a frame names the rows
+ * its own path runs through, which the occurrences behind the rows need not be
+ * read to answer.
  */
-export function rowIdsByEvent(rows: readonly ScopedRow[]): Map<number, number[]> {
-  const byEvent = new Map<number, number[]>();
+export function rowIdsByPath(rows: readonly ScopedRow[]): Map<number, number> {
+  const byPath = new Map<number, number>();
   const stack = [...rows];
   while (stack.length) {
     const row = stack.pop()!;
-    for (const eventIndex of locatableEventIndexes(row)) {
-      const ids = byEvent.get(eventIndex);
-      if (ids) {
-        ids.push(row.id);
-      } else {
-        byEvent.set(eventIndex, [row.id]);
-      }
+    if (row._pathId !== undefined) {
+      // One row per path in a view: a bucket is minted per parent path and key.
+      byPath.set(row._pathId, row.id);
     }
     if (row._children) {
       // Pushed one at a time: a spread (and `push.apply`) passes each element as
@@ -90,7 +131,7 @@ export function rowIdsByEvent(rows: readonly ScopedRow[]): Map<number, number[]>
       }
     }
   }
-  return byEvent;
+  return byPath;
 }
 
 export interface ScopedCallTree {
@@ -106,6 +147,15 @@ export interface ScopedCallTree {
   /** True where Time Order merges the occurrences of one frame, so its rows carry
    *  synthetic ids like the grouped views rather than event indexes. */
   timeOrderMerged: boolean;
+  /**
+   * True where the frame is one this tree stands for. Absent on the whole-log
+   * tree, which stands for every frame.
+   *
+   * A merged row is named by its bucket path, and a frame elsewhere in the log
+   * can sit at the same path — a second call of the same method, which a loop or
+   * a trigger makes common. So a mark asks the tree rather than trusting the path.
+   */
+  holds?: (eventIndex: number) => boolean;
   /** The three views, built on first call and cached (only one is on screen).
    *  Each hands the frame back as it works, and returns null when abandoned. */
   timeOrder(options: FrameBudgetOptions): Promise<ScopedRow[] | null>;
@@ -316,7 +366,28 @@ export async function buildScopedCallTree(
     return null;
   }
 
+  // The two top-down views root the selection under its callers, so a caller is
+  // a row here too. Built on the first mark, since only a pointer needs it.
+  let callers: Set<number> | null = null;
+  const selected = new Set(selectedEvents.map((event) => event.eventIndex));
+  const holds = (eventIndex: number): boolean => {
+    if (selected.has(eventIndex)) {
+      return true;
+    }
+    callers ??= callerIndexes(selectedEvents);
+    if (callers.has(eventIndex)) {
+      return true;
+    }
+    for (let node = store.eventByIndex(eventIndex)?.parent; node; node = node.parent) {
+      if (selected.has(node.eventIndex)) {
+        return true;
+      }
+    }
+    return false;
+  };
+
   return lazyCallTree({
+    holds,
     // Only the two top-down views read the callers, and bottom-up is what most
     // selections open on, so the spine is built on first read like the views are.
     topDown: (viewOptions) =>
@@ -325,10 +396,25 @@ export async function buildScopedCallTree(
     rootTotal,
     logTotal: apexLog.duration.total,
     calls: scope.calls,
+    paths: store.keyPathIds(),
     // Occurrences of one frame are the same call made again, so merge them into a
     // single root; a single occurrence is already that.
     mergeTimeOrder: scope.roots.length > 1,
   });
+}
+
+/** Every frame above the selection: the rows the two top-down views root it in. */
+function callerIndexes(selectedEvents: readonly LogEvent[]): Set<number> {
+  const above = new Set<number>();
+  for (const event of selectedEvents) {
+    for (let node = event.parent; node; node = node.parent) {
+      if (above.has(node.eventIndex)) {
+        break; // this chain, and every chain above it, is already in
+      }
+      above.add(node.eventIndex);
+    }
+  }
+  return above;
 }
 
 /** What the three views are built from. */
@@ -340,6 +426,10 @@ interface CallTreeInput {
   rootTotal: number;
   logTotal: number;
   calls: number;
+  /** The log's interned bucket paths, which the merged views name their rows by. */
+  paths: KeyPathIds;
+  /** {@link ScopedCallTree.holds}, absent where the tree stands for the whole log. */
+  holds?: (eventIndex: number) => boolean;
   /** Folds the occurrences of one frame into a single root (a scoped aggregate),
    *  which makes Time Order the same answer as Aggregated. The whole-log tree and
    *  a single occurrence keep their exact order. */
@@ -352,7 +442,7 @@ interface CallTreeInput {
  * every retained subtree.
  */
 function lazyCallTree(input: CallTreeInput): ScopedCallTree {
-  const { rootTotal, calls, logTotal, mergeTimeOrder } = input;
+  const { rootTotal, calls, logTotal, mergeTimeOrder, paths, holds } = input;
   let topDownRows: ScopedRow[] | null = null;
   let aggregatedRows: ScopedRow[] | null = null;
   let bottomUpRows: ScopedRow[] | null = null;
@@ -363,6 +453,7 @@ function lazyCallTree(input: CallTreeInput): ScopedCallTree {
     calls,
     logTotal,
     timeOrderMerged: mergeTimeOrder,
+    holds,
     async timeOrder(viewOptions) {
       // Merged, the two views are the same walk, so they share one answer.
       return mergeTimeOrder ? this.aggregated(viewOptions) : topDown(viewOptions);
@@ -370,12 +461,12 @@ function lazyCallTree(input: CallTreeInput): ScopedCallTree {
     async aggregated(viewOptions) {
       if (!aggregatedRows) {
         const rows = await topDown(viewOptions);
-        aggregatedRows = rows && (await aggregate(rows, viewOptions));
+        aggregatedRows = rows && (await aggregate(rows, paths, viewOptions));
       }
       return aggregatedRows;
     },
     async bottomUp(viewOptions) {
-      bottomUpRows ??= await buildBottomUp(input.bottomUp, viewOptions);
+      bottomUpRows ??= await buildBottomUp(input.bottomUp, paths, viewOptions);
       return bottomUpRows;
     },
   };
@@ -393,8 +484,9 @@ function lazyCallTree(input: CallTreeInput): ScopedCallTree {
 export async function buildWholeLogCallTree(
   options: FrameBudgetOptions,
 ): Promise<ScopedCallTree | null> {
-  const apexLog = currentLogStore()?.log;
-  if (!apexLog) {
+  const store = currentLogStore();
+  const apexLog = store?.log;
+  if (!store || !apexLog) {
     return null;
   }
 
@@ -412,6 +504,7 @@ export async function buildWholeLogCallTree(
     rootTotal: apexLog.duration.total,
     logTotal: apexLog.duration.total,
     calls: scope.calls,
+    paths: store.keyPathIds(),
     mergeTimeOrder: false,
   });
 }
@@ -419,6 +512,7 @@ export async function buildWholeLogCallTree(
 /** Top-down aggregation: merge sibling frames sharing a key, summing metrics. */
 async function aggregate(
   rows: ScopedRow[],
+  paths: KeyPathIds,
   options: FrameBudgetOptions,
 ): Promise<ScopedRow[] | null> {
   const tick = frameBudget(options);
@@ -427,7 +521,7 @@ async function aggregate(
 
   // The recursion follows the call depth, which is shallow; each level's input
   // is the wide dimension, so that is where the slicing goes.
-  async function merge(input: ScopedRow[]): Promise<ScopedRow[] | null> {
+  async function merge(input: ScopedRow[], parentPathId: number): Promise<ScopedRow[] | null> {
     const groups = new Map<string, ScopedRow>();
     const order: string[] = [];
     // The occurrences behind each group — a set, so one frame cannot be listed
@@ -450,6 +544,7 @@ async function aggregate(
           callCount: 0,
           eventIndexes: [],
           onPath: row.onPath,
+          _pathId: paths.pathId(parentPathId, key),
           _children: [],
         };
         groups.set(key, group);
@@ -482,7 +577,7 @@ async function aggregate(
       group.eventIndexes = [...indexes.get(key)!];
       const kids = group._children as ScopedRow[];
       if (kids.length) {
-        const mergedKids = await merge(kids);
+        const mergedKids = await merge(kids, group._pathId!);
         if (!mergedKids) {
           return null;
         }
@@ -495,30 +590,24 @@ async function aggregate(
     return merged;
   }
 
-  return merge(rows);
+  return merge(rows, ROOT_PATH_ID);
 }
 
 interface BottomUpNode extends ScopedRow {
-  _map: Map<string, BottomUpNode>;
-  /** The occurrences behind the row. A set, because a caller is met once per
-   *  seed beneath it, and a hot caller has many. */
-  _indexes: Set<number>;
-}
-
-/** A row's ancestors, innermost first. Siblings share the whole tail, so the
- *  walk carries a link per node instead of a copy of the path. */
-interface CallerChain {
-  row: ScopedRow;
-  key: string;
-  caller: CallerChain | null;
+  _pathId: number;
+  _seed: OccurrenceSeed;
 }
 
 /** A frame on the walk. Both visits share it, so each key is built once and the
- *  time the frame keeps survives from the first visit to the second. */
+ *  time the frame keeps survives from the first visit to the second. A child
+ *  carries its parent's entry as its caller chain, so the ancestor path costs no
+ *  link of its own. */
 interface WalkEntry {
   row: ScopedRow;
-  callers: CallerChain | null;
-  key: string;
+  callers: WalkEntry | null;
+  /** The frame's bucket key, interned: a chain link is stepped by id, and the
+   *  key of a hot frame is built once rather than once per caller it has. */
+  keyId: number;
   stackKey: string;
   leaving: boolean;
   /** The frame's time, less every call of the same frame inside it. */
@@ -543,22 +632,23 @@ interface WalkEntry {
  */
 async function buildBottomUp(
   rows: ScopedRow[],
+  paths: KeyPathIds,
   options: FrameBudgetOptions,
 ): Promise<ScopedRow[] | null> {
   const tick = frameBudget(options);
   let idSeq = 0;
   const nextId = () => (idSeq -= 1);
-  const topMap = new Map<string, BottomUpNode>();
+  const nodeByPath = new Map<number, BottomUpNode>();
   const topOrder: BottomUpNode[] = [];
-  const everyNode: BottomUpNode[] = [];
 
-  const ensure = (
-    map: Map<string, BottomUpNode>,
-    order: BottomUpNode[] | null,
-    src: ScopedRow,
-    key: string,
-  ) => {
-    let node = map.get(key);
+  /**
+   * The row for a path, minted on first use and linked under its caller as it is.
+   * A path is unique to a row, so it is what the tree is keyed by.
+   *
+   * @param under - the row this one nests in, null for a top-level row
+   */
+  const ensure = (under: BottomUpNode | null, src: ScopedRow, pathId: number): BottomUpNode => {
+    let node = nodeByPath.get(pathId);
     if (!node) {
       node = {
         id: nextId(),
@@ -567,14 +657,20 @@ async function buildBottomUp(
         type: src.type,
         duration: { total: 0, self: 0 },
         callCount: 0,
-        eventIndexes: [],
+        // A top-level row holds its occurrences; a caller row derives its own
+        // from that row, so it stores none.
+        eventIndexes: under ? null : [],
+        _seed: under ? under._seed : { eventIndexes: [], chains: [], paths },
+        _pathId: pathId,
         _children: null,
-        _map: new Map(),
-        _indexes: new Set(),
       };
-      map.set(key, node);
-      order?.push(node);
-      everyNode.push(node);
+      if (under) {
+        (under._children ??= []).push(node);
+      } else {
+        node.eventIndexes = node._seed.eventIndexes;
+        topOrder.push(node);
+      }
+      nodeByPath.set(pathId, node);
     }
     return node;
   };
@@ -586,10 +682,10 @@ async function buildBottomUp(
   // recurses as a method entry is the same frame to both.
   const open = new Map<string, WalkEntry | null>();
 
-  const entryFor = (row: ScopedRow, callers: CallerChain | null): WalkEntry => ({
+  const entryFor = (row: ScopedRow, callers: WalkEntry | null): WalkEntry => ({
     row,
     callers,
-    key: getEventKey(row.originalData),
+    keyId: paths.keyId(getEventKey(row.originalData)),
     stackKey: getStackKey(row.originalData),
     leaving: false,
     attributed: 0,
@@ -622,11 +718,8 @@ async function buildBottomUp(
       entry.leaving = true;
       stack.push(entry);
       if (row._children) {
-        // Shared by every child, so the ancestor path costs one link per node
-        // rather than a copy of the whole path.
-        const childCallers: CallerChain = { row, key: entry.key, caller: callers };
         for (let i = row._children.length - 1; i >= 0; i--) {
-          stack.push(entryFor(row._children[i]!, childCallers));
+          stack.push(entryFor(row._children[i]!, entry));
         }
       }
       continue;
@@ -637,45 +730,36 @@ async function buildBottomUp(
     if (row.duration.self > 0) {
       // The seed row, then its callers up to the root. The chain is already in
       // that order, so it is walked in place rather than copied and reversed.
-      const seed = ensure(topMap, topOrder, row, entry.key);
+      let pathId = paths.step(ROOT_PATH_ID, entry.keyId);
+      const seed = ensure(null, row, pathId);
       seed.duration.total += attributed;
       seed.duration.self += row.duration.self;
       seed.callCount += 1;
-      const seedIndexes = locatableEventIndexes(row);
-      for (const index of seedIndexes) {
-        seed._indexes.add(index);
-      }
-      let map = seed._map;
-      for (let link = callers; link; link = link.caller) {
-        const node = ensure(map, null, link.row, link.key);
+      let node = seed;
+      for (let link = callers; link; link = link.callers) {
+        pathId = paths.step(pathId, link.keyId);
+        node = ensure(node, link.row, pathId);
         node.duration.total += attributed;
-        // A caller row stands for the calls it conducted, not for the caller
-        // frame, so it holds the same frames its time and count are taken from.
-        // That is what the grids send for their own caller rows, so the two sides
-        // point at the same calls.
-        for (const index of seedIndexes) {
-          node._indexes.add(index);
-        }
         // Callers count the call they contributed too, matching the Call Tree
         // tab's bottom-up (every bucket in the chain accumulates); counting
         // only the seed left every caller row reading "Calls 0".
         node.callCount += 1;
-        map = node._map;
+      }
+      // Each occurrence is tagged with the chain that reached it, which is how a
+      // caller row picks out the ones it stands for.
+      const store = seed._seed;
+      const held = row.eventIndexes;
+      if (held) {
+        for (let i = 0; i < held.length; i++) {
+          store.eventIndexes.push(held[i]!);
+          store.chains.push(pathId);
+        }
+      } else {
+        store.eventIndexes.push(row.originalData.eventIndex);
+        store.chains.push(pathId);
       }
     }
   }
 
-  // The nodes are already ScopedRows; publishing each caller map as `_children`
-  // in place saves a second tree's worth of allocation.
-  for (let i = 0; i < everyNode.length; i++) {
-    if (i % CHECK_EVERY === 0 && !(await tick())) {
-      return null;
-    }
-    const node = everyNode[i]!;
-    node._children = node._map.size ? [...node._map.values()] : null;
-    node._map.clear(); // its entries live in `_children` now
-    node.eventIndexes = [...node._indexes];
-    node._indexes.clear(); // its entries live in `eventIndexes` now
-  }
   return topOrder.sort((a, b) => b.duration.self - a.duration.self);
 }

--- a/log-viewer/src/core/log/LogStore.ts
+++ b/log-viewer/src/core/log/LogStore.ts
@@ -9,6 +9,8 @@ import {
   SOSLExecuteBeginLine,
 } from 'apex-log-parser';
 
+import { KeyPathIds } from './keyPathIds.js';
+
 export type Stack = LogEvent[];
 
 /**
@@ -22,6 +24,7 @@ export class LogStore {
   readonly log: ApexLog;
 
   private _statements: Statements | null = null;
+  private _keyPathIds: KeyPathIds | null = null;
 
   constructor(log: ApexLog) {
     this.log = log;
@@ -62,6 +65,12 @@ export class LogStore {
   /** Every SOSL statement in the log, in log order. */
   soslLines(): SOSLExecuteBeginLine[] {
     return this.statements().sosl;
+  }
+
+  /** The interned bucket paths of this log, shared by every view that marks a row
+   *  whose occurrences are merged. */
+  keyPathIds(): KeyPathIds {
+    return (this._keyPathIds ??= new KeyPathIds());
   }
 
   private statements(): Statements {

--- a/log-viewer/src/core/log/__tests__/keyPathIds.test.ts
+++ b/log-viewer/src/core/log/__tests__/keyPathIds.test.ts
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2026 Certinia Inc. All rights reserved.
+ */
+import { beforeEach, describe, expect, it } from '@jest/globals';
+
+import { KeyPathIds, ROOT_PATH_ID } from '../keyPathIds.js';
+
+describe('KeyPathIds', () => {
+  let ids: KeyPathIds;
+  beforeEach(() => {
+    ids = new KeyPathIds();
+  });
+
+  /** Interns a whole path, named outermost key first as a row reads. */
+  function pathFor(table: KeyPathIds, ...keys: string[]): number {
+    return table.pathOf([...keys].reverse());
+  }
+
+  it('gives one id to the same path, however often it is asked for', () => {
+    expect(pathFor(ids, 'A', 'B')).toBe(pathFor(ids, 'A', 'B'));
+  });
+
+  it('tells the same key apart under different parents', () => {
+    // The reason a key alone cannot name a row: a bucket map is allocated per
+    // parent, so one method holds a row under every caller it has.
+    expect(pathFor(ids, 'Trigger1', 'Util.log')).not.toBe(pathFor(ids, 'Trigger2', 'Util.log'));
+  });
+
+  it('tells a path apart from the prefix it extends', () => {
+    expect(pathFor(ids, 'A', 'B')).not.toBe(pathFor(ids, 'A'));
+  });
+
+  it('names the two directions apart, since a row means each in one view only', () => {
+    const chain = ['leaf', 'caller'];
+
+    // Top-down names the whole chain; bottom-up names the leaf, then the leaf
+    // under its caller.
+    expect(ids.prefixesOf(chain)).toEqual([pathFor(ids, 'leaf'), expect.any(Number)]);
+    expect(ids.prefixesOf(chain)[1]).not.toBe(ids.pathOf(chain));
+  });
+
+  it('reads a path back, outermost first', () => {
+    expect(ids.keysOf(pathFor(ids, 'A', 'B', 'C'))).toEqual(['A', 'B', 'C']);
+  });
+
+  it('reads the empty path as no keys, since no row stands for it', () => {
+    expect(ids.keysOf(ROOT_PATH_ID)).toEqual([]);
+  });
+
+  it('reports a path as running through itself and through every prefix', () => {
+    const inner = pathFor(ids, 'A', 'B', 'C');
+
+    expect(ids.reaches(inner, inner)).toBe(true);
+    expect(ids.reaches(inner, pathFor(ids, 'A'))).toBe(true);
+    expect(ids.reaches(inner, pathFor(ids, 'A', 'B'))).toBe(true);
+    // The other way round, and a path off to the side, both miss.
+    expect(ids.reaches(pathFor(ids, 'A'), inner)).toBe(false);
+    expect(ids.reaches(inner, pathFor(ids, 'Z'))).toBe(false);
+  });
+
+  it('mints on its own, so an id from one log means nothing to another', () => {
+    const other = new KeyPathIds();
+
+    expect(pathFor(other, 'Z')).toBe(pathFor(ids, 'A'));
+    expect(other.keysOf(pathFor(other, 'Z'))).toEqual(['Z']);
+    expect(ids.keysOf(pathFor(ids, 'A'))).toEqual(['A']);
+  });
+});

--- a/log-viewer/src/core/log/keyPathIds.ts
+++ b/log-viewer/src/core/log/keyPathIds.ts
@@ -1,0 +1,131 @@
+/*
+ * Copyright (c) 2026 Certinia Inc. All rights reserved.
+ */
+
+/** The path every chain starts from, which no row stands for. */
+export const ROOT_PATH_ID = 0;
+
+/**
+ * The bucket paths of one log, each interned to an integer.
+ *
+ * A row in a view whose rows merge occurrences is named by the bucket keys that
+ * reach it, since one method holds a row under every caller it has. Joining
+ * those keys into a string is what named it before, and the join was the whole
+ * cost of a mark. An id per distinct path bounds the table by the tree rather
+ * than by the calls, and makes matching an integer test.
+ *
+ * Every caller depends on one invariant: a row's id is the interned chain of the
+ * frames the row holds. Compose ids through {@link pathOf} or
+ * {@link prefixesOf} rather than folding {@link pathId} by hand, since the two
+ * directions are separate spaces and an id from one means nothing in the other.
+ *
+ * One table per log, held by `LogStore`: an id means nothing to another log.
+ */
+export class KeyPathIds {
+  private keyIds = new Map<string, number>();
+  private keys: string[] = [];
+  // Indexed by path id: the paths reachable from it, its own parent, and the key
+  // it was minted with. Index 0 is the empty path.
+  private children: Array<Map<number, number> | undefined> = [new Map()];
+  private parents: number[] = [ROOT_PATH_ID];
+  private keyOf: number[] = [-1];
+
+  /**
+   * The id for the path that reaches `key` through `parentPathId`, minted on
+   * first use.
+   *
+   * @param parentPathId - {@link ROOT_PATH_ID} for the outermost key of a chain
+   */
+  public pathId(parentPathId: number, key: string): number {
+    return this.step(parentPathId, this.keyId(key));
+  }
+
+  /**
+   * The id of one bucket key, interned. A walk that steps the same key many times
+   * interns it once and calls {@link step}, since hashing the key is what a path
+   * id exists to avoid.
+   */
+  public keyId(key: string): number {
+    let id = this.keyIds.get(key);
+    if (id === undefined) {
+      id = this.keys.length;
+      this.keyIds.set(key, id);
+      this.keys.push(key);
+    }
+    return id;
+  }
+
+  /** {@link pathId} for a key already interned by {@link keyId}. */
+  public step(parentPathId: number, keyId: number): number {
+    const reachable = (this.children[parentPathId] ??= new Map());
+    let id = reachable.get(keyId);
+    if (id === undefined) {
+      // Counted off `parents`, which is only ever pushed to: reaching for a path
+      // that does not exist leaves `children` with a hole, and an id taken from
+      // its length would then part company with the other two.
+      id = this.parents.length;
+      reachable.set(keyId, id);
+      this.children.push(undefined);
+      this.parents.push(parentPathId);
+      this.keyOf.push(keyId);
+    }
+    return id;
+  }
+
+  /**
+   * The id for a whole chain, outermost key first: what names a top-down row.
+   *
+   * @param keys - the chain innermost first, as `eventKeyChain` gives it
+   */
+  public pathOf(keys: readonly string[]): number {
+    let id = ROOT_PATH_ID;
+    for (let depth = keys.length - 1; depth >= 0; depth--) {
+      id = this.pathId(id, keys[depth]!);
+    }
+    return id;
+  }
+
+  /**
+   * An id per step out along a chain: the bottom-up rows a frame heads, which are
+   * the frame alone, then the frame under one caller, and so on.
+   *
+   * @param keys - the chain innermost first
+   */
+  public prefixesOf(keys: readonly string[]): number[] {
+    const prefixes: number[] = [];
+    let id = ROOT_PATH_ID;
+    for (const key of keys) {
+      id = this.pathId(id, key);
+      prefixes.push(id);
+    }
+    return prefixes;
+  }
+
+  /**
+   * True where `path` runs through `pathId`: the same path, or one that extends
+   * it. An id is minted per parent and key, so running through a path is being
+   * that path or a descendant of it.
+   *
+   * A path is always minted after its parent, so ids fall as the walk climbs and
+   * it can stop at the depth asked about rather than at the root.
+   */
+  public reaches(path: number, pathId: number): boolean {
+    let id = path;
+    while (id > pathId) {
+      id = this.parents[id]!;
+    }
+    return id === pathId;
+  }
+
+  /**
+   * The keys `pathId` stands for, outermost first. For reading a stamped id back
+   * while debugging: nothing on a hot path calls it.
+   */
+  public keysOf(pathId: number): string[] {
+    const keys: string[] = [];
+    for (let id = pathId; id > ROOT_PATH_ID; id = this.parents[id]!) {
+      keys.push(this.keys[this.keyOf[id]!]!);
+    }
+    return keys.reverse();
+  }
+}

--- a/log-viewer/src/core/utility/FrameBudget.ts
+++ b/log-viewer/src/core/utility/FrameBudget.ts
@@ -11,8 +11,9 @@ const SLICE_MS = 8;
 export const CHECK_EVERY = 256;
 
 export interface FrameBudgetOptions {
-  /** Hands the frame back between work slices. */
-  yieldFrame: () => Promise<void>;
+  /** Hands the thread back between work slices. Defaults to
+   *  {@link waitForNextTask}, which is what a walk wants. */
+  yieldSlice?: () => Promise<void>;
   /** Aborting it abandons the build, which then returns null. */
   signal?: AbortSignal;
 }
@@ -20,22 +21,39 @@ export interface FrameBudgetOptions {
 /** Returns false once the build has been abandoned. */
 export type Tick = () => Promise<boolean>;
 
-/** Resolve after the next animation frame — the usual `yieldFrame`, and what
- *  lets a just-shown host lay itself out before anything measures it. */
+/** Resolve after the next animation frame: what lets a just-shown host lay
+ *  itself out before anything measures it. */
 export function waitForNextFrame(): Promise<void> {
   return new Promise((resolve) => {
     requestAnimationFrame(() => resolve());
   });
 }
 
+/** Resolve after the next task. A frame yield hands back a whole frame per 8ms
+ *  slice, which caps a walk at half the machine; a task yield costs about
+ *  nothing, and the slice is short enough that paint still gets in. */
+export function waitForNextTask(): Promise<void> {
+  return new Promise((resolve) => {
+    // A channel per yield rather than one shared: a live port with a handler
+    // holds Node's event loop open, and this module is loaded outside a browser.
+    const channel = new MessageChannel();
+    channel.port1.onmessage = () => {
+      channel.port1.close();
+      resolve();
+    };
+    channel.port2.postMessage(null);
+  });
+}
+
 /** A slice timer: cheap while the slice has time left, yields once it doesn't. */
 export function frameBudget(options: FrameBudgetOptions): Tick {
+  const yieldSlice = options.yieldSlice ?? waitForNextTask;
   let deadline = performance.now() + SLICE_MS;
   return async () => {
     if (performance.now() < deadline) {
       return true;
     }
-    await options.yieldFrame();
+    await yieldSlice();
     deadline = performance.now() + SLICE_MS;
     return !options.signal?.aborted;
   };

--- a/log-viewer/src/core/utility/__tests__/FrameBudget.test.ts
+++ b/log-viewer/src/core/utility/__tests__/FrameBudget.test.ts
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2026 Certinia Inc. All rights reserved.
+ */
+import { describe, expect, it, jest } from '@jest/globals';
+
+import { frameBudget, waitForNextTask } from '../FrameBudget.js';
+
+describe('waitForNextTask', () => {
+  it('resolves without an animation frame, which is the whole point', async () => {
+    // A frame that never comes: awaiting one here would hang the test.
+    globalThis.requestAnimationFrame = () => 0;
+
+    await expect(waitForNextTask()).resolves.toBeUndefined();
+  });
+});
+
+describe('frameBudget', () => {
+  it('yields once the slice is spent, and reports an abandoned build', async () => {
+    const controller = new AbortController();
+    const yieldSlice = jest.fn(() => Promise.resolve());
+    // Runs the clock past the 8ms slice, so the next tick must yield.
+    const now = jest.spyOn(performance, 'now');
+    now.mockReturnValue(0);
+    const tick = frameBudget({ yieldSlice, signal: controller.signal });
+
+    expect(await tick()).toBe(true);
+    expect(yieldSlice).not.toHaveBeenCalled();
+
+    now.mockReturnValue(100);
+    expect(await tick()).toBe(true);
+    expect(yieldSlice).toHaveBeenCalledTimes(1);
+
+    now.mockReturnValue(200);
+    controller.abort();
+    expect(await tick()).toBe(false);
+    now.mockRestore();
+  });
+});

--- a/log-viewer/src/features/analysis/components/AnalysisView.ts
+++ b/log-viewer/src/features/analysis/components/AnalysisView.ts
@@ -638,7 +638,7 @@ export class AnalysisView extends LitElement {
             this._clearSearchHighlights();
           }
         },
-        rowFormatter: groupedRowFormatter,
+        rowFormatter: groupedRowFormatter(rootMethod),
       },
       {
         placeholder: 'No Analysis Available',

--- a/log-viewer/src/features/call-tree/components/CalltreeView.ts
+++ b/log-viewer/src/features/call-tree/components/CalltreeView.ts
@@ -1130,7 +1130,7 @@ export class CalltreeView extends LitElement {
           this._clearSearchHighlights();
         }
       },
-      rowFormatter: groupedRowFormatter,
+      rowFormatter: groupedRowFormatter(rootMethod),
     });
     this.aggregatedTreeTable = table;
     await tableBuilt;
@@ -1156,7 +1156,7 @@ export class CalltreeView extends LitElement {
             this._clearSearchHighlights();
           }
         },
-        rowFormatter: groupedRowFormatter,
+        rowFormatter: groupedRowFormatter(rootMethod),
       },
       {
         selectableRows: 'highlight',

--- a/log-viewer/src/features/call-tree/utils/CategoryColoring.ts
+++ b/log-viewer/src/features/call-tree/utils/CategoryColoring.ts
@@ -1,10 +1,12 @@
 /*
  * Copyright (c) 2025 Certinia Inc. All rights reserved.
  */
+import type { ApexLog } from 'apex-log-parser';
 import { css } from 'lit';
 import type { RowComponent } from 'tabulator-tables';
 
-import { stampRowKeyPath } from '../../../components/locatedRow.js';
+import { rowPathStamper } from '../../../components/locatedRow.js';
+import { logStoreFor } from '../../../core/log/LogStore.js';
 import { VSCodeExtensionMessenger } from '../../../core/messaging/VSCodeExtensionMessenger.js';
 import { subscribeSettings, type LanaSettings } from '../../settings/Settings.js';
 import { CATEGORY_THEME_KEY, DEFAULT_THEME_NAME } from '../../timeline/themes/Themes.js';
@@ -43,11 +45,15 @@ export const categoryRowFormatter = (row: RowComponent): void => {
 };
 
 /** The `rowFormatter` for a view whose rows merge occurrences: the colour strip,
- *  plus the key path the inspector's mark finds the row by. */
-export const groupedRowFormatter = (row: RowComponent): void => {
-  categoryRowFormatter(row);
-  stampRowKeyPath(row);
-};
+ *  plus the path id the inspector's mark finds the row by. The ids are the log's,
+ *  so a row and the frames it holds reach the same one. */
+export function groupedRowFormatter(root: ApexLog): (row: RowComponent) => void {
+  const stamp = rowPathStamper(logStoreFor(root).keyPathIds());
+  return (row) => {
+    categoryRowFormatter(row);
+    stamp(row);
+  };
+}
 
 function applyCategoryTheme(host: HTMLElement, themeName: string): void {
   const theme = getTheme(themeName);

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "copy:package-docs": "node ./scripts/copy-package-docs.mjs",
     "typecheck": "tsc -b",
     "typecheck:tsc6": "tsc6 -b",
+    "measure": "rolldown -c scripts/measure/rolldown.config.ts && node --expose-gc --max-old-space-size=12288 scripts/measure/out/measure.mjs",
     "lint": "concurrently -r -g 'eslint . --cache --cache-location node_modules/.cache/eslint/' 'prettier --cache **/*.{ts,css,md,mdx,scss} --check --experimental-cli' 'pnpm run typecheck'",
     "test": "jest",
     "test:ci": "jest --runInBand",

--- a/scripts/measure/measure.ts
+++ b/scripts/measure/measure.ts
@@ -1,0 +1,132 @@
+/*
+ * Copyright (c) 2026 Certinia Inc. All rights reserved.
+ */
+
+/**
+ * Times the call tree builds and the inspector's row mark on a real log.
+ *
+ * The whole path is free of the DOM, so it runs under Node: a browser cannot
+ * profile a 100MB log without its own parse blocking the tools.
+ *
+ *   pnpm measure <path to a log>
+ *
+ * Heap figures need `--expose-gc`, which the `measure` script passes. No log is
+ * committed: the path is always an argument.
+ */
+import { readFileSync } from 'node:fs';
+
+import { parse } from 'apex-log-parser';
+
+import { LocatedRowIds } from '../../log-viewer/src/components/locatedRow.js';
+import {
+  buildWholeLogCallTree,
+  rowIdsByPath,
+  type ScopedRow,
+} from '../../log-viewer/src/components/scopedCallTree.js';
+import { setCurrentLog } from '../../log-viewer/src/core/log/LogStore.js';
+import {
+  toAggregatedCallTree,
+  toBottomUpTree,
+} from '../../log-viewer/src/features/call-tree/utils/Aggregation.js';
+
+const gc = globalThis.gc as (() => void) | undefined;
+
+/** Heap after a collection, so a figure is what the step retained, not its litter. */
+function heapMb(): number {
+  gc?.();
+  return Math.round(process.memoryUsage().heapUsed / 1048576);
+}
+
+const now = (): number => Number(process.hrtime.bigint() / 1000000n);
+// The builds slice themselves against this; resolving at once measures the work
+// rather than the frames it would hand back on screen.
+const yieldSlice = () => Promise.resolve();
+
+function report(label: string, ms: number, before: number): void {
+  console.log(`${label.padEnd(32)} ${String(ms).padStart(7)}ms  heap ${before} -> ${heapMb()}MB`);
+}
+
+async function time<T>(label: string, body: () => T | Promise<T>): Promise<T> {
+  const before = heapMb();
+  const start = now();
+  const out = await body();
+  report(label, now() - start, before);
+  return out;
+}
+
+interface Shape {
+  nodes: number;
+  /** Event indexes the rows store between them: what a row per occurrence costs.
+   *  A row that derives its own stores none. */
+  indexes: number;
+  fattest: ScopedRow | null;
+}
+
+function shapeOf(rows: readonly ScopedRow[]): Shape {
+  const shape: Shape = { nodes: 0, indexes: 0, fattest: null };
+  const stack = [...rows];
+  while (stack.length) {
+    const row = stack.pop()!;
+    shape.nodes += 1;
+    const held = row.eventIndexes?.length ?? 0;
+    shape.indexes += held;
+    if (held > (shape.fattest?.eventIndexes?.length ?? 0)) {
+      shape.fattest = row;
+    }
+    if (row._children) {
+      for (const child of row._children) {
+        stack.push(child);
+      }
+    }
+  }
+  return shape;
+}
+
+const logPath = process.argv[2];
+if (!logPath) {
+  console.error('usage: pnpm measure <path to a log>');
+  process.exit(1);
+}
+
+const text = await time('read file', () => readFileSync(logPath, 'utf8'));
+console.log(`log ${Math.round(text.length / 1048576)}MB, ${text.split('\n').length} lines\n`);
+
+const log = await time('parse', () => parse(text));
+setCurrentLog(log);
+
+const scoped = await time('buildWholeLogCallTree', () => buildWholeLogCallTree({ yieldSlice }));
+if (!scoped) {
+  throw new Error('nothing in scope');
+}
+
+const bottomUp = (await time('inspector bottomUp() rows', () => scoped.bottomUp({ yieldSlice })))!;
+const aggregated = (await time('inspector aggregated() rows', () =>
+  scoped.aggregated({ yieldSlice }),
+))!;
+const timeOrder = (await time('inspector timeOrder() rows', () =>
+  scoped.timeOrder({ yieldSlice }),
+))!;
+
+const shape = shapeOf(bottomUp);
+const counts = ({ nodes, indexes }: Shape) => `${nodes} nodes, ${indexes} indexes held`;
+console.log(`bottom-up   ${counts(shape)}`);
+console.log(`aggregated  ${counts(shapeOf(aggregated))}`);
+console.log(`time-order  ${counts(shapeOf(timeOrder))}\n`);
+
+const byPathBottomUp = await time('rowIdsByPath bottom-up', () => rowIdsByPath(bottomUp));
+const byPathAggregated = await time('rowIdsByPath aggregated', () => rowIdsByPath(aggregated));
+console.log(`map entries: bottom-up ${byPathBottomUp.size}, aggregated ${byPathAggregated.size}`);
+
+// The mark, on the worst row there is: the frames a picked bucket counts,
+// translated into the ids of every row they name.
+const picked = shape.fattest?.eventIndexes ?? [];
+console.log(`\nfattest row: ${picked.length} occurrences of "${shape.fattest?.text ?? ''}"`);
+const ids = new LocatedRowIds();
+await time('mark callers (first)', () => ids.idsFor(log, picked, 'callers'));
+await time('mark callers (same pick)', () => ids.idsFor(log, picked, 'callers'));
+await time('mark callees', () => new LocatedRowIds().idsFor(log, picked, 'callees'));
+
+// The Call Tree tab's own grouped builds, for comparison with the inspector's.
+console.log('');
+await time('grid toAggregatedCallTree', () => toAggregatedCallTree(log.children));
+await time('grid toBottomUpTree', () => toBottomUpTree(log.children));

--- a/scripts/measure/rolldown.config.ts
+++ b/scripts/measure/rolldown.config.ts
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2026 Certinia Inc. All rights reserved.
+ */
+import path from 'node:path';
+import url from 'node:url';
+
+import { defineConfig } from 'rolldown';
+
+const here = path.dirname(url.fileURLToPath(import.meta.url));
+
+// The parser is aliased to its source: a Node bundle leaves a bare workspace
+// package external, and nothing installs it under this directory.
+export default defineConfig({
+  input: path.join(here, 'measure.ts'),
+  output: { file: path.join(here, 'out/measure.mjs'), format: 'esm', sourcemap: false },
+  platform: 'node',
+  external: [/^node:/],
+  resolve: {
+    alias: {
+      'apex-log-parser': path.join(here, '../../apex-log-parser/src/index.ts'),
+    },
+  },
+});


### PR DESCRIPTION
# 📝 PR Overview

On a large log the inspector's Bottom-Up view took seconds to appear and hovering the Timeline lagged the pointer. Two causes, both measured on a 100MB log (864k lines, 431k calls): every caller row stored a copy of every call beneath it (10.4 million indexes across 14,990 rows), and matching a row to a frame joined and hashed bucket-key strings.

A merged row is now named by its bucket path, interned to an integer once per log, and a caller row derives the calls it stands for instead of holding them. A sliced walk also hands back a task rather than a whole animation frame, so it no longer waits 16ms per 8ms of work.

| 100MB log | Before | After |
| --- | --- | --- |
| Bottom-Up build | 2,253ms, +88MB | **551ms, +18MB** |
| Indexes held by the rows | 10,423,550 | **431,307** |
| First Timeline hover | 269ms, +185MB | **1ms, +1MB** |
| Mark a 42,433-occurrence bucket | 2,182ms | **298ms** |
| 1s of sliced work, wall clock | 2,051ms | **1,005ms** |

The 20MB sample log improves too: build 165ms to 103ms, hover map 29ms to 1ms.

## 🛠️ Changes made

- Intern each distinct bucket path to an integer, one table per log — the string join was 2,087ms of the 2,182ms mark, against 23ms walking the frames.
- A top-level Bottom-Up row keeps its calls tagged with the chain that reached each one; a caller row reads back the ones whose chain runs through it, so 14,990 rows share one list per top-level row.
- Key the hover lookup by path instead of by call: 14,990 entries rather than one per call, so it no longer reads the calls behind every row.
- Ask the scoped tree whether it holds a frame before marking — a path names a position, and a second call of the same method elsewhere in the log sits at the same one.
- Hand back a task, not an animation frame, between work slices; `waitForNextFrame` stays only where a just-shown host must lay itself out before being measured.
- Add `pnpm measure <path to a log>`, a Node harness that times the parse, the three views, the mark and both grid builds with heap deltas. A browser cannot profile a 100MB log, since its own parse blocks the tools.

## 🧩 Type of change (check all applicable)

- [ ] 🐛 Bug fix - something not working as expected
- [ ] ✨ New feature – adds new functionality
- [ ] ♻️ Refactor - internal changes with no user impact
- [x] ⚡ Performance Improvement
- [ ] 📝 Documentation - README or documentation site changes
- [x] 🔧 Chore - dev tooling, CI, config
- [ ] 💥 Breaking change

## 📷 Screenshots / gifs / video [optional]

N/A — nothing changes on screen.

## 🔗 Related Issues

related #113
related #373
related #405

## ✅ Tests added?

- [x] 👍 yes

`keyPathIds` (path identity, both chain directions, prefix tests), the derivation of a caller row's calls, the path-keyed row lookup, scope membership, and a regression test that a frame the scope does not hold stays unmarked. 1983 tests pass.

## 📚 Docs updated?

- [x] 🙅 not needed

Everything here is unreleased work already described by the #113 and #373 entries.

## Anything else we need to know? [optional]

Test plan: `pnpm lint`, `pnpm test`, `pnpm build`, then in the extension host open a large log, select a frame, and switch the inspector to Bottom-Up; hover the Timeline with Aggregated and with Bottom-Up; pick a merged row in each view and check Details reads the calls it counts.

Two follow-ups this leaves open: the Call Tree grid still recovers the same two facts by walking Tabulator tree parents and splitting key strings, so it can adopt the interned paths and retire `bottomUpOccurrences.ts`; and the 298ms mark is now almost all building one bucket key per ancestor per occurrence, which a per-event key-id cache would remove.