### PR TITLE
fix(log-viewer): keep the inspector mark and the tab it points at in step

### DIFF
--- a/log-viewer/src/components/__tests__/inspectorLocate.test.ts
+++ b/log-viewer/src/components/__tests__/inspectorLocate.test.ts
@@ -1,0 +1,122 @@
+/*
+ * Copyright (c) 2026 Certinia Inc. All rights reserved.
+ */
+import { describe, expect, it } from '@jest/globals';
+
+import { InspectorEmphasis } from '../inspectorEmphasis.js';
+import { inspectorLocateHandler } from '../inspectorLocate.js';
+
+describe('inspectorLocateHandler', () => {
+  /** A view whose move settles only when the test says so, which is the window a
+   *  later report has to arrive in. */
+  function wire(move?: (eventIndex: number) => Promise<void>) {
+    const marks: Array<readonly number[]> = [];
+    const revealed: number[] = [];
+    let settle: () => void = () => {};
+    const emphasis = new InspectorEmphasis();
+    const handle = inspectorLocateHandler(
+      'calltree',
+      emphasis,
+      (eventIndexes) => marks.push(eventIndexes),
+      move === undefined
+        ? (eventIndex) => {
+            revealed.push(eventIndex);
+            return new Promise<void>((resolve) => {
+              settle = resolve;
+            });
+          }
+        : move,
+    );
+    return { marks, revealed, emphasis, finish: () => settle(), handle };
+  }
+
+  const settled = () => new Promise((resolve) => setTimeout(resolve, 0));
+
+  it('leaves a report for another tab alone', () => {
+    const { marks, revealed, handle } = wire();
+
+    handle({ source: 'analysis', eventIndexes: [4], sticky: true });
+
+    expect(marks).toEqual([]);
+    expect(revealed).toEqual([]);
+  });
+
+  it('marks under the pointer without moving the view', () => {
+    const { marks, revealed, handle } = wire();
+
+    handle({ source: 'calltree', eventIndexes: [4, 5], sticky: false });
+
+    expect(marks).toEqual([[4, 5]]);
+    expect(revealed).toEqual([]);
+  });
+
+  it('moves to a picked row first, then marks', async () => {
+    const { marks, revealed, finish, handle } = wire();
+
+    handle({ source: 'calltree', eventIndexes: [4, 5], sticky: true });
+    expect(revealed).toEqual([4]);
+    // The mark waits: the move re-renders the rows it lands on.
+    expect(marks).toEqual([]);
+
+    finish();
+    await settled();
+
+    expect(marks).toEqual([[4, 5]]);
+  });
+
+  it('marks what a report arriving during the move replaced it with', async () => {
+    const { marks, finish, handle } = wire();
+
+    handle({ source: 'calltree', eventIndexes: [4], sticky: true });
+    // The pointer reaches another row while the move it started is in flight.
+    handle({ source: 'calltree', eventIndexes: [9], sticky: false });
+    finish();
+    await settled();
+
+    // The move re-rendered the rows that hover had marked, so it goes on again.
+    expect(marks.at(-1)).toEqual([9]);
+  });
+
+  it('clears the mark where the pick was dropped during the move', async () => {
+    const { marks, finish, handle } = wire();
+
+    handle({ source: 'calltree', eventIndexes: [4], sticky: true });
+    handle({ source: 'calltree', eventIndexes: [], sticky: true });
+    finish();
+    await settled();
+
+    expect(marks.at(-1)).toEqual([]);
+  });
+
+  it('clears the mark where the view cleared its own emphasis during the move', async () => {
+    const { marks, emphasis, finish, handle } = wire();
+
+    handle({ source: 'calltree', eventIndexes: [4], sticky: true });
+    // Escape reaches the view as `selection:clear`, which never passes here.
+    emphasis.pick([]);
+    finish();
+    await settled();
+
+    expect(marks.at(-1)).toEqual([]);
+  });
+
+  it('marks even where the move fails, since the mark still says where the frames are', async () => {
+    const { marks, handle } = wire(() => Promise.reject(new Error('no row for it')));
+
+    handle({ source: 'calltree', eventIndexes: [4], sticky: true });
+    await settled();
+
+    expect(marks).toEqual([[4]]);
+  });
+
+  it('marks a picked row where the view cannot move to one', () => {
+    const marks: Array<readonly number[]> = [];
+    const handle = inspectorLocateHandler('calltree', new InspectorEmphasis(), (ids) =>
+      marks.push(ids),
+    );
+
+    handle({ source: 'calltree', eventIndexes: [4], sticky: true });
+
+    expect(marks).toEqual([[4]]);
+  });
+});

