### PR TITLE
refactor(log-viewer): find a grid's body through the one helper that names it

### DIFF
--- a/log-viewer/src/features/analysis/components/AnalysisView.ts
+++ b/log-viewer/src/features/analysis/components/AnalysisView.ts
@@ -47,6 +47,7 @@ import {
 import { expandCollapseAll } from '../../call-tree/utils/ExpandCollapse.js';
 
 import { onTableReshaped } from '../../../tabulator/module/tableReshape.js';
+import { tableHolder } from '../../../tabulator/module/tableHolder.js';
 
 import dataGridStyles from '../../../tabulator/style/DataGrid.scss';
 
@@ -553,7 +554,7 @@ export class AnalysisView extends LitElement {
     }
     table.blockRedraw();
     expandCollapseAll(table.getRows(), expand);
-    table.element?.querySelector<HTMLElement>('.tabulator-tableholder')?.focus();
+    tableHolder(table.element)?.focus();
     table.restoreRedraw();
   }
 

--- a/log-viewer/src/features/call-tree/components/CalltreeView.ts
+++ b/log-viewer/src/features/call-tree/components/CalltreeView.ts
@@ -34,6 +34,7 @@ import { waitForNextFrame } from '../../../core/utility/FrameBudget.js';
 import { inMsRange, type FilterRange } from '../../../tabulator/filters/MinMax.js';
 import { withCodeDrivenExpand } from '../../../tabulator/module/expandOrigin.js';
 import { onTableReshaped } from '../../../tabulator/module/tableReshape.js';
+import { tableHolder } from '../../../tabulator/module/tableHolder.js';
 
 import dataGridStyles from '../../../tabulator/style/DataGrid.scss';
 
@@ -839,7 +840,7 @@ export class CalltreeView extends LitElement {
     }
     table.blockRedraw();
     expandCollapseAll(table.getRows(), true);
-    table.element?.querySelector<HTMLElement>('.tabulator-tableholder')?.focus();
+    tableHolder(table.element)?.focus();
     table.restoreRedraw();
   }
 
@@ -850,7 +851,7 @@ export class CalltreeView extends LitElement {
     }
     table.blockRedraw();
     expandCollapseAll(table.getRows(), false);
-    table.element?.querySelector<HTMLElement>('.tabulator-tableholder')?.focus();
+    tableHolder(table.element)?.focus();
     table.restoreRedraw();
   }
 

