### PR TITLE
fix(log-viewer): make a timeline resize smooth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - 📏 **Timeline length**: the chart stopped at the last frame the log recorded, so it drew shorter than the log's own duration — 10.8s of a 27.1s log where the size cap cut the log off. The chart now spans the whole log, and the truncation marker shades the part the log never recorded. ([#828])
 - 🧭 **Hot spots**: the log itself topped the Inspector's hot spots, and the Analysis findings, whenever time went unrecorded — the gap between frames lands on the log, which is a container and not code. It is now left out of both.
 - 📊 **Governor limits strip**: where a log records nothing — it hit the maximum size, or lines were skipped — the strip drew its last reading across the gap as though it had been measured. The area fills, the over-100% band and the collapsed traffic light now leave the gap blank, the step line holds its last level, and the tooltip names the reason and the range, such as `Max-Size-reached · 10.8s → 27.1s`. Truncation shading also ends with its marker instead of running on to the next one. ([#828])
+- ⚡ **Timeline resize**: the Flame Chart flashed and trailed a frame behind as you dragged the window or the panel edge — it cleared its canvases in one frame and drew in the next, sized to a box the drag had already left. It now clears, sizes and draws in the frame the layout changed, and no longer recomputes the minimap for a change that cannot alter it.
 
 ## [1.20.1] 2026-07-23
 

--- a/log-viewer/src/features/timeline/optimised/FlameChart.ts
+++ b/log-viewer/src/features/timeline/optimised/FlameChart.ts
@@ -187,6 +187,9 @@ export class FlameChart<E extends EventNode = EventNode> {
   // Used to convert canvas-relative coordinates to container-relative for tooltip positioning
   private mainTimelineYOffset = 0;
 
+  /** The minimap height the last applied resize used, so a resize can tell nothing moved. */
+  private appliedMinimapHeight: number | null = null;
+
   // Cached culled rectangles (reused when viewport unchanged - Phase 3 optimization)
   // INVARIANT: These caches are invalidated when renderDirty.culling is set to true.
   // Any code that changes viewport state must call invalidateAll() or set culling dirty flag.
@@ -425,11 +428,7 @@ export class FlameChart<E extends EventNode = EventNode> {
    * Clean up resources and remove event listeners.
    */
   public destroy(): void {
-    // Stop render loop
-    if (this.renderLoopId !== null) {
-      cancelAnimationFrame(this.renderLoopId);
-      this.renderLoopId = null;
-    }
+    this.cancelScheduledRender();
 
     // Clean up interaction handler
     if (this.interactionHandler) {
@@ -723,19 +722,58 @@ export class FlameChart<E extends EventNode = EventNode> {
   private scheduleRender(): void {
     if (this.renderLoopId === null) {
       this.renderLoopId = requestAnimationFrame(() => {
-        if (this.state && this.state.needsRender) {
-          this.render();
-          this.state.needsRender = false;
-
-          // Setup ResizeObserver after first render to avoid double render on init.
-          // By this point, layout is finalized and ResizeObserver baseline matches rendered state.
-          if (this.resizeHandler && !this.resizeObserverActive) {
-            this.resizeHandler.setupResizeObserver();
-            this.resizeObserverActive = true;
-          }
-        }
+        // Cleared before the render, not after: a listener that asks for a render from inside
+        // one then books the next frame rather than having its request swallowed by this one.
         this.renderLoopId = null;
+
+        if (this.state?.needsRender) {
+          this.flushRender();
+        }
       });
+    }
+  }
+
+  /** Drop a render booked for the next frame. */
+  private cancelScheduledRender(): void {
+    if (this.renderLoopId !== null) {
+      cancelAnimationFrame(this.renderLoopId);
+      this.renderLoopId = null;
+    }
+  }
+
+  /**
+   * Draw everything in this frame, rather than booking the next one.
+   *
+   * For a caller that has already changed what is on screen and cannot leave the frame to
+   * composite the result — a resize wipes each canvas as it sizes it. `invalidateAll` covers
+   * whatever a dropped render was waiting for.
+   */
+  private renderNow(): void {
+    this.cancelScheduledRender();
+    this.invalidateAll();
+    this.flushRender();
+
+    // A frame was dropped to draw in this one. If the chart could not draw after all, that
+    // dropped frame is still owed.
+    if (this.state?.needsRender) {
+      this.scheduleRender();
+    }
+  }
+
+  /**
+   * Draw, then settle the loop: nothing is left pending and nothing renders twice.
+   *
+   * The one place a render is followed through, whether the frame loop asked for it or a
+   * caller drew straight away.
+   */
+  private flushRender(): void {
+    this.render();
+
+    // Setup ResizeObserver after first render to avoid double render on init.
+    // By this point, layout is finalized and ResizeObserver baseline matches rendered state.
+    if (this.resizeHandler && !this.resizeObserverActive) {
+      this.resizeHandler.setupResizeObserver();
+      this.resizeObserverActive = true;
     }
   }
 
@@ -743,13 +781,13 @@ export class FlameChart<E extends EventNode = EventNode> {
    * Handle window resize.
    * Calculates main timeline height by subtracting visible component heights.
    */
-  public resize(newWidth: number, newHeight: number): void {
+  public resize(newWidth: number, newHeight: number): boolean {
     if (!this.app || !this.viewport || !this.container || !this.index) {
-      return;
+      return false;
     }
 
     if (newWidth <= 0 || newHeight <= 0) {
-      return;
+      return false;
     }
 
     const oldState = this.viewport.getState();
@@ -776,8 +814,21 @@ export class FlameChart<E extends EventNode = EventNode> {
     const mainTimelineHeight = newHeight - totalOverheadHeight;
 
     if (mainTimelineHeight <= 0) {
-      return; // Invalid state, skip resize
+      return false; // Invalid state, skip resize
     }
+
+    // Nothing moved, so no canvas is about to be wiped and a render already booked still
+    // stands. Load reaches here with the geometry init already set. The minimap is checked
+    // too: its height is a tenth of the container's, so it can move on its own while the main
+    // timeline keeps the height it had.
+    if (
+      newWidth === oldWidth &&
+      mainTimelineHeight === oldState.displayHeight &&
+      minimapHeight === this.appliedMinimapHeight
+    ) {
+      return false;
+    }
+    this.appliedMinimapHeight = minimapHeight;
 
     // Update offset for converting canvas-relative to container-relative coordinates
     this.mainTimelineYOffset = totalOverheadHeight;
@@ -811,7 +862,10 @@ export class FlameChart<E extends EventNode = EventNode> {
     // Update viewport with main timeline dimensions only
     this.viewport.setStateForResize(newWidth, mainTimelineHeight, newZoom, newOffsetX, newOffsetY);
 
-    this.requestRender();
+    // Each `renderer.resize` above wiped its canvas, so a scheduled render would leave this
+    // frame to composite three blank ones.
+    this.renderNow();
+    return true;
   }
 
   /**
@@ -958,6 +1012,9 @@ export class FlameChart<E extends EventNode = EventNode> {
     // Metric strip starts collapsed, so use collapsed height for initial layout
     const minimapHeight = calculateMinimapHeight(height);
     const metricStripHeight = METRIC_STRIP_COLLAPSED_HEIGHT;
+
+    // This is the applied geometry, so a resize to the same size has nothing to do.
+    this.appliedMinimapHeight = minimapHeight;
 
     // Create wrapper container with flexbox layout
     this.wrapper = document.createElement('div');
@@ -1469,9 +1526,14 @@ export class FlameChart<E extends EventNode = EventNode> {
         }
         // Trigger full layout recalculation to resize main timeline
         // The container size doesn't change, but internal flexbox layout does
-        if (this.container) {
-          const { width, height } = this.container.getBoundingClientRect();
-          this.resize(width, height);
+        if (!this.container) {
+          return;
+        }
+        const { width, height } = this.container.getBoundingClientRect();
+        if (!this.resize(width, height)) {
+          // The strip resized its own canvas before asking, so it is blank until something
+          // draws. A resize that could not run leaves that to us.
+          this.requestRender();
         }
       },
     });
@@ -2191,6 +2253,10 @@ export class FlameChart<E extends EventNode = EventNode> {
     if (!this.canRender()) {
       return;
     }
+
+    // Committed to drawing, so the request is served. A render that bailed above leaves the
+    // request standing, for a later frame to honour.
+    this.state!.needsRender = false;
 
     const viewportState = this.viewport!.getState();
     this.state!.viewport = viewportState;

--- a/log-viewer/src/features/timeline/optimised/__tests__/FlameChartResize.test.ts
+++ b/log-viewer/src/features/timeline/optimised/__tests__/FlameChartResize.test.ts
@@ -1,0 +1,159 @@
+/**
+ * @jest-environment jsdom
+ */
+
+/*
+ * Copyright (c) 2026 Certinia Inc. All rights reserved.
+ */
+
+/**
+ * A resize must repaint in the same frame it clears in. PIXI's `renderer.resize` assigns
+ * `canvas.width`, which wipes the drawing buffer, so a repaint deferred to the next frame
+ * leaves this one to composite a blank canvas.
+ */
+
+import { afterEach, describe, expect, it, jest } from '@jest/globals';
+import { FlameChart } from '../FlameChart.js';
+
+/** The private collaborators `resize` and `render` need, and nothing else. */
+function stubbedChart(displayHeight = 300): {
+  chart: FlameChart;
+  rendererResize: jest.Mock;
+  appRender: jest.Mock;
+} {
+  const chart = new FlameChart();
+  const rendererResize = jest.fn();
+  const appRender = jest.fn();
+
+  const internals = chart as unknown as Record<string, unknown>;
+  internals['app'] = {
+    renderer: { resize: rendererResize },
+    screen: { height: 300 },
+    render: appRender,
+  };
+  internals['container'] = document.createElement('div');
+  internals['index'] = { maxDepth: 1 };
+  internals['worldContainer'] = { position: { set: jest.fn() } };
+  internals['batchRenderer'] = { render: jest.fn(), clear: jest.fn() };
+  internals['rectangleManager'] = {
+    getCulledRectangles: () => ({ visibleRects: new Map(), buckets: new Map() }),
+  };
+  internals['viewport'] = {
+    getState: () => ({
+      zoom: 1,
+      offsetX: 0,
+      offsetY: 0,
+      displayWidth: 400,
+      displayHeight,
+    }),
+    setStateForResize: jest.fn(),
+  };
+  // The geometry init applied: 364 container - 60 minimap - 4 gap = the 300 below.
+  internals['appliedMinimapHeight'] = 60;
+  internals['state'] = {
+    viewport: null,
+    needsRender: false,
+    batchColorsCache: new Map(),
+    renderDirty: {
+      background: false,
+      culling: false,
+      eventRendering: false,
+      highlights: false,
+      overlays: false,
+      minimap: false,
+      metricStrip: false,
+    },
+  };
+
+  return { chart, rendererResize, appRender };
+}
+
+describe('FlameChart.resize', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('paints before it returns, so the cleared canvas is never composited', () => {
+    const { chart, rendererResize, appRender } = stubbedChart();
+    const raf = jest.spyOn(window, 'requestAnimationFrame').mockReturnValue(1);
+
+    chart.resize(500, 400);
+
+    // Both inside the one call: the clear and the paint share a frame.
+    expect(rendererResize).toHaveBeenCalled();
+    expect(appRender).toHaveBeenCalled();
+    // Nothing left for a later frame to do.
+    expect(raf).not.toHaveBeenCalled();
+  });
+
+  // A resize that changes nothing has no canvas to wipe, so drawing now buys nothing and a
+  // render already booked still stands. Loading a log arrives here with the geometry unchanged.
+  it('does not draw when the geometry is unchanged', () => {
+    const { chart, rendererResize, appRender } = stubbedChart();
+
+    // 364 - 60 minimap - 4 gap = the 300 the viewport already reports, at the same width.
+    chart.resize(400, 364);
+
+    expect(rendererResize).not.toHaveBeenCalled();
+    expect(appRender).not.toHaveBeenCalled();
+  });
+
+  it('still draws when the main timeline height changes at the same width', () => {
+    const { chart, appRender } = stubbedChart();
+    jest.spyOn(window, 'requestAnimationFrame').mockReturnValue(1);
+
+    chart.resize(400, 400);
+
+    expect(appRender).toHaveBeenCalled();
+  });
+
+  // The minimap is a tenth of the container, clamped, so it can move a pixel while the main
+  // timeline keeps the height it had. Skipping then leaves its canvas short of its box.
+  it('draws when only the minimap height moved', () => {
+    // 604 - 60 - 4 and 605 - 61 - 4 are both 540, so only the minimap changed.
+    const { chart, appRender } = stubbedChart(540);
+    jest.spyOn(window, 'requestAnimationFrame').mockReturnValue(1);
+
+    expect(chart.resize(400, 605)).toBe(true);
+    expect(appRender).toHaveBeenCalled();
+  });
+
+  // The metric strip resizes its own canvas before asking the host to relayout, so a resize
+  // that cannot run has to say so — otherwise nothing draws the strip it just blanked.
+  it('reports whether it applied, so a caller can draw instead', () => {
+    const { chart } = stubbedChart();
+    jest.spyOn(window, 'requestAnimationFrame').mockReturnValue(1);
+
+    // Smaller than the minimap and its gap, so no main timeline is left.
+    expect(chart.resize(400, 40)).toBe(false);
+    expect(chart.resize(400, 400)).toBe(true);
+  });
+
+  // The queued paint is dropped to draw in this frame. If the draw cannot happen, the paint
+  // is still owed, or the chart stays blank with nothing left to fill it.
+  it('books the dropped frame again when it cannot draw after all', () => {
+    const { chart, appRender } = stubbedChart();
+    const internals = chart as unknown as Record<string, unknown>;
+    // No rectangleManager, so `canRender` fails and `render` bails.
+    internals['rectangleManager'] = null;
+    (internals['state'] as { needsRender: boolean }).needsRender = true;
+    const raf = jest.spyOn(window, 'requestAnimationFrame').mockReturnValue(1);
+
+    chart.resize(500, 400);
+
+    expect(appRender).not.toHaveBeenCalled();
+    expect(raf).toHaveBeenCalled();
+  });
+
+  it('drops a render already queued, rather than painting twice', () => {
+    const { chart, appRender } = stubbedChart();
+    const cancel = jest.spyOn(window, 'cancelAnimationFrame').mockImplementation(() => {});
+    (chart as unknown as Record<string, unknown>)['renderLoopId'] = 7;
+
+    chart.resize(500, 400);
+
+    expect(cancel).toHaveBeenCalledWith(7);
+    expect(appRender).toHaveBeenCalledTimes(1);
+    expect((chart as unknown as Record<string, number | null>)['renderLoopId']).toBeNull();
+  });
+});

--- a/log-viewer/src/features/timeline/optimised/__tests__/MetricStripToggle.test.ts
+++ b/log-viewer/src/features/timeline/optimised/__tests__/MetricStripToggle.test.ts
@@ -1,0 +1,47 @@
+/**
+ * @jest-environment jsdom
+ */
+
+/*
+ * Copyright (c) 2026 Certinia Inc. All rights reserved.
+ */
+
+/**
+ * Collapsing or expanding the strip changes the main timeline's height, so the host relayouts
+ * and draws as part of that. Asking it to draw again is a second full render for one click.
+ */
+
+import { describe, expect, it, jest } from '@jest/globals';
+import {
+  MetricStripOrchestrator,
+  type MetricStripOrchestratorCallbacks,
+} from '../metric-strip/MetricStripOrchestrator.js';
+
+function orchestrator(): {
+  strip: MetricStripOrchestrator;
+  onHeightChange: jest.Mock;
+  requestRender: jest.Mock;
+} {
+  const onHeightChange = jest.fn();
+  const requestRender = jest.fn();
+  const callbacks = {
+    onZoomToRegion: jest.fn(),
+    onCursorMove: jest.fn(),
+    requestRender,
+    requestCursorRender: jest.fn(),
+    onHeightChange,
+  } as unknown as MetricStripOrchestratorCallbacks;
+
+  return { strip: new MetricStripOrchestrator(callbacks), onHeightChange, requestRender };
+}
+
+describe('collapsing the metric strip', () => {
+  it('asks the host to relayout, and does not also ask it to draw', () => {
+    const { strip, onHeightChange, requestRender } = orchestrator();
+
+    strip.toggleCollapsed();
+
+    expect(onHeightChange).toHaveBeenCalledTimes(1);
+    expect(requestRender).not.toHaveBeenCalled();
+  });
+});

--- a/log-viewer/src/features/timeline/optimised/interaction/TimelineResizeHandler.ts
+++ b/log-viewer/src/features/timeline/optimised/interaction/TimelineResizeHandler.ts
@@ -19,7 +19,6 @@ export class TimelineResizeHandler {
   private containerRef: HTMLElement;
   private renderer: IResizable | null = null;
 
-  private resizeDebounceFrameId: number | null = null;
   private lastResizeWidth: number;
   private lastResizeHeight: number;
 
@@ -60,31 +59,22 @@ export class TimelineResizeHandler {
         return; // Skip if unchanged (covers initial callback case)
       }
 
-      // Update dimensions before debounce to prevent rapid duplicate checks
       this.lastResizeWidth = roundedWidth;
       this.lastResizeHeight = roundedHeight;
 
-      // Debounce actual resize handling to prevent flickering
-      if (this.resizeDebounceFrameId !== null) {
-        cancelAnimationFrame(this.resizeDebounceFrameId);
-      }
-
-      this.resizeDebounceFrameId = requestAnimationFrame(() => {
-        this.renderer?.resize(roundedWidth, roundedHeight);
-        this.resizeDebounceFrameId = null;
-      });
+      // Straight through, with no frame in between. Observer callbacks are delivered after
+      // this frame's animation callbacks, so a resize deferred to the next frame sizes the
+      // canvas to a box the drag has already left: one frame behind on every step of a drag,
+      // which reads as the chart sliding off the bottom edge until the drag stops.
+      // Nothing inside the observed element can change that element's height, so this cannot
+      // start an observer loop.
+      this.renderer?.resize(roundedWidth, roundedHeight);
     });
 
     this.resizeObserver.observe(this.containerRef);
   }
 
   public destroy(): void {
-    // Clear any pending resize frame request
-    if (this.resizeDebounceFrameId !== null) {
-      cancelAnimationFrame(this.resizeDebounceFrameId);
-      this.resizeDebounceFrameId = null;
-    }
-
     // Disconnect resize observer
     if (this.resizeObserver) {
       this.resizeObserver.disconnect();

--- a/log-viewer/src/features/timeline/optimised/metric-strip/MetricStripOrchestrator.ts
+++ b/log-viewer/src/features/timeline/optimised/metric-strip/MetricStripOrchestrator.ts
@@ -114,7 +114,7 @@ export interface MetricStripOrchestratorCallbacks {
    *
    * @param newHeight - New height in pixels
    */
-  onHeightChange?: (newHeight: number) => void;
+  onHeightChange: (newHeight: number) => void;
 }
 
 /**
@@ -414,9 +414,9 @@ export class MetricStripOrchestrator {
     this.renderer?.setHeight(newHeight);
     this.renderer?.setCollapsed(this.isCollapsed);
 
-    // Notify FlameChart to recalculate layout
-    this.callbacks.onHeightChange?.(newHeight);
-    this.callbacks.requestRender();
+    // The host sizes the container for the new height and draws as part of that, so asking it
+    // to draw again would be a second full render for one click.
+    this.callbacks.onHeightChange(newHeight);
   }
 
   /**

--- a/log-viewer/src/features/timeline/optimised/minimap/MinimapDensityQuery.ts
+++ b/log-viewer/src/features/timeline/optimised/minimap/MinimapDensityQuery.ts
@@ -131,14 +131,14 @@ export class MinimapDensityQuery {
   private totalDuration: number;
 
   /**
-   * Simple cache for exact bucket count.
-   * Key: bucket count
-   * Value: computed density data
+   * The one density held, and the bucket count it was computed for.
    *
-   * Invalidated when data changes. No multi-resolution downscaling needed
-   * since we compute at exact bucket count with O(B × log N) complexity.
+   * One width at a time: every caller asks for the width on screen, and a density holds a
+   * bucket per pixel of it, so keeping the widths a drag passed through would cost more memory
+   * than the recompute it saves.
    */
-  private densityCache: Map<number, MinimapDensityData> = new Map();
+  private cachedBucketCount: number | null = null;
+  private cachedDensity: MinimapDensityData | null = null;
 
   /** Optional segment tree for O(B×log N) density computation. */
   private segmentTree: TemporalSegmentTree | null = null;
@@ -173,9 +173,8 @@ export class MinimapDensityQuery {
     bucketCount = Number.isFinite(bucketCount) ? Math.floor(bucketCount) : 0;
 
     // Fast path: exact match in cache
-    const cached = this.densityCache.get(bucketCount);
-    if (cached) {
-      return cached;
+    if (this.cachedDensity !== null && this.cachedBucketCount === bucketCount) {
+      return this.cachedDensity;
     }
 
     // Compute at exact bucket count using sliding window algorithm if tree available
@@ -183,15 +182,20 @@ export class MinimapDensityQuery {
       ? this.computeDensitySlidingWindow(bucketCount)
       : this.computeDensity(bucketCount);
 
-    this.densityCache.set(bucketCount, density);
+    this.cachedBucketCount = bucketCount;
+    this.cachedDensity = density;
     return density;
   }
 
   /**
    * Invalidate cache (call when timeline data changes).
+   *
+   * A resize needs no call: the cache is keyed by width, so a new width misses on its own and
+   * a height change leaves the entry as true as it was.
    */
   public invalidateCache(): void {
-    this.densityCache.clear();
+    this.cachedBucketCount = null;
+    this.cachedDensity = null;
   }
 
   /**

--- a/log-viewer/src/features/timeline/optimised/orchestrators/MinimapOrchestrator.ts
+++ b/log-viewer/src/features/timeline/optimised/orchestrators/MinimapOrchestrator.ts
@@ -282,9 +282,7 @@ export class MinimapOrchestrator {
       this.minimapViewport.resize(newWidth, newHeight);
     }
 
-    if (this.densityQuery) {
-      this.densityQuery.invalidateCache();
-    }
+    // No density invalidation here: it is keyed by width (see MinimapDensityQuery).
 
     if (this.renderer) {
       this.renderer.invalidateStatic();


### PR DESCRIPTION
Dragging the window or the panel edge made the Flame Chart flash, and the chart trailed a
frame behind the drag. Four commits, one concern each.

**The flash.** `renderer.resize` assigns `canvas.width`, which wipes the drawing buffer.
`resize()` cleared all three canvases and booked the repaint for the *next* frame, so the
frame between composited three blank canvases. It now draws before it returns.

**The lag.** Observer callbacks are delivered after a frame's animation callbacks and after
layout, so a resize deferred to the next frame always sized the canvas to the box the drag
had already left. Because depth 0 sits at the canvas bottom inside an `overflow: hidden`
box, a fast shrink clipped the bottom frames away rather than merely lagging. The observer
already coalesces to one delivery per rendering opportunity, so the frame hop bought no
batching, and nothing inside the observed element can change that element's height, so
resizing from the callback cannot loop.

**Two things that ran more than once.** A chevron toggle asked the host to relayout — which
draws — and then asked it to draw again. And the minimap density cache, which is keyed by
width, was cleared on every resize, so a height-only drag paid a full recompute per step.

### Measured, 100MB log

| | before | after |
| --- | --- | --- |
| height drag | 23-25ms a step | **2-4ms** |
| chevron toggle | 2 full renders | 1 |
| load | a synchronous render inside `init()` | the booked render stands |

A width drag is still 75-92ms: a new width is a genuine cache miss, and
`computeDensitySlidingWindow` pushes every frame into every bucket it spans before
`resolveCategoryFromSkyline` sorts per bucket. That is a separate piece of work and gets its
own issue.

### Verification

`tsc -b`, eslint and prettier clean; 1983 tests pass, and each commit compiles on its own.
New `FlameChartResize.test.ts` (7) and `MetricStripToggle.test.ts` cover: drawing before
returning, dropping a queued frame, re-booking one it could not draw, skipping an unchanged
geometry, still drawing when only the minimap height moved, and rendering once per toggle.
Each was checked by reverting its fix and confirming it fails.

Checked by hand in the dev host on a 100MB log: no blank frame at any size, horizontal and
vertical drags smooth, no blink on the chevron.

Relates to #373. Merge this before the other two timeline PRs — they touch the same
`scheduleRender`/`render` block.

## 🔗 Related Issues

related #405