### PR TITLE
fix(log-viewer): mark a row the renderer hands back without rebuilding it

### DIFF
--- a/log-viewer/src/components/__tests__/locatedRow.test.ts
+++ b/log-viewer/src/components/__tests__/locatedRow.test.ts
@@ -51,20 +51,40 @@ function ev(text: string, parent: LogEvent | null, eventIndex?: number): LogEven
   return { type: 'METHOD_ENTRY', namespace: '', text, parent, eventIndex } as unknown as LogEvent;
 }
 
-/** A table host holding a rendered row element per index, as the stamp leaves them. */
+/** A table host holding a rendered row element per index, as the stamp leaves
+ *  them, inside the holder and spacer element Tabulator mounts. */
 function host(...indexes: number[]): HTMLElement {
   const element = document.createElement('div');
+  const holder = document.createElement('div');
+  holder.classList.add('tabulator-tableholder');
+  const spacers = document.createElement('div');
+  spacers.classList.add('tabulator-table');
+  // The renderer always writes both spacers, so start where a rendered table is.
+  spacers.style.paddingTop = '0px';
+  spacers.style.paddingBottom = '0px';
+  holder.append(spacers);
+  element.append(holder);
   for (const index of indexes) {
     const row = document.createElement('div');
     row.classList.add('tabulator-row');
     stamp(rowComponent(row, { eventIndex: index }));
-    element.append(row);
+    spacers.append(row);
   }
   return element;
 }
 
