### PR TITLE
fix(lana): read files through workspace.fs, not Salesforce Services

### DIFF
--- a/lana/src/cache/LogEventCache.ts
+++ b/lana/src/cache/LogEventCache.ts
@@ -1,12 +1,12 @@
 /*
  * Copyright (c) 2026 Certinia Inc. All rights reserved.
  */
-import { workspace } from 'vscode';
+import { workspace, type Uri } from 'vscode';
 
 import { parse, type ApexLog, type LogEvent } from 'apex-log-parser';
 
 import type { Context } from '../Context.js';
-import { readFile } from '../services/salesforceServices.js';
+import { readFileText } from '../fs/workspaceFs.js';
 
 export interface EventSearchResult {
   event: LogEvent;
@@ -17,17 +17,18 @@ export class LogEventCache {
   private static readonly MAX_CACHE_SIZE = 10;
   private static cache = new Map<string, ApexLog>();
 
-  static async getApexLog(uriString: string): Promise<ApexLog | null> {
-    const cached = LogEventCache.cache.get(uriString);
+  static async getApexLog(uri: Uri): Promise<ApexLog | null> {
+    const key = uri.toString();
+    const cached = LogEventCache.cache.get(key);
     if (cached) {
       // Move to end (most recently used)
-      LogEventCache.cache.delete(uriString);
-      LogEventCache.cache.set(uriString, cached);
+      LogEventCache.cache.delete(key);
+      LogEventCache.cache.set(key, cached);
       return cached;
     }
 
     try {
-      const content = await readFile(uriString);
+      const content = await readFileText(uri);
       const apexLog = parse(content);
 
       // Evict oldest if at capacity
@@ -38,7 +39,7 @@ export class LogEventCache {
         }
       }
 
-      LogEventCache.cache.set(uriString, apexLog);
+      LogEventCache.cache.set(key, apexLog);
       return apexLog;
     } catch {
       return null;

--- a/lana/src/cache/__tests__/LogEventCache.test.ts
+++ b/lana/src/cache/__tests__/LogEventCache.test.ts
@@ -2,7 +2,7 @@
  * Copyright (c) 2026 Certinia Inc. All rights reserved.
  */
 import { beforeEach, describe, expect, it } from '@jest/globals';
-import { workspace } from 'vscode';
+import { Uri, workspace } from 'vscode';
 
 import {
   createMockApexLog,
@@ -17,13 +17,12 @@ jest.mock('apex-log-parser', () => ({
 }));
 
 import { parse } from 'apex-log-parser';
-import { readFile } from '../../services/salesforceServices.js';
 
-jest.mock('../../services/salesforceServices.js', () => ({
-  readFile: jest.fn(),
-}));
-
-const mockReadFile = readFile as jest.Mock;
+// The file-I/O layer is deliberately not mocked out. Stubbing the whole module is
+// what let getApexLog read through a service that throws until another extension
+// initialises it, with the failure swallowed by its own catch.
+const mockReadFile = workspace.fs.readFile as jest.Mock;
+const readsText = (text: string) => new TextEncoder().encode(text);
 const mockParse = parse as jest.Mock;
 
 describe('LogEventCache', () => {
@@ -37,16 +36,16 @@ describe('LogEventCache', () => {
     describe('cache behavior', () => {
       it('should return cached ApexLog on subsequent calls', async () => {
         const mockApexLog = createMockApexLog({ size: 1000 });
-        mockReadFile.mockResolvedValueOnce('log content');
+        mockReadFile.mockResolvedValueOnce(readsText('log content'));
         mockParse.mockReturnValueOnce(mockApexLog);
 
         // First call - should read and parse
-        const result1 = await LogEventCache.getApexLog('/test/file.log');
+        const result1 = await LogEventCache.getApexLog(Uri.file('/test/file.log'));
         expect(result1).toBe(mockApexLog);
         expect(mockReadFile).toHaveBeenCalledTimes(1);
 
         // Second call - should return cached
-        const result2 = await LogEventCache.getApexLog('/test/file.log');
+        const result2 = await LogEventCache.getApexLog(Uri.file('/test/file.log'));
         expect(result2).toBe(mockApexLog);
         expect(mockReadFile).toHaveBeenCalledTimes(1); // Still 1
       });
@@ -55,28 +54,30 @@ describe('LogEventCache', () => {
         const log1 = createMockApexLog({ size: 100 });
         const log2 = createMockApexLog({ size: 200 });
 
-        mockReadFile.mockResolvedValueOnce('content1').mockResolvedValueOnce('content2');
+        mockReadFile
+          .mockResolvedValueOnce(readsText('content1'))
+          .mockResolvedValueOnce(readsText('content2'));
         mockParse.mockReturnValueOnce(log1).mockReturnValueOnce(log2);
 
-        await LogEventCache.getApexLog('/test/file1.log');
-        await LogEventCache.getApexLog('/test/file2.log');
+        await LogEventCache.getApexLog(Uri.file('/test/file1.log'));
+        await LogEventCache.getApexLog(Uri.file('/test/file2.log'));
 
         // Access file1 again - should move to end
-        await LogEventCache.getApexLog('/test/file1.log');
+        await LogEventCache.getApexLog(Uri.file('/test/file1.log'));
 
         // @ts-expect-error - accessing private static for testing
         const keys = Array.from(LogEventCache.cache.keys());
-        expect(keys).toEqual(['/test/file2.log', '/test/file1.log']);
+        expect(keys).toEqual(['file:///test/file2.log', 'file:///test/file1.log']);
       });
 
       it('should evict oldest entry when cache reaches MAX_CACHE_SIZE', async () => {
         // Create 11 logs to trigger eviction (MAX_CACHE_SIZE is 10)
         for (let i = 0; i < 11; i++) {
           const mockLog = createMockApexLog({ size: i * 100 });
-          mockReadFile.mockResolvedValueOnce(`content${i}`);
+          mockReadFile.mockResolvedValueOnce(readsText(`content${i}`));
           mockParse.mockReturnValueOnce(mockLog);
 
-          await LogEventCache.getApexLog(`/test/file${i}.log`);
+          await LogEventCache.getApexLog(Uri.file(`/test/file${i}.log`));
         }
 
         // @ts-expect-error - accessing private static for testing
@@ -85,30 +86,30 @@ describe('LogEventCache', () => {
 
         // First file should be evicted
         // @ts-expect-error - accessing private static for testing
-        const hasFirst = LogEventCache.cache.has('/test/file0.log');
+        const hasFirst = LogEventCache.cache.has('file:///test/file0.log');
         expect(hasFirst).toBe(false);
 
         // Last file should exist
         // @ts-expect-error - accessing private static for testing
-        const hasLast = LogEventCache.cache.has('/test/file10.log');
+        const hasLast = LogEventCache.cache.has('file:///test/file10.log');
         expect(hasLast).toBe(true);
       });
 
       it('should return null when file read fails', async () => {
         mockReadFile.mockRejectedValueOnce(new Error('File not found'));
 
-        const result = await LogEventCache.getApexLog('/test/nonexistent.log');
+        const result = await LogEventCache.getApexLog(Uri.file('/test/nonexistent.log'));
 
         expect(result).toBeNull();
       });
 
       it('should return null when parse fails', async () => {
-        mockReadFile.mockResolvedValueOnce('invalid content');
+        mockReadFile.mockResolvedValueOnce(readsText('invalid content'));
         mockParse.mockImplementationOnce(() => {
           throw new Error('Parse error');
         });
 
-        const result = await LogEventCache.getApexLog('/test/invalid.log');
+        const result = await LogEventCache.getApexLog(Uri.file('/test/invalid.log'));
 
         expect(result).toBeNull();
       });
@@ -314,41 +315,43 @@ describe('LogEventCache', () => {
   describe('clearCache', () => {
     it('should remove specific entry from cache', async () => {
       const mockApexLog = createMockApexLog();
-      mockReadFile.mockResolvedValueOnce('content');
+      mockReadFile.mockResolvedValueOnce(readsText('content'));
       mockParse.mockReturnValueOnce(mockApexLog);
 
-      await LogEventCache.getApexLog('/test/file.log');
+      await LogEventCache.getApexLog(Uri.file('/test/file.log'));
 
       // @ts-expect-error - accessing private static for testing
-      expect(LogEventCache.cache.has('/test/file.log')).toBe(true);
+      expect(LogEventCache.cache.has('file:///test/file.log')).toBe(true);
 
-      LogEventCache.clearCache('/test/file.log');
+      LogEventCache.clearCache('file:///test/file.log');
 
       // @ts-expect-error - accessing private static for testing
-      expect(LogEventCache.cache.has('/test/file.log')).toBe(false);
+      expect(LogEventCache.cache.has('file:///test/file.log')).toBe(false);
     });
 
     it('should not affect other cached entries', async () => {
       const log1 = createMockApexLog({ size: 100 });
       const log2 = createMockApexLog({ size: 200 });
 
-      mockReadFile.mockResolvedValueOnce('content1').mockResolvedValueOnce('content2');
+      mockReadFile
+        .mockResolvedValueOnce(readsText('content1'))
+        .mockResolvedValueOnce(readsText('content2'));
       mockParse.mockReturnValueOnce(log1).mockReturnValueOnce(log2);
 
-      await LogEventCache.getApexLog('/test/file1.log');
-      await LogEventCache.getApexLog('/test/file2.log');
+      await LogEventCache.getApexLog(Uri.file('/test/file1.log'));
+      await LogEventCache.getApexLog(Uri.file('/test/file2.log'));
 
-      LogEventCache.clearCache('/test/file1.log');
+      LogEventCache.clearCache('file:///test/file1.log');
 
       // @ts-expect-error - accessing private static for testing
-      expect(LogEventCache.cache.has('/test/file1.log')).toBe(false);
+      expect(LogEventCache.cache.has('file:///test/file1.log')).toBe(false);
       // @ts-expect-error - accessing private static for testing
-      expect(LogEventCache.cache.has('/test/file2.log')).toBe(true);
+      expect(LogEventCache.cache.has('file:///test/file2.log')).toBe(true);
     });
 
     it('should handle clearing non-existent entry gracefully', () => {
       expect(() => {
-        LogEventCache.clearCache('/test/nonexistent.log');
+        LogEventCache.clearCache('file:///test/nonexistent.log');
       }).not.toThrow();
     });
   });
@@ -366,9 +369,9 @@ describe('LogEventCache', () => {
     it('should clear cache when apexlog document is closed', async () => {
       // Setup cache
       const mockApexLog = createMockApexLog();
-      mockReadFile.mockResolvedValueOnce('content');
+      mockReadFile.mockResolvedValueOnce(readsText('content'));
       mockParse.mockReturnValueOnce(mockApexLog);
-      await LogEventCache.getApexLog('/test/file.log');
+      await LogEventCache.getApexLog(Uri.file('/test/file.log'));
 
       // Capture the callback
       let closeCallback:
@@ -384,19 +387,19 @@ describe('LogEventCache', () => {
       // Simulate closing an apexlog document
       closeCallback!({
         languageId: 'apexlog',
-        uri: { toString: () => '/test/file.log' },
+        uri: { toString: () => 'file:///test/file.log' },
       });
 
       // @ts-expect-error - accessing private static for testing
-      expect(LogEventCache.cache.has('/test/file.log')).toBe(false);
+      expect(LogEventCache.cache.has('file:///test/file.log')).toBe(false);
     });
 
     it('should not clear cache when non-apexlog document is closed', async () => {
       // Setup cache
       const mockApexLog = createMockApexLog();
-      mockReadFile.mockResolvedValueOnce('content');
+      mockReadFile.mockResolvedValueOnce(readsText('content'));
       mockParse.mockReturnValueOnce(mockApexLog);
-      await LogEventCache.getApexLog('/test/file.log');
+      await LogEventCache.getApexLog(Uri.file('/test/file.log'));
 
       // Capture the callback
       let closeCallback:
@@ -412,11 +415,11 @@ describe('LogEventCache', () => {
       // Simulate closing a non-apexlog document
       closeCallback!({
         languageId: 'javascript',
-        uri: { toString: () => '/test/file.log' },
+        uri: { toString: () => 'file:///test/file.log' },
       });
 
       // @ts-expect-error - accessing private static for testing
-      expect(LogEventCache.cache.has('/test/file.log')).toBe(true);
+      expect(LogEventCache.cache.has('file:///test/file.log')).toBe(true);
     });
   });
 });

--- a/lana/src/commands/LogView.ts
+++ b/lana/src/commands/LogView.ts
@@ -8,7 +8,7 @@ import type { Context } from '../Context.js';
 import { OpenFileInPackage } from '../display/OpenFileInPackage.js';
 import { WebView } from '../display/WebView.js';
 import { RawLogNavigation } from '../log-features/RawLogNavigation.js';
-import { fileOrFolderExists, readFile, writeFile } from '../services/salesforceServices.js';
+import { fileOrFolderExists, readFileText, writeFileText } from '../fs/workspaceFs.js';
 import {
   PRIVATE_SECTIONS,
   getColumnOverrides,
@@ -177,7 +177,7 @@ export class LogView {
               });
 
               if (destinationFile) {
-                writeFile(destinationFile, fileContent).catch((error) => {
+                writeFileText(destinationFile, fileContent).catch((error) => {
                   const msg = error instanceof Error ? error.message : String(error);
                   vscWindow.showErrorMessage(`Unable to save file: ${msg}`);
                 });
@@ -229,7 +229,7 @@ export class LogView {
   }
 
   private static async getFile(fileUri: Uri): Promise<string> {
-    return readFile(fileUri);
+    return readFileText(fileUri);
   }
 
   private static async sendLog(

--- a/lana/src/commands/ShowLogAnalysis.ts
+++ b/lana/src/commands/ShowLogAnalysis.ts
@@ -5,7 +5,7 @@ import { TabInputText, window, type Uri } from 'vscode';
 
 import { appName } from '../AppSettings.js';
 import type { Context } from '../Context.js';
-import { fileOrFolderExists } from '../services/salesforceServices.js';
+import { fileOrFolderExists } from '../fs/workspaceFs.js';
 import { Command } from './Command.js';
 import { LogView } from './LogView.js';
 

--- a/lana/src/commands/__tests__/LogView.test.ts
+++ b/lana/src/commands/__tests__/LogView.test.ts
@@ -6,16 +6,10 @@ import { describe, expect, it } from '@jest/globals';
 import { createMockContext } from '../../__tests__/helpers/test-builders.js';
 import { Uri, workspace } from '../../__tests__/mocks/vscode.js';
 import { WebView } from '../../display/WebView.js';
-import { readFile } from '../../services/salesforceServices.js';
 import { LogView } from '../LogView.js';
 
 jest.mock('../../display/WebView.js', () => ({
   WebView: { apply: jest.fn() },
-}));
-jest.mock('../../services/salesforceServices.js', () => ({
-  fileOrFolderExists: jest.fn(),
-  readFile: jest.fn(),
-  writeFile: jest.fn(),
 }));
 jest.mock('../../workspace/AppConfig.js', () => ({
   PRIVATE_SECTIONS: [],
@@ -38,7 +32,10 @@ jest.mock('../../workspace/AppConfig.js', () => ({
 }));
 
 const mockApplyWebView = WebView.apply as jest.Mock;
-const mockReadFile = readFile as jest.Mock;
+// The file-I/O layer is deliberately not mocked out: createView reads its own
+// bundled index.html, and mocking that module away is what hid it reading
+// through a service that throws unless another extension has initialised it.
+const mockReadFile = workspace.fs.readFile as unknown as jest.Mock;
 
 describe('LogView', () => {
   it('uses a display path in the payload and the captured URI for open actions', async () => {
@@ -59,7 +56,9 @@ describe('LogView', () => {
       },
     };
     mockApplyWebView.mockReturnValue(panel as unknown as import('vscode').WebviewPanel);
-    mockReadFile.mockResolvedValue('<script src="bundle.js"></script><link href="codicon.css">');
+    mockReadFile.mockResolvedValue(
+      new TextEncoder().encode('<script src="bundle.js"></script><link href="codicon.css">'),
+    );
     workspace.asRelativePath.mockReturnValue('workspace/logs/virtual.log');
     const context = createMockContext();
     const logUri = Uri.parse('memfs:/repository/logs/virtual.log');
@@ -70,6 +69,12 @@ describe('LogView', () => {
       logUri,
       'log body',
     );
+    // createView must resolve and rewrite the bundled index.html. It read that
+    // file through a service needing another extension's initialisation, so it
+    // rejected before the webview had any content.
+    expect(panel.webview.html).toContain('webview:/test/extension/out/bundle.js');
+    expect(panel.webview.html).not.toContain('src="bundle.js"');
+
     await receiveMessage?.({ cmd: 'fetchLog', requestId: 'request-1' });
 
     expect(postMessage).toHaveBeenCalledWith({

--- a/lana/src/decorations/RawLogLineDecoration.ts
+++ b/lana/src/decorations/RawLogLineDecoration.ts
@@ -90,7 +90,7 @@ export class RawLogLineDecoration {
     const timestamp = parseInt(match[1], 10);
     const filePath = document.uri.toString();
 
-    const apexLog = await LogEventCache.getApexLog(filePath);
+    const apexLog = await LogEventCache.getApexLog(document.uri);
     if (!apexLog) {
       this.clearDecorations(editor);
       return;

--- a/lana/src/folding/RawLogFoldingProvider.ts
+++ b/lana/src/folding/RawLogFoldingProvider.ts
@@ -28,7 +28,7 @@ class RawLogFoldingProvider implements FoldingRangeProvider {
     document: TextDocument,
     _context: FoldingContext,
   ): Promise<FoldingRange[]> {
-    const apexLog = await LogEventCache.getApexLog(document.uri.toString());
+    const apexLog = await LogEventCache.getApexLog(document.uri);
 
     if (!apexLog) {
       return [];
@@ -90,7 +90,7 @@ class RawLogFoldingProvider implements FoldingRangeProvider {
       return;
     }
 
-    void LogEventCache.getApexLog(document.uri.toString()).then((apexLog) => {
+    void LogEventCache.getApexLog(document.uri).then((apexLog) => {
       if (apexLog) {
         this.changeEmitter.fire();
       }

--- a/lana/src/folding/__tests__/RawLogFoldingProvider.test.ts
+++ b/lana/src/folding/__tests__/RawLogFoldingProvider.test.ts
@@ -366,7 +366,9 @@ describe('RawLogFoldingProvider', () => {
       openHandler(doc);
       await flush();
 
-      expect(mockGetApexLog).toHaveBeenCalledWith('file:///test/file.log');
+      expect(mockGetApexLog).toHaveBeenCalledWith(
+        expect.objectContaining({ scheme: 'file', path: '/test/file.log' }),
+      );
       expect(fired).toHaveBeenCalledTimes(1);
     });
 
@@ -380,7 +382,9 @@ describe('RawLogFoldingProvider', () => {
       activeEditorHandler({ document: doc });
       await flush();
 
-      expect(mockGetApexLog).toHaveBeenCalledWith('file:///test/file.log');
+      expect(mockGetApexLog).toHaveBeenCalledWith(
+        expect.objectContaining({ scheme: 'file', path: '/test/file.log' }),
+      );
       expect(fired).toHaveBeenCalledTimes(1);
     });
 
@@ -407,7 +411,9 @@ describe('RawLogFoldingProvider', () => {
       openHandler(doc);
       await flush();
 
-      expect(mockGetApexLog).toHaveBeenCalledWith('file:///test/file.log');
+      expect(mockGetApexLog).toHaveBeenCalledWith(
+        expect.objectContaining({ scheme: 'file', path: '/test/file.log' }),
+      );
       expect(fired).not.toHaveBeenCalled();
     });
   });

--- a/lana/src/fs/workspaceFs.ts
+++ b/lana/src/fs/workspaceFs.ts
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2026 Certinia Inc. All rights reserved.
+ */
+import { workspace, type Uri } from 'vscode';
+
+const decoder = new TextDecoder();
+const encoder = new TextEncoder();
+
+/**
+ * Reads a file as UTF-8 text.
+ *
+ * One decode pass, one string: no normalisation and no intermediate copy, so a
+ * multi-hundred-MB log does not double its peak memory here.
+ */
+export async function readFileText(uri: Uri): Promise<string> {
+  return decoder.decode(await workspace.fs.readFile(uri));
+}
+
+export async function writeFileText(uri: Uri, content: string): Promise<void> {
+  await workspace.fs.writeFile(uri, encoder.encode(content));
+}
+
+/**
+ * `workspace.fs` has no `exists`, so `stat` is the idiom. Any failure — missing,
+ * unreadable, or no provider for the scheme — answers the question every caller
+ * is really asking: can this be read?
+ */
+export async function fileOrFolderExists(uri: Uri): Promise<boolean> {
+  try {
+    await workspace.fs.stat(uri);
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/lana/src/hovers/RawLogHoverProvider.ts
+++ b/lana/src/hovers/RawLogHoverProvider.ts
@@ -9,6 +9,7 @@ import {
   type Position,
   type ProviderResult,
   type TextDocument,
+  type Uri,
 } from 'vscode';
 
 import { LogEventCache } from '../cache/LogEventCache.js';
@@ -25,14 +26,15 @@ class RawLogHoverProvider implements HoverProvider {
     }
 
     const timestamp = parseInt(match[1], 10);
-    return this.buildHover(document.uri.toString(), timestamp);
+    return this.buildHover(document.uri, timestamp);
   }
 
-  private async buildHover(filePath: string, timestamp: number): Promise<Hover> {
-    const args = encodeURIComponent(JSON.stringify({ timestamp, filePath }));
+  private async buildHover(uri: Uri, timestamp: number): Promise<Hover> {
+    // A command URI argument must be JSON, so the URI travels as a string here.
+    const args = encodeURIComponent(JSON.stringify({ timestamp, filePath: uri.toString() }));
     const commandUri = `command:lana.showInLogAnalysis?${args}`;
 
-    const apexLog = await LogEventCache.getApexLog(filePath);
+    const apexLog = await LogEventCache.getApexLog(uri);
     const result = apexLog ? LogEventCache.findEventByTimestamp(apexLog, timestamp) : null;
 
     const metricParts = result ? buildMetricParts(result.event) : [];

--- a/lana/src/log-features/RawLogNavigation.ts
+++ b/lana/src/log-features/RawLogNavigation.ts
@@ -3,7 +3,7 @@
  */
 import { Selection, commands, window, type Uri } from 'vscode';
 
-import { readFile } from '../services/salesforceServices.js';
+import { readFileText } from '../fs/workspaceFs.js';
 
 /**
  * Handles navigation within raw Apex log files.
@@ -20,7 +20,7 @@ export class RawLogNavigation {
   public static async goToLineByTimestamp(logUri: Uri, timestamp: number): Promise<void> {
     try {
       // Read file (no normalization - avoids doubling memory for large files)
-      const text = await readFile(logUri);
+      const text = await readFileText(logUri);
 
       // Find the exact timestamp pattern: (nanoseconds)|
       const index = text.indexOf(`(${timestamp})|`);

--- a/lana/src/services/salesforceServices.ts
+++ b/lana/src/services/salesforceServices.ts
@@ -29,11 +29,6 @@ export function getLogBody(logId: string): Promise<string> {
   return getRuntime().runPromise(ApexLogService.getLogBody(logId));
 }
 
-export function readFile(uri: Uri | string): Promise<string> {
-  const { FsService } = getServicesApi().services;
-  return getRuntime().runPromise(FsService.readFile(uri));
-}
-
 export function writeFile(uri: Uri | string, content: string): Promise<void> {
   const { FsService } = getServicesApi().services;
   return getRuntime().runPromise(FsService.safeWriteFile(uri, content));

--- a/lana/src/services/servicesRuntime.ts
+++ b/lana/src/services/servicesRuntime.ts
@@ -88,7 +88,6 @@ export function isSalesforceServicesApi(value: unknown): value is SalesforceVSCo
     isObject(dependencies) &&
     typeof getProperty(apexLogService, 'listLogs') === 'function' &&
     typeof getProperty(apexLogService, 'getLogBody') === 'function' &&
-    typeof getProperty(fsService, 'readFile') === 'function' &&
     typeof getProperty(fsService, 'safeWriteFile') === 'function' &&
     typeof getProperty(fsService, 'fileOrFolderExists') === 'function'
   );

--- a/lana/src/symbols/RawLogSymbolProvider.ts
+++ b/lana/src/symbols/RawLogSymbolProvider.ts
@@ -29,7 +29,7 @@ class RawLogSymbolProvider implements DocumentSymbolProvider {
     document: TextDocument,
     _token: CancellationToken,
   ): Promise<DocumentSymbol[]> {
-    const apexLog = await LogEventCache.getApexLog(document.uri.toString());
+    const apexLog = await LogEventCache.getApexLog(document.uri);
 
     if (!apexLog) {
       return [];


### PR DESCRIPTION
# PR overview

Follow-up to #952. Plain file I/O went through `@salesforce/vscode-services`' `FsService`, which
throws until `initServices()` has run — and nothing runs it outside `RetrieveLogFile`.

/cc @peternhale — raising this here rather than on #952 so your stack keeps moving. `#953`'s
`"type": "module"` question (below) is still yours; it is not touched here.

## The bug

`LogView.getFile()` read the extension's **own bundled `out/index.html`** through `FsService`.
`getServicesApi()` throws `Salesforce Services is not initialized.` unless `initServices()` has
run, and the only path to it is `ensureServicesAvailable()` from `RetrieveLogFile.ts`. So
`createView` rejected and the analysis view never opened, in any session where Retrieve Log had
not been run first.

`LogEventCache.getApexLog` hit the same throw and swallowed it in its own `catch { return null }`,
silently disabling folding, document symbols, sticky scroll and the cursor-line decoration.
`ShowLogAnalysis` and `RawLogNavigation` were affected too.

Why CI stayed green: every suite covering these paths `jest.mock`ed
`../../services/salesforceServices.js` — mocking out the module that throws.

## Changes made

- Add `lana/src/fs/workspaceFs.ts` — `readFileText` / `writeFileText` / `fileOrFolderExists` over
  `workspace.fs`. URI-native, works unchanged in the web extension host, needs no other extension
  and no initialisation. This is already the majority pattern from #952
  (`ApexLogLanguageDetector`, `SfdxProjectReader`); the service-based file I/O was the outlier.
- Point `LogView`, `ShowLogAnalysis`, `RawLogNavigation` and `LogEventCache` at it.
- `LogEventCache.getApexLog` now takes a `Uri` rather than a URI string, since `workspace.fs`
  needs one. The cache stays keyed on `uri.toString()`, so the four callers just drop
  `.toString()`.
- Delete the now-unused `salesforceServices.readFile` and its probe in `isSalesforceServicesApi`.
  Salesforce Services keeps `listLogs`, `getLogBody` and the `RetrieveLogFile` write, which are
  genuine org operations behind `ensureServicesAvailable()`.
- Stop mocking the file-I/O layer in the affected suites; they drive `workspace.fs` instead, so
  reintroducing the dependency fails loudly.

`Main.ts` is unchanged — activation stays decoupled from Salesforce Services, and is now correct
rather than broken.

## Type of change

- [x] Bug fix

## Related issues

related W-23939830

## Validation

- `tsc -b lana` clean; `eslint lana/src` clean
- 329 tests pass across 20 suites
- Regression proof: reverting `LogView.ts` and `salesforceServices.ts` to their merged state makes
  `LogView.test.ts` fail with `Salesforce Services is not initialized.`; restoring them passes.
  The suite now also asserts the webview HTML is actually rewritten, which it never checked before.

## Deliberately not in scope

Kept to the one blocking defect so it can land quickly. To follow:

- The detector's `workspace.fs.readFile` reads the whole file to decode 4 KB (0.056ms -> 2.9ms and
  a 163MB RSS peak on the 19.7MB sample, on every tab-change event) — the thread on #952 is still open.
- Dropping the `scheme: 'file'` selectors means `warmAndSignal` now eagerly parses diff sides.
- The save dialog defaults into the extension's install directory when no workspace folder is open.
- The webview still sends a now-ignored `openPath` payload.
- New suites for `RawLogNavigation` and `ShowLogAnalysis`, which have none.