### PR TITLE
fix(log-viewer): span the timeline across the whole log

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - 🗄️ **Flow database usage**: SOQL and DML run by a Flow or Process Builder element went uncounted, because the log never reports it as a statement; the element's own usage is now counted and rolls up like any other. Needs `WORKFLOW` at `FINER` or above. ([#871])
 - 📏 **Timeline length**: the chart stopped at the last frame the log recorded, so it drew shorter than the log's own duration — 10.8s of a 27.1s log where the size cap cut the log off. The chart now spans the whole log, and the truncation marker shades the part the log never recorded. ([#828])
 - 🧭 **Hot spots**: the log itself topped the Inspector's hot spots, and the Analysis findings, whenever time went unrecorded — the gap between frames lands on the log, which is a container and not code. It is now left out of both.
+- 📊 **Governor limits strip**: where a log records nothing — it hit the maximum size, or lines were skipped — the strip drew its last reading across the gap as though it had been measured. The area fills, the over-100% band and the collapsed traffic light now leave the gap blank, the step line holds its last level, and the tooltip names the reason and the range, such as `Max-Size-reached · 10.8s → 27.1s`. Truncation shading also ends with its marker instead of running on to the next one. ([#828])
 
 ## [1.20.1] 2026-07-23
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - 📐 **Timeline height**: the Flame Chart stopped short of the bottom of its panel, leaving a strip of empty space; it now fills the panel and follows the Inspector as you resize or re-dock it.
 - 🗄️ **Flow database usage**: SOQL and DML run by a Flow or Process Builder element went uncounted, because the log never reports it as a statement; the element's own usage is now counted and rolls up like any other. Needs `WORKFLOW` at `FINER` or above. ([#871])
 - 📏 **Timeline length**: the chart stopped at the last frame the log recorded, so it drew shorter than the log's own duration — 10.8s of a 27.1s log where the size cap cut the log off. The chart now spans the whole log, and the truncation marker shades the part the log never recorded. ([#828])
+- 🧭 **Hot spots**: the log itself topped the Inspector's hot spots, and the Analysis findings, whenever time went unrecorded — the gap between frames lands on the log, which is a container and not code. It is now left out of both.
 
 ## [1.20.1] 2026-07-23
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - 🐛 **Go to Code**: Match methods with namespace/`System`-qualified parameter types. ([#834])
 - 📐 **Timeline height**: the Flame Chart stopped short of the bottom of its panel, leaving a strip of empty space; it now fills the panel and follows the Inspector as you resize or re-dock it.
 - 🗄️ **Flow database usage**: SOQL and DML run by a Flow or Process Builder element went uncounted, because the log never reports it as a statement; the element's own usage is now counted and rolls up like any other. Needs `WORKFLOW` at `FINER` or above. ([#871])
+- 📏 **Timeline length**: the chart stopped at the last frame the log recorded, so it drew shorter than the log's own duration — 10.8s of a 27.1s log where the size cap cut the log off. The chart now spans the whole log, and the truncation marker shades the part the log never recorded. ([#828])
 
 ## [1.20.1] 2026-07-23
 

--- a/log-viewer/src/features/analysis/services/LogDiagnostics.ts
+++ b/log-viewer/src/features/analysis/services/LogDiagnostics.ts
@@ -881,6 +881,10 @@ async function analyse(log: ApexLog): Promise<LogDiagnostics> {
   const selfTime = new Map<string, number>();
   let totalSelf = 0;
   for (const event of log.eventsById) {
+    // The log itself holds the gap time, and no call stands for it.
+    if (event === log) {
+      continue;
+    }
     switch (event.type) {
       case 'SOQL_EXECUTE_BEGIN':
         queries.push(event as SOQLExecuteBeginLine);

--- a/log-viewer/src/features/call-tree/utils/ExecutionHighlights.ts
+++ b/log-viewer/src/features/call-tree/utils/ExecutionHighlights.ts
@@ -88,7 +88,7 @@ export function computeExecutionHighlights(apexLog: ApexLog): ExecutionHighlight
   return {
     totalTime: apexLog.duration.total,
     ...computeHotPath(apexLog.children),
-    ...scanEvents(apexLog.eventsById),
+    ...scanEvents(apexLog),
   };
 }
 
@@ -199,19 +199,23 @@ function largestInstance(instances: LogEvent[]): LogEvent {
  * pass. Every instance counts, including the untimed ones, so the count divides
  * the self time honestly; signatures with no self time at all drop out at the
  * end. Total time counts the outermost instances only: recursion nests the same
- * wall time inside itself, and `events` is in time order, so an instance that
+ * wall time inside itself, and `eventsById` is in time order, so an instance that
  * starts before the last counted one of its signature ended is inside it. The
  * call-stack route `Aggregation.ts` and `RowGrouper.ts` take with a `Multiset`
  * is not open to a flat pass, which never sees a frame close.
  * Truncation flags every unclosed frame in a cut-off chain, so only top-most
  * flagged events count as regions; the first one seen is the first in the log.
  */
-function scanEvents(events: LogEvent[]): Pick<ExecutionHighlights, 'hotSpots' | 'truncation'> {
+function scanEvents(apexLog: ApexLog): Pick<ExecutionHighlights, 'hotSpots' | 'truncation'> {
   const spots = new Map<string, { row: HotSpotRow; maxSelf: number; countedUntil: number }>();
   let regionCount = 0;
   let firstEventIndex = -1;
 
-  for (const event of events) {
+  for (const event of apexLog.eventsById) {
+    // The log itself holds the gap time, and no call stands for it.
+    if (event === apexLog) {
+      continue;
+    }
     if (event.isTruncated && !event.parent?.isTruncated) {
       regionCount++;
       if (firstEventIndex < 0) {

--- a/log-viewer/src/features/call-tree/utils/__tests__/ExecutionHighlights.test.ts
+++ b/log-viewer/src/features/call-tree/utils/__tests__/ExecutionHighlights.test.ts
@@ -6,7 +6,8 @@ import { describe, expect, it } from '@jest/globals';
 import type { ApexLog, LogEvent } from 'apex-log-parser';
 import { computeExecutionHighlights, getExecutionHighlights } from '../ExecutionHighlights.js';
 
-let nextEventIndex = 0;
+// The parser takes 0 for the log itself, so real events start at 1.
+let nextEventIndex = 1;
 let nextStamp = 0;
 
 /**
@@ -47,12 +48,20 @@ function createEvent(
   return event;
 }
 
-function createLog(total: number): ApexLog {
-  return {
-    duration: { self: 0, total },
+/**
+ * The pseudo-root, holding the log's gap time as its own self time. It registers
+ * itself as `eventsById[0]` exactly as the parser does, so the pass has to skip it.
+ */
+function createLog(total: number, self = 0): ApexLog {
+  const log = {
+    text: 'LOG_ROOT',
+    eventIndex: 0,
+    duration: { self, total },
     children: [],
     eventsById: [],
   } as unknown as ApexLog;
+  log.eventsById.push(log as unknown as LogEvent);
+  return log;
 }
 
 /** Register tree events on the flat lookup, the way the parser does. */
@@ -429,6 +438,17 @@ describe('computeExecutionHighlights hot spots', () => {
     const { hotSpots } = computeExecutionHighlights(log);
 
     expect(hotSpots).toEqual([]);
+  });
+
+  it('never names the log itself, whatever gap time it holds', () => {
+    // A truncated log leaves most of its time unaccounted, so the pseudo-root
+    // outweighs every real call. It is a container, not code.
+    const log = createLog(1000, 900);
+    index(log, createEvent({ text: 'Work', self: 100, total: 100 }));
+
+    const { hotSpots } = computeExecutionHighlights(log);
+
+    expect(hotSpots.map((row) => row.text)).toEqual(['Work']);
   });
 });
 

--- a/log-viewer/src/features/timeline/__tests__/marker-utils.test.ts
+++ b/log-viewer/src/features/timeline/__tests__/marker-utils.test.ts
@@ -8,7 +8,8 @@
 
 import { describe, expect, it } from '@jest/globals';
 import type { ApexLog, LogEvent, LogIssue } from 'apex-log-parser';
-import { extractExceptionMarkers, extractMarkers } from '../utils/marker-utils.js';
+import type { TimelineMarker } from '../types/flamechart.types.js';
+import { extractExceptionMarkers, extractMarkers, noDataSpans } from '../utils/marker-utils.js';
 
 function logWith(overrides: Partial<ApexLog>): ApexLog {
   return { logIssues: [], exceptions: [], ...overrides } as unknown as ApexLog;
@@ -89,5 +90,46 @@ describe('extractExceptionMarkers', () => {
 
   it('returns an empty array when there are no exceptions', () => {
     expect(extractExceptionMarkers(logWith({ exceptions: [] }))).toEqual([]);
+  });
+});
+
+describe('noDataSpans', () => {
+  function marker(overrides: Partial<TimelineMarker>): TimelineMarker {
+    return {
+      id: 'm',
+      type: 'skip',
+      startTime: 0,
+      summary: 'Skipped-Lines',
+      ...overrides,
+    } as TimelineMarker;
+  }
+
+  it('reports a bounded skip as its own range, named by the marker', () => {
+    const spans = noDataSpans([
+      marker({ startTime: 100, endTime: 500, summary: 'Max-Size-reached' }),
+    ]);
+
+    expect(spans).toEqual([{ startTime: 100, endTime: 500, summary: 'Max-Size-reached' }]);
+  });
+
+  it('ignores a skip with no end, which is a moment and not a gap', () => {
+    expect(noDataSpans([marker({ startTime: 100 })])).toEqual([]);
+    expect(noDataSpans([marker({ startTime: 100, endTime: 100 })])).toEqual([]);
+  });
+
+  // An exception is a point in recorded time; the log kept running through it.
+  it('ignores markers that are not skips', () => {
+    const spans = noDataSpans([marker({ type: 'exception', startTime: 100, endTime: 500 })]);
+
+    expect(spans).toEqual([]);
+  });
+
+  it('sorts by start time, since the markers are not globally sorted', () => {
+    const spans = noDataSpans([
+      marker({ startTime: 800, endTime: 900 }),
+      marker({ startTime: 100, endTime: 500 }),
+    ]);
+
+    expect(spans.map((span) => span.startTime)).toEqual([100, 800]);
   });
 });

--- a/log-viewer/src/features/timeline/__tests__/tree-converter.test.ts
+++ b/log-viewer/src/features/timeline/__tests__/tree-converter.test.ts
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2026 Certinia Inc. All rights reserved.
+ */
+
+/**
+ * Unit tests for the time range the unified conversion reports, which sets the
+ * chart's own width.
+ */
+
+import { describe, expect, it } from '@jest/globals';
+import type { LogEvent } from 'apex-log-parser';
+import { logEventToTreeAndRects } from '../utils/tree-converter.js';
+
+/** A root frame spanning `start` to `end`; equal stamps give it no duration. */
+function event(start: number, end: number): LogEvent {
+  const duration = end - start;
+  return {
+    text: 'event',
+    type: 'METHOD_ENTRY',
+    category: 'Apex',
+    duration: { self: duration, total: duration },
+    timestamp: start,
+    exitStamp: end,
+    children: [],
+  } as unknown as LogEvent;
+}
+
+const categories = new Set(['Apex']);
+
+describe('logEventToTreeAndRects totalDuration', () => {
+  it('reaches the last frame when the log ends with it', () => {
+    const { totalDuration } = logEventToTreeAndRects([event(0, 500)], categories, 500);
+
+    expect(totalDuration).toBe(500);
+  });
+
+  it('reaches the log end when the frames stop short of it', () => {
+    // A truncated log: the last logged frame ends long before the log does, and
+    // the trailing FATAL_ERROR that closes it carries no duration of its own.
+    const frames = [event(0, 500), event(2000, 2000)];
+
+    const { totalDuration } = logEventToTreeAndRects(frames, categories, 2000);
+
+    expect(totalDuration).toBe(2000);
+  });
+
+  it('still reaches the last frame when it outlives the given log end', () => {
+    const { totalDuration } = logEventToTreeAndRects([event(0, 900)], categories, 100);
+
+    expect(totalDuration).toBe(900);
+  });
+});

--- a/log-viewer/src/features/timeline/optimised/ApexLogTimeline.ts
+++ b/log-viewer/src/features/timeline/optimised/ApexLogTimeline.ts
@@ -118,6 +118,9 @@ export class ApexLogTimeline {
     // - TimelineEventIndex.calculateMaxDepth
     // - TimelineEventIndex.calculateTotalDuration
     // - RectangleCache.flattenEvents
+    // `exitStamp`, not `executionEndTime`: a trailing zero-duration event, such as the
+    // FATAL_ERROR closing a truncated log, still ends the log.
+    const logEndTime = this.apexLog.exitStamp;
     const {
       treeNodes,
       maps,
@@ -127,7 +130,7 @@ export class ApexLogTimeline {
       maxDepth,
       totalDuration,
       preSorted,
-    } = logEventToTreeAndRects(this.events, categories);
+    } = logEventToTreeAndRects(this.events, categories, logEndTime);
 
     // Initialize FlameChart with Apex-specific callbacks and precomputed data
     await this.flamechart.init(

--- a/log-viewer/src/features/timeline/optimised/ApexLogTimeline.ts
+++ b/log-viewer/src/features/timeline/optimised/ApexLogTimeline.ts
@@ -42,7 +42,7 @@ import {
 import type { SearchCursor } from '../types/search.types.js';
 import { InspectorEmphasis } from '../../../components/inspectorEmphasis.js';
 import { isFrameOffscreen, toDetailSelection } from '../utils/detail-selection-sync.js';
-import { extractExceptionMarkers, extractMarkers } from '../utils/marker-utils.js';
+import { extractExceptionMarkers, extractMarkers, noDataSpans } from '../utils/marker-utils.js';
 import { seekWindow } from '../utils/navigate-window.js';
 import { logEventToTreeAndRects } from '../utils/tree-converter.js';
 import { FlameChart } from './FlameChart.js';
@@ -207,7 +207,7 @@ export class ApexLogTimeline {
     // memoised per log and shared with the inspector's governor trend charts.
     const heatStripSeries = apexLimitTimeSeries(this.apexLog);
     this.flamechart.setHeatStripTimeSeries(
-      heatStripSeries.events.length > 0 ? heatStripSeries : null,
+      heatStripSeries.events.length > 0 ? { ...heatStripSeries, gaps: noDataSpans(markers) } : null,
     );
 
     // Subscribe to EventBus for timeline navigation requests (from CalltreeView and raw-log entry).

--- a/log-viewer/src/features/timeline/optimised/TimelineEventIndex.ts
+++ b/log-viewer/src/features/timeline/optimised/TimelineEventIndex.ts
@@ -236,6 +236,9 @@ export class TimelineEventIndex {
 
   /**
    * Calculate total timeline duration.
+   *
+   * Fallback for callers with no precomputed range: it is not floored at the log's end,
+   * so a truncated log stops at its last frame.
    */
   private calculateTotalDuration(events: LogEvent[]): number {
     if (events.length === 0) {

--- a/log-viewer/src/features/timeline/optimised/__tests__/MarkerProcessor.test.ts
+++ b/log-viewer/src/features/timeline/optimised/__tests__/MarkerProcessor.test.ts
@@ -5,6 +5,7 @@ import { describe, expect, it } from '@jest/globals';
 
 import {
   layoutMarkerRects,
+  noDataSpanAt,
   markerDuration,
   type MarkerLayoutItem,
 } from '../markers/MarkerProcessor.js';
@@ -91,5 +92,29 @@ describe('layoutMarkerRects', () => {
       expect(rects).toHaveLength(2);
       expect(rects[1]!.x).toBe(51);
     });
+  });
+});
+
+describe('noDataSpanAt', () => {
+  const spans = [
+    { startTime: 100, endTime: 500, summary: 'Skipped-Lines' },
+    { startTime: 800, endTime: 900, summary: 'Max-Size-reached' },
+  ];
+
+  it('names the span covering the instant', () => {
+    expect(noDataSpanAt(spans, 300)?.summary).toBe('Skipped-Lines');
+    expect(noDataSpanAt(spans, 850)?.summary).toBe('Max-Size-reached');
+  });
+
+  // Half-open: the span ends the moment the log resumes, so its end is recorded time.
+  it('covers its start but not its end', () => {
+    expect(noDataSpanAt(spans, 100)?.summary).toBe('Skipped-Lines');
+    expect(noDataSpanAt(spans, 500)).toBeUndefined();
+  });
+
+  it('reports nothing between spans, or with no spans at all', () => {
+    expect(noDataSpanAt(spans, 600)).toBeUndefined();
+    expect(noDataSpanAt([], 300)).toBeUndefined();
+    expect(noDataSpanAt(undefined, 300)).toBeUndefined();
   });
 });

--- a/log-viewer/src/features/timeline/optimised/markers/MarkerProcessor.ts
+++ b/log-viewer/src/features/timeline/optimised/markers/MarkerProcessor.ts
@@ -10,7 +10,7 @@
  * used by both MeshMarkerRenderer and TimelineMarkerRenderer.
  */
 
-import type { TimelineMarker } from '../../types/flamechart.types.js';
+import type { NoDataSpan, TimelineMarker } from '../../types/flamechart.types.js';
 import { SEVERITY_RANK } from '../../types/flamechart.types.js';
 
 /**
@@ -53,6 +53,30 @@ export interface MarkerLayoutItem {
  */
 export function markerDuration(marker: Pick<TimelineMarker, 'startTime' | 'endTime'>): number {
   return (marker.endTime ?? marker.startTime) - marker.startTime;
+}
+
+/**
+ * The span covering `timeNs`, or `undefined` when the log recorded that instant.
+ *
+ * Half-open: a span ends the moment the log resumes. This is the one place the rule is
+ * stated, so the strip's fills, its traffic light and its tooltip all agree.
+ *
+ * @param spans - Spans sorted by start time, as `noDataSpans` returns them
+ * @param timeNs - The instant to test
+ */
+export function noDataSpanAt(
+  spans: readonly NoDataSpan[] | undefined,
+  timeNs: number,
+): NoDataSpan | undefined {
+  if (!spans) {
+    return undefined;
+  }
+  for (const span of spans) {
+    if (timeNs >= span.startTime && timeNs < span.endTime) {
+      return span;
+    }
+  }
+  return undefined;
 }
 
 /** A resolved rectangle to draw. */

--- a/log-viewer/src/features/timeline/optimised/metric-strip/MetricStripOrchestrator.ts
+++ b/log-viewer/src/features/timeline/optimised/metric-strip/MetricStripOrchestrator.ts
@@ -24,11 +24,13 @@
 import * as PIXI from 'pixi.js';
 
 import { destroyTimelineApp } from '../rendering/pixiApp.js';
+import { formatTimeRange } from '../../../../core/utility/Util.js';
 import type {
   HeatStripTimeSeries,
   TimelineMarker,
   ViewportState,
 } from '../../types/flamechart.types.js';
+import { noDataSpanAt } from '../markers/MarkerProcessor.js';
 import { MeshAxisRenderer } from '../time-axis/MeshAxisRenderer.js';
 import { wheelZoomFactor } from '../ViewportUtils.js';
 import { MetricStripRenderer } from './MetricStripRenderer.js';
@@ -458,7 +460,7 @@ export class MetricStripOrchestrator {
 
     // Render the step chart with markers
     this.renderer.render(
-      data ?? { points: [], classifiedMetrics: [], globalMaxPercent: 0, hasData: false },
+      data ?? { points: [], classifiedMetrics: [], globalMaxPercent: 0, hasData: false, gaps: [] },
       context.viewportState,
       context.totalDuration,
       context.markers,
@@ -569,6 +571,10 @@ export class MetricStripOrchestrator {
       // Update tooltip - position below the metric strip
       const dataPoint = this.classifier.getDataPointAtTime(clampedTimeNs);
       if (dataPoint) {
+        const gap = noDataSpanAt(this.classifier.getData()?.gaps, clampedTimeNs);
+        this.tooltipRenderer?.setNoDataLabel(
+          gap ? `${gap.summary} · ${formatTimeRange(gap.startTime, gap.endTime)}` : null,
+        );
         this.tooltipRenderer?.show(
           this.mouseX,
           this.mouseY,

--- a/log-viewer/src/features/timeline/optimised/metric-strip/MetricStripRenderer.test.ts
+++ b/log-viewer/src/features/timeline/optimised/metric-strip/MetricStripRenderer.test.ts
@@ -1,0 +1,87 @@
+/**
+ * @jest-environment jsdom
+ */
+
+/*
+ * Copyright (c) 2026 Certinia Inc. All rights reserved.
+ */
+
+import { describe, expect, it } from '@jest/globals';
+import type {
+  MetricStripClassifiedMetric,
+  MetricStripDataPoint,
+  MetricStripProcessedData,
+  NoDataSpan,
+  ViewportState,
+} from '../../types/flamechart.types.js';
+import { MetricStripRenderer } from './MetricStripRenderer.js';
+
+const TOTAL_DURATION = 4000;
+
+const cpuTime: MetricStripClassifiedMetric = {
+  metricId: 'cpuTime',
+  displayName: 'CPU Time',
+  tier: 1,
+  globalMaxPercent: 0.5,
+  limit: 100,
+  color: 0xff0000,
+  priority: 0,
+  unit: '',
+};
+
+/** A reading of `percent` at `timestamp`. */
+function point(timestamp: number, percent: number): MetricStripDataPoint {
+  return {
+    timestamp,
+    values: new Map([['cpuTime', percent]]),
+    rawValues: new Map(),
+    tier3Max: 0,
+  };
+}
+
+function data(points: MetricStripDataPoint[], gaps: NoDataSpan[]): MetricStripProcessedData {
+  return { points, classifiedMetrics: [cpuTime], globalMaxPercent: 0.5, hasData: true, gaps };
+}
+
+const viewportState: ViewportState = {
+  zoom: 0.1,
+  offsetX: 0,
+  offsetY: 0,
+  displayWidth: 400,
+  displayHeight: 60,
+} as ViewportState;
+
+/** How many separate shapes the area fill painted. */
+function areaFillCount(renderer: MetricStripRenderer): number {
+  // Index 2 of the render-order list is the area fill layer.
+  const graphics = renderer.getGraphics()[2]!;
+  return graphics.context.instructions.filter((i) => i.action === 'fill').length;
+}
+
+describe('MetricStripRenderer area fills', () => {
+  const readings = [point(0, 0.5), point(1000, 0.5), point(3000, 0.5)];
+
+  it('paints one shape when the log recorded throughout', () => {
+    const renderer = new MetricStripRenderer();
+    renderer.setHeight(60);
+
+    renderer.render(data(readings, []), viewportState, TOTAL_DURATION);
+
+    expect(areaFillCount(renderer)).toBe(1);
+  });
+
+  // One shape spanning the gap ramps straight across it, which reads as measured volume.
+  it('breaks the shape at a span the log recorded nothing in', () => {
+    const renderer = new MetricStripRenderer();
+    renderer.setHeight(60);
+
+    renderer.render(
+      data(readings, [{ startTime: 1500, endTime: 2500, summary: 'Skipped-Lines' }]),
+      viewportState,
+      TOTAL_DURATION,
+    );
+
+    // One shape up to the gap, one after it.
+    expect(areaFillCount(renderer)).toBe(2);
+  });
+});

--- a/log-viewer/src/features/timeline/optimised/metric-strip/MetricStripRenderer.ts
+++ b/log-viewer/src/features/timeline/optimised/metric-strip/MetricStripRenderer.ts
@@ -31,10 +31,24 @@ import { Graphics } from 'pixi.js';
 import type {
   MetricStripDataPoint,
   MetricStripProcessedData,
+  NoDataSpan,
   TimelineMarker,
   ViewportState,
 } from '../../types/flamechart.types.js';
-import { MARKER_ALPHA, MARKER_COLORS } from '../../types/flamechart.types.js';
+import {
+  MARKER_ALPHA,
+  MARKER_BUCKET_PX,
+  MARKER_COLORS,
+  MARKER_GAP_PX,
+  MARKER_MIN_WIDTH_PX,
+} from '../../types/flamechart.types.js';
+import {
+  layoutMarkerRects,
+  markerDuration,
+  noDataSpanAt,
+  sortMarkersByTimeAndSeverity,
+  type MarkerLayoutItem,
+} from '../markers/MarkerProcessor.js';
 import {
   BREACH_AREA_OPACITY,
   DANGER_ZONE_OPACITY,
@@ -117,6 +131,9 @@ export class MetricStripRenderer {
   /** Effective Y-max for dynamic scaling. */
   private effectiveYMax = METRIC_STRIP_Y_MAX_PERCENT;
 
+  /** Spans the log recorded nothing in; nothing measured is drawn inside one. */
+  private noDataSpans: NoDataSpan[] = [];
+
   /** Whether the metric strip is in collapsed mode. */
   private isCollapsed = false;
 
@@ -174,6 +191,33 @@ export class MetricStripRenderer {
     this.effectiveYMax = yMax;
   }
 
+  /** Whether the log recorded nothing at this instant. */
+  private isNoData(timeNs: number): boolean {
+    return noDataSpanAt(this.noDataSpans, timeNs) !== undefined;
+  }
+
+  /**
+   * Where a point's segment ends, or `null` when the point sits in a gap.
+   *
+   * A segment stops at the next point, at the range's end, or at the next gap — whichever
+   * comes first — so nothing measured is drawn across time the log did not record.
+   */
+  private recordedSegmentEnd(timeNs: number, nextTimeNs: number): number | null {
+    if (this.noDataSpans.length === 0) {
+      return nextTimeNs;
+    }
+    let end = nextTimeNs;
+    for (const span of this.noDataSpans) {
+      if (timeNs >= span.startTime && timeNs < span.endTime) {
+        return null;
+      }
+      if (span.startTime > timeNs && span.startTime < end) {
+        end = span.startTime;
+      }
+    }
+    return end;
+  }
+
   /**
    * Set the collapsed state.
    */
@@ -225,12 +269,15 @@ export class MetricStripRenderer {
     // Clear all graphics
     this.clear();
 
+    // The gaps ride on the processed data, so the strip has one source for them.
+    this.noDataSpans = data.gaps;
+
     const { displayWidth } = viewportState;
     const height = this.height;
 
     // Always render markers (background layer) - visible in both collapsed and expanded modes
     if (markers && markers.length > 0) {
-      this.renderMarkers(markers, viewportState, totalDuration);
+      this.renderMarkers(markers, viewportState);
     }
 
     // Note: Time grid lines are now rendered by MeshAxisRenderer in MetricStripOrchestrator
@@ -243,7 +290,9 @@ export class MetricStripRenderer {
       return;
     }
 
-    // Render expanded view layers (back to front)
+    // Render expanded view layers (back to front). The fills and the breach band leave the
+    // unrecorded spans blank: a fill reads as measured volume and the band is a verdict. The
+    // step line carries its last reading across, because a governor total cannot fall.
     this.renderDangerZone(displayWidth, height);
     this.renderAreaFills(data, viewportState, totalDuration, height);
     this.renderStepChartLines(data, viewportState, totalDuration, height);
@@ -342,7 +391,8 @@ export class MetricStripRenderer {
       let color = 0;
       let alpha = 0;
 
-      if (cachedResult) {
+      // A traffic light is a verdict, so the strip draws none over unrecorded time.
+      if (cachedResult && !this.isNoData(bucketStartTime)) {
         const maxPercent = this.getMaxPercentAtPoint(cachedResult.point);
         const colorInfo = getTrafficLightColor(maxPercent);
         color = colorInfo.color;
@@ -395,42 +445,40 @@ export class MetricStripRenderer {
 
   /**
    * Render marker backgrounds as vertical colored bands.
-   * Follows the same pattern as minimap marker rendering.
+   *
+   * Shares the chart's and minimap's layout, so a point marker such as an exception keeps a
+   * visible hairline and a dense cluster collapses to one line.
    */
-  private renderMarkers(
-    markers: TimelineMarker[],
-    viewportState: ViewportState,
-    totalDuration: number,
-  ): void {
+  private renderMarkers(markers: TimelineMarker[], viewportState: ViewportState): void {
     const { zoom, offsetX, displayWidth } = viewportState;
     const g = this.markerGraphics;
 
-    const gap = 1;
-    const halfGap = gap / 2;
-
-    for (let i = 0; i < markers.length; i++) {
-      const marker = markers[i]!;
-      const startX = marker.startTime * zoom - offsetX;
-      const endTime = markers[i + 1]?.startTime ?? totalDuration;
-      const endX = endTime * zoom - offsetX;
-
-      // Viewport culling
-      if (endX < 0 || startX > displayWidth) {
-        continue;
-      }
-
+    // Sorted by start time, which is start-X order too, as the layout requires.
+    const items: MarkerLayoutItem[] = [];
+    for (const marker of sortMarkersByTimeAndSeverity(markers)) {
       const color = MARKER_COLORS[marker.type];
       if (color === undefined) {
         continue;
       }
 
-      const gappedStartX = Math.max(0, startX + halfGap);
-      const gappedEndX = Math.min(displayWidth, endX - halfGap);
-      const gappedWidth = gappedEndX - gappedStartX;
+      const startX = marker.startTime * zoom - offsetX;
+      // A bounded marker shades its own range; an unbounded one is a point, as the chart
+      // and minimap draw it. Running on to the next marker shaded sections that recovered.
+      const exactWidth = markerDuration(marker) * zoom;
+      if (startX + exactWidth < 0 || startX > displayWidth) {
+        continue;
+      }
 
-      if (gappedWidth > 0) {
-        g.rect(gappedStartX, 0, gappedWidth, this.height);
-        g.fill({ color, alpha: MARKER_ALPHA });
+      items.push({ screenStartX: startX, exactWidth, color, alpha: MARKER_ALPHA });
+    }
+
+    const rects = layoutMarkerRects(items, MARKER_MIN_WIDTH_PX, MARKER_GAP_PX, MARKER_BUCKET_PX);
+    for (const rect of rects) {
+      const x = Math.max(0, rect.x);
+      const width = Math.min(displayWidth, rect.x + rect.width) - x;
+      if (width > 0) {
+        g.rect(x, 0, width, this.height);
+        g.fill({ color: rect.color, alpha: rect.alpha });
       }
     }
   }
@@ -520,8 +568,16 @@ export class MetricStripRenderer {
 
     for (let i = 0; i < points.length; i++) {
       const point = points[i]!;
-      const segmentEnd = points[i + 1]?.timestamp ?? totalDuration;
+      const nextTime = points[i + 1]?.timestamp ?? totalDuration;
+      const segmentEnd = this.recordedSegmentEnd(point.timestamp, nextTime);
 
+      // A gap ends the run: one shape spanning it would ramp straight across the
+      // unrecorded time, which reads as measured volume.
+      if (segmentEnd === null) {
+        this.fillArea(g, pathPoints, baseY, color, alpha);
+        pathPoints.length = 0;
+        continue;
+      }
       if (segmentEnd < visibleStartTime) {
         continue;
       }
@@ -540,18 +596,34 @@ export class MetricStripRenderer {
 
       pathPoints.push({ x: Math.max(0, x1), y });
       pathPoints.push({ x: Math.min(displayWidth, x2), y });
+
+      // A gap cut the segment short, so the run ends here even though no reading fell in it.
+      if (segmentEnd < nextTime) {
+        this.fillArea(g, pathPoints, baseY, color, alpha);
+        pathPoints.length = 0;
+      }
     }
 
+    this.fillArea(g, pathPoints, baseY, color, alpha);
+  }
+
+  /** Close one run of the area fill back to the baseline and paint it. */
+  private fillArea(
+    g: Graphics,
+    pathPoints: Array<{ x: number; y: number }>,
+    baseY: number,
+    color: number,
+    alpha: number,
+  ): void {
     if (pathPoints.length < 2) {
       return;
     }
-
-    pathPoints.push({ x: pathPoints[pathPoints.length - 1]!.x, y: baseY });
 
     g.moveTo(pathPoints[0]!.x, pathPoints[0]!.y);
     for (let i = 1; i < pathPoints.length; i++) {
       g.lineTo(pathPoints[i]!.x, pathPoints[i]!.y);
     }
+    g.lineTo(pathPoints[pathPoints.length - 1]!.x, baseY);
     g.closePath();
     g.fill({ color, alpha });
   }
@@ -695,8 +767,14 @@ export class MetricStripRenderer {
 
     for (let i = 0; i < data.points.length; i++) {
       const point = data.points[i]!;
-      const segmentEnd = data.points[i + 1]?.timestamp ?? totalDuration;
+      const segmentEnd = this.recordedSegmentEnd(
+        point.timestamp,
+        data.points[i + 1]?.timestamp ?? totalDuration,
+      );
 
+      if (segmentEnd === null) {
+        continue;
+      }
       if (segmentEnd < visibleStartTime) {
         continue;
       }

--- a/log-viewer/src/features/timeline/optimised/metric-strip/MetricStripTooltipRenderer.test.ts
+++ b/log-viewer/src/features/timeline/optimised/metric-strip/MetricStripTooltipRenderer.test.ts
@@ -228,4 +228,55 @@ describe('MetricStripTooltipRenderer', () => {
     expect(cpuEarly).toBeLessThan(soqlEarly);
     expect(cpuLate).toBeLessThan(soqlLate);
   });
+
+  describe('no data note', () => {
+    it('says nothing while the reading is the one at the cursor', () => {
+      renderer.setNoDataLabel(null);
+      renderer.show(100, 0, onePoint, oneMetric, 60);
+
+      expect(panel().textContent).not.toContain('Max-Size-reached');
+    });
+
+    it('sits under the rows', () => {
+      renderer.setNoDataLabel('Max-Size-reached · 10.8s → 27.1s');
+      renderer.show(100, 0, onePoint, oneMetric, 60);
+
+      const children = [...panel().children] as HTMLElement[];
+      expect(children[children.length - 1]!.textContent).toBe('Max-Size-reached · 10.8s → 27.1s');
+    });
+
+    // One reading covers the whole unrecorded region, so the note has to appear and clear
+    // without the data point changing, which is what skips the panel rebuild.
+    it('appears and clears on the same reading', () => {
+      renderer.show(100, 0, onePoint, oneMetric, 60);
+      expect(panel().textContent).not.toContain('Max-Size-reached');
+
+      renderer.setNoDataLabel('Max-Size-reached · 10.8s → 27.1s');
+      renderer.show(140, 0, onePoint, oneMetric, 60);
+      expect(panel().textContent).toContain('Max-Size-reached · 10.8s → 27.1s');
+
+      renderer.setNoDataLabel(null);
+      renderer.show(180, 0, onePoint, oneMetric, 60);
+      expect(panel().textContent).not.toContain('Max-Size-reached');
+    });
+
+    // The note is written once and never re-appended, so a later reading that grows the
+    // row pool has to insert its rows above it rather than under it.
+    it('stays last when a later reading adds a row', () => {
+      renderer.setNoDataLabel('Max-Size-reached · 10.8s → 27.1s');
+      renderer.show(100, 0, onePoint, oneMetric, 60);
+
+      const two = [metric('cpuTime', 'CPU Time', 0.9), metric('heapSize', 'Heap Size', 0.5)];
+      const twoPoint: MetricStripDataPoint = {
+        ...onePoint,
+        values: new Map([
+          ['cpuTime', 0.5],
+          ['heapSize', 0.5],
+        ]),
+      };
+      renderer.show(100, 0, twoPoint, two, 60);
+
+      expect(panel().lastElementChild?.textContent).toBe('Max-Size-reached · 10.8s → 27.1s');
+    });
+  });
 });

--- a/log-viewer/src/features/timeline/optimised/metric-strip/MetricStripTooltipRenderer.ts
+++ b/log-viewer/src/features/timeline/optimised/metric-strip/MetricStripTooltipRenderer.ts
@@ -111,6 +111,15 @@ export class MetricStripTooltipRenderer extends BaseTooltipRenderer {
   /** Set once the panel's title exists. */
   private titleNode: HTMLElement | null = null;
 
+  /** Set once the no-data note exists; hidden while the cursor is over recorded time. */
+  private noDataNode: HTMLElement | null = null;
+
+  /** The note asked for. */
+  private noDataLabel: string | null = null;
+
+  /** The note on the panel, so an unchanged one is never touched again. */
+  private noDataShown: string | null = null;
+
   constructor(htmlContainer: HTMLElement, options: MetricStripTooltipOptions = {}) {
     super(htmlContainer, { mode: 'below-anchor', offset: 8, padding: 4 });
 
@@ -123,6 +132,17 @@ export class MetricStripTooltipRenderer extends BaseTooltipRenderer {
    */
   public setTheme(_isDark: boolean): void {
     // No-op: metric strip uses universal colors
+  }
+
+  /**
+   * Note that the log recorded nothing here, so the rows are the last reading it has.
+   *
+   * Applied by the next `show`, which is what appends the panel's title.
+   *
+   * @param label - Short note to show, or null while the reading is the one at the cursor
+   */
+  public setNoDataLabel(label: string | null): void {
+    this.noDataLabel = label;
   }
 
   /**
@@ -162,6 +182,10 @@ export class MetricStripTooltipRenderer extends BaseTooltipRenderer {
       this.renderRows(rows);
       this.shownPoint = dataPoint;
     }
+
+    // After the rebuild, which appends the title: the note is the panel's last line. One
+    // reading covers a whole unrecorded span, so the note changes while the rows do not.
+    this.renderNoDataNote();
 
     this.showElement();
 
@@ -310,7 +334,8 @@ export class MetricStripTooltipRenderer extends BaseTooltipRenderer {
       const row = pooled ?? this.createRow();
       if (!pooled) {
         this.rowPool.push(row);
-        this.tooltipElement.appendChild(row.root);
+        // Before the note, which is the panel's last line; `null` appends.
+        this.tooltipElement.insertBefore(row.root, this.noDataNode);
       }
 
       row.swatch.setAttribute('color', data.color);
@@ -326,6 +351,34 @@ export class MetricStripTooltipRenderer extends BaseTooltipRenderer {
     for (const spare of this.rowPool.slice(rows.length)) {
       spare.root.style.display = 'none';
     }
+  }
+
+  /** Writes the no-data note. Reads nothing back from the DOM: this runs per pointer move. */
+  private renderNoDataNote(): void {
+    const label = this.noDataLabel;
+    if (label === this.noDataShown) {
+      return;
+    }
+    this.noDataShown = label;
+
+    if (!label) {
+      if (this.noDataNode) {
+        this.noDataNode.style.display = 'none';
+        // Cleared too: a hidden node still reads out of the panel's text.
+        this.noDataNode.textContent = '';
+      }
+      return;
+    }
+
+    let node = this.noDataNode;
+    if (!node) {
+      node = document.createElement('div');
+      node.style.cssText = `margin-top:6px;font-style:italic;color:${TOOLTIP_CSS.descriptionForegroundMuted};`;
+      this.tooltipElement.appendChild(node);
+      this.noDataNode = node;
+    }
+    node.textContent = label;
+    node.style.display = 'block';
   }
 
   /** One row's elements, in the order the grid lays them out. */

--- a/log-viewer/src/features/timeline/optimised/metric-strip/MetricTierClassifier.ts
+++ b/log-viewer/src/features/timeline/optimised/metric-strip/MetricTierClassifier.ts
@@ -76,6 +76,7 @@ export class MetricTierClassifier {
         classifiedMetrics: [],
         globalMaxPercent: 0,
         hasData: false,
+        gaps: timeSeries.gaps ?? [],
       };
       return this.processedData;
     }
@@ -101,6 +102,7 @@ export class MetricTierClassifier {
       classifiedMetrics,
       globalMaxPercent,
       hasData: points.length > 0,
+      gaps: timeSeries.gaps ?? [],
     };
 
     return this.processedData;

--- a/log-viewer/src/features/timeline/types/flamechart.types.ts
+++ b/log-viewer/src/features/timeline/types/flamechart.types.ts
@@ -873,6 +873,16 @@ export interface HeatStripTimeSeries {
   metrics: Map<string, HeatStripMetric>;
   /** Time series events ordered by timestamp */
   events: HeatStripEvent[];
+  /** Spans the log recorded nothing in, so no reading is carried across them */
+  gaps?: NoDataSpan[];
+}
+
+/** A span the log recorded nothing in, named by the marker that reports it. */
+export interface NoDataSpan {
+  startTime: number;
+  endTime: number;
+  /** The marker's own summary, so a reader is told the reason, not just the gap. */
+  summary: string;
 }
 
 /**
@@ -959,6 +969,8 @@ export interface MetricStripProcessedData {
   globalMaxPercent: number;
   /** Whether there's any data to render */
   hasData: boolean;
+  /** Spans the log recorded nothing in, carried through from the series */
+  gaps: NoDataSpan[];
 }
 
 /**

--- a/log-viewer/src/features/timeline/utils/marker-utils.ts
+++ b/log-viewer/src/features/timeline/utils/marker-utils.ts
@@ -9,7 +9,7 @@
  */
 
 import type { ApexLog } from 'apex-log-parser';
-import type { TimelineMarker } from '../types/flamechart.types.js';
+import type { NoDataSpan, TimelineMarker } from '../types/flamechart.types.js';
 import { isMarkerType, markerTypeForIssue } from '../types/flamechart.types.js';
 
 /**
@@ -105,6 +105,34 @@ export function extractExceptionMarkers(log: ApexLog): TimelineMarker[] {
   }
 
   return markers;
+}
+
+/**
+ * The spans the log recorded nothing in, earliest first.
+ *
+ * A `skip` marker with an end time is the log saying it stopped between two instants —
+ * the size cap, or lines dropped mid-log. Anything measured, such as the governor strip,
+ * has no reading in that span and must not carry its last one across it. Markers without
+ * an end time are moments, not spans, so they report no gap.
+ *
+ * @param markers - Markers extracted from the log
+ * @returns Spans sorted by start time
+ */
+export function noDataSpans(markers: TimelineMarker[]): NoDataSpan[] {
+  const spans: NoDataSpan[] = [];
+  for (const marker of markers) {
+    if (marker.type !== 'skip' || marker.endTime === undefined) {
+      continue;
+    }
+    if (marker.endTime > marker.startTime) {
+      spans.push({
+        startTime: marker.startTime,
+        endTime: marker.endTime,
+        summary: marker.summary,
+      });
+    }
+  }
+  return spans.sort((a, b) => a.startTime - b.startTime);
 }
 
 /**

--- a/log-viewer/src/features/timeline/utils/tree-converter.ts
+++ b/log-viewer/src/features/timeline/utils/tree-converter.ts
@@ -190,7 +190,7 @@ export interface UnifiedConversionResult {
   rectMap: Map<LogEvent, PrecomputedRect>;
   /** Maximum depth in tree (tracked during traversal) */
   maxDepth: number;
-  /** Total duration in nanoseconds (tracked during traversal) */
+  /** The range's end timestamp, not a duration: the later of the last frame and the log's end */
   totalDuration: number;
   /** Whether rectsByCategory arrays are pre-sorted by timeStart (skip sorting in RectangleCache) */
   preSorted: boolean;
@@ -227,11 +227,13 @@ interface ConversionWorkItem {
  *
  * @param events - Array of LogEvent objects
  * @param categories - Set of valid categories for rectangle indexing
+ * @param logEndTime - The log's own end timestamp, which floors `totalDuration`.
  * @returns UnifiedConversionResult with all data structures
  */
 export function logEventToTreeAndRects(
   events: LogEvent[],
   categories: Set<string>,
+  logEndTime: number,
 ): UnifiedConversionResult {
   const maps: NavigationMaps = {
     originalMap: new Map(),
@@ -256,7 +258,7 @@ export function logEventToTreeAndRects(
 
   // Metrics tracked during traversal
   let maxDepth = 0;
-  let totalDuration = 0;
+  let totalDuration = logEndTime;
 
   // Root result array
   const rootResult: TreeNode<EventNode & { original: LogEvent }>[] = [];


### PR DESCRIPTION
On a log the size cap cut off, the header said 27.1s and the chart drew 10.8s. Three fixes follow from that one gap.

### Timeline length

The chart's width came from the last frame the log recorded, not the log's own end. It now spans the whole log, so the truncation marker shades the part the log never recorded.

### Hot spots

The log is a container, not code, but it holds unrecorded time as self time — 16.3s on this log — which put it top of the Inspector's hot spots and of the Analysis findings. It is now left out of both, as it already was everywhere else.

### Governor limits strip

Where a log records nothing — the size cap, or skipped lines — the strip carried its last reading across the gap as though it had been measured.

The gaps come from the log's own skip markers and ride on the metric series, so the strip has one source for them. The area fills, the over-100% band and the collapsed traffic light leave a gap blank, the step line holds its last level, and the tooltip names the reason and the range, such as `Max-Size-reached · 10.8s → 27.1s`.

The strip's marker bands now take the layout the chart and the minimap share, so a point marker keeps a visible hairline and shading ends with its own marker instead of running on to the next one.

### Testing

`pnpm lint` and `pnpm test` pass. New tests cover the range the conversion reports, the log's exclusion from hot spots, gap derivation from markers, the containment rule, and the area fill breaking at a gap rather than ramping across it.

Closes #828