### PR TITLE
fix(log-viewer): point the inspector at one row, not the whole chain above it

### DIFF
--- a/log-viewer/src/components/__tests__/inspectorTab.test.ts
+++ b/log-viewer/src/components/__tests__/inspectorTab.test.ts
@@ -16,9 +16,14 @@ describe('wireInspectorTab', () => {
   });
 
   /** A Call Tree-like view: it records what it marked, moved to and cleared. */
-  function wire(movesToMergedPick = true, reveal?: (eventIndex: number) => Promise<void>) {
+  function wire(
+    movesToMergedPick = true,
+    reveal?: (eventIndex: number, signal: AbortSignal) => Promise<void>,
+  ) {
     const marks: Array<readonly number[]> = [];
     const revealed: number[] = [];
+    /** The signal each move was given, so a test can read which were abandoned. */
+    const signals: AbortSignal[] = [];
     /** Marks and moves in the order they arrived, which the two lists cannot show. */
     const order: string[] = [];
     let clears = 0;
@@ -27,10 +32,11 @@ describe('wireInspectorTab', () => {
         marks.push(eventIndexes);
         order.push('mark');
       },
-      reveal: (eventIndex) => {
+      reveal: (eventIndex, signal) => {
         order.push('move');
+        signals.push(signal);
         if (reveal) {
-          return reveal(eventIndex);
+          return reveal(eventIndex, signal);
         }
         revealed.push(eventIndex);
       },
@@ -39,7 +45,7 @@ describe('wireInspectorTab', () => {
       },
       movesToMergedPick,
     });
-    return { marks, revealed, order, clears: () => clears };
+    return { marks, revealed, order, signals, clears: () => clears };
   }
 
   it('leaves an event for another tab alone', () => {
@@ -119,6 +125,28 @@ describe('wireInspectorTab', () => {
     await new Promise((resolve) => setTimeout(resolve, 0));
 
     expect(view.marks).toEqual([[4]]);
+  });
+
+  it('abandons a move the next one replaces, and keeps both marks', () => {
+    const view = wire();
+
+    eventBus.emit('inspector:reveal', { source: 'calltree', eventIndex: 4 });
+    eventBus.emit('inspector:locate', { source: 'calltree', eventIndexes: [9], sticky: true });
+
+    // The pointer crossing rows asks for a move per row, and the one it stops on
+    // is the one that scrolls.
+    expect(view.signals.map((signal) => signal.aborted)).toEqual([true, false]);
+    expect(view.marks).toEqual([[9]]);
+  });
+
+  it('abandons the move in flight when the view goes away', () => {
+    const view = wire();
+
+    eventBus.emit('inspector:reveal', { source: 'calltree', eventIndex: 4 });
+    off?.();
+    off = null;
+
+    expect(view.signals[0]?.aborted).toBe(true);
   });
 
   it('stops answering once unsubscribed', () => {

--- a/log-viewer/src/components/__tests__/locatedRow.test.ts
+++ b/log-viewer/src/components/__tests__/locatedRow.test.ts
@@ -287,13 +287,17 @@ describe('LocatedRowIds', () => {
   const frame = ev('inner', outerFrame);
   const log = { eventsById: { 5: frame } } as unknown as ApexLog;
 
-  it('builds the paths of the rows the frames belong to', () => {
-    const found = new LocatedRowIds().idsFor(log, [5], 'callers');
+  it('builds the paths of the rows the frames stand for', () => {
+    const paths = logStoreFor(log).keyPathIds();
+    // The row the frame is, and a row for it under another bucket.
+    const own = paths.step(ROOT_PATH_ID, paths.keyIdOf(frame));
+    const under = paths.step(paths.step(ROOT_PATH_ID, paths.keyId('other')), paths.keyIdOf(frame));
+    // The row of the caller above it, which stands for the caller.
+    paths.step(own, paths.keyIdOf(outerFrame));
 
-    // The log's own table, so a row stamped from it reaches the same ids.
-    const expected = new Set<number>();
-    logStoreFor(log).keyPathIds().pathIdsOf(frame, 'callers', expected);
-    expect(found).toEqual([...expected]);
+    expect(new LocatedRowIds().idsFor(log, [5], 'callers').slice().sort()).toEqual(
+      [own, under].sort(),
+    );
   });
 
   it('reuses what it built for the frames it was last asked about', () => {

--- a/log-viewer/src/components/inspectorTab.ts
+++ b/log-viewer/src/components/inspectorTab.ts
@@ -12,8 +12,11 @@ export interface InspectorTabSync {
   /**
    * Move to one frame. A rejection is the view's own to report: it says the view
    * cannot reach the frame, and the mark still says where the frame is.
+   *
+   * @param signal - aborted once a later move has replaced this one. A view that
+   * waits on anything checks it before it scrolls.
    */
-  reveal: (eventIndex: number) => void | Promise<void>;
+  reveal: (eventIndex: number, signal: AbortSignal) => void | Promise<void>;
 
   /** Drop the view's own selection, for the app-wide Escape. */
   clear: () => void;
@@ -40,9 +43,15 @@ export function wireInspectorTab(
   emphasis: InspectorEmphasis,
   sync: InspectorTabSync,
 ): () => void {
+  let moving: AbortController | null = null;
   const move = (eventIndex: number): void => {
+    // A move waits on a render, and a pointer crossing rows asks for several, so
+    // the last one asked for is the one that scrolls. Only the move is abandoned:
+    // the mark of the move that is dropped went on before it.
+    moving?.abort();
+    moving = new AbortController();
     // The view reports its own failure; the mark stands either way.
-    void Promise.resolve(sync.reveal(eventIndex)).catch(() => {});
+    void Promise.resolve(sync.reveal(eventIndex, moving.signal)).catch(() => {});
   };
 
   const offs = [
@@ -66,6 +75,8 @@ export function wireInspectorTab(
   ];
 
   return () => {
+    moving?.abort();
+    moving = null;
     for (const off of offs) {
       off();
     }

--- a/log-viewer/src/components/locatedRow.ts
+++ b/log-viewer/src/components/locatedRow.ts
@@ -6,6 +6,7 @@ import type { ApexLog, LogEvent } from 'apex-log-parser';
 import type { RowComponent } from 'tabulator-tables';
 
 import type { DetailSelection, SelectionView } from '../core/events/EventBus.js';
+import type { KeyPathIds } from '../core/log/keyPathIds.js';
 import { logStoreFor } from '../core/log/LogStore.js';
 import { eventByEventIndex } from '../core/utility/EventSearch.js';
 
@@ -139,6 +140,7 @@ const rowCallData = (row: RowComponent): CallRow => row.getData() as CallRow;
 const derivedIndexes = new WeakMap<CallRow, number[]>();
 
 const NO_CALLS: LogEvent[] = [];
+const NO_FRAMES: number[] = [];
 
 /**
  * The root bucket a derived row reads its calls from, or null where the walk
@@ -298,17 +300,45 @@ export function rowFrames(
   if (cached) {
     return cached;
   }
-  const levels = data._pathId === undefined ? 0 : store.keyPathIds().depthOf(data._pathId) - 1;
-  const conducted = rowOccurrences(row, root);
-  if (levels <= 0) {
-    return conducted;
+  const paths = store.keyPathIds();
+  const pathId = data._pathId;
+  if (pathId === undefined || paths.depthOf(pathId) <= 1) {
+    // A row at the depth of its own calls stands for them.
+    return rowOccurrences(row, root);
   }
-  const frames = store.framesAbove(conducted, levels);
+  const frames = callerFramesOf(row, data, pathId, paths);
   if (frames.length) {
     // Not kept where nothing climbed, for the reason `rowOccurrences` gives.
     derivedCallerFrames.set(data, frames);
   }
   return frames;
+}
+
+/**
+ * The frames a caller row is: the node each of its bucket's chains passes through
+ * at the row's own depth.
+ *
+ * One walk per occurrence answers both questions the row asks, since the walk
+ * that decides whether a chain reaches the row stands on that node when it does.
+ */
+function callerFramesOf(
+  row: RowComponent,
+  data: CallRow,
+  pathId: number,
+  paths: KeyPathIds,
+): number[] {
+  const instances = rootBucketOf(row, data)?.instances;
+  if (!instances?.length) {
+    return NO_FRAMES;
+  }
+  const own = new Set<number>();
+  for (const event of instances) {
+    const node = paths.chainNodeAt(event, pathId);
+    if (node) {
+      own.add(node.eventIndex);
+    }
+  }
+  return [...own];
 }
 
 /**

--- a/log-viewer/src/components/locatedRow.ts
+++ b/log-viewer/src/components/locatedRow.ts
@@ -231,9 +231,9 @@ function deriveCalls(row: RowComponent, data: CallRow, root: ApexLog | null): Lo
  * The path ids that the frames `eventIndexes` name stand for, so a grid whose
  * rows merge occurrences can mark them.
  *
- * Every occurrence is walked: occurrences of one frame sit under distinct parent
- * frames, so there is no cheaper set to walk, and only the paths they produce
- * repeat.
+ * A bottom-up row is the frame at its own depth, so a frame stands for the rows
+ * its own key heads, wherever they sit; the chain above it holds its callers'
+ * rows. A top-down row sits on the frame's own chain, so one id names it.
  */
 function pathIdsForEvents(
   root: ApexLog,
@@ -241,11 +241,21 @@ function pathIdsForEvents(
   direction: SelectionView,
 ): number[] {
   const paths = logStoreFor(root).keyPathIds();
-  const found = new Set<number>();
+  const events: LogEvent[] = [];
   for (const eventIndex of eventIndexes) {
     const event = eventByEventIndex(root, eventIndex);
     if (event) {
-      paths.pathIdsOf(event, direction, found);
+      events.push(event);
+    }
+  }
+  if (direction === 'callers') {
+    return paths.pathsEndingIn(new Set(events.map((event) => paths.keyIdOf(event))));
+  }
+  const found = new Set<number>();
+  for (const event of events) {
+    const pathId = paths.pathIdOf(event);
+    if (pathId !== undefined) {
+      found.add(pathId);
     }
   }
   return [...found];

--- a/log-viewer/src/components/locatedRow.ts
+++ b/log-viewer/src/components/locatedRow.ts
@@ -6,7 +6,7 @@ import type { ApexLog, LogEvent } from 'apex-log-parser';
 import type { RowComponent } from 'tabulator-tables';
 
 import type { DetailSelection, SelectionView } from '../core/events/EventBus.js';
-import type { KeyPathIds } from '../core/log/keyPathIds.js';
+import { ROOT_PATH_ID } from '../core/log/keyPathIds.js';
 import { logStoreFor } from '../core/log/LogStore.js';
 import { eventByEventIndex } from '../core/utility/EventSearch.js';
 
@@ -140,7 +140,6 @@ const rowCallData = (row: RowComponent): CallRow => row.getData() as CallRow;
 const derivedIndexes = new WeakMap<CallRow, number[]>();
 
 const NO_CALLS: LogEvent[] = [];
-const NO_FRAMES: number[] = [];
 
 /**
  * The root bucket a derived row reads its calls from, or null where the walk
@@ -205,26 +204,61 @@ function rowCallOccurrences(row: RowComponent, root: ApexLog | null): LogEvent[]
   if (data.key === undefined) {
     return data.originalData ? [data.originalData] : NO_CALLS;
   }
-  return deriveCalls(row, data, root);
+  return derivedRowOf(row, data, root).calls;
 }
 
+/** What a derived row's bucket answers: the calls whose chain runs through the
+ *  row, and the frames the row is at its own depth. */
+interface DerivedRow {
+  calls: LogEvent[];
+  frames: number[];
+}
+
+const NOTHING_DERIVED: DerivedRow = { calls: NO_CALLS, frames: [] };
+
+/** Held per row: a pointer sweep re-enters rows and the click that follows a
+ *  hover asks again, but deriving reads every occurrence the root bucket holds. */
+const derivedRows = new WeakMap<CallRow, DerivedRow>();
+
 /**
- * The root bucket's calls whose own chain runs through the row.
+ * The root bucket's calls whose own chain runs through the row, and the frames
+ * the row stands for.
+ *
+ * One walk per occurrence answers both: the walk that decides whether a chain
+ * reaches the row stands on the row's own frame when it does.
  *
  * The table is the log's that built the rows: a path id is minted per log, so
  * another log's table would answer about a path of its own.
  */
-function deriveCalls(row: RowComponent, data: CallRow, root: ApexLog | null): LogEvent[] {
+function derivedRowOf(row: RowComponent, data: CallRow, root: ApexLog | null): DerivedRow {
+  const cached = derivedRows.get(data);
+  if (cached) {
+    return cached;
+  }
   const pathId = data._pathId;
   if (pathId === undefined || !root) {
-    return NO_CALLS;
+    return NOTHING_DERIVED;
   }
   const paths = logStoreFor(root).keyPathIds();
   const instances = rootBucketOf(row, data)?.instances;
   if (!instances?.length) {
-    return NO_CALLS;
+    return NOTHING_DERIVED;
   }
-  return instances.filter((event) => paths.chainReaches(event, pathId));
+  const calls: LogEvent[] = [];
+  const own = new Set<number>();
+  for (const event of instances) {
+    const node = paths.chainNodeAt(event, pathId);
+    if (node) {
+      calls.push(event);
+      own.add(node.eventIndex);
+    }
+  }
+  const derived = { calls, frames: [...own] };
+  if (calls.length) {
+    // Not kept where nothing derived, for the reason `rowOccurrences` gives.
+    derivedRows.set(data, derived);
+  }
+  return derived;
 }
 
 /**
@@ -279,10 +313,6 @@ export function rowOccurrences(row: RowComponent, root: ApexLog | null): number[
   return indexes;
 }
 
-/** Held per row, for the same reason {@link derivedIndexes} is. Only a caller
- *  row ever climbs, so only a caller row's answer is in here. */
-const derivedCallerFrames = new WeakMap<CallRow, number[]>();
-
 /**
  * The frames a row is, which is what the inspector marks it by.
  *
@@ -302,53 +332,15 @@ export function rowFrames(
   direction: SelectionView,
 ): number[] {
   const data = rowCallData(row);
-  const store = direction === 'callers' && root ? logStoreFor(root) : null;
-  if (!store) {
+  const pathId = data._pathId;
+  if (direction !== 'callers' || !root || pathId === undefined) {
     return rowOccurrences(row, root);
   }
-  const cached = derivedCallerFrames.get(data);
-  if (cached) {
-    return cached;
-  }
-  const paths = store.keyPathIds();
-  const pathId = data._pathId;
-  if (pathId === undefined || paths.depthOf(pathId) <= 1) {
+  if (logStoreFor(root).keyPathIds().parentOf(pathId) === ROOT_PATH_ID) {
     // A row at the depth of its own calls stands for them.
     return rowOccurrences(row, root);
   }
-  const frames = callerFramesOf(row, data, pathId, paths);
-  if (frames.length) {
-    // Not kept where nothing climbed, for the reason `rowOccurrences` gives.
-    derivedCallerFrames.set(data, frames);
-  }
-  return frames;
-}
-
-/**
- * The frames a caller row is: the node each of its bucket's chains passes through
- * at the row's own depth.
- *
- * One walk per occurrence answers both questions the row asks, since the walk
- * that decides whether a chain reaches the row stands on that node when it does.
- */
-function callerFramesOf(
-  row: RowComponent,
-  data: CallRow,
-  pathId: number,
-  paths: KeyPathIds,
-): number[] {
-  const instances = rootBucketOf(row, data)?.instances;
-  if (!instances?.length) {
-    return NO_FRAMES;
-  }
-  const own = new Set<number>();
-  for (const event of instances) {
-    const node = paths.chainNodeAt(event, pathId);
-    if (node) {
-      own.add(node.eventIndex);
-    }
-  }
-  return [...own];
+  return derivedRowOf(row, data, root).frames;
 }
 
 /**

--- a/log-viewer/src/core/log/__tests__/keyPathIds.test.ts
+++ b/log-viewer/src/core/log/__tests__/keyPathIds.test.ts
@@ -61,6 +61,27 @@ describe('KeyPathIds', () => {
     expect(ids.reaches(inner, pathFor(ids, 'Z'))).toBe(false);
   });
 
+  describe('chainNodeAt', () => {
+    const root = ev(1, 'exec', null);
+    const outer = ev(2, 'outer', root);
+    const inner = ev(3, 'inner', outer);
+
+    it('names the frame the row sits at, which is what a caller row stands for', () => {
+      const leafRow = pathFor(ids, 'METHOD_ENTRY||inner');
+      const callerRow = pathFor(ids, 'METHOD_ENTRY||inner', 'METHOD_ENTRY||outer');
+
+      expect(ids.chainNodeAt(inner, leafRow)).toBe(inner);
+      expect(ids.chainNodeAt(inner, callerRow)).toBe(outer);
+    });
+
+    it('answers for a path the chain misses with nothing, as reaches says false', () => {
+      const elsewhere = pathFor(ids, 'METHOD_ENTRY||Z');
+
+      expect(ids.chainNodeAt(inner, elsewhere)).toBeNull();
+      expect(ids.chainReaches(inner, elsewhere)).toBe(false);
+    });
+  });
+
   it('reads back how many keys a path stands for, and none for the empty one', () => {
     expect(ids.depthOf(pathFor(ids, 'A', 'B', 'C'))).toBe(3);
     expect(ids.depthOf(ROOT_PATH_ID)).toBe(0);

--- a/log-viewer/src/core/log/__tests__/keyPathIds.test.ts
+++ b/log-viewer/src/core/log/__tests__/keyPathIds.test.ts
@@ -138,34 +138,47 @@ describe('KeyPathIds', () => {
     });
   });
 
-  describe('pathIdsOf', () => {
+  describe('pathIdOf', () => {
     const root = ev(1, 'exec', null);
     const outer = ev(2, 'outer', root);
     const inner = ev(3, 'inner', outer);
 
-    /** The ids the walk adds, in the order it adds them. */
-    function found(event: LogEvent, direction: 'callers' | 'callees'): number[] {
-      const into = new Set<number>();
-      ids.pathIdsOf(event, direction, into);
-      return [...into];
+    it('names one row in a top-down view, at the depth the frame ran at', () => {
+      expect(ids.pathIdOf(inner)).toBe(pathFor(ids, 'METHOD_ENTRY||outer', 'METHOD_ENTRY||inner'));
+    });
+
+    it('leaves the log root out, as it heads no row', () => {
+      expect(ids.pathIdOf(root)).toBeUndefined();
+    });
+  });
+
+  describe('pathsEndingIn', () => {
+    /** The ids a key heads, over the paths the table has been asked for. */
+    function found(...keys: string[]): number[] {
+      return ids.pathsEndingIn(new Set(keys.map((key) => ids.keyId(key))));
     }
 
-    it('names one row in a top-down view, at the depth the frame ran at', () => {
-      expect(found(inner, 'callees')).toEqual([
-        pathFor(ids, 'METHOD_ENTRY||outer', 'METHOD_ENTRY||inner'),
-      ]);
+    it('names the rows a frame is, and not the rows of the callers above it', () => {
+      const own = pathFor(ids, 'A');
+      const elsewhere = pathFor(ids, 'B', 'A');
+      // A row for the caller of A, which stands for that caller and not for A.
+      pathFor(ids, 'A', 'C');
+
+      expect(found('A').sort()).toEqual([own, elsewhere].sort());
     });
 
-    it('names a row per caller depth in a bottom-up view', () => {
-      // The frame heads a row on its own, and one under each caller above it.
-      expect(found(inner, 'callers')).toEqual([
-        pathFor(ids, 'METHOD_ENTRY||inner'),
-        pathFor(ids, 'METHOD_ENTRY||inner', 'METHOD_ENTRY||outer'),
-      ]);
+    it('answers for several frames at once, which one pointed-at row can name', () => {
+      const a = pathFor(ids, 'A');
+      const b = pathFor(ids, 'B');
+
+      expect(found('A', 'B').sort()).toEqual([a, b].sort());
     });
 
-    it('leaves the log root out, as it heads a row in neither view', () => {
-      expect(found(root, 'callers')).toEqual([]);
+    it('leaves the empty path out, since no row stands for it, and asks nothing of no keys', () => {
+      pathFor(ids, 'A');
+
+      expect(found()).toEqual([]);
+      expect(found('Z')).toEqual([]);
     });
   });
 });

--- a/log-viewer/src/core/log/__tests__/keyPathIds.test.ts
+++ b/log-viewer/src/core/log/__tests__/keyPathIds.test.ts
@@ -74,11 +74,10 @@ describe('KeyPathIds', () => {
       expect(ids.chainNodeAt(inner, callerRow)).toBe(outer);
     });
 
-    it('answers for a path the chain misses with nothing, as reaches says false', () => {
+    it('answers for a path the chain misses with nothing', () => {
       const elsewhere = pathFor(ids, 'METHOD_ENTRY||Z');
 
       expect(ids.chainNodeAt(inner, elsewhere)).toBeNull();
-      expect(ids.chainReaches(inner, elsewhere)).toBe(false);
     });
   });
 

--- a/log-viewer/src/core/log/keyPathIds.ts
+++ b/log-viewer/src/core/log/keyPathIds.ts
@@ -124,25 +124,36 @@ export class KeyPathIds {
   /**
    * True where the frame's own chain of callers runs through `pathId`: what tells
    * the calls a bottom-up caller row holds from the rest of its bucket's.
+   */
+  public chainReaches(event: LogEvent, pathId: number): boolean {
+    return this.chainNodeAt(event, pathId) !== null;
+  }
+
+  /**
+   * The frame in the chain that `pathId` names, or null where the chain does not
+   * run through it: the caller a bottom-up row is, at the depth the row sits at.
+   *
+   * The walk that decides membership stands on that frame when it gets there, so
+   * a caller row's frames come out of it rather than out of a second climb.
    *
    * Reads without minting, unlike {@link step}: a query that grew the table would
    * leave a node behind for every frame it was asked about. Ids only rise as a
    * chain deepens, so the walk stops once it passes the depth asked about.
    */
-  public chainReaches(event: LogEvent, pathId: number): boolean {
+  public chainNodeAt(event: LogEvent, pathId: number): LogEvent | null {
     let id = ROOT_PATH_ID;
     for (let node: LogEvent | null = event; node?.parent; node = node.parent) {
       const next = this.children[id]?.get(this.keyIdOf(node));
       if (next === undefined || next > pathId) {
         // Never minted, so no row stands for it; or past the row's own depth.
-        return false;
+        return null;
       }
       id = next;
       if (id === pathId) {
-        return true;
+        return node;
       }
     }
-    return false;
+    return null;
   }
 
   /**

--- a/log-viewer/src/core/log/keyPathIds.ts
+++ b/log-viewer/src/core/log/keyPathIds.ts
@@ -128,14 +128,6 @@ export class KeyPathIds {
   }
 
   /**
-   * True where the frame's own chain of callers runs through `pathId`: what tells
-   * the calls a bottom-up caller row holds from the rest of its bucket's.
-   */
-  public chainReaches(event: LogEvent, pathId: number): boolean {
-    return this.chainNodeAt(event, pathId) !== null;
-  }
-
-  /**
    * The frame in the chain that `pathId` names, or null where the chain does not
    * run through it: the caller a bottom-up row is, at the depth the row sits at.
    *
@@ -216,6 +208,11 @@ export class KeyPathIds {
       id = this.parents[id]!;
     }
     return id === pathId;
+  }
+
+  /** The path `pathId` extends, {@link ROOT_PATH_ID} for a row of its own depth. */
+  public parentOf(pathId: number): number {
+    return this.parents[pathId]!;
   }
 
   /** How many keys `pathId` stands for: the depth of the row it names, 0 at the

--- a/log-viewer/src/core/log/keyPathIds.ts
+++ b/log-viewer/src/core/log/keyPathIds.ts
@@ -3,7 +3,6 @@
  */
 import type { LogEvent } from 'apex-log-parser';
 
-import type { SelectionView } from '../events/EventBus.js';
 import { getEventKey, getStackKey } from './eventKeys.js';
 
 /** The path every chain starts from, which no row stands for. */
@@ -19,9 +18,9 @@ export const ROOT_PATH_ID = 0;
  * than by the calls, and makes matching an integer test.
  *
  * One invariant holds it together: a row's id is the interned chain of the
- * frames the row holds. {@link pathIdsOf} names the rows a frame belongs to and
- * {@link chainReaches} asks whether a frame's chain runs through one, so the two
- * chain directions stay separate spaces here rather than in every caller.
+ * frames the row holds. {@link pathIdOf} and {@link pathsEndingIn} name the rows
+ * a frame stands for, one direction each, and {@link chainNodeAt} reads a row's
+ * own frame back out of a chain.
  *
  * One table per log, held by `LogStore`: an id means nothing to another log.
  */
@@ -39,7 +38,10 @@ export class KeyPathIds {
   private children: Array<Map<number, number> | undefined> = [new Map()];
   private parents: number[] = [ROOT_PATH_ID];
   private keyOf: number[] = [-1];
-  /** One frame's chain, reused: {@link pathIdsOf} never yields, so one is enough.
+  /** The paths each key heads, which is how a frame finds the rows it stands
+   *  for. Filled as paths are minted, so the answer costs what it holds. */
+  private pathsByKey: number[][] = [];
+  /** One frame's chain, reused: {@link pathIdOf} never yields, so one is enough.
    *  Per table rather than per module, so two logs cannot share the buffer. */
   private chain: number[] = [];
 
@@ -86,28 +88,12 @@ export class KeyPathIds {
   }
 
   /**
-   * The ids naming the rows a frame belongs to in a merged view, added to `into`.
-   *
-   * A top-down row sits at the frame's own depth, so one id names it. A
-   * bottom-up row is the frame plus however many of its callers the chain shows,
-   * so every prefix names a row the frame heads — which is why one frame marks
-   * several rows there.
-   *
-   * The log root heads no row in either view, so the walk stops below it.
+   * The id naming the row a frame sits in, top-down, or undefined for the log
+   * root, which heads no row.
    */
-  public pathIdsOf(event: LogEvent, direction: SelectionView, into: Set<number>): void {
+  public pathIdOf(event: LogEvent): number | undefined {
     if (!event.parent) {
-      return;
-    }
-    if (direction === 'callers') {
-      // The parent walk is already innermost first, which is the order these ids
-      // compose in, so nothing is collected on the way.
-      let id = ROOT_PATH_ID;
-      for (let node: LogEvent | null = event; node?.parent; node = node.parent) {
-        id = this.step(id, this.keyIdOf(node));
-        into.add(id);
-      }
-      return;
+      return undefined;
     }
     const chain = this.chain;
     chain.length = 0;
@@ -118,7 +104,27 @@ export class KeyPathIds {
     for (let depth = chain.length - 1; depth >= 0; depth--) {
       id = this.step(id, chain[depth]!);
     }
-    into.add(id);
+    return id;
+  }
+
+  /**
+   * The paths whose own key is one of `keyIds`: the rows that stand for those
+   * frames in a bottom-up view, wherever they sit.
+   *
+   * A bottom-up row is the frame at its own depth, so a frame heads the bucket
+   * for it and any caller row for it under another bucket. The chains above it
+   * are other frames' rows, which is why they are not here.
+   */
+  public pathsEndingIn(keyIds: ReadonlySet<number>): number[] {
+    const found: number[] = [];
+    for (const keyId of keyIds) {
+      // A path holds one key, so no path is reached twice.
+      const paths = this.pathsByKey[keyId];
+      if (paths) {
+        found.push(...paths);
+      }
+    }
+    return found;
   }
 
   /**
@@ -175,6 +181,7 @@ export class KeyPathIds {
       this.children.push(undefined);
       this.parents.push(parentPathId);
       this.keyOf.push(keyId);
+      (this.pathsByKey[keyId] ??= []).push(id);
     }
     return id;
   }

--- a/log-viewer/src/features/analysis/components/AnalysisView.ts
+++ b/log-viewer/src/features/analysis/components/AnalysisView.ts
@@ -174,7 +174,7 @@ export class AnalysisView extends LitElement {
       mark: (eventIndexes) => this._markLocated(eventIndexes),
       // An inspector finding names one event; the grid holds it in the bucket for
       // its method, so that bucket is what gets revealed.
-      reveal: (eventIndex) => this._revealEventIndex(eventIndex),
+      reveal: (eventIndex, signal) => this._revealEventIndex(eventIndex, signal),
       clear: () => {
         // The table reports the clear itself, which is what reaches the inspector.
         this.analysisTable?.deselectRow();
@@ -219,7 +219,7 @@ export class AnalysisView extends LitElement {
    * inspector keeps the findings it was clicked in rather than being rebuilt around
    * the row it just asked for.
    */
-  private async _revealEventIndex(eventIndex: number): Promise<void> {
+  private async _revealEventIndex(eventIndex: number, signal: AbortSignal): Promise<void> {
     const table = this.analysisTable;
     const root = this.timelineRoot;
     if (!table || !root) {
@@ -242,6 +242,10 @@ export class AnalysisView extends LitElement {
     if (!this.filterState.showDetails && !this._showDetailsFilter(match.getData() as BottomUpRow)) {
       this._handleShowDetailsChange();
       await this.updateComplete;
+    }
+
+    if (signal.aborted) {
+      return;
     }
 
     await this._echoGuard.runAsync(() =>

--- a/log-viewer/src/features/analysis/components/AnalysisView.ts
+++ b/log-viewer/src/features/analysis/components/AnalysisView.ts
@@ -46,6 +46,8 @@ import {
 } from '../../call-tree/utils/CategoryColoring.js';
 import { expandCollapseAll } from '../../call-tree/utils/ExpandCollapse.js';
 
+import { onTableReshaped } from '../../../tabulator/module/tableReshape.js';
+
 import dataGridStyles from '../../../tabulator/style/DataGrid.scss';
 
 // styles
@@ -501,6 +503,9 @@ export class AnalysisView extends LitElement {
 
   _groupBy(event: Event) {
     const target = event.target as HTMLInputElement;
+    // Grouping renumbers the matches both ways round, and `dataGrouped` reports
+    // only the way that leaves the table grouped.
+    this._dropSearch();
     const fieldName =
       target.value === 'Caller Namespace' ? 'callerNamespace' : target.value.toLowerCase();
     if (this.analysisTable) {
@@ -520,6 +525,7 @@ export class AnalysisView extends LitElement {
     if (!table) {
       return;
     }
+    this._dropSearch();
     table.blockRedraw();
     table.clearFilter(false);
     if (!this.filterState.showDetails) {
@@ -613,18 +619,6 @@ export class AnalysisView extends LitElement {
       rootMethod,
       {
         showDetailsFilter: this._showDetailsFilter,
-        onFilterCacheClear: () => {
-          if (!this.blockClearHighlights && this.totalMatches > 0) {
-            this._resetFindWidget();
-            this._clearSearchHighlights();
-          }
-        },
-        onRenderStarted: () => {
-          if (!this.blockClearHighlights && this.totalMatches > 0) {
-            this._resetFindWidget();
-            this._clearSearchHighlights();
-          }
-        },
         rowFormatter: groupedRowFormatter,
       },
       {
@@ -636,19 +630,7 @@ export class AnalysisView extends LitElement {
     );
     this.analysisTable = table;
 
-    this.analysisTable.on('dataSorted', () => {
-      if (!this.blockClearHighlights && this.totalMatches > 0) {
-        this._resetFindWidget();
-        this._clearSearchHighlights();
-      }
-    });
-
-    this.analysisTable.on('dataGrouped', () => {
-      if (!this.blockClearHighlights && this.totalMatches > 0) {
-        this._resetFindWidget();
-        this._clearSearchHighlights();
-      }
-    });
+    onTableReshaped(this.analysisTable, () => this._dropSearch());
 
     // Feed the inspector. Analysis rows merge many calls, so they
     // scope to every call they count.
@@ -684,6 +666,14 @@ export class AnalysisView extends LitElement {
 
   _resetFindWidget() {
     document.dispatchEvent(new CustomEvent('lv-find-results', { detail: { totalMatches: 0 } }));
+  }
+
+  /** Drop the search where its match numbering no longer describes the table. */
+  _dropSearch() {
+    if (!this.blockClearHighlights && this.totalMatches > 0) {
+      this._resetFindWidget();
+      this._clearSearchHighlights();
+    }
   }
 
   _clearSearchHighlights() {

--- a/log-viewer/src/features/analysis/components/__tests__/AnalysisView.test.ts
+++ b/log-viewer/src/features/analysis/components/__tests__/AnalysisView.test.ts
@@ -18,6 +18,12 @@ jest.mock('../../../call-tree/components/BottomUpTable.js', () => ({
         return stub.rows;
       },
       goToRow: (row: RowComponent) => stub.revealed.push(row),
+      clearFindHighlights: () => {},
+      blockRedraw: () => {},
+      restoreRedraw: () => {},
+      clearFilter: () => {},
+      addFilter: () => {},
+      setSortedGroupBy: () => {},
     },
     // Left pending: the columns are applied on build, and none are set up here.
     tableBuilt: new Promise<Tabulator>(() => {}),
@@ -104,6 +110,23 @@ function findRow(rows: BottomUpRow[], text: string): BottomUpRow {
   return row;
 }
 
+/**
+ * A view with its table rendered against `log`.
+ *
+ * The app hands the log down as a property, and a row's calls are read through
+ * the table that built it. The table mounts in a wrapper the view finds in its
+ * render root, which it has none of until it is updated, so one is stood in.
+ */
+function mountView(log: ApexLog): AnalysisView {
+  handlers.clear();
+  stub = { rows: [], getRowsArgs: [], revealed: [] };
+  const view = new AnalysisView();
+  view.timelineRoot = log;
+  view.tableContainer = document.createElement('div');
+  void view._renderAnalysis(log);
+  return view;
+}
+
 describe('analysis-view selection', () => {
   let view: AnalysisView;
   let log: ApexLog;
@@ -113,18 +136,9 @@ describe('analysis-view selection', () => {
 
   beforeEach(() => {
     byEventIndex = [];
-    handlers.clear();
-    stub = { rows: [], getRowsArgs: [], revealed: [] };
     log = recursiveLog();
     roots = toBottomUpTree(log.children, logStoreFor(log).keyPathIds());
-    view = new AnalysisView();
-    // The app hands the log down as a property, and a row's calls are read
-    // through the table that built it.
-    view.timelineRoot = log;
-    // The table mounts in a wrapper the view finds in its render root; it has
-    // none until it is updated, so stand one in.
-    view.tableContainer = document.createElement('div');
-    void view._renderAnalysis(log);
+    view = mountView(log);
     seen = [];
     off = eventBus.on('detail:select', (detail) => seen.push(detail));
   });
@@ -226,5 +240,65 @@ describe('analysis-view selection', () => {
     );
 
     expect(seen).toEqual([{ source: 'analysis', selection: null, view: 'callers' }]);
+  });
+});
+
+describe('analysis-view search lifetime', () => {
+  let view: AnalysisView;
+
+  beforeEach(() => {
+    byEventIndex = [];
+    view = mountView(recursiveLog());
+    // What a finished search leaves behind: matches, and nothing of its own in
+    // flight to guard against.
+    view.totalMatches = 3;
+    view.blockClearHighlights = false;
+  });
+
+  afterEach(() => {
+    view.disconnectedCallback();
+  });
+
+  /** What Tabulator reports, which an expand repeats with the sort in force. */
+  function sorted(dir: string): void {
+    (handlers.get('dataSorting') as (sorters: unknown[]) => void)([{ field: 'selfTime', dir }]);
+  }
+
+  it('drops the search where a sort renumbers the matches', () => {
+    sorted('desc');
+
+    expect(view.totalMatches).toBe(0);
+  });
+
+  it('drops the search where a column goes off show, which it counted over', () => {
+    (handlers.get('columnVisibilityChanged') as () => void)();
+
+    expect(view.totalMatches).toBe(0);
+  });
+
+  it('drops the search where grouping is turned off, which reports no grouping', () => {
+    // Tabulator's dataGrouped fires only while the table stays grouped, so this
+    // is the way round it never reports.
+    view._groupBy({ target: { value: 'None' } } as unknown as Event);
+
+    expect(view.totalMatches).toBe(0);
+  });
+
+  it('keeps the search where an expand orders the children it opened', () => {
+    sorted('desc');
+    view.totalMatches = 3;
+
+    // Expanding sorts each opened subtree through the same call, so the event
+    // arrives again with the sort the table already had.
+    sorted('desc');
+    sorted('desc');
+
+    expect(view.totalMatches).toBe(3);
+  });
+
+  it('drops the search where a filter changes which rows there are', () => {
+    view._handleShowDetailsChange();
+
+    expect(view.totalMatches).toBe(0);
   });
 });

--- a/log-viewer/src/features/call-tree/components/AggregatedTable.ts
+++ b/log-viewer/src/features/call-tree/components/AggregatedTable.ts
@@ -182,19 +182,6 @@ export function createAggregatedTable(
   });
   tableRef.current = table;
 
-  // The host's filter caches (search/type/debug/namespace/duration) are cleared once per
-  // render via `renderStarted` — see CalltreeView's `onFilterCacheClear`. Row ids produced
-  // by `toAggregatedCallTree` are globally unique within a build (per-build monotonic
-  // counter), so cached `deepFilter` results stay valid across the cascaded
-  // `filter.filter()` passes Tabulator runs for each expanded subtree —
-  // `getChildren` → `filter.filter(config.children)` would otherwise fire `dataFiltered`
-  // multiple times per user action, defeating the cache. If row ids ever lose their
-  // uniqueness guarantee this must move back to `dataFiltered`.
-  table.on('renderStarted', () => {
-    callbacks.onFilterCacheClear?.();
-    callbacks.onRenderStarted();
-  });
-
   const tableBuilt = new Promise<void>((resolve) => {
     table.on('tableBuilt', () => {
       resolve();

--- a/log-viewer/src/features/call-tree/components/BottomUpTable.ts
+++ b/log-viewer/src/features/call-tree/components/BottomUpTable.ts
@@ -246,19 +246,6 @@ export function createBottomUpTable(
     ...tabulatorOptionOverrides,
   });
 
-  // Filter caches are cleared once per render via `renderStarted`. Row ids
-  // produced by `toBottomUpTree` are globally unique within a build
-  // (per-build monotonic counter), so cached `deepFilter` results stay valid
-  // across the cascaded `filter.filter()` passes Tabulator runs for each
-  // expanded subtree — `getChildren` → `filter.filter(config.children)`
-  // would otherwise fire `dataFiltered` multiple times per user action,
-  // defeating the cache. If row ids ever lose their uniqueness guarantee
-  // this must move back to `dataFiltered`.
-  table.on('renderStarted', () => {
-    callbacks.onFilterCacheClear?.();
-    callbacks.onRenderStarted();
-  });
-
   const tableBuilt = new Promise<void>((resolve) => {
     table.on('tableBuilt', () => {
       resolve();

--- a/log-viewer/src/features/call-tree/components/CalltreeView.ts
+++ b/log-viewer/src/features/call-tree/components/CalltreeView.ts
@@ -33,6 +33,7 @@ import { waitForNextFrame } from '../../../core/utility/FrameBudget.js';
 
 import { inMsRange, type FilterRange } from '../../../tabulator/filters/MinMax.js';
 import { withCodeDrivenExpand } from '../../../tabulator/module/expandOrigin.js';
+import { onTableReshaped } from '../../../tabulator/module/tableReshape.js';
 
 import dataGridStyles from '../../../tabulator/style/DataGrid.scss';
 
@@ -597,6 +598,9 @@ export class CalltreeView extends LitElement {
   _handleBottomUpGroupBy(event: Event) {
     const target = event.target as HTMLInputElement;
     this.bottomUpGroupBy = target.value;
+    // Grouping renumbers the matches both ways round, and `dataGrouped` reports
+    // only the way that leaves the table grouped.
+    this._dropSearch();
     const fieldName =
       target.value === 'Caller Namespace' ? 'callerNamespace' : target.value.toLowerCase();
     if (this.bottomUpTreeTable) {
@@ -760,11 +764,8 @@ export class CalltreeView extends LitElement {
       return;
     }
 
-    this.debugOnlyFilterCache.clear();
-    this.typeFilterCache.clear();
-    this.namespaceFilterCache.clear();
-    this.totalTimeFilterCache.clear();
-    this.selfTimeFilterCache.clear();
+    this._dropSearch();
+    this._clearFilterCaches();
 
     const filtersToAdd = [];
 
@@ -1048,19 +1049,6 @@ export class CalltreeView extends LitElement {
 
     const { table, tableBuilt } = createTimeOrderTable(callTreeTableContainer, rootMethod, {
       showDetailsFilter: this._showDetailsFilter,
-      onFilterCacheClear: () => {
-        this.debugOnlyFilterCache.clear();
-        this.typeFilterCache.clear();
-        this.namespaceFilterCache.clear();
-        this.totalTimeFilterCache.clear();
-        this.selfTimeFilterCache.clear();
-      },
-      onRenderStarted: () => {
-        if (!this.blockClearHighlights && this.totalMatches > 0) {
-          this._resetFindWidget();
-          this._clearSearchHighlights();
-        }
-      },
       onContextMenu: (e, row) => {
         if (window.getSelection()?.type === 'Range') {
           return;
@@ -1072,6 +1060,7 @@ export class CalltreeView extends LitElement {
       rowFormatter: timeOrderRowFormatter,
     });
     this.calltreeTable = table;
+    this._watchTable(table, true);
     await tableBuilt;
     this._initTableColumns(table);
     this._emitDetailSelection(table);
@@ -1089,22 +1078,10 @@ export class CalltreeView extends LitElement {
 
     const { table, tableBuilt } = createAggregatedTable(container, rootMethod, {
       showDetailsFilter: this._showDetailsFilter,
-      onFilterCacheClear: () => {
-        this.debugOnlyFilterCache.clear();
-        this.typeFilterCache.clear();
-        this.namespaceFilterCache.clear();
-        this.totalTimeFilterCache.clear();
-        this.selfTimeFilterCache.clear();
-      },
-      onRenderStarted: () => {
-        if (!this.blockClearHighlights && this.totalMatches > 0) {
-          this._resetFindWidget();
-          this._clearSearchHighlights();
-        }
-      },
       rowFormatter: groupedRowFormatter,
     });
     this.aggregatedTreeTable = table;
+    this._watchTable(table, true);
     await tableBuilt;
     this._initTableColumns(table);
     this._emitDetailSelection(table);
@@ -1122,12 +1099,6 @@ export class CalltreeView extends LitElement {
       rootMethod,
       {
         showDetailsFilter: this._showDetailsFilter,
-        onRenderStarted: () => {
-          if (!this.blockClearHighlights && this.totalMatches > 0) {
-            this._resetFindWidget();
-            this._clearSearchHighlights();
-          }
-        },
         rowFormatter: groupedRowFormatter,
       },
       {
@@ -1137,6 +1108,7 @@ export class CalltreeView extends LitElement {
       },
     );
     this.bottomUpTreeTable = table;
+    this._watchTable(table, false);
     await tableBuilt;
     this._initTableColumns(table);
     this._emitDetailSelection(table);
@@ -1217,6 +1189,41 @@ export class CalltreeView extends LitElement {
 
   private _resetFindWidget() {
     document.dispatchEvent(new CustomEvent('lv-find-results', { detail: { totalMatches: 0 } }));
+  }
+
+  /** Drop the search where its match numbering no longer describes the table. */
+  private _dropSearch() {
+    if (!this.blockClearHighlights && this.totalMatches > 0) {
+      this._resetFindWidget();
+      this._clearSearchHighlights();
+    }
+  }
+
+  /**
+   * Watch `table` for what a view has to answer per render.
+   *
+   * The filter caches are cleared once per render rather than on `dataFiltered`:
+   * row ids are unique within a build, so a cached `deepFilter` result stays
+   * valid across the cascaded filter passes Tabulator runs for each expanded
+   * subtree, which would otherwise fire `dataFiltered` several times per user
+   * action and defeat the cache.
+   *
+   * @param clearsFilterCaches - Bottom Up reads the caches but has never cleared
+   * them per render, so it keeps that behaviour here.
+   */
+  private _watchTable(table: Tabulator, clearsFilterCaches: boolean) {
+    onTableReshaped(table, () => this._dropSearch());
+    if (clearsFilterCaches) {
+      table.on('renderStarted', () => this._clearFilterCaches());
+    }
+  }
+
+  private _clearFilterCaches() {
+    this.debugOnlyFilterCache.clear();
+    this.typeFilterCache.clear();
+    this.namespaceFilterCache.clear();
+    this.totalTimeFilterCache.clear();
+    this.selfTimeFilterCache.clear();
   }
 
   private _clearSearchHighlights() {

--- a/log-viewer/src/features/call-tree/components/CalltreeView.ts
+++ b/log-viewer/src/features/call-tree/components/CalltreeView.ts
@@ -180,7 +180,7 @@ export class CalltreeView extends LitElement {
 
     this._inspectorUnsubscribe = wireInspectorTab('calltree', this._emphasis, {
       mark: (eventIndexes) => this._markLocated(eventIndexes),
-      reveal: (eventIndex) => this._revealEventIndex(eventIndex),
+      reveal: (eventIndex, signal) => this._revealEventIndex(eventIndex, signal),
       clear: () => {
         // The table reports the clear itself, which is what reaches the inspector.
         for (const table of this._tables) {
@@ -902,14 +902,14 @@ export class CalltreeView extends LitElement {
    * switch, no view-mode change and no focus steal, unlike {@link _goToRow}.
    * Focus stays where the click was, which is the inspector.
    */
-  private async _revealEventIndex(eventIndex: number): Promise<void> {
+  private async _revealEventIndex(eventIndex: number, signal: AbortSignal): Promise<void> {
     const table = this._getActiveTable();
     if (!table) {
       return;
     }
 
     const treeRow = await this._findRowFor(table, eventIndex);
-    if (!treeRow) {
+    if (!treeRow || signal.aborted) {
       return;
     }
 

--- a/log-viewer/src/features/call-tree/components/TableShared.ts
+++ b/log-viewer/src/features/call-tree/components/TableShared.ts
@@ -23,8 +23,6 @@ import { makeSumFieldAllVisible } from '../utils/BottomCalcs.js';
 import { governorCostBreakdown, type GovernorCostRow } from '../utils/GovernorCost.js';
 
 export interface TableCallbacks {
-  onFilterCacheClear?: () => void;
-  onRenderStarted: () => void;
   rowFormatter?: (row: RowComponent) => void;
 }
 

--- a/log-viewer/src/features/call-tree/components/TimeOrderTable.ts
+++ b/log-viewer/src/features/call-tree/components/TimeOrderTable.ts
@@ -143,18 +143,6 @@ export function createTimeOrderTable(
   });
   tableRef.current = table;
 
-  // The host's filter caches (search/type/debug/namespace/duration) are cleared once per
-  // render via `renderStarted` — see CalltreeView's `onFilterCacheClear`. Row ids produced
-  // by `toTimeOrderTree` are globally unique within a build (per-build monotonic counter),
-  // so cached `deepFilter` results stay valid across the cascaded `filter.filter()` passes
-  // Tabulator runs for each expanded subtree — `getChildren` → `filter.filter(config.children)`
-  // would otherwise fire `dataFiltered` multiple times per user action, defeating the cache.
-  // If row ids ever lose their uniqueness guarantee this must move back to `dataFiltered`.
-  table.on('renderStarted', () => {
-    callbacks.onFilterCacheClear?.();
-    callbacks.onRenderStarted();
-  });
-
   table.on('rowContext', (e: UIEvent, row: RowComponent) => {
     callbacks.onContextMenu(e, row);
   });

--- a/log-viewer/src/features/call-tree/utils/__tests__/Aggregation.test.ts
+++ b/log-viewer/src/features/call-tree/utils/__tests__/Aggregation.test.ts
@@ -1062,7 +1062,7 @@ describe('bottom-up caller row scope', () => {
   /** The root bucket's calls whose own chain of callers runs through the row,
    *  which is what the grid counts the row's totals from. */
   function derivedFor(paths: KeyPathIds, root: BottomUpRow, row: BottomUpRow): LogEvent[] {
-    return root.instances.filter((event) => paths.chainReaches(event, row._pathId));
+    return root.instances.filter((event) => paths.chainNodeAt(event, row._pathId) !== null);
   }
 
   it('counts one call per occurrence the row derives', () => {

--- a/log-viewer/src/styles/global.styles.ts
+++ b/log-viewer/src/styles/global.styles.ts
@@ -71,13 +71,14 @@ export const globalStyles = [
       background-color: var(--vscode-scrollbarSlider-background);
     }
 
+    /* findMatch is the match you are on; findMatchHighlight is the rest. */
     ::highlight(find-match) {
-      color: var(--vscode-editor-findMatchForeground);
+      color: var(--vscode-editor-findMatchHighlightForeground);
       background-color: var(--vscode-editor-findMatchHighlightBackground, yellow);
     }
 
     ::highlight(current-find-match) {
-      color: var(--vscode-editor-findMatchHighlightForeground);
+      color: var(--vscode-editor-findMatchForeground);
       background-color: var(--vscode-editor-findMatchBackground, #8b8000);
     }
 

--- a/log-viewer/src/tabulator/module/Find.ts
+++ b/log-viewer/src/tabulator/module/Find.ts
@@ -27,6 +27,7 @@ export class Find extends Module {
   _cachedRegex: RegExp | null = null;
   _currentMatchIndex = 0;
   _matchIndexes: { [key: number]: RowComponent } = {};
+  _highlightFrame: number | null = null;
 
   // Headless formatter execution: single detached element (never in the document)
   // and a per-row-field text cache keyed by the stable row-data object reference.
@@ -61,39 +62,33 @@ export class Find extends Module {
     });
 
     this.table.on('renderComplete', () => {
-      if (this._findArgs?.text) {
-        this._applyHighlights();
-      }
+      this._scheduleHighlights();
     });
 
-    // Virtual scroll doesn't fire renderComplete, so listen for scroll events
-    // to apply highlights to newly visible rows. Debounced to avoid blocking
-    // the main thread during fast scrolling, plus scrollend for instant final update.
-    const holder = this.table.element.querySelector('.tabulator-tableholder');
-    if (holder) {
-      let rafId: number | null = null;
-      holder.addEventListener('scroll', () => {
-        if (!this._findArgs?.text) {
-          return;
-        }
-        if (rafId === null) {
-          rafId = requestAnimationFrame(() => {
-            rafId = null;
-            this._applyHighlights();
-          });
-        }
-      });
+    // A row arrives with no highlight in it, and renderComplete does not report
+    // every arrival. A scroll brings rows in without one, on our renderer and on
+    // Tabulator's own.
+    this.table.on('scrollVertical', () => {
+      this._scheduleHighlights();
+    });
 
-      holder.addEventListener('scrollend', () => {
-        if (rafId !== null) {
-          cancelAnimationFrame(rafId);
-          rafId = null;
-        }
-        if (this._findArgs?.text) {
-          this._applyHighlights();
-        }
-      });
+    // And a sort or a filter brings rows in without a scroll. Ours alone reports
+    // this, so a grid on Tabulator's renderer is covered by the scroll above.
+    this.subscribe('render-virtual-attach', () => {
+      this._scheduleHighlights();
+    });
+  }
+
+  /** Re-apply once for the frame: a render can attach twice and complete once,
+   *  and the rebuild reads every cell on screen. */
+  _scheduleHighlights() {
+    if (this._highlightFrame !== null || !this._findArgs?.text) {
+      return;
     }
+    this._highlightFrame = requestAnimationFrame(() => {
+      this._highlightFrame = null;
+      this._applyHighlights();
+    });
   }
 
   async _find(findArgs: FindArgs) {
@@ -232,6 +227,12 @@ export class Find extends Module {
   }
 
   _applyHighlights() {
+    if (this._highlightFrame !== null) {
+      // Whatever asked for this frame is being answered now.
+      cancelAnimationFrame(this._highlightFrame);
+      this._highlightFrame = null;
+    }
+
     // Lazy-init static Highlights
     if (!Find._findHighlight) {
       Find._findHighlight = new Highlight();
@@ -268,6 +269,12 @@ export class Find extends Module {
       }
 
       const data = row.getData();
+      // A row the search visited and found nothing in cannot hold a match, so
+      // none of its cells are worth a text walk. A row built since the search
+      // ran has no list at all, and is walked.
+      if (data.highlightIndexes?.length === 0) {
+        continue;
+      }
 
       let matchIdx = 0;
       row.getCells().forEach((cell) => {

--- a/log-viewer/src/tabulator/module/Find.ts
+++ b/log-viewer/src/tabulator/module/Find.ts
@@ -28,6 +28,9 @@ export class Find extends Module {
   _currentMatchIndex = 0;
   _matchIndexes: { [key: number]: RowComponent } = {};
   _highlightFrame: number | null = null;
+  /** The fields the last search covered, which the highlights follow so the two
+   *  describe the same matches. */
+  _searchedFields: Set<string> = new Set();
 
   // Headless formatter execution: single detached element (never in the document)
   // and a per-row-field text cache keyed by the stable row-data object reference.
@@ -140,6 +143,7 @@ export class Find extends Module {
       // columnManager.getRealColumns() is internal — returns columnsByIndex, same order as getCells()
       const internalCols: Array<{
         field: string;
+        visible: boolean;
         getComponent: () => ColumnComponent;
         getFieldValue: (data: object) => unknown;
         modules?: {
@@ -153,6 +157,13 @@ export class Find extends Module {
           };
         };
       }> = this.table.columnManager?.getRealColumns?.() ?? [];
+
+      // columnsByIndex holds every column, shown or not: a hidden column's match
+      // cannot be seen, so counting it gives a total the user cannot reach and a
+      // number the highlights cannot line up with.
+      this._searchedFields = new Set(
+        internalCols.filter((col) => col.field && col.visible).map((col) => col.field),
+      );
 
       const len = flattenedRows.length;
       for (let i = 0; i < len; i++) {
@@ -172,7 +183,7 @@ export class Find extends Module {
 
         for (const col of internalCols) {
           const field = col.field;
-          if (!field) {
+          if (!field || !this._searchedFields.has(field)) {
             continue;
           }
 
@@ -278,6 +289,10 @@ export class Find extends Module {
 
       let matchIdx = 0;
       row.getCells().forEach((cell) => {
+        if (!this._searchedFields.has(cell.getField())) {
+          return;
+        }
+
         const elem = cell.getElement();
         // Build a flat text-node map so we can create Ranges that span across
         // adjacent elements (e.g. two <span>s whose text forms a single match).

--- a/log-viewer/src/tabulator/module/__tests__/Find.test.ts
+++ b/log-viewer/src/tabulator/module/__tests__/Find.test.ts
@@ -1,0 +1,94 @@
+/**
+ * @jest-environment jsdom
+ */
+/*
+ * Copyright (c) 2026 Certinia Inc. All rights reserved.
+ */
+import { describe, expect, it } from '@jest/globals';
+
+// The tabulator ESM build doesn't load under jest, and the module registers
+// itself on import.
+jest.mock('tabulator-tables', () => ({
+  Module: class {
+    table: unknown;
+    constructor(table: unknown) {
+      this.table = table;
+    }
+    registerTableOption() {}
+    registerTableFunction() {}
+    subscribe() {}
+  },
+}));
+
+import { waitForNextFrame } from '../../../core/utility/FrameBudget.js';
+import { Find } from '../Find.js';
+
+function setup() {
+  const subscribed: Record<string, (() => void)[]> = {};
+  const listened: string[] = [];
+  const tableEvents: Record<string, (() => void)[]> = {};
+  const table = {
+    on: (event: string, callback: () => void) => {
+      (tableEvents[event] ??= []).push(callback);
+    },
+    element: {
+      querySelector: () => ({
+        addEventListener: (event: string) => {
+          listened.push(event);
+        },
+      }),
+    },
+  };
+  const find = new Find(table as never);
+  find.subscribe = (event: string, callback: () => void) => {
+    (subscribed[event] ??= []).push(callback);
+  };
+  find.initialize();
+
+  const applied = jest.fn();
+  find._applyHighlights = applied;
+  const attach = () => subscribed['render-virtual-attach']?.forEach((fn) => fn());
+  const scroll = () => tableEvents['scrollVertical']?.forEach((fn) => fn());
+  const nextFrame = waitForNextFrame;
+  return { find, applied, attach, scroll, nextFrame, listened };
+}
+
+describe('Find highlights on the rows a render attaches', () => {
+  it('re-applies once for the frame, however many attaches it took', async () => {
+    const { find, applied, attach, nextFrame } = setup();
+    find._findArgs = { text: 'a', count: 0, options: { matchCase: false } };
+
+    attach();
+    attach();
+    expect(applied).not.toHaveBeenCalled();
+    await nextFrame();
+
+    expect(applied).toHaveBeenCalledTimes(1);
+  });
+
+  it('leaves the rows alone while nothing is being searched for', async () => {
+    const { applied, attach, nextFrame } = setup();
+
+    attach();
+    await nextFrame();
+
+    expect(applied).not.toHaveBeenCalled();
+  });
+
+  it("re-applies on a scroll, which is all a grid on Tabulator's renderer reports", async () => {
+    const { find, applied, scroll, nextFrame } = setup();
+    find._findArgs = { text: 'a', count: 0, options: { matchCase: false } };
+
+    scroll();
+    await nextFrame();
+
+    expect(applied).toHaveBeenCalledTimes(1);
+  });
+
+  it('takes the scroll from the table, not from the holder element', () => {
+    // Tabulator reports it for every renderer, and the holder is rebuilt.
+    const { listened } = setup();
+
+    expect(listened).toEqual([]);
+  });
+});

--- a/log-viewer/src/tabulator/module/__tests__/Find.test.ts
+++ b/log-viewer/src/tabulator/module/__tests__/Find.test.ts
@@ -92,3 +92,58 @@ describe('Find highlights on the rows a render attaches', () => {
     expect(listened).toEqual([]);
   });
 });
+
+/** A one-row table whose columns hold `value`, some of them hidden. */
+function findOver(columns: Array<{ field: string; visible: boolean; value: string }>) {
+  const rowData = {};
+  const rows = [{ getData: () => rowData }];
+  const table = {
+    on: () => {},
+    getGroups: () => [],
+    getRows: () => rows,
+    modules: {},
+    options: {},
+    columnManager: {
+      // Tabulator indexes every column here, shown or not.
+      getRealColumns: () =>
+        columns.map((column) => ({
+          field: column.field,
+          visible: column.visible,
+          getComponent: () => ({}),
+          getFieldValue: () => column.value,
+        })),
+    },
+  };
+  const find = new Find(table as never);
+  // CSS.highlights does not exist in jsdom, and the count is what is under test.
+  find._applyHighlights = () => {};
+  return find;
+}
+
+describe('Find counts what the table is showing', () => {
+  const search = { text: 'default', count: 1, options: { matchCase: false } };
+
+  it('leaves a hidden column out of the count', async () => {
+    const find = findOver([
+      { field: 'text', visible: true, value: 'Account default' },
+      { field: 'namespace', visible: false, value: 'default' },
+    ]);
+
+    const result = await find._find(search);
+
+    // A match nobody can see is a total the user cannot reach, and a number the
+    // highlights cannot line up with.
+    expect(result.totalMatches).toBe(1);
+  });
+
+  it('counts the same column once it is shown', async () => {
+    const find = findOver([
+      { field: 'text', visible: true, value: 'Account default' },
+      { field: 'namespace', visible: true, value: 'default' },
+    ]);
+
+    const result = await find._find(search);
+
+    expect(result.totalMatches).toBe(2);
+  });
+});

--- a/log-viewer/src/tabulator/module/__tests__/tableReshape.test.ts
+++ b/log-viewer/src/tabulator/module/__tests__/tableReshape.test.ts
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2026 Certinia Inc. All rights reserved.
+ */
+import { describe, expect, it, jest } from '@jest/globals';
+import type { SorterFromTable, Tabulator } from 'tabulator-tables';
+
+import { onTableReshaped } from '../tableReshape.js';
+
+function setup() {
+  const handlers = new Map<string, (payload: SorterFromTable[]) => void>();
+  const table = {
+    on: (event: string, handler: (payload: SorterFromTable[]) => void) => {
+      handlers.set(event, handler);
+    },
+  } as unknown as Tabulator;
+  const changed = jest.fn();
+  onTableReshaped(table, changed);
+  return {
+    changed,
+    events: [...handlers.keys()],
+    sorted: (...sorters: Array<[string, string]>) =>
+      handlers.get('dataSorting')?.(
+        sorters.map(([field, dir]) => ({ field, dir }) as SorterFromTable),
+      ),
+    columnsChanged: () => handlers.get('columnVisibilityChanged')?.([]),
+  };
+}
+
+describe('onTableReshaped', () => {
+  it('reports an order the table did not have before', () => {
+    const { changed, sorted } = setup();
+
+    sorted(['selfTime', 'desc']);
+    expect(changed).toHaveBeenCalledTimes(1);
+
+    sorted(['selfTime', 'asc']);
+    sorted(['name', 'asc']);
+    expect(changed).toHaveBeenCalledTimes(3);
+  });
+
+  it('stays quiet where the order is the one already in force', () => {
+    const { changed, sorted } = setup();
+    sorted(['selfTime', 'desc']);
+
+    // What expanding a tree row does: each opened subtree is ordered through the
+    // same call, so the event repeats the order the table has.
+    sorted(['selfTime', 'desc']);
+    sorted(['selfTime', 'desc']);
+
+    expect(changed).toHaveBeenCalledTimes(1);
+  });
+
+  it('tells a second sort column from the first alone', () => {
+    const { changed, sorted } = setup();
+    sorted(['selfTime', 'desc']);
+
+    sorted(['selfTime', 'desc'], ['name', 'asc']);
+
+    expect(changed).toHaveBeenCalledTimes(2);
+  });
+
+  it('reports a column going on or off show, which the matches are counted over', () => {
+    const { changed, columnsChanged } = setup();
+
+    columnsChanged();
+
+    expect(changed).toHaveBeenCalledTimes(1);
+  });
+
+  it('reads the sort as it starts, so no row component is built to report it', () => {
+    // A dataSorted subscriber makes Tabulator build a component per sorted row.
+    expect(setup().events).toEqual(['dataSorting', 'columnVisibilityChanged']);
+  });
+});

--- a/log-viewer/src/tabulator/module/tableReshape.ts
+++ b/log-viewer/src/tabulator/module/tableReshape.ts
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2026 Certinia Inc. All rights reserved.
+ */
+import type { SorterFromTable, Tabulator } from 'tabulator-tables';
+
+/** Whether `sorters` is the order already recorded in `fields` and `dirs`. */
+function unchanged(
+  sorters: readonly SorterFromTable[],
+  fields: readonly string[],
+  dirs: readonly string[],
+): boolean {
+  if (sorters.length !== fields.length) {
+    return false;
+  }
+  for (let i = 0; i < sorters.length; i++) {
+    if (sorters[i]!.field !== fields[i] || sorters[i]!.dir !== dirs[i]) {
+      return false;
+    }
+  }
+  return true;
+}
+
+/**
+ * Call `changed` when `table` reshapes under the user: the rows come back in a
+ * different order, or a different set of columns is on show.
+ *
+ * A sort event does not say the order changed: expanding or collapsing a tree row
+ * orders that row's children through the same `Sort.sort` call, so the event fires
+ * once per opened subtree carrying the order the table already had. The order
+ * itself is what is compared, and compared without allocating, because an expand
+ * of a large tree fires this per subtree.
+ *
+ * Read from `dataSorting` rather than `dataSorted`: both fire from that one call
+ * with the same sorters, but a `dataSorted` subscriber makes Tabulator build a row
+ * component for every row it sorted, and those are cached on the rows.
+ *
+ * Tabulator's own `sort-changed` is truthful about a sort but reaches modules only,
+ * and fires for any `setSort` call, including one re-applying the order in force.
+ *
+ * Grouping is not here: `dataGrouped` fires only while the table is grouped, so
+ * turning grouping off reports nothing. The caller asks for the grouping it wants,
+ * so it knows both ways round.
+ */
+export function onTableReshaped(table: Tabulator, changed: () => void): void {
+  const fields: string[] = [];
+  const dirs: string[] = [];
+  table.on('dataSorting', (sorters) => {
+    if (unchanged(sorters, fields, dirs)) {
+      return;
+    }
+    fields.length = 0;
+    dirs.length = 0;
+    for (const sorter of sorters) {
+      fields.push(sorter.field);
+      dirs.push(sorter.dir);
+    }
+    changed();
+  });
+  table.on('columnVisibilityChanged', () => {
+    changed();
+  });
+}

--- a/log-viewer/src/tabulator/renderer/VirtualVerticalRenderer.ts
+++ b/log-viewer/src/tabulator/renderer/VirtualVerticalRenderer.ts
@@ -87,6 +87,7 @@ interface RendererBase {
   styleRow: (row: RowInternals, index: number) => void;
   // CoreFeature.dispatch → table.eventBus (internal event chain). Stock
   // fires 'render-virtual-fill' after every fill; GroupRows depends on it.
+  // Ours adds 'render-virtual-attach', after every attach.
   dispatch: (event: string) => void;
 }
 
@@ -1229,6 +1230,11 @@ export class VirtualVerticalRenderer extends Renderer {
         this._setHeight(entry.index, h, entry.row.data);
       }
     }
+
+    // Ours: rows are in the table. What decorates rendered rows needs this and
+    // not 'render-virtual-fill', which an incremental scroll tick skips, nor a
+    // scroll event, which a sort or a filter never fires.
+    self.dispatch('render-virtual-attach');
   }
 
   private _detachAllRendered(): void {

--- a/log-viewer/src/tabulator/renderer/__tests__/VirtualVerticalRendererAttach.test.ts
+++ b/log-viewer/src/tabulator/renderer/__tests__/VirtualVerticalRendererAttach.test.ts
@@ -277,6 +277,58 @@ describe('VirtualVerticalRenderer render-virtual-fill dispatch (stock contract)'
   });
 });
 
+describe('VirtualVerticalRenderer render-virtual-attach dispatch', () => {
+  interface AttachDispatchInternals extends AttachRendererInternals {
+    table: { rowManager: { element: { scrollTop: number } }; eventBus: { dispatch: jest.Mock } };
+    _renderWindow: () => void;
+  }
+
+  function makeDispatchSetup(rowCount: number): {
+    rr: AttachDispatchInternals;
+    rows: AttachRowStub[];
+    attachCalls: () => number;
+    fillCalls: () => number;
+  } {
+    const { r, rows } = makeAttachSetup(rowCount);
+    const rr = r as AttachDispatchInternals;
+    const dispatched = jest.fn();
+    rr.table.eventBus.dispatch = dispatched;
+    const calls = (event: string) => () =>
+      dispatched.mock.calls.filter((c) => c[0] === event).length;
+    return {
+      rr,
+      rows,
+      attachCalls: calls('render-virtual-attach'),
+      fillCalls: calls('render-virtual-fill'),
+    };
+  }
+
+  it('dispatches once per attach, and not for a range that attached nothing', () => {
+    const { rr, rows, attachCalls } = makeDispatchSetup(4);
+    rr._attachRanges(rows, [[0, 3]], 0);
+    expect(attachCalls()).toBe(1);
+
+    rr._attachRanges(rows, [], 0);
+    expect(attachCalls()).toBe(1);
+  });
+
+  it('reports a scroll tick that fill deliberately skips', () => {
+    const { rr, attachCalls, fillCalls } = makeDispatchSetup(200);
+    rr._renderWindow();
+    const filled = fillCalls();
+    const attached = attachCalls();
+
+    // Incremental scroll: rows enter the window, but the window is not
+    // replaced, so the stock fill contract stays silent.
+    rr.table.rowManager.element.scrollTop = 60;
+    rr.inScrollDrivenRender = true;
+    rr._renderWindow();
+
+    expect(fillCalls()).toBe(filled);
+    expect(attachCalls()).toBe(attached + 1);
+  });
+});
+
 describe('VirtualVerticalRenderer PseudoRow (group row) tolerance', () => {
   it('attaches PseudoRow-shaped rows without measuring or throwing', () => {
     const { r, rows, tableElement } = makeAttachSetup(5);


### PR DESCRIPTION
# 📝 PR Overview

Pointing the inspector at one frame lit its bucket **and** one row per caller
depth, so a single frame read as a whole chain selected. A move could also land
on a row the pointer had already left, because a move waits on a render and a
pointer crossing inspector rows asks for one per row.

A bottom-up row is the frame at its own depth, so a frame now marks the rows its
own key heads: its bucket, and any caller row for it under another bucket. The
wiring holds one move, and a new one abandons the one before it.

**Stacked on #985 — merge that first.**

## 🛠️ Changes made

- `pathsEndingIn` names the rows a frame stands for; `pathIdsOf` becomes `pathIdOf`, top-down only.
- The paths a key heads are indexed as they are minted, so the mark costs what it returns rather than a scan of every path the log has minted.
- One move at a time: `wireInspectorTab` holds an `AbortController`, and the two views that await check it before they scroll. The mark is never dropped, only the move.
- A caller row's calls and its frames come from one walk of its bucket, held in one cache — the walk that decides membership already stands on the row's own frame.
- `LogStore.framesAbove` keeps its remaining caller in the inspector's scoped tree.

## 🧩 Type of change (check all applicable)

- [x] 🐛 Bug fix - something not working as expected
- [ ] ✨ New feature – adds new functionality
- [ ] ♻️ Refactor - internal changes with no user impact
- [x] ⚡ Performance Improvement
- [ ] 📝 Documentation - README or documentation site changes
- [ ] 🔧 Chore - dev tooling, CI, config
- [ ] 💥 Breaking change

## 🔗 Related Issues

related #

## ✅ Tests added?

- [x] 👍 yes

`pnpm test`: 1588 tests, 131 suites. Each new test was proven by removing its fix.

Measured in a browser on the 19.7MB sample log, Bottom-Up with a bucket expanded to four callers: hovering that bucket's frame marks 1 row, hovering a caller frame marks its own 1 row, and a frame no rendered row stands for marks none. Before, the first of those marked five.

## 📚 Docs updated?

- [x] 🙅 not needed