### PR TITLE
docs(log-viewer): say what the row mark actually missed

### DIFF
--- a/log-viewer/src/components/__tests__/locatedRow.test.ts
+++ b/log-viewer/src/components/__tests__/locatedRow.test.ts
@@ -66,8 +66,8 @@ function rowFor(container: HTMLElement, index: number): HTMLElement {
   return container.children[index] as HTMLElement;
 }
 
-/** A row entering an already-mounted table, which is what the renderer does with
- *  one scrolled back into view: in the DOM first, stamped as it initialises. */
+/** A row entering an already-mounted table, which is what the renderer does the
+ *  first time one is scrolled to: in the DOM first, stamped as it initialises. */
 function renderRow(container: HTMLElement, index: number): HTMLElement {
   const row = document.createElement('div');
   row.classList.add('tabulator-row');
@@ -162,7 +162,7 @@ describe('LocatedRowMarker', () => {
     expect(row.classList.contains(LOCATED_ROW_CLASS)).toBe(false);
   });
 
-  it('lights a row that arrives after the mark, as a scroll back brings one', () => {
+  it('lights a row that arrives after the mark, as scrolling to a new one does', () => {
     const container = host();
     new LocatedRowMarker().mark(container, [4]);
 

--- a/log-viewer/src/components/locatedRow.ts
+++ b/log-viewer/src/components/locatedRow.ts
@@ -22,9 +22,9 @@ const NOTHING_WANTED: ReadonlySet<string> = new Set();
  * The stamped ids each marked table wants lit.
  *
  * Held per host rather than on the marker so a row can light itself as it enters
- * the DOM. The renderer de-initialises a row scrolled out of view and builds it
- * again on the way back, which drops the class the sweep put on it, so a mark
- * held only as a list of elements is lost the moment the user scrolls.
+ * the DOM. Tabulator builds a row's element on its first render, so a sweep of
+ * what is rendered cannot reach a row that has never been on screen: one below
+ * the viewport, or a tree child built after the mark was set.
  */
 const wantedByHost = new WeakMap<HTMLElement, ReadonlySet<string>>();
 


### PR DESCRIPTION
# 📝 PR Overview

#975 explained the row mark with a mechanism that does not exist: that the renderer de-initialises a row scrolled out of view and rebuilds it, dropping the class. A reader who trusts that comment would expect an ordinary scroll to lose a mark, and would look in the wrong place when the mark misbehaves.

What actually happens: `Row.create()` is guarded by `this.created`, `Row.initialize()` deletes cells but re-uses the element, `RowManager.styleRow` adds and removes parity classes rather than assigning `className`, and our renderer only detaches and re-attaches the element. A class on a row element survives scrolling. The gap the declarative mark closes is the **first** render: a row that has never been on screen has no element, so a sweep of what is rendered cannot reach it.

## 🛠️ Changes made

- Correct the `wantedByHost` comment to name the real gap: a row below the viewport, or a tree child built after the mark was set.
- Rename one test from "as a scroll back brings one" to "as scrolling to a new one does", and correct its helper comment, so the test says which case it guards.

## 🧩 Type of change (check all applicable)

- [ ] 🐛 Bug fix - something not working as expected
- [ ] ✨ New feature – adds new functionality
- [ ] ♻️ Refactor - internal changes with no user impact
- [ ] ⚡ Performance Improvement
- [x] 📝 Documentation - README or documentation site changes
- [ ] 🔧 Chore - dev tooling, CI, config
- [ ] 💥 Breaking change

## 📷 Screenshots / gifs / video [optional]

N/A.

## 🔗 Related Issues

Corrects comments added in #975.

## ✅ Tests added?

- [ ] 👍 yes
- [x] 🙅 no, not needed
- [ ] 🙋 no, I need help

Comments and one test name. The nine `LocatedRowMarker` tests still pass unchanged.

## 📚 Docs updated?

- [ ] 🔖 README.md
- [ ] 🔖 CHANGELOG.md
- [ ] 📖 help site
- [ ] 🧪 Marked any pre-release-only features
- [x] 🙅 not needed

Nothing user-visible changes.

## Anything else we need to know? [optional]

No code changes: 6 insertions and 6 deletions, all inside comments and one `it` title.