--- a/log-viewer/src/components/inspectorLocate.ts
+++ b/log-viewer/src/components/inspectorLocate.ts
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2026 Certinia Inc. All rights reserved.
+ */
+import type { DetailSource, EventDetail } from '../core/events/EventBus.js';
+import type { InspectorEmphasis } from './inspectorEmphasis.js';
+
+/**
+ * A view's answer to the inspector pointing at frames: mark what the report
+ * names, and where a picked row merges occurrences, move to the first of them.
+ *
+ * @param source - the tab this view is, so a report for another is left alone
+ * @param revealFirstOccurrence - omitted where jumping to one of several merged
+ *   occurrences would be arbitrary, which is why the Database grids and the
+ *   flame chart only mark. A pick of a single frame arrives as
+ *   `inspector:reveal` instead, and every view answers that.
+ */
+export function inspectorLocateHandler(
+  source: DetailSource,
+  emphasis: InspectorEmphasis,
+  mark: (eventIndexes: readonly number[]) => void,
+  revealFirstOccurrence?: (eventIndex: number) => Promise<void>,
+): (detail: EventDetail<'inspector:locate'>) => void {
+  return (detail) => {
+    if (detail.source !== source) {
+      return;
+    }
+    const marked = emphasis.report(detail.eventIndexes, detail.sticky);
+    if (!revealFirstOccurrence || !detail.sticky || !detail.eventIndexes.length) {
+      mark(marked);
+      return;
+    }
+    // Moving re-renders the rows a mark sits on, so the mark goes on after it.
+    void (async () => {
+      try {
+        await revealFirstOccurrence(detail.eventIndexes[0]!);
+      } catch {
+        // The move failed, and the view reports that itself. The mark still has
+        // to go on: it says where the frames are, moved to or not.
+      }
+      // Read again rather than re-applying the report that started the move: a
+      // report arriving while it ran has already replaced that one, and the
+      // re-render stripped whatever mark it had put on.
+      mark(emphasis.current());
+    })();
+  };
+}

--- a/log-viewer/src/core/events/EventBus.ts
+++ b/log-viewer/src/core/events/EventBus.ts
@@ -109,6 +109,10 @@ interface EventMap {
   'detail:locate': { source: DetailSource; eventIndexes: readonly number[] };
 }
 
