### PR TITLE
perf(log-viewer): cut the inspector's row mark from 298ms to 75ms on a 100MB log

### DIFF
--- a/log-viewer/src/components/__tests__/locatedRow.test.ts
+++ b/log-viewer/src/components/__tests__/locatedRow.test.ts
@@ -8,7 +8,7 @@ import type { RowComponent } from 'tabulator-tables';
 
 import type { ApexLog, LogEvent } from 'apex-log-parser';
 
-import { logStoreFor } from '../../core/log/LogStore.js';
+import { logStoreFor, type LogStore } from '../../core/log/LogStore.js';
 import { ROOT_PATH_ID, KeyPathIds } from '../../core/log/keyPathIds.js';
 import {
   LOCATED_ROW_CLASS,
@@ -127,13 +127,17 @@ describe('eventPathIds', () => {
   const root = ev('exec', null);
   const outer = ev('outer', root);
   const inner = ev('inner', outer);
+  let store: LogStore;
   let ids: KeyPathIds;
   beforeEach(() => {
-    ids = new KeyPathIds();
+    // A store per test, since each expects an empty table. The frames are not in
+    // this log's index, so the ids are minted rather than read from the cache.
+    store = logStoreFor({ eventsById: [] } as unknown as ApexLog);
+    ids = store.keyPathIds();
   });
 
   it('names one row in a top-down view, at the depth the frame ran at', () => {
-    const found = eventPathIds(inner, 'callees', ids);
+    const found = eventPathIds(inner, 'callees', store);
 
     expect(found).toHaveLength(1);
     expect(found[0]).toBe(rowPathId(bucketRow('METHOD_ENTRY||outer', 'METHOD_ENTRY||inner'), ids));
@@ -141,7 +145,7 @@ describe('eventPathIds', () => {
 
   it('names a row per caller depth in a bottom-up view', () => {
     // The frame heads a row on its own, and one under each caller above it.
-    const found = eventPathIds(inner, 'callers', ids);
+    const found = eventPathIds(inner, 'callers', store);
 
     expect(found).toEqual([
       rowPathId(bucketRow('METHOD_ENTRY||inner'), ids),
@@ -150,7 +154,7 @@ describe('eventPathIds', () => {
   });
 
   it('leaves the log root out, as it is a row in neither view', () => {
-    expect(eventPathIds(root, 'callers', ids)).toEqual([]);
+    expect(eventPathIds(root, 'callers', store)).toEqual([]);
   });
 });
 
@@ -224,7 +228,7 @@ describe('LocatedRowIds', () => {
     const found = new LocatedRowIds().idsFor(log, [5], 'callers');
 
     // The log's own table, so a row stamped from it reaches the same ids.
-    expect(found).toEqual(eventPathIds(frame, 'callers', logStoreFor(log).keyPathIds()));
+    expect(found).toEqual(eventPathIds(frame, 'callers', logStoreFor(log)));
   });
 
   it('reuses what it built for the frames it was last asked about', () => {

--- a/log-viewer/src/components/__tests__/scopedCallTree.test.ts
+++ b/log-viewer/src/components/__tests__/scopedCallTree.test.ts
@@ -3,6 +3,8 @@
  */
 import { describe, expect, it } from '@jest/globals';
 
+import type { LogEvent } from 'apex-log-parser';
+
 interface FakeEvent {
   eventIndex: number;
   type: string;
@@ -54,11 +56,16 @@ let selectedIndex = 4;
 const { KeyPathIds } = jest.requireActual<typeof import('../../core/log/keyPathIds.js')>(
   '../../core/log/keyPathIds.js',
 );
+const { getEventKey, getStackKey } = jest.requireActual<
+  typeof import('../../core/log/eventKeys.js')
+>('../../core/log/eventKeys.js');
 const paths = new KeyPathIds();
 jest.mock('../../core/log/LogStore.js', () => ({
   currentLogStore: () => ({
     log: root,
     keyPathIds: () => paths,
+    keyIdOf: (event: FakeEvent) => paths.keyId(getEventKey(event as unknown as LogEvent)),
+    stackIdOf: (event: FakeEvent) => paths.keyId(getStackKey(event as unknown as LogEvent)),
     eventByIndex: (i: number) => byId.get(i) ?? null,
     // Mirrors LogStore.stackByEventIndex over the fixture's own index.
     stackByEventIndex: (i: number) => {

--- a/log-viewer/src/components/locatedRow.ts
+++ b/log-viewer/src/components/locatedRow.ts
@@ -6,10 +6,9 @@ import type { ApexLog, LogEvent } from 'apex-log-parser';
 import type { RowComponent } from 'tabulator-tables';
 
 import type { DetailSelection, SelectionView } from '../core/events/EventBus.js';
-import { logStoreFor } from '../core/log/LogStore.js';
-import type { KeyPathIds } from '../core/log/keyPathIds.js';
+import { logStoreFor, type LogStore } from '../core/log/LogStore.js';
+import { ROOT_PATH_ID, type KeyPathIds } from '../core/log/keyPathIds.js';
 import { eventByEventIndex } from '../core/utility/EventSearch.js';
-import { eventKeyChain } from '../features/call-tree/utils/Aggregation.js';
 import { occurrencesThrough } from '../features/call-tree/utils/bottomUpOccurrences.js';
 
 /** Class the marked row carries; each table styles it itself. */
@@ -166,12 +165,31 @@ export function rowPathStamper(ids: KeyPathIds): (row: RowComponent) => void {
  *
  * The log root is not a row in either view, so the walk stops below it.
  */
-export function eventPathIds(event: LogEvent, direction: SelectionView, ids: KeyPathIds): number[] {
-  const keys = eventKeyChain(event);
-  if (!keys.length) {
+export function eventPathIds(event: LogEvent, direction: SelectionView, store: LogStore): number[] {
+  if (!event.parent) {
     return [];
   }
-  return direction === 'callees' ? [ids.pathOf(keys)] : ids.prefixesOf(keys);
+  const paths = store.keyPathIds();
+  if (direction === 'callers') {
+    // The parent walk is already innermost first, which is the order the ids are
+    // composed in, so the chain needs no array of its own.
+    const prefixes: number[] = [];
+    let id = ROOT_PATH_ID;
+    for (let node: LogEvent | null = event; node?.parent; node = node.parent) {
+      id = paths.step(id, store.keyIdOf(node));
+      prefixes.push(id);
+    }
+    return prefixes;
+  }
+  const chain: number[] = [];
+  for (let node: LogEvent | null = event; node?.parent; node = node.parent) {
+    chain.push(store.keyIdOf(node));
+  }
+  let id = ROOT_PATH_ID;
+  for (let depth = chain.length - 1; depth >= 0; depth--) {
+    id = paths.step(id, chain[depth]!);
+  }
+  return [id];
 }
 
 /** True where the row holds no calls of its own, so its chain answers for it. */
@@ -214,14 +232,14 @@ function pathIdsForEvents(
   eventIndexes: readonly number[],
   direction: SelectionView,
 ): number[] {
-  const ids = logStoreFor(root).keyPathIds();
+  const store = logStoreFor(root);
   const found = new Set<number>();
   for (const eventIndex of eventIndexes) {
     const event = eventByEventIndex(root, eventIndex);
     if (!event) {
       continue;
     }
-    for (const id of eventPathIds(event, direction, ids)) {
+    for (const id of eventPathIds(event, direction, store)) {
       found.add(id);
     }
   }

--- a/log-viewer/src/components/scopedCallTree.ts
+++ b/log-viewer/src/components/scopedCallTree.ts
@@ -7,7 +7,6 @@ import { currentLogStore, type LogStore } from '../core/log/LogStore.js';
 import { ROOT_PATH_ID, type KeyPathIds } from '../core/log/keyPathIds.js';
 import { outermostEvents } from '../core/utility/EventTree.js';
 import { EXCLUDED_DETAIL_TYPES } from '../features/call-tree/utils/DetailsFilter.js';
-import { getEventKey, getStackKey } from '../features/call-tree/utils/Aggregation.js';
 import {
   CHECK_EVERY,
   frameBudget,
@@ -396,7 +395,7 @@ export async function buildScopedCallTree(
     rootTotal,
     logTotal: apexLog.duration.total,
     calls: scope.calls,
-    paths: store.keyPathIds(),
+    store,
     // Occurrences of one frame are the same call made again, so merge them into a
     // single root; a single occurrence is already that.
     mergeTimeOrder: scope.roots.length > 1,
@@ -426,8 +425,8 @@ interface CallTreeInput {
   rootTotal: number;
   logTotal: number;
   calls: number;
-  /** The log's interned bucket paths, which the merged views name their rows by. */
-  paths: KeyPathIds;
+  /** The log, which the merged views take their interned keys and paths from. */
+  store: LogStore;
   /** {@link ScopedCallTree.holds}, absent where the tree stands for the whole log. */
   holds?: (eventIndex: number) => boolean;
   /** Folds the occurrences of one frame into a single root (a scoped aggregate),
@@ -442,7 +441,7 @@ interface CallTreeInput {
  * every retained subtree.
  */
 function lazyCallTree(input: CallTreeInput): ScopedCallTree {
-  const { rootTotal, calls, logTotal, mergeTimeOrder, paths, holds } = input;
+  const { rootTotal, calls, logTotal, mergeTimeOrder, store, holds } = input;
   let topDownRows: ScopedRow[] | null = null;
   let aggregatedRows: ScopedRow[] | null = null;
   let bottomUpRows: ScopedRow[] | null = null;
@@ -461,12 +460,12 @@ function lazyCallTree(input: CallTreeInput): ScopedCallTree {
     async aggregated(viewOptions) {
       if (!aggregatedRows) {
         const rows = await topDown(viewOptions);
-        aggregatedRows = rows && (await aggregate(rows, paths, viewOptions));
+        aggregatedRows = rows && (await aggregate(rows, store, viewOptions));
       }
       return aggregatedRows;
     },
     async bottomUp(viewOptions) {
-      bottomUpRows ??= await buildBottomUp(input.bottomUp, paths, viewOptions);
+      bottomUpRows ??= await buildBottomUp(input.bottomUp, store, viewOptions);
       return bottomUpRows;
     },
   };
@@ -504,7 +503,7 @@ export async function buildWholeLogCallTree(
     rootTotal: apexLog.duration.total,
     logTotal: apexLog.duration.total,
     calls: scope.calls,
-    paths: store.keyPathIds(),
+    store,
     mergeTimeOrder: false,
   });
 }
@@ -512,9 +511,10 @@ export async function buildWholeLogCallTree(
 /** Top-down aggregation: merge sibling frames sharing a key, summing metrics. */
 async function aggregate(
   rows: ScopedRow[],
-  paths: KeyPathIds,
+  store: LogStore,
   options: FrameBudgetOptions,
 ): Promise<ScopedRow[] | null> {
+  const paths = store.keyPathIds();
   const tick = frameBudget(options);
   let idSeq = 0;
   const nextId = () => (idSeq -= 1);
@@ -522,17 +522,17 @@ async function aggregate(
   // The recursion follows the call depth, which is shallow; each level's input
   // is the wide dimension, so that is where the slicing goes.
   async function merge(input: ScopedRow[], parentPathId: number): Promise<ScopedRow[] | null> {
-    const groups = new Map<string, ScopedRow>();
-    const order: string[] = [];
+    const groups = new Map<number, ScopedRow>();
+    const order: number[] = [];
     // The occurrences behind each group — a set, so one frame cannot be listed
     // twice.
-    const indexes = new Map<string, Set<number>>();
+    const indexes = new Map<number, Set<number>>();
     for (let i = 0; i < input.length; i++) {
       if (i % CHECK_EVERY === 0 && !(await tick())) {
         return null;
       }
       const row = input[i]!;
-      const key = getEventKey(row.originalData);
+      const key = store.keyIdOf(row.originalData);
       let group = groups.get(key);
       if (!group) {
         group = {
@@ -544,7 +544,7 @@ async function aggregate(
           callCount: 0,
           eventIndexes: [],
           onPath: row.onPath,
-          _pathId: paths.pathId(parentPathId, key),
+          _pathId: paths.step(parentPathId, key),
           _children: [],
         };
         groups.set(key, group);
@@ -606,9 +606,10 @@ interface WalkEntry {
   row: ScopedRow;
   callers: WalkEntry | null;
   /** The frame's bucket key, interned: a chain link is stepped by id, and the
-   *  key of a hot frame is built once rather than once per caller it has. */
+   *  key is built once for the log rather than once per visit. */
   keyId: number;
-  stackKey: string;
+  /** The frame's stack key, interned: the walk only ever compares it. */
+  stackId: number;
   leaving: boolean;
   /** The frame's time, less every call of the same frame inside it. */
   attributed: number;
@@ -632,9 +633,10 @@ interface WalkEntry {
  */
 async function buildBottomUp(
   rows: ScopedRow[],
-  paths: KeyPathIds,
+  store: LogStore,
   options: FrameBudgetOptions,
 ): Promise<ScopedRow[] | null> {
+  const paths = store.keyPathIds();
   const tick = frameBudget(options);
   let idSeq = 0;
   const nextId = () => (idSeq -= 1);
@@ -680,13 +682,13 @@ async function buildBottomUp(
   // a row is filled in on the way out rather than on the way in. Keyed as the
   // Call Tree tab keys recursion, without the event type, so a code unit that
   // recurses as a method entry is the same frame to both.
-  const open = new Map<string, WalkEntry | null>();
+  const open = new Map<number, WalkEntry | null>();
 
   const entryFor = (row: ScopedRow, callers: WalkEntry | null): WalkEntry => ({
     row,
     callers,
-    keyId: paths.keyId(getEventKey(row.originalData)),
-    stackKey: getStackKey(row.originalData),
+    keyId: store.keyIdOf(row.originalData),
+    stackId: store.stackIdOf(row.originalData),
     leaving: false,
     attributed: 0,
     outer: null,
@@ -706,7 +708,7 @@ async function buildBottomUp(
     const entry = stack.pop()!;
     const { row, callers } = entry;
     if (!entry.leaving) {
-      const outer = open.get(entry.stackKey) ?? null;
+      const outer = open.get(entry.stackId) ?? null;
       if (outer) {
         // Inside a call of the same frame, so this call's time is already part
         // of that one's.
@@ -714,7 +716,7 @@ async function buildBottomUp(
       }
       entry.outer = outer;
       entry.attributed = row.duration.total;
-      open.set(entry.stackKey, entry);
+      open.set(entry.stackId, entry);
       entry.leaving = true;
       stack.push(entry);
       if (row._children) {
@@ -725,7 +727,7 @@ async function buildBottomUp(
       continue;
     }
 
-    open.set(entry.stackKey, entry.outer);
+    open.set(entry.stackId, entry.outer);
     const attributed = entry.attributed;
     if (row.duration.self > 0) {
       // The seed row, then its callers up to the root. The chain is already in

--- a/log-viewer/src/core/log/LogStore.ts
+++ b/log-viewer/src/core/log/LogStore.ts
@@ -9,6 +9,7 @@ import {
   SOSLExecuteBeginLine,
 } from 'apex-log-parser';
 
+import { getEventKey, getStackKey } from './eventKeys.js';
 import { KeyPathIds } from './keyPathIds.js';
 
 export type Stack = LogEvent[];
@@ -25,6 +26,8 @@ export class LogStore {
 
   private _statements: Statements | null = null;
   private _keyPathIds: KeyPathIds | null = null;
+  private _keyIds: Int32Array | null = null;
+  private _stackIds: Int32Array | null = null;
 
   constructor(log: ApexLog) {
     this.log = log;
@@ -73,9 +76,56 @@ export class LogStore {
     return (this._keyPathIds ??= new KeyPathIds());
   }
 
+  /**
+   * The event's interned bucket key, kept per event.
+   *
+   * A mark walks the caller chain of every occurrence a pick names, and those
+   * occurrences share their ancestors, so building the key string per frame was
+   * most of what a mark cost.
+   */
+  keyIdOf(event: LogEvent): number {
+    const cache = (this._keyIds ??= idCache(this.log));
+    const at = event.eventIndex;
+    if (at >= 0 && at < cache.length) {
+      let id = cache[at]!;
+      if (id < 0) {
+        id = this.keyPathIds().keyId(getEventKey(event));
+        cache[at] = id;
+      }
+      return id;
+    }
+    // An event the log's own index does not cover, so there is no slot to keep.
+    return this.keyPathIds().keyId(getEventKey(event));
+  }
+
+  /**
+   * The event's interned stack key, which tells a recursive call from a fresh
+   * one. Interned in the same table as {@link keyIdOf}, since the two vocabularies
+   * are never compared with each other.
+   */
+  stackIdOf(event: LogEvent): number {
+    const cache = (this._stackIds ??= idCache(this.log));
+    const at = event.eventIndex;
+    if (at >= 0 && at < cache.length) {
+      let id = cache[at]!;
+      if (id < 0) {
+        id = this.keyPathIds().keyId(getStackKey(event));
+        cache[at] = id;
+      }
+      return id;
+    }
+    // An event the log's own index does not cover, so there is no slot to keep.
+    return this.keyPathIds().keyId(getStackKey(event));
+  }
+
   private statements(): Statements {
     return (this._statements ??= collectStatements(this.log));
   }
+}
+
+/** One slot per event, -1 until the event is asked about. */
+function idCache(log: ApexLog): Int32Array {
+  return new Int32Array(log.eventsById.length).fill(-1);
 }
 
 interface Statements {

--- a/log-viewer/src/core/log/__tests__/LogStore.test.ts
+++ b/log-viewer/src/core/log/__tests__/LogStore.test.ts
@@ -63,6 +63,33 @@ describe('LogStore', () => {
     expect(stack[stack.length - 1]?.text).toBe('ns.ClassTwo.second()');
   });
 
+  it('gives a frame one interned key, and tells the two vocabularies apart', () => {
+    const log =
+      '09:18:22.6 (6574780)|EXECUTION_STARTED\n' +
+      '09:18:22.6 (6586704)|CODE_UNIT_STARTED|[EXTERNAL]|066d0000002m8ij|ns.Thing.run()\n' +
+      '09:19:13.82 (51592737891)|CODE_UNIT_FINISHED|ns.Thing.run()\n' +
+      '09:19:13.82 (51595120059)|EXECUTION_FINISHED\n';
+
+    const apexLog = parse(log);
+    const store = logStoreFor(apexLog);
+    const unit = apexLog.eventsById.find((event) => event.text === 'ns.Thing.run()')!;
+
+    // Asked twice, kept once — the mark reads the same frame per occurrence.
+    expect(store.keyIdOf(unit)).toBe(store.keyIdOf(unit));
+    // The bucket key carries the event type and the stack key does not, so a
+    // frame's two ids are not the same id.
+    expect(store.stackIdOf(unit)).not.toBe(store.keyIdOf(unit));
+  });
+
+  it('keys a frame the log index does not cover', () => {
+    const apexLog = parse('09:18:22.6 (6574780)|EXECUTION_STARTED\n');
+    const store = logStoreFor(apexLog);
+    // Built rather than parsed, so it has no slot in the log's own index.
+    const loose = { type: 'METHOD_ENTRY', namespace: '', text: 'made up', eventIndex: 9999 };
+
+    expect(store.keyIdOf(loose as never)).toBe(store.keyIdOf(loose as never));
+  });
+
   it('gives one log one store, whichever view asks', () => {
     const log =
       '09:18:22.6 (6574780)|EXECUTION_STARTED\n' + '09:18:22.6 (7400000)|EXECUTION_FINISHED\n';

--- a/log-viewer/src/core/log/eventKeys.ts
+++ b/log-viewer/src/core/log/eventKeys.ts
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2026 Certinia Inc. All rights reserved.
+ */
+import type { LogEvent } from 'apex-log-parser';
+
+/**
+ * Generates a unique key for grouping events by signature.
+ * Includes event type so different entry types (e.g. CODE_UNIT_STARTED vs METHOD_ENTRY)
+ * are displayed as separate rows. Field order (type|namespace|text) is the shared
+ * canonical bucket-key shape used by aggregated, bottom-up, and analysis views.
+ */
+export function getEventKey(event: LogEvent): string {
+  return `${event.type ?? ''}|${event.namespace}|${event.text}`;
+}
+
+/**
+ * Generates a key for call-stack tracking to detect recursive calls.
+ * Excludes event type so the same method is recognised regardless of entry type
+ * (e.g. CODE_UNIT_STARTED at the top level, METHOD_ENTRY for recursive calls).
+ * Matches the approach used by the analysis view's RowGrouper.
+ */
+export function getStackKey(event: LogEvent): string {
+  return `${event.namespace}|${event.text}`;
+}

--- a/log-viewer/src/features/analysis/services/LogDiagnostics.ts
+++ b/log-viewer/src/features/analysis/services/LogDiagnostics.ts
@@ -11,7 +11,7 @@ import type {
 
 import { GOVERNOR_METRICS, limitTotals } from '../../../components/logOverviewMetrics.js';
 import { formatByteSize, formatDuration, formatInteger } from '../../../core/utility/Util.js';
-import { getEventKey } from '../../call-tree/utils/Aggregation.js';
+import { getEventKey } from '../../../core/log/eventKeys.js';
 import { currentLogStore } from '../../../core/log/LogStore.js';
 import { outermostEvents } from '../../../core/utility/EventTree.js';
 import { deriveSoqlObject } from '../../database/services/sobjectClassification.js';

--- a/log-viewer/src/features/analysis/services/SelfTimeSpread.ts
+++ b/log-viewer/src/features/analysis/services/SelfTimeSpread.ts
@@ -3,7 +3,7 @@
  */
 import type { ApexLog, LogCategory, LogEvent } from 'apex-log-parser';
 
-import { getEventKey } from '../../call-tree/utils/Aggregation.js';
+import { getEventKey } from '../../../core/log/eventKeys.js';
 
 /** Signatures the spread draws a histogram for, the most self time first. */
 const LANE_COUNT = 5;

--- a/log-viewer/src/features/call-tree/utils/Aggregation.ts
+++ b/log-viewer/src/features/call-tree/utils/Aggregation.ts
@@ -3,6 +3,7 @@
  */
 
 import type { GovernorLimits, LogEvent, SelfTotal } from 'apex-log-parser';
+import { getEventKey, getStackKey } from '../../../core/log/eventKeys.js';
 import { getCallerNamespace } from '../../../core/utility/CallerNamespace.js';
 import { Multiset } from '../../../core/utility/Multiset.js';
 import { computeHasDetailsDeep } from './DetailsFilter.js';
@@ -134,16 +135,6 @@ export interface BottomUpRow {
 }
 
 /**
- * Generates a unique key for grouping events by signature.
- * Includes event type so different entry types (e.g. CODE_UNIT_STARTED vs METHOD_ENTRY)
- * are displayed as separate rows. Field order (type|namespace|text) is the shared
- * canonical bucket-key shape used by aggregated, bottom-up, and analysis views.
- */
-export function getEventKey(event: LogEvent): string {
-  return `${event.type ?? ''}|${event.namespace}|${event.text}`;
-}
-
-/**
  * The bucket keys from `event` out to its outermost frame, innermost first. The
  * log root heads no row in any view, so the walk stops below it.
  */
@@ -153,16 +144,6 @@ export function eventKeyChain(event: LogEvent): string[] {
     keys.push(getEventKey(node));
   }
   return keys;
-}
-
-/**
- * Generates a key for call-stack tracking to detect recursive calls.
- * Excludes event type so the same method is recognised regardless of entry type
- * (e.g. CODE_UNIT_STARTED at the top level, METHOD_ENTRY for recursive calls).
- * Matches the approach used by the analysis view's RowGrouper.
- */
-export function getStackKey(event: LogEvent): string {
-  return `${event.namespace}|${event.text}`;
 }
 
 /**

--- a/log-viewer/src/features/call-tree/utils/ExecutionHighlights.ts
+++ b/log-viewer/src/features/call-tree/utils/ExecutionHighlights.ts
@@ -3,7 +3,7 @@
  */
 import type { ApexLog, LogCategory, LogEvent } from 'apex-log-parser';
 
-import { getEventKey } from './Aggregation.js';
+import { getEventKey } from '../../../core/log/eventKeys.js';
 
 /** One frame on the hot path, entry point first. */
 export interface HotPathFrame {

--- a/log-viewer/src/features/call-tree/utils/__tests__/bottomUpOccurrences.test.ts
+++ b/log-viewer/src/features/call-tree/utils/__tests__/bottomUpOccurrences.test.ts
@@ -4,7 +4,7 @@
 import { describe, expect, it } from '@jest/globals';
 import type { LogEvent } from 'apex-log-parser';
 
-import { getEventKey as keyOf } from '../Aggregation.js';
+import { getEventKey as keyOf } from '../../../../core/log/eventKeys.js';
 import { occurrencesThrough } from '../bottomUpOccurrences.js';
 
 let nextEventIndex = 0;

--- a/log-viewer/src/features/call-tree/utils/bucketRows.ts
+++ b/log-viewer/src/features/call-tree/utils/bucketRows.ts
@@ -7,7 +7,8 @@ import type { RowComponent } from 'tabulator-tables';
 
 import type { SelectionView } from '../../../core/events/EventBus.js';
 import { withCodeDrivenExpand } from '../../../tabulator/module/expandOrigin.js';
-import { eventKeyChain, getEventKey } from './Aggregation.js';
+import { getEventKey } from '../../../core/log/eventKeys.js';
+import { eventKeyChain } from './Aggregation.js';
 
 interface BucketRow {
   key?: string;


### PR DESCRIPTION
# 📝 PR Overview

#968 made a merged row match a frame by an interned bucket path instead of by the calls it holds. That left the key string itself as the cost: a mark walks the caller chain of every occurrence a pick names, and those occurrences share their ancestors, so a 42,433-occurrence pick built and hashed about 424,000 key strings — every time the pointer moved to it.

Each event's bucket key and stack key are now interned once for the log, kept in one slot per event. A mark walks the parent pointers interning as it climbs, so it builds no key string and no chain array; the bottom-up walk and the aggregation read the same slots and key their maps by integer.

| 100MB log (864k lines, 431k calls) | Before | After |
| --- | --- | --- |
| Mark a 42,433-occurrence pick, callers | 298ms | **75ms** |
| The same, callees | 273ms | **65ms** |
| Aggregated build | 232ms | **124ms** |
| Bottom-Up build | 545ms | **508ms** |

20MB sample log: the mark goes 83ms to 22ms.

## 🛠️ Changes made

- `LogStore.keyIdOf` and `stackIdOf`: one `Int32Array` slot per event, filled as each frame is first asked about — a hot frame's key is built once for the log rather than once per caller it has.
- `eventPathIds` walks the parent pointers and interns as it climbs. The natural order is the order the ids compose in, so the chain array is gone too.
- The bottom-up walk keys recursion by interned stack id, and the aggregation groups by interned bucket key, so neither hashes a string per frame.
- `getEventKey` and `getStackKey` move to `core/log/eventKeys.ts`: the store now reads them, and `core/` must not import `features/`.

## 🧩 Type of change (check all applicable)

- [ ] 🐛 Bug fix - something not working as expected
- [ ] ✨ New feature – adds new functionality
- [ ] ♻️ Refactor - internal changes with no user impact
- [x] ⚡ Performance Improvement
- [ ] 📝 Documentation - README or documentation site changes
- [ ] 🔧 Chore - dev tooling, CI, config
- [ ] 💥 Breaking change

## 📷 Screenshots / gifs / video [optional]

N/A — nothing changes on screen.

## 🔗 Related Issues

related #113
related #373
related #405

## ✅ Tests added?

- [x] 👍 yes

`LogStore` keeps one id per frame, tells the two key vocabularies apart, and still answers for a frame its index does not cover. The existing path and marking suites cover the rest.

## 📚 Docs updated?

- [x] 🙅 not needed

Unreleased inspector work already described by the #113 and #373 entries.

## Anything else we need to know? [optional]

Measured with `pnpm measure` (added in #968) on a 95MB log. The cheap version of this was tried first and was worse: a `Map` cache inside the build made it slower, because the walk visits each event once and so has nothing to reuse. The win needs a per-log array that the build fills and the mark reads.

Follow-up this leaves open: the Call Tree grid still recovers a row's path by walking Tabulator tree parents, and its caller occurrences by splitting key strings, so it can adopt the interned keys and paths and retire `bottomUpOccurrences.ts` and `rowCallChain`.