### PR TITLE
fix(log-viewer): keep grid search highlights in step with the rows on screen

### DIFF
--- a/log-viewer/src/features/analysis/components/AnalysisView.ts
+++ b/log-viewer/src/features/analysis/components/AnalysisView.ts
@@ -46,6 +46,8 @@ import {
 } from '../../call-tree/utils/CategoryColoring.js';
 import { expandCollapseAll } from '../../call-tree/utils/ExpandCollapse.js';
 
+import { onTableReshaped } from '../../../tabulator/module/tableReshape.js';
+
 import dataGridStyles from '../../../tabulator/style/DataGrid.scss';
 
 // styles
@@ -501,6 +503,9 @@ export class AnalysisView extends LitElement {
 
   _groupBy(event: Event) {
     const target = event.target as HTMLInputElement;
+    // Grouping renumbers the matches both ways round, and `dataGrouped` reports
+    // only the way that leaves the table grouped.
+    this._dropSearch();
     const fieldName =
       target.value === 'Caller Namespace' ? 'callerNamespace' : target.value.toLowerCase();
     if (this.analysisTable) {
@@ -520,6 +525,7 @@ export class AnalysisView extends LitElement {
     if (!table) {
       return;
     }
+    this._dropSearch();
     table.blockRedraw();
     table.clearFilter(false);
     if (!this.filterState.showDetails) {
@@ -613,18 +619,6 @@ export class AnalysisView extends LitElement {
       rootMethod,
       {
         showDetailsFilter: this._showDetailsFilter,
-        onFilterCacheClear: () => {
-          if (!this.blockClearHighlights && this.totalMatches > 0) {
-            this._resetFindWidget();
-            this._clearSearchHighlights();
-          }
-        },
-        onRenderStarted: () => {
-          if (!this.blockClearHighlights && this.totalMatches > 0) {
-            this._resetFindWidget();
-            this._clearSearchHighlights();
-          }
-        },
         rowFormatter: groupedRowFormatter,
       },
       {
@@ -636,19 +630,7 @@ export class AnalysisView extends LitElement {
     );
     this.analysisTable = table;
 
-    this.analysisTable.on('dataSorted', () => {
-      if (!this.blockClearHighlights && this.totalMatches > 0) {
-        this._resetFindWidget();
-        this._clearSearchHighlights();
-      }
-    });
-
-    this.analysisTable.on('dataGrouped', () => {
-      if (!this.blockClearHighlights && this.totalMatches > 0) {
-        this._resetFindWidget();
-        this._clearSearchHighlights();
-      }
-    });
+    onTableReshaped(this.analysisTable, () => this._dropSearch());
 
     // Feed the inspector. Analysis rows merge many calls, so they
     // scope to every call they count.
@@ -684,6 +666,14 @@ export class AnalysisView extends LitElement {
 
   _resetFindWidget() {
     document.dispatchEvent(new CustomEvent('lv-find-results', { detail: { totalMatches: 0 } }));
+  }
+
+  /** Drop the search where its match numbering no longer describes the table. */
+  _dropSearch() {
+    if (!this.blockClearHighlights && this.totalMatches > 0) {
+      this._resetFindWidget();
+      this._clearSearchHighlights();
+    }
   }
 
   _clearSearchHighlights() {

--- a/log-viewer/src/features/analysis/components/__tests__/AnalysisView.test.ts
+++ b/log-viewer/src/features/analysis/components/__tests__/AnalysisView.test.ts
@@ -18,6 +18,12 @@ jest.mock('../../../call-tree/components/BottomUpTable.js', () => ({
         return stub.rows;
       },
       goToRow: (row: RowComponent) => stub.revealed.push(row),
+      clearFindHighlights: () => {},
+      blockRedraw: () => {},
+      restoreRedraw: () => {},
+      clearFilter: () => {},
+      addFilter: () => {},
+      setSortedGroupBy: () => {},
     },
     // Left pending: the columns are applied on build, and none are set up here.
     tableBuilt: new Promise<Tabulator>(() => {}),
@@ -104,6 +110,23 @@ function findRow(rows: BottomUpRow[], text: string): BottomUpRow {
   return row;
 }
 
+/**
+ * A view with its table rendered against `log`.
+ *
+ * The app hands the log down as a property, and a row's calls are read through
+ * the table that built it. The table mounts in a wrapper the view finds in its
+ * render root, which it has none of until it is updated, so one is stood in.
+ */
+function mountView(log: ApexLog): AnalysisView {
+  handlers.clear();
+  stub = { rows: [], getRowsArgs: [], revealed: [] };
+  const view = new AnalysisView();
+  view.timelineRoot = log;
+  view.tableContainer = document.createElement('div');
+  void view._renderAnalysis(log);
+  return view;
+}
+
 describe('analysis-view selection', () => {
   let view: AnalysisView;
   let log: ApexLog;
@@ -113,18 +136,9 @@ describe('analysis-view selection', () => {
 
   beforeEach(() => {
     byEventIndex = [];
-    handlers.clear();
-    stub = { rows: [], getRowsArgs: [], revealed: [] };
     log = recursiveLog();
     roots = toBottomUpTree(log.children, logStoreFor(log).keyPathIds());
-    view = new AnalysisView();
-    // The app hands the log down as a property, and a row's calls are read
-    // through the table that built it.
-    view.timelineRoot = log;
-    // The table mounts in a wrapper the view finds in its render root; it has
-    // none until it is updated, so stand one in.
-    view.tableContainer = document.createElement('div');
-    void view._renderAnalysis(log);
+    view = mountView(log);
     seen = [];
     off = eventBus.on('detail:select', (detail) => seen.push(detail));
   });
@@ -226,5 +240,65 @@ describe('analysis-view selection', () => {
     );
 
     expect(seen).toEqual([{ source: 'analysis', selection: null, view: 'callers' }]);
+  });
+});
+
+describe('analysis-view search lifetime', () => {
+  let view: AnalysisView;
+
+  beforeEach(() => {
+    byEventIndex = [];
+    view = mountView(recursiveLog());
+    // What a finished search leaves behind: matches, and nothing of its own in
+    // flight to guard against.
+    view.totalMatches = 3;
+    view.blockClearHighlights = false;
+  });
+
+  afterEach(() => {
+    view.disconnectedCallback();
+  });
+
+  /** What Tabulator reports, which an expand repeats with the sort in force. */
+  function sorted(dir: string): void {
+    (handlers.get('dataSorting') as (sorters: unknown[]) => void)([{ field: 'selfTime', dir }]);
+  }
+
+  it('drops the search where a sort renumbers the matches', () => {
+    sorted('desc');
+
+    expect(view.totalMatches).toBe(0);
+  });
+
+  it('drops the search where a column goes off show, which it counted over', () => {
+    (handlers.get('columnVisibilityChanged') as () => void)();
+
+    expect(view.totalMatches).toBe(0);
+  });
+
+  it('drops the search where grouping is turned off, which reports no grouping', () => {
+    // Tabulator's dataGrouped fires only while the table stays grouped, so this
+    // is the way round it never reports.
+    view._groupBy({ target: { value: 'None' } } as unknown as Event);
+
+    expect(view.totalMatches).toBe(0);
+  });
+
+  it('keeps the search where an expand orders the children it opened', () => {
+    sorted('desc');
+    view.totalMatches = 3;
+
+    // Expanding sorts each opened subtree through the same call, so the event
+    // arrives again with the sort the table already had.
+    sorted('desc');
+    sorted('desc');
+
+    expect(view.totalMatches).toBe(3);
+  });
+
+  it('drops the search where a filter changes which rows there are', () => {
+    view._handleShowDetailsChange();
+
+    expect(view.totalMatches).toBe(0);
   });
 });

--- a/log-viewer/src/features/call-tree/components/AggregatedTable.ts
+++ b/log-viewer/src/features/call-tree/components/AggregatedTable.ts
@@ -182,19 +182,6 @@ export function createAggregatedTable(
   });
   tableRef.current = table;
 
-  // The host's filter caches (search/type/debug/namespace/duration) are cleared once per
-  // render via `renderStarted` — see CalltreeView's `onFilterCacheClear`. Row ids produced
-  // by `toAggregatedCallTree` are globally unique within a build (per-build monotonic
-  // counter), so cached `deepFilter` results stay valid across the cascaded
-  // `filter.filter()` passes Tabulator runs for each expanded subtree —
-  // `getChildren` → `filter.filter(config.children)` would otherwise fire `dataFiltered`
-  // multiple times per user action, defeating the cache. If row ids ever lose their
-  // uniqueness guarantee this must move back to `dataFiltered`.
-  table.on('renderStarted', () => {
-    callbacks.onFilterCacheClear?.();
-    callbacks.onRenderStarted();
-  });
-
   const tableBuilt = new Promise<void>((resolve) => {
     table.on('tableBuilt', () => {
       resolve();

--- a/log-viewer/src/features/call-tree/components/BottomUpTable.ts
+++ b/log-viewer/src/features/call-tree/components/BottomUpTable.ts
@@ -246,19 +246,6 @@ export function createBottomUpTable(
     ...tabulatorOptionOverrides,
   });
 
-  // Filter caches are cleared once per render via `renderStarted`. Row ids
-  // produced by `toBottomUpTree` are globally unique within a build
-  // (per-build monotonic counter), so cached `deepFilter` results stay valid
-  // across the cascaded `filter.filter()` passes Tabulator runs for each
-  // expanded subtree — `getChildren` → `filter.filter(config.children)`
-  // would otherwise fire `dataFiltered` multiple times per user action,
-  // defeating the cache. If row ids ever lose their uniqueness guarantee
-  // this must move back to `dataFiltered`.
-  table.on('renderStarted', () => {
-    callbacks.onFilterCacheClear?.();
-    callbacks.onRenderStarted();
-  });
-
   const tableBuilt = new Promise<void>((resolve) => {
     table.on('tableBuilt', () => {
       resolve();

--- a/log-viewer/src/features/call-tree/components/CalltreeView.ts
+++ b/log-viewer/src/features/call-tree/components/CalltreeView.ts
@@ -33,6 +33,7 @@ import { waitForNextFrame } from '../../../core/utility/FrameBudget.js';
 
 import { inMsRange, type FilterRange } from '../../../tabulator/filters/MinMax.js';
 import { withCodeDrivenExpand } from '../../../tabulator/module/expandOrigin.js';
+import { onTableReshaped } from '../../../tabulator/module/tableReshape.js';
 
 import dataGridStyles from '../../../tabulator/style/DataGrid.scss';
 
@@ -597,6 +598,9 @@ export class CalltreeView extends LitElement {
   _handleBottomUpGroupBy(event: Event) {
     const target = event.target as HTMLInputElement;
     this.bottomUpGroupBy = target.value;
+    // Grouping renumbers the matches both ways round, and `dataGrouped` reports
+    // only the way that leaves the table grouped.
+    this._dropSearch();
     const fieldName =
       target.value === 'Caller Namespace' ? 'callerNamespace' : target.value.toLowerCase();
     if (this.bottomUpTreeTable) {
@@ -760,11 +764,8 @@ export class CalltreeView extends LitElement {
       return;
     }
 
-    this.debugOnlyFilterCache.clear();
-    this.typeFilterCache.clear();
-    this.namespaceFilterCache.clear();
-    this.totalTimeFilterCache.clear();
-    this.selfTimeFilterCache.clear();
+    this._dropSearch();
+    this._clearFilterCaches();
 
     const filtersToAdd = [];
 
@@ -1048,19 +1049,6 @@ export class CalltreeView extends LitElement {
 
     const { table, tableBuilt } = createTimeOrderTable(callTreeTableContainer, rootMethod, {
       showDetailsFilter: this._showDetailsFilter,
-      onFilterCacheClear: () => {
-        this.debugOnlyFilterCache.clear();
-        this.typeFilterCache.clear();
-        this.namespaceFilterCache.clear();
-        this.totalTimeFilterCache.clear();
-        this.selfTimeFilterCache.clear();
-      },
-      onRenderStarted: () => {
-        if (!this.blockClearHighlights && this.totalMatches > 0) {
-          this._resetFindWidget();
-          this._clearSearchHighlights();
-        }
-      },
       onContextMenu: (e, row) => {
         if (window.getSelection()?.type === 'Range') {
           return;
@@ -1072,6 +1060,7 @@ export class CalltreeView extends LitElement {
       rowFormatter: timeOrderRowFormatter,
     });
     this.calltreeTable = table;
+    this._watchTable(table, true);
     await tableBuilt;
     this._initTableColumns(table);
     this._emitDetailSelection(table);
@@ -1089,22 +1078,10 @@ export class CalltreeView extends LitElement {
 
     const { table, tableBuilt } = createAggregatedTable(container, rootMethod, {
       showDetailsFilter: this._showDetailsFilter,
-      onFilterCacheClear: () => {
-        this.debugOnlyFilterCache.clear();
-        this.typeFilterCache.clear();
-        this.namespaceFilterCache.clear();
-        this.totalTimeFilterCache.clear();
-        this.selfTimeFilterCache.clear();
-      },
-      onRenderStarted: () => {
-        if (!this.blockClearHighlights && this.totalMatches > 0) {
-          this._resetFindWidget();
-          this._clearSearchHighlights();
-        }
-      },
       rowFormatter: groupedRowFormatter,
     });
     this.aggregatedTreeTable = table;
+    this._watchTable(table, true);
     await tableBuilt;
     this._initTableColumns(table);
     this._emitDetailSelection(table);
@@ -1122,12 +1099,6 @@ export class CalltreeView extends LitElement {
       rootMethod,
       {
         showDetailsFilter: this._showDetailsFilter,
-        onRenderStarted: () => {
-          if (!this.blockClearHighlights && this.totalMatches > 0) {
-            this._resetFindWidget();
-            this._clearSearchHighlights();
-          }
-        },
         rowFormatter: groupedRowFormatter,
       },
       {
@@ -1137,6 +1108,7 @@ export class CalltreeView extends LitElement {
       },
     );
     this.bottomUpTreeTable = table;
+    this._watchTable(table, false);
     await tableBuilt;
     this._initTableColumns(table);
     this._emitDetailSelection(table);
@@ -1217,6 +1189,41 @@ export class CalltreeView extends LitElement {
 
   private _resetFindWidget() {
     document.dispatchEvent(new CustomEvent('lv-find-results', { detail: { totalMatches: 0 } }));
+  }
+
+  /** Drop the search where its match numbering no longer describes the table. */
+  private _dropSearch() {
+    if (!this.blockClearHighlights && this.totalMatches > 0) {
+      this._resetFindWidget();
+      this._clearSearchHighlights();
+    }
+  }
+
+  /**
+   * Watch `table` for what a view has to answer per render.
+   *
+   * The filter caches are cleared once per render rather than on `dataFiltered`:
+   * row ids are unique within a build, so a cached `deepFilter` result stays
+   * valid across the cascaded filter passes Tabulator runs for each expanded
+   * subtree, which would otherwise fire `dataFiltered` several times per user
+   * action and defeat the cache.
+   *
+   * @param clearsFilterCaches - Bottom Up reads the caches but has never cleared
+   * them per render, so it keeps that behaviour here.
+   */
+  private _watchTable(table: Tabulator, clearsFilterCaches: boolean) {
+    onTableReshaped(table, () => this._dropSearch());
+    if (clearsFilterCaches) {
+      table.on('renderStarted', () => this._clearFilterCaches());
+    }
+  }
+
+  private _clearFilterCaches() {
+    this.debugOnlyFilterCache.clear();
+    this.typeFilterCache.clear();
+    this.namespaceFilterCache.clear();
+    this.totalTimeFilterCache.clear();
+    this.selfTimeFilterCache.clear();
   }
 
   private _clearSearchHighlights() {

--- a/log-viewer/src/features/call-tree/components/TableShared.ts
+++ b/log-viewer/src/features/call-tree/components/TableShared.ts
@@ -23,8 +23,6 @@ import { makeSumFieldAllVisible } from '../utils/BottomCalcs.js';
 import { governorCostBreakdown, type GovernorCostRow } from '../utils/GovernorCost.js';
 
 export interface TableCallbacks {
-  onFilterCacheClear?: () => void;
-  onRenderStarted: () => void;
   rowFormatter?: (row: RowComponent) => void;
 }
 

--- a/log-viewer/src/features/call-tree/components/TimeOrderTable.ts
+++ b/log-viewer/src/features/call-tree/components/TimeOrderTable.ts
@@ -143,18 +143,6 @@ export function createTimeOrderTable(
   });
   tableRef.current = table;
 
-  // The host's filter caches (search/type/debug/namespace/duration) are cleared once per
-  // render via `renderStarted` — see CalltreeView's `onFilterCacheClear`. Row ids produced
-  // by `toTimeOrderTree` are globally unique within a build (per-build monotonic counter),
-  // so cached `deepFilter` results stay valid across the cascaded `filter.filter()` passes
-  // Tabulator runs for each expanded subtree — `getChildren` → `filter.filter(config.children)`
-  // would otherwise fire `dataFiltered` multiple times per user action, defeating the cache.
-  // If row ids ever lose their uniqueness guarantee this must move back to `dataFiltered`.
-  table.on('renderStarted', () => {
-    callbacks.onFilterCacheClear?.();
-    callbacks.onRenderStarted();
-  });
-
   table.on('rowContext', (e: UIEvent, row: RowComponent) => {
     callbacks.onContextMenu(e, row);
   });

--- a/log-viewer/src/styles/global.styles.ts
+++ b/log-viewer/src/styles/global.styles.ts
@@ -71,13 +71,14 @@ export const globalStyles = [
       background-color: var(--vscode-scrollbarSlider-background);
     }
 
+    /* findMatch is the match you are on; findMatchHighlight is the rest. */
     ::highlight(find-match) {
-      color: var(--vscode-editor-findMatchForeground);
+      color: var(--vscode-editor-findMatchHighlightForeground);
       background-color: var(--vscode-editor-findMatchHighlightBackground, yellow);
     }
 
     ::highlight(current-find-match) {
-      color: var(--vscode-editor-findMatchHighlightForeground);
+      color: var(--vscode-editor-findMatchForeground);
       background-color: var(--vscode-editor-findMatchBackground, #8b8000);
     }
 

--- a/log-viewer/src/tabulator/module/Find.ts
+++ b/log-viewer/src/tabulator/module/Find.ts
@@ -27,6 +27,7 @@ export class Find extends Module {
   _cachedRegex: RegExp | null = null;
   _currentMatchIndex = 0;
   _matchIndexes: { [key: number]: RowComponent } = {};
+  _highlightFrame: number | null = null;
 
   // Headless formatter execution: single detached element (never in the document)
   // and a per-row-field text cache keyed by the stable row-data object reference.
@@ -61,39 +62,33 @@ export class Find extends Module {
     });
 
     this.table.on('renderComplete', () => {
-      if (this._findArgs?.text) {
-        this._applyHighlights();
-      }
+      this._scheduleHighlights();
     });
 
-    // Virtual scroll doesn't fire renderComplete, so listen for scroll events
-    // to apply highlights to newly visible rows. Debounced to avoid blocking
-    // the main thread during fast scrolling, plus scrollend for instant final update.
-    const holder = this.table.element.querySelector('.tabulator-tableholder');
-    if (holder) {
-      let rafId: number | null = null;
-      holder.addEventListener('scroll', () => {
-        if (!this._findArgs?.text) {
-          return;
-        }
-        if (rafId === null) {
-          rafId = requestAnimationFrame(() => {
-            rafId = null;
-            this._applyHighlights();
-          });
-        }
-      });
+    // A row arrives with no highlight in it, and renderComplete does not report
+    // every arrival. A scroll brings rows in without one, on our renderer and on
+    // Tabulator's own.
+    this.table.on('scrollVertical', () => {
+      this._scheduleHighlights();
+    });
 
-      holder.addEventListener('scrollend', () => {
-        if (rafId !== null) {
-          cancelAnimationFrame(rafId);
-          rafId = null;
-        }
-        if (this._findArgs?.text) {
-          this._applyHighlights();
-        }
-      });
+    // And a sort or a filter brings rows in without a scroll. Ours alone reports
+    // this, so a grid on Tabulator's renderer is covered by the scroll above.
+    this.subscribe('render-virtual-attach', () => {
+      this._scheduleHighlights();
+    });
+  }
+
+  /** Re-apply once for the frame: a render can attach twice and complete once,
+   *  and the rebuild reads every cell on screen. */
+  _scheduleHighlights() {
+    if (this._highlightFrame !== null || !this._findArgs?.text) {
+      return;
     }
+    this._highlightFrame = requestAnimationFrame(() => {
+      this._highlightFrame = null;
+      this._applyHighlights();
+    });
   }
 
   async _find(findArgs: FindArgs) {
@@ -232,6 +227,12 @@ export class Find extends Module {
   }
 
   _applyHighlights() {
+    if (this._highlightFrame !== null) {
+      // Whatever asked for this frame is being answered now.
+      cancelAnimationFrame(this._highlightFrame);
+      this._highlightFrame = null;
+    }
+
     // Lazy-init static Highlights
     if (!Find._findHighlight) {
       Find._findHighlight = new Highlight();
@@ -268,6 +269,12 @@ export class Find extends Module {
       }
 
       const data = row.getData();
+      // A row the search visited and found nothing in cannot hold a match, so
+      // none of its cells are worth a text walk. A row built since the search
+      // ran has no list at all, and is walked.
+      if (data.highlightIndexes?.length === 0) {
+        continue;
+      }
 
       let matchIdx = 0;
       row.getCells().forEach((cell) => {

--- a/log-viewer/src/tabulator/module/Find.ts
+++ b/log-viewer/src/tabulator/module/Find.ts
@@ -28,6 +28,9 @@ export class Find extends Module {
   _currentMatchIndex = 0;
   _matchIndexes: { [key: number]: RowComponent } = {};
   _highlightFrame: number | null = null;
+  /** The fields the last search covered, which the highlights follow so the two
+   *  describe the same matches. */
+  _searchedFields: Set<string> = new Set();
 
   // Headless formatter execution: single detached element (never in the document)
   // and a per-row-field text cache keyed by the stable row-data object reference.
@@ -140,6 +143,7 @@ export class Find extends Module {
       // columnManager.getRealColumns() is internal — returns columnsByIndex, same order as getCells()
       const internalCols: Array<{
         field: string;
+        visible: boolean;
         getComponent: () => ColumnComponent;
         getFieldValue: (data: object) => unknown;
         modules?: {
@@ -153,6 +157,13 @@ export class Find extends Module {
           };
         };
       }> = this.table.columnManager?.getRealColumns?.() ?? [];
+
+      // columnsByIndex holds every column, shown or not: a hidden column's match
+      // cannot be seen, so counting it gives a total the user cannot reach and a
+      // number the highlights cannot line up with.
+      this._searchedFields = new Set(
+        internalCols.filter((col) => col.field && col.visible).map((col) => col.field),
+      );
 
       const len = flattenedRows.length;
       for (let i = 0; i < len; i++) {
@@ -172,7 +183,7 @@ export class Find extends Module {
 
         for (const col of internalCols) {
           const field = col.field;
-          if (!field) {
+          if (!field || !this._searchedFields.has(field)) {
             continue;
           }
 
@@ -278,6 +289,10 @@ export class Find extends Module {
 
       let matchIdx = 0;
       row.getCells().forEach((cell) => {
+        if (!this._searchedFields.has(cell.getField())) {
+          return;
+        }
+
         const elem = cell.getElement();
         // Build a flat text-node map so we can create Ranges that span across
         // adjacent elements (e.g. two <span>s whose text forms a single match).

--- a/log-viewer/src/tabulator/module/__tests__/Find.test.ts
+++ b/log-viewer/src/tabulator/module/__tests__/Find.test.ts
@@ -1,0 +1,94 @@
+/**
+ * @jest-environment jsdom
+ */
+/*
+ * Copyright (c) 2026 Certinia Inc. All rights reserved.
+ */
+import { describe, expect, it } from '@jest/globals';
+
+// The tabulator ESM build doesn't load under jest, and the module registers
+// itself on import.
+jest.mock('tabulator-tables', () => ({
+  Module: class {
+    table: unknown;
+    constructor(table: unknown) {
+      this.table = table;
+    }
+    registerTableOption() {}
+    registerTableFunction() {}
+    subscribe() {}
+  },
+}));
+
+import { waitForNextFrame } from '../../../core/utility/FrameBudget.js';
+import { Find } from '../Find.js';
+
+function setup() {
+  const subscribed: Record<string, (() => void)[]> = {};
+  const listened: string[] = [];
+  const tableEvents: Record<string, (() => void)[]> = {};
+  const table = {
+    on: (event: string, callback: () => void) => {
+      (tableEvents[event] ??= []).push(callback);
+    },
+    element: {
+      querySelector: () => ({
+        addEventListener: (event: string) => {
+          listened.push(event);
+        },
+      }),
+    },
+  };
+  const find = new Find(table as never);
+  find.subscribe = (event: string, callback: () => void) => {
+    (subscribed[event] ??= []).push(callback);
+  };
+  find.initialize();
+
+  const applied = jest.fn();
+  find._applyHighlights = applied;
+  const attach = () => subscribed['render-virtual-attach']?.forEach((fn) => fn());
+  const scroll = () => tableEvents['scrollVertical']?.forEach((fn) => fn());
+  const nextFrame = waitForNextFrame;
+  return { find, applied, attach, scroll, nextFrame, listened };
+}
+
+describe('Find highlights on the rows a render attaches', () => {
+  it('re-applies once for the frame, however many attaches it took', async () => {
+    const { find, applied, attach, nextFrame } = setup();
+    find._findArgs = { text: 'a', count: 0, options: { matchCase: false } };
+
+    attach();
+    attach();
+    expect(applied).not.toHaveBeenCalled();
+    await nextFrame();
+
+    expect(applied).toHaveBeenCalledTimes(1);
+  });
+
+  it('leaves the rows alone while nothing is being searched for', async () => {
+    const { applied, attach, nextFrame } = setup();
+
+    attach();
+    await nextFrame();
+
+    expect(applied).not.toHaveBeenCalled();
+  });
+
+  it("re-applies on a scroll, which is all a grid on Tabulator's renderer reports", async () => {
+    const { find, applied, scroll, nextFrame } = setup();
+    find._findArgs = { text: 'a', count: 0, options: { matchCase: false } };
+
+    scroll();
+    await nextFrame();
+
+    expect(applied).toHaveBeenCalledTimes(1);
+  });
+
+  it('takes the scroll from the table, not from the holder element', () => {
+    // Tabulator reports it for every renderer, and the holder is rebuilt.
+    const { listened } = setup();
+
+    expect(listened).toEqual([]);
+  });
+});

--- a/log-viewer/src/tabulator/module/__tests__/Find.test.ts
+++ b/log-viewer/src/tabulator/module/__tests__/Find.test.ts
@@ -92,3 +92,58 @@ describe('Find highlights on the rows a render attaches', () => {
     expect(listened).toEqual([]);
   });
 });
+
+/** A one-row table whose columns hold `value`, some of them hidden. */
+function findOver(columns: Array<{ field: string; visible: boolean; value: string }>) {
+  const rowData = {};
+  const rows = [{ getData: () => rowData }];
+  const table = {
+    on: () => {},
+    getGroups: () => [],
+    getRows: () => rows,
+    modules: {},
+    options: {},
+    columnManager: {
+      // Tabulator indexes every column here, shown or not.
+      getRealColumns: () =>
+        columns.map((column) => ({
+          field: column.field,
+          visible: column.visible,
+          getComponent: () => ({}),
+          getFieldValue: () => column.value,
+        })),
+    },
+  };
+  const find = new Find(table as never);
+  // CSS.highlights does not exist in jsdom, and the count is what is under test.
+  find._applyHighlights = () => {};
+  return find;
+}
+
+describe('Find counts what the table is showing', () => {
+  const search = { text: 'default', count: 1, options: { matchCase: false } };
+
+  it('leaves a hidden column out of the count', async () => {
+    const find = findOver([
+      { field: 'text', visible: true, value: 'Account default' },
+      { field: 'namespace', visible: false, value: 'default' },
+    ]);
+
+    const result = await find._find(search);
+
+    // A match nobody can see is a total the user cannot reach, and a number the
+    // highlights cannot line up with.
+    expect(result.totalMatches).toBe(1);
+  });
+
+  it('counts the same column once it is shown', async () => {
+    const find = findOver([
+      { field: 'text', visible: true, value: 'Account default' },
+      { field: 'namespace', visible: true, value: 'default' },
+    ]);
+
+    const result = await find._find(search);
+
+    expect(result.totalMatches).toBe(2);
+  });
+});

--- a/log-viewer/src/tabulator/module/__tests__/tableReshape.test.ts
+++ b/log-viewer/src/tabulator/module/__tests__/tableReshape.test.ts
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2026 Certinia Inc. All rights reserved.
+ */
+import { describe, expect, it, jest } from '@jest/globals';
+import type { SorterFromTable, Tabulator } from 'tabulator-tables';
+
+import { onTableReshaped } from '../tableReshape.js';
+
+function setup() {
+  const handlers = new Map<string, (payload: SorterFromTable[]) => void>();
+  const table = {
+    on: (event: string, handler: (payload: SorterFromTable[]) => void) => {
+      handlers.set(event, handler);
+    },
+  } as unknown as Tabulator;
+  const changed = jest.fn();
+  onTableReshaped(table, changed);
+  return {
+    changed,
+    events: [...handlers.keys()],
+    sorted: (...sorters: Array<[string, string]>) =>
+      handlers.get('dataSorting')?.(
+        sorters.map(([field, dir]) => ({ field, dir }) as SorterFromTable),
+      ),
+    columnsChanged: () => handlers.get('columnVisibilityChanged')?.([]),
+  };
+}
+
+describe('onTableReshaped', () => {
+  it('reports an order the table did not have before', () => {
+    const { changed, sorted } = setup();
+
+    sorted(['selfTime', 'desc']);
+    expect(changed).toHaveBeenCalledTimes(1);
+
+    sorted(['selfTime', 'asc']);
+    sorted(['name', 'asc']);
+    expect(changed).toHaveBeenCalledTimes(3);
+  });
+
+  it('stays quiet where the order is the one already in force', () => {
+    const { changed, sorted } = setup();
+    sorted(['selfTime', 'desc']);
+
+    // What expanding a tree row does: each opened subtree is ordered through the
+    // same call, so the event repeats the order the table has.
+    sorted(['selfTime', 'desc']);
+    sorted(['selfTime', 'desc']);
+
+    expect(changed).toHaveBeenCalledTimes(1);
+  });
+
+  it('tells a second sort column from the first alone', () => {
+    const { changed, sorted } = setup();
+    sorted(['selfTime', 'desc']);
+
+    sorted(['selfTime', 'desc'], ['name', 'asc']);
+
+    expect(changed).toHaveBeenCalledTimes(2);
+  });
+
+  it('reports a column going on or off show, which the matches are counted over', () => {
+    const { changed, columnsChanged } = setup();
+
+    columnsChanged();
+
+    expect(changed).toHaveBeenCalledTimes(1);
+  });
+
+  it('reads the sort as it starts, so no row component is built to report it', () => {
+    // A dataSorted subscriber makes Tabulator build a component per sorted row.
+    expect(setup().events).toEqual(['dataSorting', 'columnVisibilityChanged']);
+  });
+});

--- a/log-viewer/src/tabulator/module/tableReshape.ts
+++ b/log-viewer/src/tabulator/module/tableReshape.ts
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2026 Certinia Inc. All rights reserved.
+ */
+import type { SorterFromTable, Tabulator } from 'tabulator-tables';
+
+/** Whether `sorters` is the order already recorded in `fields` and `dirs`. */
+function unchanged(
+  sorters: readonly SorterFromTable[],
+  fields: readonly string[],
+  dirs: readonly string[],
+): boolean {
+  if (sorters.length !== fields.length) {
+    return false;
+  }
+  for (let i = 0; i < sorters.length; i++) {
+    if (sorters[i]!.field !== fields[i] || sorters[i]!.dir !== dirs[i]) {
+      return false;
+    }
+  }
+  return true;
+}
+
+/**
+ * Call `changed` when `table` reshapes under the user: the rows come back in a
+ * different order, or a different set of columns is on show.
+ *
+ * A sort event does not say the order changed: expanding or collapsing a tree row
+ * orders that row's children through the same `Sort.sort` call, so the event fires
+ * once per opened subtree carrying the order the table already had. The order
+ * itself is what is compared, and compared without allocating, because an expand
+ * of a large tree fires this per subtree.
+ *
+ * Read from `dataSorting` rather than `dataSorted`: both fire from that one call
+ * with the same sorters, but a `dataSorted` subscriber makes Tabulator build a row
+ * component for every row it sorted, and those are cached on the rows.
+ *
+ * Tabulator's own `sort-changed` is truthful about a sort but reaches modules only,
+ * and fires for any `setSort` call, including one re-applying the order in force.
+ *
+ * Grouping is not here: `dataGrouped` fires only while the table is grouped, so
+ * turning grouping off reports nothing. The caller asks for the grouping it wants,
+ * so it knows both ways round.
+ */
+export function onTableReshaped(table: Tabulator, changed: () => void): void {
+  const fields: string[] = [];
+  const dirs: string[] = [];
+  table.on('dataSorting', (sorters) => {
+    if (unchanged(sorters, fields, dirs)) {
+      return;
+    }
+    fields.length = 0;
+    dirs.length = 0;
+    for (const sorter of sorters) {
+      fields.push(sorter.field);
+      dirs.push(sorter.dir);
+    }
+    changed();
+  });
+  table.on('columnVisibilityChanged', () => {
+    changed();
+  });
+}

--- a/log-viewer/src/tabulator/renderer/VirtualVerticalRenderer.ts
+++ b/log-viewer/src/tabulator/renderer/VirtualVerticalRenderer.ts
@@ -87,6 +87,7 @@ interface RendererBase {
   styleRow: (row: RowInternals, index: number) => void;
   // CoreFeature.dispatch → table.eventBus (internal event chain). Stock
   // fires 'render-virtual-fill' after every fill; GroupRows depends on it.
+  // Ours adds 'render-virtual-attach', after every attach.
   dispatch: (event: string) => void;
 }
 
@@ -1229,6 +1230,11 @@ export class VirtualVerticalRenderer extends Renderer {
         this._setHeight(entry.index, h, entry.row.data);
       }
     }
+
+    // Ours: rows are in the table. What decorates rendered rows needs this and
+    // not 'render-virtual-fill', which an incremental scroll tick skips, nor a
+    // scroll event, which a sort or a filter never fires.
+    self.dispatch('render-virtual-attach');
   }
 
   private _detachAllRendered(): void {

--- a/log-viewer/src/tabulator/renderer/__tests__/VirtualVerticalRendererAttach.test.ts
+++ b/log-viewer/src/tabulator/renderer/__tests__/VirtualVerticalRendererAttach.test.ts
@@ -277,6 +277,58 @@ describe('VirtualVerticalRenderer render-virtual-fill dispatch (stock contract)'
   });
 });
 
+describe('VirtualVerticalRenderer render-virtual-attach dispatch', () => {
+  interface AttachDispatchInternals extends AttachRendererInternals {
+    table: { rowManager: { element: { scrollTop: number } }; eventBus: { dispatch: jest.Mock } };
+    _renderWindow: () => void;
+  }
+
+  function makeDispatchSetup(rowCount: number): {
+    rr: AttachDispatchInternals;
+    rows: AttachRowStub[];
+    attachCalls: () => number;
+    fillCalls: () => number;
+  } {
+    const { r, rows } = makeAttachSetup(rowCount);
+    const rr = r as AttachDispatchInternals;
+    const dispatched = jest.fn();
+    rr.table.eventBus.dispatch = dispatched;
+    const calls = (event: string) => () =>
+      dispatched.mock.calls.filter((c) => c[0] === event).length;
+    return {
+      rr,
+      rows,
+      attachCalls: calls('render-virtual-attach'),
+      fillCalls: calls('render-virtual-fill'),
+    };
+  }
+
+  it('dispatches once per attach, and not for a range that attached nothing', () => {
+    const { rr, rows, attachCalls } = makeDispatchSetup(4);
+    rr._attachRanges(rows, [[0, 3]], 0);
+    expect(attachCalls()).toBe(1);
+
+    rr._attachRanges(rows, [], 0);
+    expect(attachCalls()).toBe(1);
+  });
+
+  it('reports a scroll tick that fill deliberately skips', () => {
+    const { rr, attachCalls, fillCalls } = makeDispatchSetup(200);
+    rr._renderWindow();
+    const filled = fillCalls();
+    const attached = attachCalls();
+
+    // Incremental scroll: rows enter the window, but the window is not
+    // replaced, so the stock fill contract stays silent.
+    rr.table.rowManager.element.scrollTop = 60;
+    rr.inScrollDrivenRender = true;
+    rr._renderWindow();
+
+    expect(fillCalls()).toBe(filled);
+    expect(attachCalls()).toBe(attached + 1);
+  });
+});
+
 describe('VirtualVerticalRenderer PseudoRow (group row) tolerance', () => {
   it('attaches PseudoRow-shaped rows without measuring or throwing', () => {
     const { r, rows, tableElement } = makeAttachSetup(5);


### PR DESCRIPTION
# 📝 PR Overview

Search in the grids drifted from what the screen showed. Rows brought in by a
scroll, a sort or a filter arrived with no highlight in them; expanding or
collapsing a tree row cleared the search outright; hidden columns were counted,
so the total led to matches nobody could reach; and the match you were on read
the same as the rest.

The renderer now announces every attach and Find takes Tabulator's own scroll
event, so every grid is covered whichever renderer it runs. The views compare
the row order itself, and drop the search only where the match numbering stops
describing the table.

## 🛠️ Changes made

- `VirtualVerticalRenderer` announces each attach, and `Find` rebuilds once per frame — the rebuild reads every cell on screen.
- `Find` also takes Tabulator's `scrollVertical`, which the stock renderer reports too, so the SOQL, DML and SOSL grids highlight on scroll again.
- The search covers only the columns on show, and the highlights follow the same set.
- New `onTableReshaped` helper: the row order is compared, so an expand is not read as a sort. It reads `dataSorting`, not `dataSorted`, which would make Tabulator build a row component per sorted row.
- The views drop the search on a real sort, a grouping either way round, a filter change, or a column going on or off show.
- The current match takes `editor.findMatchBackground`, the rest `editor.findMatchHighlightBackground`, foreground included.

## 🧩 Type of change (check all applicable)

- [x] 🐛 Bug fix - something not working as expected
- [ ] ✨ New feature – adds new functionality
- [ ] ♻️ Refactor - internal changes with no user impact
- [x] ⚡ Performance Improvement
- [ ] 📝 Documentation - README or documentation site changes
- [ ] 🔧 Chore - dev tooling, CI, config
- [ ] 💥 Breaking change

## 🔗 Related Issues

related #

## ✅ Tests added?

- [x] 👍 yes

`pnpm test`: 1582 tests, 131 suites. Each new test was proven by removing its fix.

Manual, 19.7MB sample log: expand and collapse hold the count and light the rows they open; a column view change and a grouping turned off both clear the search; a hidden column contributes no match, and a shown one does.

## 📚 Docs updated?

- [x] 🙅 not needed