+/** One event's payload, for code that answers an event it is handed rather than
+ *  one it names itself. The map stays where each payload is described. */
+export type EventDetail<K extends keyof EventMap> = EventMap[K];
+
 type EventCallback<K extends keyof EventMap> = (detail: EventMap[K]) => void;
 
 class EventBusImpl {

--- a/log-viewer/src/features/analysis/components/AnalysisView.ts
+++ b/log-viewer/src/features/analysis/components/AnalysisView.ts
@@ -22,6 +22,7 @@ import {
   rowOccurrences,
 } from '../../../components/locatedRow.js';
 import { InspectorEmphasis } from '../../../components/inspectorEmphasis.js';
+import { inspectorLocateHandler } from '../../../components/inspectorLocate.js';
 import { SelectionEchoGuard } from '../../../core/events/SelectionEchoGuard.js';
 import { eventByEventIndex } from '../../../core/utility/EventSearch.js';
 import { isVisible } from '../../../core/utility/Util.js';
@@ -163,9 +164,6 @@ export class AnalysisView extends LitElement {
   private _locatedRow = new LocatedRowMarker();
   private _locateIds = new LocatedRowIds();
   private _emphasis = new InspectorEmphasis();
-  /** Counts the locate reports, so a mark held back by a reveal is dropped once
-   *  a later report has replaced it. */
-  private _locateReport = 0;
 
   constructor() {
     super();
@@ -179,27 +177,15 @@ export class AnalysisView extends LitElement {
     });
     // Mark the buckets the inspector points at. A row is a method bucket rather
     // than one event, so a frame is translated into the paths of the rows it heads.
-    this._inspectorLocateUnsubscribe = eventBus.on('inspector:locate', (detail) => {
-      if (detail.source !== 'analysis') {
-        return;
-      }
-      const ids = this._emphasis.report(detail.eventIndexes, detail.sticky);
-      if (detail.sticky && detail.eventIndexes.length) {
-        // A picked row moves the grid to the bucket it names, as one picked in
-        // the Call Tree does. The reveal re-renders the rows the mark lands on,
-        // so the mark goes on after, and only while it is still the last report:
-        // dropping the pick clears the mark while the reveal is still in flight.
-        const reported = ++this._locateReport;
-        void this._revealEventIndex(detail.eventIndexes[0]!).then(() => {
-          if (reported === this._locateReport) {
-            this._markLocated(ids);
-          }
-        });
-      } else {
-        this._locateReport++;
-        this._markLocated(ids);
-      }
-    });
+    this._inspectorLocateUnsubscribe = eventBus.on(
+      'inspector:locate',
+      inspectorLocateHandler(
+        'analysis',
+        this._emphasis,
+        (eventIndexes) => this._markLocated(eventIndexes),
+        (eventIndex) => this._revealEventIndex(eventIndex),
+      ),
+    );
     document.addEventListener('lv-find', this._findEvt);
     document.addEventListener('lv-find-match', this._findEvt);
     document.addEventListener('lv-find-close', this._findEvt);

--- a/log-viewer/src/features/call-tree/components/CalltreeView.ts
+++ b/log-viewer/src/features/call-tree/components/CalltreeView.ts
@@ -72,6 +72,7 @@ import {
   rowOccurrences,
 } from '../../../components/locatedRow.js';
 import { InspectorEmphasis } from '../../../components/inspectorEmphasis.js';
+import { inspectorLocateHandler } from '../../../components/inspectorLocate.js';
 import { createTimeOrderTable } from './TimeOrderTable.js';
 
 /** Time Order keys its rows by event index; the grouped views key theirs by the
@@ -187,21 +188,17 @@ export class CalltreeView extends LitElement {
     });
 
     // Mark the frames the inspector points at, while the Call Tree is the tab the
-    // inspector is showing.
-    this._inspectorLocateUnsubscribe = eventBus.on('inspector:locate', (detail) => {
-      if (detail.source === 'calltree') {
-        const ids = this._emphasis.report(detail.eventIndexes, detail.sticky);
-        if (detail.sticky && detail.eventIndexes.length) {
-          // A picked inspector row merges calls, so the mark shows all of them
-          // while the view moves to the first, as a pick of one frame does. The
-          // reveal expands and scrolls, which re-renders the rows the mark lands
-          // on, so it goes on after.
-          void this._revealEventIndex(detail.eventIndexes[0]!).then(() => this._markLocated(ids));
-        } else {
-          this._markLocated(ids);
-        }
-      }
-    });
+    // inspector is showing. A picked row merges calls, so the mark shows all of
+    // them while the view moves to the first, as a pick of one frame does.
+    this._inspectorLocateUnsubscribe = eventBus.on(
+      'inspector:locate',
+      inspectorLocateHandler(
+        'calltree',
+        this._emphasis,
+        (eventIndexes) => this._markLocated(eventIndexes),
+        (eventIndex) => this._revealEventIndex(eventIndex),
+      ),
+    );
 
     // Escape (app-wide) deselects here; the table reports the clear itself. It
     // also drops a mark held by a picked inspector row, which is no selection of

--- a/log-viewer/src/features/database/components/DatabaseView.ts
+++ b/log-viewer/src/features/database/components/DatabaseView.ts
@@ -17,6 +17,7 @@ import { limitTotals } from '../../../components/logOverviewMetrics.js';
 import { eventBus, type StatementType } from '../../../core/events/EventBus.js';
 import { apexLimitTimeSeries } from '../../timeline/optimised/apex-limit-series.js';
 import { InspectorEmphasis } from '../../../components/inspectorEmphasis.js';
+import { inspectorLocateHandler } from '../../../components/inspectorLocate.js';
 import { SelectionEchoGuard } from '../../../core/events/SelectionEchoGuard.js';
 import { isVisible } from '../../../core/utility/Util.js';
 import { soslRowsMetric } from '../limits.js';
@@ -119,11 +120,12 @@ export class DatabaseView extends LitElement {
     // Mark the statements the inspector points at, while the Database tab is the
     // tab the inspector is showing. The eventIndex belongs to one grid, so the
     // others simply find nothing to mark.
-    this._offInspectorLocate = eventBus.on('inspector:locate', (d) => {
-      if (d.source === 'database') {
-        this._markLocated(this._emphasis.report(d.eventIndexes, d.sticky));
-      }
-    });
+    this._offInspectorLocate = eventBus.on(
+      'inspector:locate',
+      inspectorLocateHandler('database', this._emphasis, (eventIndexes) =>
+        this._markLocated(eventIndexes),
+      ),
+    );
 
     // Escape (app-wide) deselects here. Only one grid holds the selection, and
     // its report of the clear reaches the inspector the same way a click does. It

--- a/log-viewer/src/features/timeline/optimised/ApexLogTimeline.ts
+++ b/log-viewer/src/features/timeline/optimised/ApexLogTimeline.ts
@@ -41,6 +41,7 @@ import {
 } from '../types/flamechart.types.js';
 import type { SearchCursor } from '../types/search.types.js';
 import { InspectorEmphasis } from '../../../components/inspectorEmphasis.js';
+import { inspectorLocateHandler } from '../../../components/inspectorLocate.js';
 import { isFrameOffscreen, toDetailSelection } from '../utils/detail-selection-sync.js';
 import { extractExceptionMarkers, extractMarkers } from '../utils/marker-utils.js';
 import { seekWindow } from '../utils/navigate-window.js';
@@ -226,11 +227,12 @@ export class ApexLogTimeline {
 
     // Dim the chart around the frames the inspector points at, while the timeline
     // is the tab the inspector is showing.
-    this.inspectorLocateUnsubscribe = eventBus.on('inspector:locate', (detail) => {
-      if (detail.source === 'timeline') {
-        this.applyEmphasis(this.emphasis.report(detail.eventIndexes, detail.sticky));
-      }
-    });
+    this.inspectorLocateUnsubscribe = eventBus.on(
+      'inspector:locate',
+      inspectorLocateHandler('timeline', this.emphasis, (eventIndexes) =>
+        this.applyEmphasis(eventIndexes),
+      ),
+    );
 
     // Escape (app-wide) deselects here; the chart reports the clear itself.
     // The flame chart's own Escape (container focused) consumes the key first.


### PR DESCRIPTION
# 📝 PR Overview

Picking a row in the inspector's call tree moves the tab's grid to the bucket it names, and the move re-renders the rows the mark sits on, so the mark has to be applied after it. The Call Tree applied the mark it had read *before* the move. Dropping the pick while the move ran cleared the mark, and the move then put it back with nothing picked; hovering another row instead had that hover's own mark stripped and never re-applied, leaving the grid unmarked until the pointer moved again.

The mark now reads what the inspector is pointing at when the move settles, which is the emphasis the view already keeps, so there is no second copy of that truth to fall out of step. The same handler was written four times, once per tab, with the defect in two of the copies; all four now share one.

## 🛠️ Changes made

- **One handler for four tabs** — `inspectorLocateHandler` in `log-viewer/src/components/inspectorLocate.ts` replaces the hand-written `inspector:locate` handlers in `CalltreeView`, `AnalysisView`, `DatabaseView` and `ApexLogTimeline`. Whether a pick moves a view is now an argument rather than a property of which handler was copied last.
- **The mark is read, not restored** — the deferred mark takes `InspectorEmphasis.current()` when the move settles, so a report that arrived during the move wins and a dropped pick stays dropped. `Escape` reaches a view as `selection:clear`, which never passes through this handler, so anything that tracked reports here rather than on the emphasis would have missed it.
- **A failed move no longer leaks** — the move is awaited in a `try`, and the mark goes on either way: it says where the frames are whether the view reached them or not. Previously a rejection surfaced as an unhandled rejection.
- **`EventDetail<K>`** — exported from `EventBus.ts` so a shared handler can be typed against one event's payload without lifting that payload out of `EventMap`, which stays where each event is described.

## 🧩 Type of change (check all applicable)

- [x] 🐛 Bug fix - something not working as expected
- [ ] ✨ New feature – adds new functionality
- [x] ♻️ Refactor - internal changes with no user impact
- [ ] ⚡ Performance Improvement
- [ ] 📝 Documentation - README or documentation site changes
- [ ] 🔧 Chore - dev tooling, CI, config
- [ ] 💥 Breaking change

## 📷 Screenshots / gifs / video [optional]

N/A. What changes is whether a mark is still on screen after a pick moves the grid.

## 🔗 Related Issues

None.

## ✅ Tests added?

- [x] 👍 yes
- [ ] 🙅 no, not needed
- [ ] 🙋 no, I need help

## 📚 Docs updated?

- [ ] 🔖 README.md
- [x] 🔖 CHANGELOG.md
- [ ] 📖 help site
- [ ] 🧪 Marked any pre-release-only features
- [ ] 🙅 not needed

No entry: the Inspector is unreleased, so this belongs to its existing entry rather than a new one. The box is ticked to record that it was considered.

## Anything else we need to know? [optional]

**Where to start.** `log-viewer/src/components/inspectorLocate.ts` is the whole of it, 46 lines. `log-viewer/src/components/inspectorEmphasis.ts` is deliberately untouched: it stays pure state, and the new module composes it.

**Test plan.**

- \`pnpm lint\` and \`pnpm test\`.
- Call Tree tab, inspector Call Tree → Bottom Up. Click a caller row, then press \`Escape\` before the scroll settles: the mark must stay gone.
- Same again, but hover a different inspector row instead of pressing \`Escape\`: the hovered row's frames must be marked once the move settles, not the picked row's, and the grid must not be left unmarked.
- Timeline: hover and pick inspector rows. The chart dims around them and must not pan.
- Database: hover and pick. Statement rows mark, and the grid must not scroll.
- Analysis: pick moves the grid and marks. Hover marks only.
- \`Escape\` on each tab clears the selection and any held mark.

**Known unrelated failure locally.** \`lana/src/services/__tests__/servicesRuntime.test.ts\` cannot resolve \`effect\` in a worktree not installed since #951. No \`lana\` file is touched here, and it passes in CI.

**Follow-ups, not in this PR.**

- **The grid mark is a one-shot DOM sweep.** \`LocatedRowMarker.mark\` adds a class to the rows present at that instant, and the row formatters stamp the row id but never re-apply the class, so scrolling a grid while a picked inspector row is lit loses the mark. Making the marker hold the wanted id set and having the formatter apply the class would fix that and delete the await-then-mark ordering this PR gets right by hand.
- **The source filter is now in nine places.** Every \`DetailSource\`-carrying event is filtered the same way in each view; an \`eventBus.onSource\` would fold all nine, and with it the four near-identical \`inspector:reveal\` handlers, so one gesture stops needing two subscriptions per view.
- **A stale move is not abandoned.** Clicking two inspector rows quickly lets the earlier move settle last and scroll away from the newer row. The mark is now correct either way, but the scroll is not; a Tabulator expand and scroll is not cancellable, so this needs its own approach.
- **Whether the Database grids and the flame chart should move on a merged pick.** Both can. They do not today, and the shared handler makes that an explicit argument rather than an accident, but changing it is a product decision.