### PR TITLE
refactor(log-viewer): give one object the whole key and path vocabulary

### DIFF
--- a/log-viewer/src/components/__tests__/CallTreeDetailScopedBuild.test.ts
+++ b/log-viewer/src/components/__tests__/CallTreeDetailScopedBuild.test.ts
@@ -53,7 +53,6 @@ import { LOCATED_ROW_CLASS } from '../locatedRow.js';
 import type { ApexLog } from 'apex-log-parser';
 
 import { logStoreFor, type LogStore } from '../../core/log/LogStore.js';
-import { ROOT_PATH_ID } from '../../core/log/keyPathIds.js';
 
 const build = jest.mocked(buildScopedCallTree);
 
@@ -297,7 +296,7 @@ describe('CallTreeDetail scoped build', () => {
     log.eventsById[8] = { ...event, parent: log, children: [] };
     const pathId = logStoreFor(log as unknown as ApexLog)
       .keyPathIds()
-      .pathId(ROOT_PATH_ID, 'METHOD_ENTRY||m');
+      .pathOf(['METHOD_ENTRY||m']);
     const merged = [
       { id: -3, eventIndexes: [8, 12], _pathId: pathId, _children: null },
     ] as unknown as ScopedRow[];
@@ -341,7 +340,7 @@ describe('CallTreeDetail scoped build', () => {
     log.eventsById[12] = { ...event, eventIndex: 12, parent: log, children: [] };
     const pathId = logStoreFor(log as unknown as ApexLog)
       .keyPathIds()
-      .pathId(ROOT_PATH_ID, 'METHOD_ENTRY||m');
+      .pathOf(['METHOD_ENTRY||m']);
     const merged = [
       { id: -3, eventIndexes: [8], _pathId: pathId, _children: null },
     ] as unknown as ScopedRow[];

--- a/log-viewer/src/components/__tests__/locatedRow.test.ts
+++ b/log-viewer/src/components/__tests__/locatedRow.test.ts
@@ -8,13 +8,12 @@ import type { RowComponent } from 'tabulator-tables';
 
 import type { ApexLog, LogEvent } from 'apex-log-parser';
 
-import { logStoreFor, type LogStore } from '../../core/log/LogStore.js';
-import { ROOT_PATH_ID, KeyPathIds } from '../../core/log/keyPathIds.js';
+import { logStoreFor } from '../../core/log/LogStore.js';
+import { KeyPathIds } from '../../core/log/keyPathIds.js';
 import {
   LOCATED_ROW_CLASS,
   LocatedRowIds,
   LocatedRowMarker,
-  eventPathIds,
   rowIndexStamper,
   rowPathId,
   rowPathStamper,
@@ -66,7 +65,7 @@ function rowFor(container: HTMLElement, index: number): HTMLElement {
 
 describe('rowPathStamper', () => {
   it('marks the row under one parent and not its namesake under another', () => {
-    const ids = new KeyPathIds();
+    const ids = new KeyPathIds(0);
     const stampPath = rowPathStamper(ids);
     const container = document.createElement('div');
     const rows = [bucketRow('Trigger1', 'Util.log'), bucketRow('Trigger2', 'Util.log')];
@@ -98,11 +97,11 @@ describe('rowIndexStamper', () => {
 describe('rowPathId', () => {
   let ids: KeyPathIds;
   beforeEach(() => {
-    ids = new KeyPathIds();
+    ids = new KeyPathIds(0);
   });
 
   it('names a top-level row by its own key alone', () => {
-    expect(rowPathId(bucketRow('A'), ids)).toBe(ids.pathId(ROOT_PATH_ID, 'A'));
+    expect(rowPathId(bucketRow('A'), ids)).toBe(ids.pathOf(['A']));
   });
 
   it('tells two same-named rows apart by the parents that reach them', () => {
@@ -120,41 +119,6 @@ describe('rowPathId', () => {
 
   it('leaves a row that stands for one frame unnamed, as its index names it', () => {
     expect(rowPathId(rowComponent(document.createElement('div'), { id: 7 }), ids)).toBeUndefined();
-  });
-});
-
-describe('eventPathIds', () => {
-  const root = ev('exec', null);
-  const outer = ev('outer', root);
-  const inner = ev('inner', outer);
-  let store: LogStore;
-  let ids: KeyPathIds;
-  beforeEach(() => {
-    // A store per test, since each expects an empty table. The frames are not in
-    // this log's index, so the ids are minted rather than read from the cache.
-    store = logStoreFor({ eventsById: [] } as unknown as ApexLog);
-    ids = store.keyPathIds();
-  });
-
-  it('names one row in a top-down view, at the depth the frame ran at', () => {
-    const found = eventPathIds(inner, 'callees', store);
-
-    expect(found).toHaveLength(1);
-    expect(found[0]).toBe(rowPathId(bucketRow('METHOD_ENTRY||outer', 'METHOD_ENTRY||inner'), ids));
-  });
-
-  it('names a row per caller depth in a bottom-up view', () => {
-    // The frame heads a row on its own, and one under each caller above it.
-    const found = eventPathIds(inner, 'callers', store);
-
-    expect(found).toEqual([
-      rowPathId(bucketRow('METHOD_ENTRY||inner'), ids),
-      rowPathId(bucketRow('METHOD_ENTRY||inner', 'METHOD_ENTRY||outer'), ids),
-    ]);
-  });
-
-  it('leaves the log root out, as it is a row in neither view', () => {
-    expect(eventPathIds(root, 'callers', store)).toEqual([]);
   });
 });
 
@@ -228,7 +192,9 @@ describe('LocatedRowIds', () => {
     const found = new LocatedRowIds().idsFor(log, [5], 'callers');
 
     // The log's own table, so a row stamped from it reaches the same ids.
-    expect(found).toEqual(eventPathIds(frame, 'callers', logStoreFor(log)));
+    const expected = new Set<number>();
+    logStoreFor(log).keyPathIds().pathIdsOf(frame, 'callers', expected);
+    expect(found).toEqual([...expected]);
   });
 
   it('reuses what it built for the frames it was last asked about', () => {

--- a/log-viewer/src/components/__tests__/scopedCallTree.test.ts
+++ b/log-viewer/src/components/__tests__/scopedCallTree.test.ts
@@ -1,9 +1,7 @@
 /*
  * Copyright (c) 2026 Certinia Inc. All rights reserved.
  */
-import { describe, expect, it } from '@jest/globals';
-
-import type { LogEvent } from 'apex-log-parser';
+import { beforeEach, describe, expect, it } from '@jest/globals';
 
 interface FakeEvent {
   eventIndex: number;
@@ -56,16 +54,14 @@ let selectedIndex = 4;
 const { KeyPathIds } = jest.requireActual<typeof import('../../core/log/keyPathIds.js')>(
   '../../core/log/keyPathIds.js',
 );
-const { getEventKey, getStackKey } = jest.requireActual<
-  typeof import('../../core/log/eventKeys.js')
->('../../core/log/eventKeys.js');
-const paths = new KeyPathIds();
+// One table per log in production. The fixtures below reuse event indexes for
+// different frames, so each test gets its own rather than one frame's key being
+// read back for another.
+let paths = new KeyPathIds(1024);
 jest.mock('../../core/log/LogStore.js', () => ({
   currentLogStore: () => ({
     log: root,
     keyPathIds: () => paths,
-    keyIdOf: (event: FakeEvent) => paths.keyId(getEventKey(event as unknown as LogEvent)),
-    stackIdOf: (event: FakeEvent) => paths.keyId(getStackKey(event as unknown as LogEvent)),
     eventByIndex: (i: number) => byId.get(i) ?? null,
     // Mirrors LogStore.stackByEventIndex over the fixture's own index.
     stackByEventIndex: (i: number) => {
@@ -92,6 +88,10 @@ import type { FrameBudgetOptions } from '../../core/utility/FrameBudget.js';
 /** These fixtures are small enough to never hit a slice deadline, so `yieldSlice`
  *  is only there to satisfy the contract. */
 const options: FrameBudgetOptions = { yieldSlice: () => Promise.resolve() };
+
+beforeEach(() => {
+  paths = new KeyPathIds(1024);
+});
 
 function build(eventIndex: number, instances?: number[]) {
   return buildScopedCallTree(eventIndex, instances ?? null, options);

--- a/log-viewer/src/components/locatedRow.ts
+++ b/log-viewer/src/components/locatedRow.ts
@@ -6,8 +6,8 @@ import type { ApexLog, LogEvent } from 'apex-log-parser';
 import type { RowComponent } from 'tabulator-tables';
 
 import type { DetailSelection, SelectionView } from '../core/events/EventBus.js';
-import { logStoreFor, type LogStore } from '../core/log/LogStore.js';
-import { ROOT_PATH_ID, type KeyPathIds } from '../core/log/keyPathIds.js';
+import { logStoreFor } from '../core/log/LogStore.js';
+import type { KeyPathIds } from '../core/log/keyPathIds.js';
 import { eventByEventIndex } from '../core/utility/EventSearch.js';
 import { occurrencesThrough } from '../features/call-tree/utils/bottomUpOccurrences.js';
 
@@ -155,43 +155,6 @@ export function rowPathStamper(ids: KeyPathIds): (row: RowComponent) => void {
   };
 }
 
-/**
- * The path ids naming the rows a frame belongs to in a merged view.
- *
- * A top-down row sits at the frame's own depth, so one id names it. A bottom-up
- * row is the frame plus however many of its callers the chain shows, so every
- * prefix names a row the frame heads — which is why one frame marks several rows
- * there, and why each prefix is interned as it is reached.
- *
- * The log root is not a row in either view, so the walk stops below it.
- */
-export function eventPathIds(event: LogEvent, direction: SelectionView, store: LogStore): number[] {
-  if (!event.parent) {
-    return [];
-  }
-  const paths = store.keyPathIds();
-  if (direction === 'callers') {
-    // The parent walk is already innermost first, which is the order the ids are
-    // composed in, so the chain needs no array of its own.
-    const prefixes: number[] = [];
-    let id = ROOT_PATH_ID;
-    for (let node: LogEvent | null = event; node?.parent; node = node.parent) {
-      id = paths.step(id, store.keyIdOf(node));
-      prefixes.push(id);
-    }
-    return prefixes;
-  }
-  const chain: number[] = [];
-  for (let node: LogEvent | null = event; node?.parent; node = node.parent) {
-    chain.push(store.keyIdOf(node));
-  }
-  let id = ROOT_PATH_ID;
-  for (let depth = chain.length - 1; depth >= 0; depth--) {
-    id = paths.step(id, chain[depth]!);
-  }
-  return [id];
-}
-
 /** True where the row holds no calls of its own, so its chain answers for it. */
 function isDerived(data: CallRow): boolean {
   return !data.instances?.length && data.key !== undefined;
@@ -232,15 +195,12 @@ function pathIdsForEvents(
   eventIndexes: readonly number[],
   direction: SelectionView,
 ): number[] {
-  const store = logStoreFor(root);
+  const paths = logStoreFor(root).keyPathIds();
   const found = new Set<number>();
   for (const eventIndex of eventIndexes) {
     const event = eventByEventIndex(root, eventIndex);
-    if (!event) {
-      continue;
-    }
-    for (const id of eventPathIds(event, direction, store)) {
-      found.add(id);
+    if (event) {
+      paths.pathIdsOf(event, direction, found);
     }
   }
   return [...found];

--- a/log-viewer/src/components/scopedCallTree.ts
+++ b/log-viewer/src/components/scopedCallTree.ts
@@ -522,20 +522,19 @@ async function aggregate(
   // The recursion follows the call depth, which is shallow; each level's input
   // is the wide dimension, so that is where the slicing goes.
   async function merge(input: ScopedRow[], parentPathId: number): Promise<ScopedRow[] | null> {
-    const groups = new Map<number, ScopedRow>();
-    const order: number[] = [];
-    // The occurrences behind each group — a set, so one frame cannot be listed
-    // twice.
-    const indexes = new Map<number, Set<number>>();
+    // The occurrences behind each group are a set, so one frame cannot be listed
+    // twice; `groups` keeps its own insertion order, so it is also the output
+    // order.
+    const groups = new Map<number, { row: ScopedRow; seen: Set<number> }>();
     for (let i = 0; i < input.length; i++) {
       if (i % CHECK_EVERY === 0 && !(await tick())) {
         return null;
       }
       const row = input[i]!;
-      const key = store.keyIdOf(row.originalData);
-      let group = groups.get(key);
-      if (!group) {
-        group = {
+      const key = paths.keyIdOf(row.originalData);
+      let held = groups.get(key);
+      if (!held) {
+        const group: ScopedRow = {
           id: nextId(),
           originalData: row.originalData,
           text: row.text,
@@ -547,10 +546,10 @@ async function aggregate(
           _pathId: paths.step(parentPathId, key),
           _children: [],
         };
-        groups.set(key, group);
-        order.push(key);
-        indexes.set(key, new Set());
+        held = { row: group, seen: new Set() };
+        groups.set(key, held);
       }
+      const group = held.row;
       if (!row.onPath) {
         // A group holding one real call is not a route, so it stays closed.
         group.onPath = undefined;
@@ -559,9 +558,8 @@ async function aggregate(
       group.duration.self += row.duration.self;
       group.callCount += row.callCount;
       // Every merged occurrence, so pointing at the group points at all of them.
-      const seen = indexes.get(key)!;
       for (const index of locatableEventIndexes(row)) {
-        seen.add(index);
+        held.seen.add(index);
       }
       if (row._children) {
         const kids = group._children as ScopedRow[];
@@ -572,9 +570,8 @@ async function aggregate(
     }
 
     const merged: ScopedRow[] = [];
-    for (const key of order) {
-      const group = groups.get(key)!;
-      group.eventIndexes = [...indexes.get(key)!];
+    for (const { row: group, seen } of groups.values()) {
+      group.eventIndexes = [...seen];
       const kids = group._children as ScopedRow[];
       if (kids.length) {
         const mergedKids = await merge(kids, group._pathId!);
@@ -687,8 +684,8 @@ async function buildBottomUp(
   const entryFor = (row: ScopedRow, callers: WalkEntry | null): WalkEntry => ({
     row,
     callers,
-    keyId: store.keyIdOf(row.originalData),
-    stackId: store.stackIdOf(row.originalData),
+    keyId: paths.keyIdOf(row.originalData),
+    stackId: paths.stackIdOf(row.originalData),
     leaving: false,
     attributed: 0,
     outer: null,
@@ -749,16 +746,16 @@ async function buildBottomUp(
       }
       // Each occurrence is tagged with the chain that reached it, which is how a
       // caller row picks out the ones it stands for.
-      const store = seed._seed;
+      const occurrences = seed._seed;
       const held = row.eventIndexes;
       if (held) {
         for (let i = 0; i < held.length; i++) {
-          store.eventIndexes.push(held[i]!);
-          store.chains.push(pathId);
+          occurrences.eventIndexes.push(held[i]!);
+          occurrences.chains.push(pathId);
         }
       } else {
-        store.eventIndexes.push(row.originalData.eventIndex);
-        store.chains.push(pathId);
+        occurrences.eventIndexes.push(row.originalData.eventIndex);
+        occurrences.chains.push(pathId);
       }
     }
   }

--- a/log-viewer/src/core/log/LogStore.ts
+++ b/log-viewer/src/core/log/LogStore.ts
@@ -9,7 +9,6 @@ import {
   SOSLExecuteBeginLine,
 } from 'apex-log-parser';
 
-import { getEventKey, getStackKey } from './eventKeys.js';
 import { KeyPathIds } from './keyPathIds.js';
 
 export type Stack = LogEvent[];
@@ -26,8 +25,6 @@ export class LogStore {
 
   private _statements: Statements | null = null;
   private _keyPathIds: KeyPathIds | null = null;
-  private _keyIds: Int32Array | null = null;
-  private _stackIds: Int32Array | null = null;
 
   constructor(log: ApexLog) {
     this.log = log;
@@ -70,62 +67,17 @@ export class LogStore {
     return this.statements().sosl;
   }
 
-  /** The interned bucket paths of this log, shared by every view that marks a row
-   *  whose occurrences are merged. */
+  /** The interned keys and bucket paths of this log, shared by every view that
+   *  marks a row whose occurrences are merged. */
   keyPathIds(): KeyPathIds {
-    return (this._keyPathIds ??= new KeyPathIds());
-  }
-
-  /**
-   * The event's interned bucket key, kept per event.
-   *
-   * A mark walks the caller chain of every occurrence a pick names, and those
-   * occurrences share their ancestors, so building the key string per frame was
-   * most of what a mark cost.
-   */
-  keyIdOf(event: LogEvent): number {
-    const cache = (this._keyIds ??= idCache(this.log));
-    const at = event.eventIndex;
-    if (at >= 0 && at < cache.length) {
-      let id = cache[at]!;
-      if (id < 0) {
-        id = this.keyPathIds().keyId(getEventKey(event));
-        cache[at] = id;
-      }
-      return id;
-    }
-    // An event the log's own index does not cover, so there is no slot to keep.
-    return this.keyPathIds().keyId(getEventKey(event));
-  }
-
-  /**
-   * The event's interned stack key, which tells a recursive call from a fresh
-   * one. Interned in the same table as {@link keyIdOf}, since the two vocabularies
-   * are never compared with each other.
-   */
-  stackIdOf(event: LogEvent): number {
-    const cache = (this._stackIds ??= idCache(this.log));
-    const at = event.eventIndex;
-    if (at >= 0 && at < cache.length) {
-      let id = cache[at]!;
-      if (id < 0) {
-        id = this.keyPathIds().keyId(getStackKey(event));
-        cache[at] = id;
-      }
-      return id;
-    }
-    // An event the log's own index does not cover, so there is no slot to keep.
-    return this.keyPathIds().keyId(getStackKey(event));
+    // No index means no slot to keep a key in, which costs only the key being
+    // built again.
+    return (this._keyPathIds ??= new KeyPathIds(this.log.eventsById?.length ?? 0));
   }
 
   private statements(): Statements {
     return (this._statements ??= collectStatements(this.log));
   }
-}
-
-/** One slot per event, -1 until the event is asked about. */
-function idCache(log: ApexLog): Int32Array {
-  return new Int32Array(log.eventsById.length).fill(-1);
 }
 
 interface Statements {

--- a/log-viewer/src/core/log/__tests__/LogStore.test.ts
+++ b/log-viewer/src/core/log/__tests__/LogStore.test.ts
@@ -63,33 +63,6 @@ describe('LogStore', () => {
     expect(stack[stack.length - 1]?.text).toBe('ns.ClassTwo.second()');
   });
 
-  it('gives a frame one interned key, and tells the two vocabularies apart', () => {
-    const log =
-      '09:18:22.6 (6574780)|EXECUTION_STARTED\n' +
-      '09:18:22.6 (6586704)|CODE_UNIT_STARTED|[EXTERNAL]|066d0000002m8ij|ns.Thing.run()\n' +
-      '09:19:13.82 (51592737891)|CODE_UNIT_FINISHED|ns.Thing.run()\n' +
-      '09:19:13.82 (51595120059)|EXECUTION_FINISHED\n';
-
-    const apexLog = parse(log);
-    const store = logStoreFor(apexLog);
-    const unit = apexLog.eventsById.find((event) => event.text === 'ns.Thing.run()')!;
-
-    // Asked twice, kept once — the mark reads the same frame per occurrence.
-    expect(store.keyIdOf(unit)).toBe(store.keyIdOf(unit));
-    // The bucket key carries the event type and the stack key does not, so a
-    // frame's two ids are not the same id.
-    expect(store.stackIdOf(unit)).not.toBe(store.keyIdOf(unit));
-  });
-
-  it('keys a frame the log index does not cover', () => {
-    const apexLog = parse('09:18:22.6 (6574780)|EXECUTION_STARTED\n');
-    const store = logStoreFor(apexLog);
-    // Built rather than parsed, so it has no slot in the log's own index.
-    const loose = { type: 'METHOD_ENTRY', namespace: '', text: 'made up', eventIndex: 9999 };
-
-    expect(store.keyIdOf(loose as never)).toBe(store.keyIdOf(loose as never));
-  });
-
   it('gives one log one store, whichever view asks', () => {
     const log =
       '09:18:22.6 (6574780)|EXECUTION_STARTED\n' + '09:18:22.6 (7400000)|EXECUTION_FINISHED\n';

--- a/log-viewer/src/core/log/__tests__/keyPathIds.test.ts
+++ b/log-viewer/src/core/log/__tests__/keyPathIds.test.ts
@@ -3,12 +3,19 @@
  */
 import { beforeEach, describe, expect, it } from '@jest/globals';
 
+import type { LogEvent } from 'apex-log-parser';
+
 import { KeyPathIds, ROOT_PATH_ID } from '../keyPathIds.js';
+
+/** A frame at `eventIndex`, of the type and text a bucket key is built from. */
+function ev(eventIndex: number, text: string, parent: LogEvent | null, type = 'METHOD_ENTRY') {
+  return { eventIndex, type, namespace: '', text, parent } as unknown as LogEvent;
+}
 
 describe('KeyPathIds', () => {
   let ids: KeyPathIds;
   beforeEach(() => {
-    ids = new KeyPathIds();
+    ids = new KeyPathIds(32);
   });
 
   /** Interns a whole path, named outermost key first as a row reads. */
@@ -28,15 +35,6 @@ describe('KeyPathIds', () => {
 
   it('tells a path apart from the prefix it extends', () => {
     expect(pathFor(ids, 'A', 'B')).not.toBe(pathFor(ids, 'A'));
-  });
-
-  it('names the two directions apart, since a row means each in one view only', () => {
-    const chain = ['leaf', 'caller'];
-
-    // Top-down names the whole chain; bottom-up names the leaf, then the leaf
-    // under its caller.
-    expect(ids.prefixesOf(chain)).toEqual([pathFor(ids, 'leaf'), expect.any(Number)]);
-    expect(ids.prefixesOf(chain)[1]).not.toBe(ids.pathOf(chain));
   });
 
   it('reads a path back, outermost first', () => {
@@ -59,10 +57,74 @@ describe('KeyPathIds', () => {
   });
 
   it('mints on its own, so an id from one log means nothing to another', () => {
-    const other = new KeyPathIds();
+    const other = new KeyPathIds(32);
 
     expect(pathFor(other, 'Z')).toBe(pathFor(ids, 'A'));
     expect(other.keysOf(pathFor(other, 'Z'))).toEqual(['Z']);
     expect(ids.keysOf(pathFor(ids, 'A'))).toEqual(['A']);
+  });
+
+  describe('keyIdOf', () => {
+    it('keeps one id per signature, not one per frame', () => {
+      const first = ev(1, 'Util.log', null);
+      const second = ev(2, 'Util.log', null);
+
+      expect(ids.keyIdOf(first)).toBe(ids.keyIdOf(first));
+      // Same type, namespace and text is the same bucket.
+      expect(ids.keyIdOf(second)).toBe(ids.keyIdOf(first));
+    });
+
+    it('keys a frame no slot of its own covers', () => {
+      // Built rather than parsed, so it sits outside the log's own index.
+      const loose = ev(9999, 'made up', null);
+
+      expect(ids.keyIdOf(loose)).toBe(ids.keyIdOf(loose));
+    });
+  });
+
+  describe('stackIdOf', () => {
+    it('reads through the entry type, which a bucket key does not', () => {
+      const unit = ev(1, 'Thing.run()', null, 'CODE_UNIT_STARTED');
+      const method = ev(2, 'Thing.run()', null, 'METHOD_ENTRY');
+
+      // A method that recurses as a code unit is one frame to the stack.
+      expect(ids.stackIdOf(unit)).toBe(ids.stackIdOf(method));
+      expect(ids.keyIdOf(unit)).not.toBe(ids.keyIdOf(method));
+    });
+
+    it('tells two frames apart', () => {
+      expect(ids.stackIdOf(ev(1, 'one', null))).not.toBe(ids.stackIdOf(ev(2, 'two', null)));
+    });
+  });
+
+  describe('pathIdsOf', () => {
+    const root = ev(1, 'exec', null);
+    const outer = ev(2, 'outer', root);
+    const inner = ev(3, 'inner', outer);
+
+    /** The ids the walk adds, in the order it adds them. */
+    function found(event: LogEvent, direction: 'callers' | 'callees'): number[] {
+      const into = new Set<number>();
+      ids.pathIdsOf(event, direction, into);
+      return [...into];
+    }
+
+    it('names one row in a top-down view, at the depth the frame ran at', () => {
+      expect(found(inner, 'callees')).toEqual([
+        pathFor(ids, 'METHOD_ENTRY||outer', 'METHOD_ENTRY||inner'),
+      ]);
+    });
+
+    it('names a row per caller depth in a bottom-up view', () => {
+      // The frame heads a row on its own, and one under each caller above it.
+      expect(found(inner, 'callers')).toEqual([
+        pathFor(ids, 'METHOD_ENTRY||inner'),
+        pathFor(ids, 'METHOD_ENTRY||inner', 'METHOD_ENTRY||outer'),
+      ]);
+    });
+
+    it('leaves the log root out, as it heads a row in neither view', () => {
+      expect(found(root, 'callers')).toEqual([]);
+    });
   });
 });

--- a/log-viewer/src/core/log/eventKeys.ts
+++ b/log-viewer/src/core/log/eventKeys.ts
@@ -22,3 +22,15 @@ export function getEventKey(event: LogEvent): string {
 export function getStackKey(event: LogEvent): string {
   return `${event.namespace}|${event.text}`;
 }
+
+/**
+ * The bucket keys from `event` out to its outermost frame, innermost first. The
+ * log root heads no row in any view, so the walk stops below it.
+ */
+export function eventKeyChain(event: LogEvent): string[] {
+  const keys: string[] = [];
+  for (let node: LogEvent | null = event; node?.parent; node = node.parent) {
+    keys.push(getEventKey(node));
+  }
+  return keys;
+}

--- a/log-viewer/src/core/log/keyPathIds.ts
+++ b/log-viewer/src/core/log/keyPathIds.ts
@@ -1,12 +1,19 @@
 /*
  * Copyright (c) 2026 Certinia Inc. All rights reserved.
  */
+import type { LogEvent } from 'apex-log-parser';
+
+import type { SelectionView } from '../events/EventBus.js';
+import { getEventKey, getStackKey } from './eventKeys.js';
 
 /** The path every chain starts from, which no row stands for. */
 export const ROOT_PATH_ID = 0;
 
+/** One frame's chain, reused: the walk never yields, so one is enough. */
+const chain: number[] = [];
+
 /**
- * The bucket paths of one log, each interned to an integer.
+ * The interned keys and bucket paths of one log.
  *
  * A row in a view whose rows merge occurrences is named by the bucket keys that
  * reach it, since one method holds a row under every caller it has. Joining
@@ -14,48 +21,121 @@ export const ROOT_PATH_ID = 0;
  * cost of a mark. An id per distinct path bounds the table by the tree rather
  * than by the calls, and makes matching an integer test.
  *
- * Every caller depends on one invariant: a row's id is the interned chain of the
- * frames the row holds. Compose ids through {@link pathOf} or
- * {@link prefixesOf} rather than folding {@link pathId} by hand, since the two
- * directions are separate spaces and an id from one means nothing in the other.
+ * One invariant holds it together: a row's id is the interned chain of the
+ * frames the row holds. {@link pathIdsOf} and {@link pathOf} are the two ways to
+ * reach one, so the two chain directions stay separate spaces here rather than
+ * in every caller.
  *
  * One table per log, held by `LogStore`: an id means nothing to another log.
  */
 export class KeyPathIds {
   private keyIds = new Map<string, number>();
   private keys: string[] = [];
+  /** Each event's bucket key, as `id + 1` so an unset slot reads as 0. */
+  private keyOfEvent: Int32Array;
+  private stackIds = new Map<string, number>();
+  /** Each bucket key's stack key. A bucket key holds the stack key, so this is
+   *  per signature rather than per event. */
+  private stackOfKey: number[] = [];
   // Indexed by path id: the paths reachable from it, its own parent, and the key
   // it was minted with. Index 0 is the empty path.
   private children: Array<Map<number, number> | undefined> = [new Map()];
   private parents: number[] = [ROOT_PATH_ID];
   private keyOf: number[] = [-1];
 
-  /**
-   * The id for the path that reaches `key` through `parentPathId`, minted on
-   * first use.
-   *
-   * @param parentPathId - {@link ROOT_PATH_ID} for the outermost key of a chain
-   */
-  public pathId(parentPathId: number, key: string): number {
-    return this.step(parentPathId, this.keyId(key));
+  constructor(eventCount: number) {
+    this.keyOfEvent = new Int32Array(eventCount);
   }
 
   /**
-   * The id of one bucket key, interned. A walk that steps the same key many times
-   * interns it once and calls {@link step}, since hashing the key is what a path
-   * id exists to avoid.
+   * The event's interned bucket key, kept per event: a mark reads the same
+   * ancestors once per occurrence it names.
    */
-  public keyId(key: string): number {
-    let id = this.keyIds.get(key);
+  public keyIdOf(event: LogEvent): number {
+    const at = event.eventIndex;
+    const cached = this.keyOfEvent[at] ?? 0;
+    if (cached) {
+      return cached - 1;
+    }
+    const id = this.keyId(getEventKey(event));
+    // Ignored where the log's own index has no such slot, which only costs the
+    // key being built again.
+    this.keyOfEvent[at] = id + 1;
+    return id;
+  }
+
+  /**
+   * The event's interned stack key, which tells a recursive call from a fresh
+   * one. Its own space: a stack key is never a step in a path.
+   */
+  public stackIdOf(event: LogEvent): number {
+    const keyId = this.keyIdOf(event);
+    let id = this.stackOfKey[keyId];
     if (id === undefined) {
-      id = this.keys.length;
-      this.keyIds.set(key, id);
-      this.keys.push(key);
+      const key = getStackKey(event);
+      id = this.stackIds.get(key) ?? this.stackIds.size;
+      this.stackIds.set(key, id);
+      this.stackOfKey[keyId] = id;
     }
     return id;
   }
 
-  /** {@link pathId} for a key already interned by {@link keyId}. */
+  /**
+   * The ids naming the rows a frame belongs to in a merged view, added to `into`.
+   *
+   * A top-down row sits at the frame's own depth, so one id names it. A
+   * bottom-up row is the frame plus however many of its callers the chain shows,
+   * so every prefix names a row the frame heads — which is why one frame marks
+   * several rows there.
+   *
+   * The log root heads no row in either view, so the walk stops below it.
+   */
+  public pathIdsOf(event: LogEvent, direction: SelectionView, into: Set<number>): void {
+    if (!event.parent) {
+      return;
+    }
+    if (direction === 'callers') {
+      // The parent walk is already innermost first, which is the order these ids
+      // compose in, so nothing is collected on the way.
+      let id = ROOT_PATH_ID;
+      for (let node: LogEvent | null = event; node?.parent; node = node.parent) {
+        id = this.step(id, this.keyIdOf(node));
+        into.add(id);
+      }
+      return;
+    }
+    chain.length = 0;
+    for (let node: LogEvent | null = event; node?.parent; node = node.parent) {
+      chain.push(this.keyIdOf(node));
+    }
+    let id = ROOT_PATH_ID;
+    for (let depth = chain.length - 1; depth >= 0; depth--) {
+      id = this.step(id, chain[depth]!);
+    }
+    into.add(id);
+  }
+
+  /**
+   * The id for a whole chain, outermost key first: what names a top-down row, and
+   * what a row built from key strings is stamped with.
+   *
+   * @param keys - the chain innermost first, as a row's own parent walk gives it
+   */
+  public pathOf(keys: readonly string[]): number {
+    let id = ROOT_PATH_ID;
+    for (let depth = keys.length - 1; depth >= 0; depth--) {
+      id = this.step(id, this.keyId(keys[depth]!));
+    }
+    return id;
+  }
+
+  /**
+   * The id for the path that reaches an interned key through `parentPathId`,
+   * minted on first use. For a walk that already holds the key's id and composes
+   * a path as it goes.
+   *
+   * @param parentPathId - {@link ROOT_PATH_ID} for the outermost key of a chain
+   */
   public step(parentPathId: number, keyId: number): number {
     const reachable = (this.children[parentPathId] ??= new Map());
     let id = reachable.get(keyId);
@@ -72,33 +152,15 @@ export class KeyPathIds {
     return id;
   }
 
-  /**
-   * The id for a whole chain, outermost key first: what names a top-down row.
-   *
-   * @param keys - the chain innermost first, as `eventKeyChain` gives it
-   */
-  public pathOf(keys: readonly string[]): number {
-    let id = ROOT_PATH_ID;
-    for (let depth = keys.length - 1; depth >= 0; depth--) {
-      id = this.pathId(id, keys[depth]!);
+  /** One bucket key's id, interned. */
+  public keyId(key: string): number {
+    let id = this.keyIds.get(key);
+    if (id === undefined) {
+      id = this.keys.length;
+      this.keyIds.set(key, id);
+      this.keys.push(key);
     }
     return id;
-  }
-
-  /**
-   * An id per step out along a chain: the bottom-up rows a frame heads, which are
-   * the frame alone, then the frame under one caller, and so on.
-   *
-   * @param keys - the chain innermost first
-   */
-  public prefixesOf(keys: readonly string[]): number[] {
-    const prefixes: number[] = [];
-    let id = ROOT_PATH_ID;
-    for (const key of keys) {
-      id = this.pathId(id, key);
-      prefixes.push(id);
-    }
-    return prefixes;
   }
 
   /**

--- a/log-viewer/src/features/call-tree/utils/Aggregation.ts
+++ b/log-viewer/src/features/call-tree/utils/Aggregation.ts
@@ -135,18 +135,6 @@ export interface BottomUpRow {
 }
 
 /**
- * The bucket keys from `event` out to its outermost frame, innermost first. The
- * log root heads no row in any view, so the walk stops below it.
- */
-export function eventKeyChain(event: LogEvent): string[] {
-  const keys: string[] = [];
-  for (let node: LogEvent | null = event; node?.parent; node = node.parent) {
-    keys.push(getEventKey(node));
-  }
-  return keys;
-}
-
-/**
  * Creates an aggregated call tree where all calls to the same function signature
  * are merged together, with aggregated metrics.
  * Uses Multiset call-stack tracking to prevent double-counting of recursive calls.

--- a/log-viewer/src/features/call-tree/utils/bucketRows.ts
+++ b/log-viewer/src/features/call-tree/utils/bucketRows.ts
@@ -7,8 +7,7 @@ import type { RowComponent } from 'tabulator-tables';
 
 import type { SelectionView } from '../../../core/events/EventBus.js';
 import { withCodeDrivenExpand } from '../../../tabulator/module/expandOrigin.js';
-import { getEventKey } from '../../../core/log/eventKeys.js';
-import { eventKeyChain } from './Aggregation.js';
+import { eventKeyChain, getEventKey } from '../../../core/log/eventKeys.js';
 
 interface BucketRow {
   key?: string;


### PR DESCRIPTION
# 📝 PR Overview

After #970 the interned keys sat on `LogStore` while the paths they step through sat in `KeyPathIds`. Nothing tied a cached key id to the table that minted it, a stack id could be stepped into a path that means nothing, and a test double had to mirror three coupled facts to work at all.

One object now owns the keys, their per-event memo, the stack keys and the paths, and states the invariant its callers rely on: a row's id is the interned chain of the frames the row holds. Tidying it also dropped work and memory.

| 100MB log (864k lines, 431k calls) | Before | After |
| --- | --- | --- |
| Bottom-Up build | 508ms | **458ms** |
| Aggregated build | 124ms | **121ms** |
| Mark a 42,433-occurrence pick | 75ms | **61ms** |
| Per-event key cache | 2 arrays, 3.4MB, filled up front | **1 array, 1.7MB, filled on use** |

## 🛠️ Changes made

- A bucket key (`type|namespace|text`) holds its stack key (`namespace|text`), so a stack id is derived from a key id and kept per signature rather than per event. That removes the second per-event array, and the two id spaces are separate by construction.
- Cache slots hold `id + 1`, so an unset slot reads as 0 and a zero-initialised array costs nothing until a frame is asked about.
- The mark walks the frames and composes their ids inside the table, so neither chain direction builds an intermediate array; `prefixesOf` is deleted rather than left with no caller.
- The scoped aggregation carries one map where it carried three, dropping an array per recursion level and a lookup per row.
- `eventKeyChain` joins its only dependency in `core/log/eventKeys.ts`, so `bucketRows` takes one import for one vocabulary.

## 🧩 Type of change (check all applicable)

- [ ] 🐛 Bug fix - something not working as expected
- [ ] ✨ New feature – adds new functionality
- [x] ♻️ Refactor - internal changes with no user impact
- [x] ⚡ Performance Improvement
- [ ] 📝 Documentation - README or documentation site changes
- [ ] 🔧 Chore - dev tooling, CI, config
- [ ] 💥 Breaking change

## 📷 Screenshots / gifs / video [optional]

N/A — nothing changes on screen.

## 🔗 Related Issues

related #113
related #373
related #405

## ✅ Tests added?

- [x] 👍 yes

The key, stack-key and both path directions are now tested on the class that owns them: one id per signature rather than per frame, the stack key reading through the entry type where the bucket key does not, and a frame naming one top-down row but one row per caller depth in bottom-up.

## 📚 Docs updated?

- [x] 🙅 not needed

Unreleased inspector work already described by the #113 and #373 entries.

## Anything else we need to know? [optional]

A `WeakMap` keyed by the event was measured as the alternative to the dense array: 542ms against 458ms for the build and 16MB more held, so the array stays.

Two fixtures failed during this and it was the fixtures, not the code: the scoped-tree test double shared one intern table across tests while its fixtures reuse `eventIndex` values for different frames, so one test's key was read back for another. A table is per log in production, so the double now takes a fresh one per test.

Follow-up, unchanged by this: the Call Tree grid still interns its keys per build (`toBottomUpTree`) or groups by string (`toAggregatedCallTree`, 335ms), and recovers a row's path by walking Tabulator tree parents and its occurrences by splitting key strings. Adopting this vocabulary there retires `bottomUpOccurrences.ts` and `rowCallChain`.