--- a/log-viewer/src/features/database/components/DMLView.ts
+++ b/log-viewer/src/features/database/components/DMLView.ts
@@ -35,6 +35,7 @@ import {
 
 // Tabulator custom modules, imports + styles
 import NumberAccessor from '../../../tabulator/dataaccessor/Number.js';
+import { tableHolder } from '../../../tabulator/module/tableHolder.js';
 import { inCountRange, inMsRange, type FilterRange } from '../../../tabulator/filters/MinMax.js';
 import { progressFormatter } from '../../../tabulator/format/Progress.js';
 import { progressFormatterMS } from '../../../tabulator/format/ProgressMS.js';
@@ -724,8 +725,7 @@ export class DMLView extends LitElement {
     });
 
     this.dmlTable.on('tableBuilt', () => {
-      const holder = this._getTableHolder();
-      holder.style.overflowAnchor = 'none';
+      this._getTableHolder()?.style.setProperty('overflow-anchor', 'none');
       //@ts-expect-error This is a custom function added in the GroupSort custom module
       this.dmlTable?.setSortedGroupBy('dml');
       if (this.dmlTable) {
@@ -739,6 +739,9 @@ export class DMLView extends LitElement {
 
     this.dmlTable.on('renderComplete', () => {
       const holder = this._getTableHolder();
+      if (!holder) {
+        return;
+      }
       const table = this._getTable();
       holder.style.minHeight = Math.min(holder.clientHeight, table.clientHeight) + 'px';
     });
@@ -794,7 +797,7 @@ export class DMLView extends LitElement {
   }
 
   _getTableHolder() {
-    this.holder = this.dmlTable?.element.querySelector('.tabulator-tableholder') as HTMLElement;
+    this.holder ??= tableHolder(this.dmlTable?.element);
     return this.holder;
   }
 

--- a/log-viewer/src/features/database/components/SOQLView.ts
+++ b/log-viewer/src/features/database/components/SOQLView.ts
@@ -44,6 +44,7 @@ import {
 
 // Tabulator custom modules, imports + styles
 import NumberAccessor from '../../../tabulator/dataaccessor/Number.js';
+import { tableHolder } from '../../../tabulator/module/tableHolder.js';
 import { inCountRange, inMsRange, type FilterRange } from '../../../tabulator/filters/MinMax.js';
 import { progressFormatter } from '../../../tabulator/format/Progress.js';
 import { progressFormatterMS } from '../../../tabulator/format/ProgressMS.js';
@@ -875,8 +876,7 @@ export class SOQLView extends LitElement {
     });
 
     this.soqlTable.on('tableBuilt', () => {
-      const holder = this._getTableHolder();
-      holder.style.overflowAnchor = 'none';
+      this._getTableHolder()?.style.setProperty('overflow-anchor', 'none');
       //@ts-expect-error This is a custom function added in the GroupSort custom module
       this.soqlTable?.setSortedGroupBy('soql');
       if (this.soqlTable) {
@@ -911,6 +911,9 @@ export class SOQLView extends LitElement {
 
     this.soqlTable.on('renderComplete', () => {
       const holder = this._getTableHolder();
+      if (!holder) {
+        return;
+      }
       const table = this._getTable();
       holder.style.minHeight = Math.min(holder.clientHeight, table.clientHeight) + 'px';
     });
@@ -945,7 +948,7 @@ export class SOQLView extends LitElement {
   }
 
   _getTableHolder() {
-    this.holder ??= this.soqlTable?.element.querySelector('.tabulator-tableholder') as HTMLElement;
+    this.holder ??= tableHolder(this.soqlTable?.element);
     return this.holder;
   }
 

--- a/log-viewer/src/features/database/components/SOSLView.ts
+++ b/log-viewer/src/features/database/components/SOSLView.ts
@@ -37,6 +37,7 @@ import {
 
 // Tabulator custom modules, imports + styles
 import NumberAccessor from '../../../tabulator/dataaccessor/Number.js';
+import { tableHolder } from '../../../tabulator/module/tableHolder.js';
 import { inCountRange, inMsRange, type FilterRange } from '../../../tabulator/filters/MinMax.js';
 import { progressFormatter } from '../../../tabulator/format/Progress.js';
 import { progressFormatterMS } from '../../../tabulator/format/ProgressMS.js';
@@ -672,8 +673,7 @@ export class SOSLView extends LitElement {
     });
 
     this.soslTable.on('tableBuilt', () => {
-      const holder = this._getTableHolder();
-      holder.style.overflowAnchor = 'none';
+      this._getTableHolder()?.style.setProperty('overflow-anchor', 'none');
       //@ts-expect-error This is a custom function added in the GroupSort custom module
       this.soslTable?.setSortedGroupBy('sosl');
       if (this.soslTable) {
@@ -686,6 +686,9 @@ export class SOSLView extends LitElement {
 
     this.soslTable.on('renderComplete', () => {
       const holder = this._getTableHolder();
+      if (!holder) {
+        return;
+      }
       const table = this._getTable();
       holder.style.minHeight = Math.min(holder.clientHeight, table.clientHeight) + 'px';
     });
@@ -741,7 +744,7 @@ export class SOSLView extends LitElement {
   }
 
   _getTableHolder() {
-    this.holder = this.soslTable?.element.querySelector('.tabulator-tableholder') as HTMLElement;
+    this.holder ??= tableHolder(this.soslTable?.element);
     return this.holder;
   }
 

--- a/log-viewer/src/tabulator/module/AnchoringPolicy.ts
+++ b/log-viewer/src/tabulator/module/AnchoringPolicy.ts
@@ -2,6 +2,7 @@
  * Copyright (c) 2026 Certinia Inc. All rights reserved.
  */
 import { Module, type RowComponent, type Tabulator } from 'tabulator-tables';
+import { tableHolder } from './tableHolder.js';
 
 const anchoringPolicyOption = 'anchoringPolicy' as const;
 
@@ -69,7 +70,7 @@ export class AnchoringPolicy extends Module {
   initialize() {
     // @ts-expect-error not in types
     if (this.options(anchoringPolicyOption)) {
-      this.tableHolder = this.table.element.querySelector('.tabulator-tableholder');
+      this.tableHolder = tableHolder(this.table.element);
       this.table.on('renderStarted', () => this._captureAnchor());
       this.table.on('renderComplete', () => this._genericRestore());
       this.table.on('dataTreeRowExpanded', (row: RowComponent) => this._preciseRestore(row));

--- a/log-viewer/src/tabulator/module/RowNavigation.ts
+++ b/log-viewer/src/tabulator/module/RowNavigation.ts
@@ -5,6 +5,7 @@ import type { Tabulator } from 'tabulator-tables';
 import { Module, type RowComponent } from 'tabulator-tables';
 
 import { withCodeDrivenExpand } from './expandOrigin.js';
+import { tableHolder } from './tableHolder.js';
 type GoToRowOptions = { scrollIfVisible: boolean; focusRow: boolean };
 export class RowNavigation extends Module {
   static moduleName = 'rowNavigation';
@@ -43,7 +44,7 @@ export class RowNavigation extends Module {
     const { focusRow } = opts;
 
     const table = this.table;
-    this.tableHolder ??= table.element.querySelector('.tabulator-tableholder') as HTMLElement;
+    this.tableHolder ??= tableHolder(table.element);
 
     table.blockRedraw();
 
@@ -76,7 +77,7 @@ export class RowNavigation extends Module {
     table.restoreRedraw();
 
     if (focusRow) {
-      this.tableHolder.focus();
+      this.tableHolder?.focus();
     }
 
     await this._waitForRenderComplete();

--- a/log-viewer/src/tabulator/module/ScrollAnchor.ts
+++ b/log-viewer/src/tabulator/module/ScrollAnchor.ts
@@ -2,6 +2,7 @@
  * Copyright (c) 2024 Certinia Inc. All rights reserved.
  */
 import { Module, type RowComponent, type Tabulator } from 'tabulator-tables';
+import { tableHolder } from './tableHolder.js';
 
 const scrollAnchorOption = 'scrollAnchor' as const;
 
@@ -63,7 +64,7 @@ export class ScrollAnchor extends Module {
   initialize() {
     // @ts-expect-error not in types
     if (this.options(scrollAnchorOption)) {
-      this.tableHolder = this.table.element.querySelector('.tabulator-tableholder');
+      this.tableHolder = tableHolder(this.table.element);
 
       this.table.on('dataTreeRowExpanded', () => this._onTreeToggle());
       this.table.on('dataTreeRowCollapsed', () => this._onTreeToggle());


### PR DESCRIPTION
Nine places re-derived a grid's scrolling body with the same `querySelector('.tabulator-tableholder')`. Four of them cast the result with `as HTMLElement`, which hid that the query can return nothing, so the class name was copied around and no caller handled a missing body.

All nine now call `tableHolder()`, the helper added in #965 and already used by the call tree detail panel and the row keyboard navigation module. After this change the class name appears only in that helper, the grid stylesheet and one test fixture.

## Changes

- `AnalysisView`, `CalltreeView`: the expand and collapse buttons focus the body through the helper.
- `ScrollAnchor`, `AnchoringPolicy`, `RowNavigation`: same for the modules that hold the body in a field.
- The DML, SOQL and SOSL views drop the `as HTMLElement` cast, so each handler now handles a missing body.
- The DML and SOSL views cache the body, as the SOQL view and their own `_getTable()` already do. This removes a `querySelector` per render, and `renderComplete` runs about once per frame while a pane is dragged.

The cache is safe because `_appendTableWhenVisible()` returns early when the table exists, so each of the three views builds one table, with one body element.

## Test plan

- `pnpm test`: 1629 tests in 138 suites pass.
- `pnpm lint`: clean.
- Dev host, `sample-app/debug-logs/sample-log.log`:
  1. Call Tree: click a row, then press the arrow keys. The selection moves and the view scrolls to it.
  2. Expand a node with its twisty, then press the arrow keys again. The selection still moves.
  3. Database: scroll the SOQL grid, then expand a row. The grid does not jump.
  4. Repeat step 3 in the DML and SOSL grids.
  5. Analysis: click a finding that reveals a hidden row. The grid takes focus and the arrow keys work.
  6. Repeat in the other theme, then in the side dock and the bottom dock.