+/**
+ * Re-attaches a row the renderer had detached, which is what a scroll or a sort
+ * does with a row it has already built. Awaits the observer, which reports after
+ * the arrival.
+ */
+async function reattach(container: HTMLElement, row: HTMLElement): Promise<void> {
+  container.querySelector('.tabulator-table')!.append(row);
+  await new Promise((resolve) => setTimeout(resolve, 0));
+}
+
 function rowFor(container: HTMLElement, index: number): HTMLElement {
-  return container.children[index] as HTMLElement;
+  return container.querySelectorAll<HTMLElement>('.tabulator-row')[index]!;
 }
 
 /** A row entering an already-mounted table, which is what the renderer does the
@@ -72,7 +92,7 @@ function rowFor(container: HTMLElement, index: number): HTMLElement {
 function renderRow(container: HTMLElement, index: number): HTMLElement {
   const row = document.createElement('div');
   row.classList.add('tabulator-row');
-  container.append(row);
+  container.querySelector('.tabulator-table')!.append(row);
   stamp(rowComponent(row, { eventIndex: index }));
   return row;
 }
@@ -196,13 +216,51 @@ describe('LocatedRowMarker', () => {
 
     row.remove();
     marker.mark(container, [5]);
-    container.append(row);
+    container.querySelector('.tabulator-table')!.append(row);
 
     expect(row.classList.contains(LOCATED_ROW_CLASS)).toBe(false);
   });
 
+  it('marks a row the renderer had detached before the mark named it', async () => {
+    // Rendered once, so it will not be stamped again, then scrolled out of view:
+    // the renderer keeps the element and detaches it.
+    const container = host();
+    const row = renderRow(container, 4);
+    row.remove();
+
+    // Only now does the mark name it, so neither half can reach it.
+    const marker = new LocatedRowMarker();
+    marker.mark(container, [4]);
+    expect(row.classList.contains(LOCATED_ROW_CLASS)).toBe(false);
+
+    // Coming back is what re-reads the mark, whatever moved the window: this
+    // holds for a sort at the top of a table, which writes no spacer at all.
+    await reattach(container, row);
+
+    expect(row.classList.contains(LOCATED_ROW_CLASS)).toBe(true);
+  });
+
+  it('keeps watching a table rebuilt into the same container', async () => {
+    // Several views destroy the table and build another in the same element, so
+    // a watch held against the old one would go quiet for good.
+    const container = host();
+    const marker = new LocatedRowMarker();
+    marker.mark(container, [4]);
+    container.querySelector('.tabulator-tableholder')!.remove();
+    const rebuilt = host(4);
+    container.append(rebuilt.querySelector('.tabulator-tableholder')!);
+
+    marker.mark(container, [4]);
+    const row = renderRow(container, 9);
+    row.remove();
+    marker.mark(container, [9]);
+    await reattach(container, row);
+
+    expect(row.classList.contains(LOCATED_ROW_CLASS)).toBe(true);
+  });
+
   it('leaves a row alone where nothing has marked its table', () => {
-    const row = renderRow(document.createElement('div'), 4);
+    const row = renderRow(host(), 4);
 
     expect(row.classList.contains(LOCATED_ROW_CLASS)).toBe(false);
   });

--- a/log-viewer/src/components/locatedRow.ts
+++ b/log-viewer/src/components/locatedRow.ts
@@ -56,6 +56,53 @@ function unlight(host: HTMLElement): void {
   lit.clear();
 }
 
+/**
+ * The row-holding element each marked table is watched through.
+ *
+ * Held per host so a table rebuilt into the same container is watched again: the
+ * element belongs to the Tabulator instance, not to the container, and several
+ * views destroy and rebuild a table in place.
+ */
+const watchedByHost = new WeakMap<HTMLElement, { rows: Element; observer: MutationObserver }>();
+
+/**
+ * Sweeps `host` again whenever rows enter its table, so a row coming back into
+ * view carries the mark as it stands.
+ *
+ * The renderer re-attaches a row it has already built without running the
+ * formatter again, so a row detached before the mark named it is out of reach of
+ * both halves: the sweep could not see it and the stamp will not run for it. That
+ * happens on a scroll and equally on a structural render, which fires no scroll
+ * event at all.
+ *
+ * Watched is the arrival itself, which is a child of the row-holding element and
+ * so cannot be missed. A signal read from the renderer's own bookkeeping can be:
+ * a scroll fires no event on a sort, and the virtual spacers are written with the
+ * value they already hold whenever the window does not move, which reports
+ * nothing at all.
+ */
+function watchRenders(host: HTMLElement): void {
+  const watching = watchedByHost.get(host);
+  const rows = host.querySelector('.tabulator-table');
+  if (watching?.rows === rows) {
+    return;
+  }
+  watching?.observer.disconnect();
+  if (!rows) {
+    watchedByHost.delete(host);
+    return;
+  }
+  const observer = new MutationObserver(() => {
+    const wanted = wantedByHost.get(host);
+    if (wanted?.size) {
+      // Only ever touches a class, so it cannot report itself back here.
+      sweep(host, wanted);
+    }
+  });
+  observer.observe(rows, { childList: true });
+  watchedByHost.set(host, { rows, observer });
+}
+
 /** Lights the rows a table has rendered that `wanted` names. */
 function sweep(host: HTMLElement, wanted: ReadonlySet<string>): void {
   for (const element of host.querySelectorAll<HTMLElement>(
@@ -436,6 +483,9 @@ export class LocatedRowMarker {
     const wanted = ids.length ? new Set(ids.map(String)) : NOTHING_WANTED;
     wantedByHost.set(host, wanted);
     sweep(host, wanted);
+    if (wanted.size) {
+      watchRenders(host);
+    }
   }
 
   /** Drop the mark, if one is set. */


### PR DESCRIPTION
# 📝 PR Overview

The inspector's row mark reached a row two ways: a sweep of the rows attached when the mark moved, and the row formatter as a row is built. Neither reaches a row that was built earlier, detached when it scrolled out of view, and only then named by a mark. The renderer re-attaches such a row without re-running the formatter, so it comes back with no mark. Scroll to it, or sort with it just off screen, and the highlight is simply missing.

The fix watches the arrival: a `MutationObserver` for `childList` on the element the renderer attaches rows to. A row entering the table is a child mutation, so a scroll and a structural render are one case, and a table destroyed and rebuilt into the same container is watched again rather than going quiet.

## 🛠️ Changes made

- **`watchRenders(host)`** — one observer per marked table, established on the first non-empty mark. The callback re-sweeps only while a mark is set, and touches nothing but a class, so it cannot report itself back.
- **Keyed on the row-holding element, not the container.** Several views destroy the table and build another in the same element; `CallStackDetail` does it on every event change. Keying on the container would leave the watch pointing at a destroyed table, and the old observer is disconnected when a new one takes over.

## 🧩 Type of change (check all applicable)

- [x] 🐛 Bug fix - something not working as expected
- [ ] ✨ New feature – adds new functionality
- [ ] ♻️ Refactor - internal changes with no user impact
- [ ] ⚡ Performance Improvement
- [ ] 📝 Documentation - README or documentation site changes
- [ ] 🔧 Chore - dev tooling, CI, config
- [ ] 💥 Breaking change

## 📷 Screenshots / gifs / video [optional]

N/A. What changes is whether a row carries its highlight when the grid hands it back.

## 🔗 Related Issues

Completes the row mark from #975 and #980.

## ✅ Tests added?

- [x] 👍 yes
- [ ] 🙅 no, not needed
- [ ] 🙋 no, I need help

Two cases: a row named while detached, and a table rebuilt into the same container. Each guard was proven by reverting the code it covers — no watch fails both; watching the spacer's `style` rather than the arrival fails both; keying so a rebuild is skipped fails the second.

## 📚 Docs updated?

- [ ] 🔖 README.md
- [x] 🔖 CHANGELOG.md
- [ ] 📖 help site
- [ ] 🧪 Marked any pre-release-only features
- [ ] 🙅 not needed

No entry: this corrects the unreleased Inspector, so it belongs to its existing entry. Ticked to record that it was considered.

## Anything else we need to know? [optional]

**Why not the signals that look more natural.** Two were tried and rejected with evidence:

- **A scroll listener.** A structural render — sort, filter, column show/hide, a tree re-expand of children already built — re-attaches an initialised row with no formatter run and fires no scroll event at all. The renderer also documents \`scrollend\` as unreliable: "The RAF stability check deliberately replaces \`scrollend\`, which never fires while the scrollbar thumb is held still" (\`VirtualVerticalRenderer.ts:430\`).
- **The virtual spacer paddings.** Reading their values is unsound, because \`ScrollAnchor\` writes them too, so a value can return to one already swept while the window has moved. Observing the write instead is no better: a CSSOM write of an unchanged value queues no mutation record at all, so a sort at the top of a table reports nothing.

**Cost.** The observer fires when rows enter or leave, which is exactly when work is due, and only while a mark is set. A sweep reads what the table has attached — the viewport plus at most \`OVERSCAN_MAX\` rows each side — never the row count, and the renderer's idle prewarm builds cells with \`inFragment: true\` so it does not widen that. The callback runs in a microtask after the render, and touches only \`classList\`, so it forces no layout.

**Test plan.**

- \`pnpm lint\` and \`pnpm test\`.
- Call Tree, Bottom Up, Inspector open. Click a caller row so grid rows mark, then **sort a column while at the top of the table**: the marks survive. That is the case a value-based signal missed.
- Filter and clear it; collapse and re-expand a marked row's parent.
- Scroll past rows never rendered and back. Then click a row, scroll a lit row out of view, press \`Escape\`, scroll back: no stale highlight.
- Large log with a mark set: scroll hard and watch for jank.
- Both themes, Inspector docked at the side and at the bottom.

**Known unrelated failure locally.** \`lana/src/services/__tests__/servicesRuntime.test.ts\` cannot resolve \`effect\` in a worktree not installed since #951. It passes in CI.

**Follow-up, not in this PR.** The renderer already knows which rows it attached: \`allAttached\` is built in \`_attachRanges\`. Dispatching that would make relighting O(rows attached) rather than O(rows rendered), and passing the \`Tabulator\` to \`mark()\` instead of its element — every one of the eight owners already holds it — would add disposal on \`tableDestroyed\` and let \`Find\` drop its own scroll listener onto the same event.