### PR TITLE
perf(log-viewer): build the minimap skyline once per log, not once per pixel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - **Help & documentation** and **Report an issue** move into a `•••` menu, which also holds the values and controls the header drops as the window narrows.
 - ♻️ Replace `webview-ui-toolkit` with [vscode-elements](https://github.com/vscode-elements/elements) for all UI controls. ([#576]).
 - ⚡ **Go to Code**: Faster in large projects — ~6× to ~10× faster ([#834]).
+- ⚡ **Timeline minimap**: ~25× faster to redraw as you resize, and holds ~40MB less on a 95MB log. Switching theme no longer rebuilds it.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,7 +60,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - **Help & documentation** and **Report an issue** move into a `•••` menu, which also holds the values and controls the header drops as the window narrows.
 - ♻️ Replace `webview-ui-toolkit` with [vscode-elements](https://github.com/vscode-elements/elements) for all UI controls. ([#576]).
 - ⚡ **Go to Code**: Faster in large projects — ~6× to ~10× faster ([#834]).
-- ⚡ **Timeline minimap**: ~25× faster to redraw as you resize, and holds ~40MB less on a 95MB log. Switching theme no longer rebuilds it.
+- ⚡ **Timeline minimap**: ~25× faster and uses less memory.
 
 ### Fixed
 

--- a/log-viewer/src/features/timeline/__tests__/minimap-density.test.ts
+++ b/log-viewer/src/features/timeline/__tests__/minimap-density.test.ts
@@ -5,16 +5,15 @@
 /**
  * Unit tests for MinimapDensityQuery
  *
- * Tests category resolution for minimap coloring, ensuring:
- * - Long-spanning parent frames are not skipped during frame collection
- * - Skyline (on-top time) algorithm correctly identifies dominant category
+ * Tests category resolution for minimap coloring: that a long-spanning parent
+ * holds every bucket its children do not, and that the skyline's on-top time
+ * picks the dominant category.
  */
 import { describe, expect, it } from '@jest/globals';
 import type { LogEvent } from 'apex-log-parser';
 
 import { MinimapDensityQuery } from '../optimised/minimap/MinimapDensityQuery.js';
 import type { PrecomputedRect } from '../optimised/RectangleCache.js';
-import { TemporalSegmentTree } from '../optimised/TemporalSegmentTree.js';
 
 /**
  * Helper to create a mock PrecomputedRect.
@@ -24,7 +23,6 @@ function createRect(
   timeStart: number,
   timeEnd: number,
   depth: number,
-  selfDuration?: number,
 ): PrecomputedRect {
   const duration = timeEnd - timeStart;
   return {
@@ -33,7 +31,7 @@ function createRect(
     timeEnd,
     depth,
     duration,
-    selfDuration: selfDuration ?? duration,
+    selfDuration: duration,
     category,
     x: 0,
     y: 0,
@@ -43,41 +41,26 @@ function createRect(
   };
 }
 
-/**
- * Build rectsByCategory from a flat list of rects.
- */
-function buildRectsByCategory(rects: PrecomputedRect[]): Map<string, PrecomputedRect[]> {
-  const map = new Map<string, PrecomputedRect[]>();
+function buildQuery(rects: PrecomputedRect[], totalDuration: number): MinimapDensityQuery {
+  const rectsByCategory = new Map<string, PrecomputedRect[]>();
   for (const rect of rects) {
-    let arr = map.get(rect.category);
-    if (!arr) {
-      arr = [];
-      map.set(rect.category, arr);
+    let grouped = rectsByCategory.get(rect.category);
+    if (!grouped) {
+      grouped = [];
+      rectsByCategory.set(rect.category, grouped);
     }
-    arr.push(rect);
+    grouped.push(rect);
   }
-  return map;
-}
-
-function buildQuery(
-  rects: PrecomputedRect[],
-  totalDuration: number,
-  maxDepth: number,
-): MinimapDensityQuery {
-  const rectsByCategory = buildRectsByCategory(rects);
-  return new MinimapDensityQuery(new TemporalSegmentTree(rectsByCategory), totalDuration, maxDepth);
+  // maxDepth only reaches MinimapDensityData.globalMaxDepth; the sweep derives its own.
+  return new MinimapDensityQuery([...rectsByCategory.values()], totalDuration, 0);
 }
 
 describe('MinimapDensityQuery', () => {
   describe('category resolution with long-spanning parent frames', () => {
     /**
-     * Regression test: A long parent Method frame spanning many buckets
-     * with a short DML child in the middle.
-     *
-     * The parent Method frame must be included in all overlapping buckets
-     * for correct skyline computation. If frames are collected via binary
-     * search on timeEnd (with timeStart-sorted data), long-spanning parent
-     * frames can be skipped, causing incorrect coloring.
+     * Regression test: a long parent Method frame spanning many buckets, with a
+     * short DML child in the middle. The parent must hold every bucket the child
+     * does not.
      *
      * Layout:
      *   depth 0: |-------- Method (0-1000) --------|
@@ -86,17 +69,14 @@ describe('MinimapDensityQuery', () => {
      * Expected: Buckets outside DML range should be Method (green).
      *           Bucket covering DML range should be DML (brown) due to weight.
      */
-    const rects = [
-      createRect('Method', 0, 1000, 0, 600), // parent, selfDuration excludes DML child time
-      createRect('DML', 300, 400, 1, 100),
-    ];
+    const rects = [createRect('Method', 0, 1000, 0), createRect('DML', 300, 400, 1)];
 
     it('should show Method in buckets outside DML range', () => {
       // 10 buckets: each covers 100ns
       // Bucket 0 [0-100]: only Method → Method
       // Bucket 3 [300-400]: Method + DML → DML wins (2.5x weight)
       // Bucket 9 [900-1000]: only Method → Method
-      const result = buildQuery(rects, 1000, 1).query(10);
+      const result = buildQuery(rects, 1000).query(10);
 
       // These buckets must be Method - the parent frame spans all of them
       expect(result.buckets[0]!.dominantCategory).toBe('Method');
@@ -109,7 +89,7 @@ describe('MinimapDensityQuery', () => {
     });
 
     it('counts every frame in each bucket it spans', () => {
-      const result = buildQuery(rects, 1000, 1).query(10);
+      const result = buildQuery(rects, 1000).query(10);
 
       // The parent alone outside the child's range, both where they overlap.
       expect(result.buckets[0]!.eventCount).toBe(1);
@@ -125,18 +105,18 @@ describe('MinimapDensityQuery', () => {
      *   depth 1: |-------- Method (0-1000) ------------|
      *   depth 2:       |-- SOQL (200-300) --|  |-- DML (600-700) --|
      *
-     * This tests that parent frames at multiple depths are all correctly
-     * collected even when short children exist between them.
+     * Parent frames at several depths must all hold their own buckets, even with
+     * short children between them.
      */
     it('should resolve Method where no SOQL/DML children exist', () => {
       const rects = [
-        createRect('Code Unit', 0, 1000, 0, 0), // code unit has 0 self duration (all children)
-        createRect('Method', 0, 1000, 1, 800), // method covers most of the time
-        createRect('SOQL', 200, 300, 2, 100),
-        createRect('DML', 600, 700, 2, 100),
+        createRect('Code Unit', 0, 1000, 0),
+        createRect('Method', 0, 1000, 1),
+        createRect('SOQL', 200, 300, 2),
+        createRect('DML', 600, 700, 2),
       ];
 
-      const result = buildQuery(rects, 1000, 2).query(10);
+      const result = buildQuery(rects, 1000).query(10);
 
       // Bucket 0 [0-100]: Code Unit + Method → Method wins (deeper)
       expect(result.buckets[0]!.dominantCategory).toBe('Method');
@@ -152,28 +132,25 @@ describe('MinimapDensityQuery', () => {
     });
   });
 
-  describe('the one width held', () => {
+  it('recomputes only when the width changes', () => {
     const rects = [createRect('Method', 0, 1000, 0), createRect('DML', 300, 400, 1)];
+    const query = buildQuery(rects, 1000);
 
-    it('recomputes only when the width changes', () => {
-      const query = buildQuery(rects, 1000, 1);
+    const first = query.query(10);
+    expect(query.query(10)).toBe(first);
 
-      const first = query.query(10);
-      expect(query.query(10)).toBe(first);
+    // A different width is a different picture, so it cannot answer from the one held.
+    const wider = query.query(11);
+    expect(wider).not.toBe(first);
 
-      // A different width is a different picture, so it cannot answer from the one held.
-      const wider = query.query(11);
-      expect(wider).not.toBe(first);
-
-      // Only one is held, so the first width has to be computed again.
-      expect(query.query(10)).not.toBe(first);
-    });
+    // Only one is held, so the first width has to be computed again.
+    expect(query.query(10)).not.toBe(first);
   });
 
   describe('edge cases', () => {
     it('should handle single frame spanning all buckets', () => {
       const rects = [createRect('Method', 0, 1000, 0)];
-      const result = buildQuery(rects, 1000, 0).query(5);
+      const result = buildQuery(rects, 1000).query(5);
 
       for (const bucket of result.buckets) {
         expect(bucket.dominantCategory).toBe('Method');
@@ -181,7 +158,7 @@ describe('MinimapDensityQuery', () => {
     });
 
     it('should handle empty timeline', () => {
-      const result = buildQuery([], 0, 0).query(10);
+      const result = buildQuery([], 0).query(10);
       expect(result.buckets).toHaveLength(0);
     });
   });
@@ -192,23 +169,22 @@ describe('MinimapDensityQuery', () => {
     // "Invalid array length" and aborted timeline init.
     const rects = [createRect('Method', 0, 1000, 0)];
 
-    it('floors a fractional bucket count to the same result as the integer count', () => {
-      const fractional = buildQuery(rects, 1000, 0).query(10.6);
-      const floored = buildQuery(rects, 1000, 0).query(10);
+    it('floors a fractional bucket count to the integer count', () => {
+      // Two queries, not one: 10.6 and 10 floor to the same width, so a single
+      // query would answer the second call from its cache and compare an object
+      // with itself.
+      const fractional = buildQuery(rects, 1000).query(10.6);
+      const floored = buildQuery(rects, 1000).query(10);
 
       expect(fractional.buckets).toHaveLength(10);
       expect(fractional.buckets).toEqual(floored.buckets);
-    });
 
-    it('floors a fractional bucket count instead of throwing', () => {
-      const query = buildQuery(rects, 1000, 0);
-
-      expect(() => query.query(1536.6667)).not.toThrow();
-      expect(query.query(1536.6667).buckets).toHaveLength(1536);
+      // A real 150% DPI width.
+      expect(buildQuery(rects, 1000).query(1536.6667).buckets).toHaveLength(1536);
     });
 
     it('treats a non-finite bucket count as empty instead of throwing', () => {
-      const query = buildQuery(rects, 1000, 0);
+      const query = buildQuery(rects, 1000);
 
       expect(() => query.query(Number.NaN)).not.toThrow();
       expect(query.query(Number.NaN).buckets).toHaveLength(0);

--- a/log-viewer/src/features/timeline/__tests__/minimap-density.test.ts
+++ b/log-viewer/src/features/timeline/__tests__/minimap-density.test.ts
@@ -8,7 +8,6 @@
  * Tests category resolution for minimap coloring, ensuring:
  * - Long-spanning parent frames are not skipped during frame collection
  * - Skyline (on-top time) algorithm correctly identifies dominant category
- * - Both fallback and segment tree paths produce consistent results
  */
 import { describe, expect, it } from '@jest/globals';
 import type { LogEvent } from 'apex-log-parser';
@@ -60,6 +59,15 @@ function buildRectsByCategory(rects: PrecomputedRect[]): Map<string, Precomputed
   return map;
 }
 
+function buildQuery(
+  rects: PrecomputedRect[],
+  totalDuration: number,
+  maxDepth: number,
+): MinimapDensityQuery {
+  const rectsByCategory = buildRectsByCategory(rects);
+  return new MinimapDensityQuery(new TemporalSegmentTree(rectsByCategory), totalDuration, maxDepth);
+}
+
 describe('MinimapDensityQuery', () => {
   describe('category resolution with long-spanning parent frames', () => {
     /**
@@ -83,30 +91,12 @@ describe('MinimapDensityQuery', () => {
       createRect('DML', 300, 400, 1, 100),
     ];
 
-    it('should show Method in buckets outside DML range (fallback path)', () => {
-      const rectsByCategory = buildRectsByCategory(rects);
-      const query = new MinimapDensityQuery(rectsByCategory, 1000, 1);
-
+    it('should show Method in buckets outside DML range', () => {
       // 10 buckets: each covers 100ns
       // Bucket 0 [0-100]: only Method → Method
       // Bucket 3 [300-400]: Method + DML → DML wins (2.5x weight)
       // Bucket 9 [900-1000]: only Method → Method
-      const result = query.query(10);
-
-      expect(result.buckets[0]!.dominantCategory).toBe('Method');
-      expect(result.buckets[1]!.dominantCategory).toBe('Method');
-      expect(result.buckets[9]!.dominantCategory).toBe('Method');
-
-      // DML bucket: DML at depth 1 is deeper, with 2.5x weight
-      expect(result.buckets[3]!.dominantCategory).toBe('DML');
-    });
-
-    it('should show Method in buckets outside DML range (segment tree path)', () => {
-      const rectsByCategory = buildRectsByCategory(rects);
-      const segmentTree = new TemporalSegmentTree(rectsByCategory);
-      const query = new MinimapDensityQuery(rectsByCategory, 1000, 1, segmentTree);
-
-      const result = query.query(10);
+      const result = buildQuery(rects, 1000, 1).query(10);
 
       // These buckets must be Method - the parent frame spans all of them
       expect(result.buckets[0]!.dominantCategory).toBe('Method');
@@ -114,25 +104,17 @@ describe('MinimapDensityQuery', () => {
       expect(result.buckets[5]!.dominantCategory).toBe('Method');
       expect(result.buckets[9]!.dominantCategory).toBe('Method');
 
-      // DML bucket
+      // DML bucket: DML at depth 1 is deeper, with 2.5x weight
       expect(result.buckets[3]!.dominantCategory).toBe('DML');
     });
 
-    it('should produce consistent results between fallback and segment tree paths', () => {
-      const rectsByCategory = buildRectsByCategory(rects);
-      const segmentTree = new TemporalSegmentTree(rectsByCategory);
+    it('counts every frame in each bucket it spans', () => {
+      const result = buildQuery(rects, 1000, 1).query(10);
 
-      const fallbackQuery = new MinimapDensityQuery(rectsByCategory, 1000, 1);
-      const treeQuery = new MinimapDensityQuery(rectsByCategory, 1000, 1, segmentTree);
-
-      const fallbackResult = fallbackQuery.query(10);
-      const treeResult = treeQuery.query(10);
-
-      for (let i = 0; i < 10; i++) {
-        expect(treeResult.buckets[i]!.dominantCategory).toBe(
-          fallbackResult.buckets[i]!.dominantCategory,
-        );
-      }
+      // The parent alone outside the child's range, both where they overlap.
+      expect(result.buckets[0]!.eventCount).toBe(1);
+      expect(result.buckets[3]!.eventCount).toBe(2);
+      expect(result.buckets[9]!.eventCount).toBe(1);
     });
   });
 
@@ -154,11 +136,7 @@ describe('MinimapDensityQuery', () => {
         createRect('DML', 600, 700, 2, 100),
       ];
 
-      const rectsByCategory = buildRectsByCategory(rects);
-      const segmentTree = new TemporalSegmentTree(rectsByCategory);
-      const query = new MinimapDensityQuery(rectsByCategory, 1000, 2, segmentTree);
-
-      const result = query.query(10);
+      const result = buildQuery(rects, 1000, 2).query(10);
 
       // Bucket 0 [0-100]: Code Unit + Method → Method wins (deeper)
       expect(result.buckets[0]!.dominantCategory).toBe('Method');
@@ -177,11 +155,7 @@ describe('MinimapDensityQuery', () => {
   describe('edge cases', () => {
     it('should handle single frame spanning all buckets', () => {
       const rects = [createRect('Method', 0, 1000, 0)];
-      const rectsByCategory = buildRectsByCategory(rects);
-      const segmentTree = new TemporalSegmentTree(rectsByCategory);
-      const query = new MinimapDensityQuery(rectsByCategory, 1000, 0, segmentTree);
-
-      const result = query.query(5);
+      const result = buildQuery(rects, 1000, 0).query(5);
 
       for (const bucket of result.buckets) {
         expect(bucket.dominantCategory).toBe('Method');
@@ -189,10 +163,7 @@ describe('MinimapDensityQuery', () => {
     });
 
     it('should handle empty timeline', () => {
-      const rectsByCategory = new Map<string, PrecomputedRect[]>();
-      const query = new MinimapDensityQuery(rectsByCategory, 0, 0);
-
-      const result = query.query(10);
+      const result = buildQuery([], 0, 0).query(10);
       expect(result.buckets).toHaveLength(0);
     });
   });
@@ -203,29 +174,23 @@ describe('MinimapDensityQuery', () => {
     // "Invalid array length" and aborted timeline init.
     const rects = [createRect('Method', 0, 1000, 0)];
 
-    it('floors a fractional bucket count instead of throwing (segment tree path)', () => {
-      const rectsByCategory = buildRectsByCategory(rects);
-      const segmentTree = new TemporalSegmentTree(rectsByCategory);
-      const query = new MinimapDensityQuery(rectsByCategory, 1000, 0, segmentTree);
-
-      const fractional = query.query(10.6);
-      const floored = query.query(10);
+    it('floors a fractional bucket count to the same result as the integer count', () => {
+      const fractional = buildQuery(rects, 1000, 0).query(10.6);
+      const floored = buildQuery(rects, 1000, 0).query(10);
 
       expect(fractional.buckets).toHaveLength(10);
       expect(fractional.buckets).toEqual(floored.buckets);
     });
 
-    it('floors a fractional bucket count instead of throwing (fallback path)', () => {
-      const rectsByCategory = buildRectsByCategory(rects);
-      const query = new MinimapDensityQuery(rectsByCategory, 1000, 0);
+    it('floors a fractional bucket count instead of throwing', () => {
+      const query = buildQuery(rects, 1000, 0);
 
       expect(() => query.query(1536.6667)).not.toThrow();
       expect(query.query(1536.6667).buckets).toHaveLength(1536);
     });
 
     it('treats a non-finite bucket count as empty instead of throwing', () => {
-      const rectsByCategory = buildRectsByCategory(rects);
-      const query = new MinimapDensityQuery(rectsByCategory, 1000, 0);
+      const query = buildQuery(rects, 1000, 0);
 
       expect(() => query.query(Number.NaN)).not.toThrow();
       expect(query.query(Number.NaN).buckets).toHaveLength(0);

--- a/log-viewer/src/features/timeline/__tests__/minimap-density.test.ts
+++ b/log-viewer/src/features/timeline/__tests__/minimap-density.test.ts
@@ -152,6 +152,24 @@ describe('MinimapDensityQuery', () => {
     });
   });
 
+  describe('the one width held', () => {
+    const rects = [createRect('Method', 0, 1000, 0), createRect('DML', 300, 400, 1)];
+
+    it('recomputes only when the width changes', () => {
+      const query = buildQuery(rects, 1000, 1);
+
+      const first = query.query(10);
+      expect(query.query(10)).toBe(first);
+
+      // A different width is a different picture, so it cannot answer from the one held.
+      const wider = query.query(11);
+      expect(wider).not.toBe(first);
+
+      // Only one is held, so the first width has to be computed again.
+      expect(query.query(10)).not.toBe(first);
+    });
+  });
+
   describe('edge cases', () => {
     it('should handle single frame spanning all buckets', () => {
       const rects = [createRect('Method', 0, 1000, 0)];

--- a/log-viewer/src/features/timeline/optimised/CLAUDE.md
+++ b/log-viewer/src/features/timeline/optimised/CLAUDE.md
@@ -66,18 +66,14 @@ The metric strip supports collapsed (heat-style) and expanded (step chart) views
 | ---------------------------------- | ------------------------------ | ------------ |
 | `query(viewport)`                  | Viewport culling for rendering | O(k log n)   |
 | `queryEventsInRegion(time, depth)` | Hit testing, spatial lookups   | O(log n + k) |
-| `takeFramesSorted()`               | Minimap skyline, once per log  | O(n log n)   |
 
 ### Access Pattern
 
 ```typescript
-// Via RectangleCache (preferred)
 const events = rectangleCache.queryEventsInRegion(timeStart, timeEnd, depthStart, depthEnd);
-
-// Direct tree access (for specialized queries)
-const tree = rectangleCache.getSegmentTree();
-const frames = tree.takeFramesSorted();
 ```
+
+`RectangleCache` fronts the tree; nothing reaches past it.
 
 ### Why Not TimelineEventIndex?
 
@@ -155,9 +151,9 @@ This ensures the minimap's viewport lens correctly shows which depth range is vi
 
 The minimap colours each pixel column by the category on top longest in it — the log seen from above.
 
-- `MinimapSkylineIndex` holds that as typed segments, built once per log from the frames the tree
-  hands over with `takeFramesSorted()`. Which frame is on top does not depend on the minimap's
-  width, so it is never rebuilt or invalidated.
+- `MinimapSkylineIndex` holds that as typed segments, built on the first minimap draw straight from
+  `RectangleCache`'s rectangles. Which frame is on top does not depend on the minimap's width, so it
+  is never rebuilt or invalidated.
 - `MinimapDensityQuery` walks those segments against the buckets, one bucket per pixel of the
   display width, and holds the one width it last computed. Nothing invalidates that either: a new
   width misses on its own, and a theme change cannot alter a category name.

--- a/log-viewer/src/features/timeline/optimised/CLAUDE.md
+++ b/log-viewer/src/features/timeline/optimised/CLAUDE.md
@@ -66,7 +66,7 @@ The metric strip supports collapsed (heat-style) and expanded (step chart) views
 | ---------------------------------- | ------------------------------ | ------------ |
 | `query(viewport)`                  | Viewport culling for rendering | O(k log n)   |
 | `queryEventsInRegion(time, depth)` | Hit testing, spatial lookups   | O(log n + k) |
-| `getAllFramesSorted()`             | Minimap skyline, once per log  | O(n log n)   |
+| `takeFramesSorted()`               | Minimap skyline, once per log  | O(n log n)   |
 
 ### Access Pattern
 
@@ -76,7 +76,7 @@ const events = rectangleCache.queryEventsInRegion(timeStart, timeEnd, depthStart
 
 // Direct tree access (for specialized queries)
 const tree = rectangleCache.getSegmentTree();
-const frames = tree.getAllFramesSorted();
+const frames = tree.takeFramesSorted();
 ```
 
 ### Why Not TimelineEventIndex?

--- a/log-viewer/src/features/timeline/optimised/CLAUDE.md
+++ b/log-viewer/src/features/timeline/optimised/CLAUDE.md
@@ -62,11 +62,11 @@ The metric strip supports collapsed (heat-style) and expanded (step chart) views
 
 ### Available Query Methods
 
-| Method                                 | Use Case                       | Complexity   |
-| -------------------------------------- | ------------------------------ | ------------ |
-| `query(viewport)`                      | Viewport culling for rendering | O(k log n)   |
-| `queryEventsInRegion(time, depth)`     | Hit testing, spatial lookups   | O(log n + k) |
-| `queryBucketStats(timeStart, timeEnd)` | Minimap density computation    | O(log n)     |
+| Method                             | Use Case                       | Complexity   |
+| ---------------------------------- | ------------------------------ | ------------ |
+| `query(viewport)`                  | Viewport culling for rendering | O(k log n)   |
+| `queryEventsInRegion(time, depth)` | Hit testing, spatial lookups   | O(log n + k) |
+| `getAllFramesSorted()`             | Minimap skyline, once per log  | O(n log n)   |
 
 ### Access Pattern
 
@@ -76,7 +76,7 @@ const events = rectangleCache.queryEventsInRegion(timeStart, timeEnd, depthStart
 
 // Direct tree access (for specialized queries)
 const tree = rectangleCache.getSegmentTree();
-const stats = tree.queryBucketStats(timeStart, timeEnd);
+const frames = tree.getAllFramesSorted();
 ```
 
 ### Why Not TimelineEventIndex?

--- a/log-viewer/src/features/timeline/optimised/CLAUDE.md
+++ b/log-viewer/src/features/timeline/optimised/CLAUDE.md
@@ -151,6 +151,19 @@ The minimap uses standard screen coordinates but maps depths to match the main t
 
 This ensures the minimap's viewport lens correctly shows which depth range is visible - when scrolled to show parent frames (depth 0), the lens highlights the BOTTOM of the chart area.
 
+### Minimap Density Architecture
+
+The minimap colours each pixel column by the category on top longest in it — the log seen from above.
+
+- `MinimapSkylineIndex` holds that as typed segments, built once per log from the frames the tree
+  hands over with `takeFramesSorted()`. Which frame is on top does not depend on the minimap's
+  width, so it is never rebuilt or invalidated.
+- `MinimapDensityQuery` walks those segments against the buckets, one bucket per pixel of the
+  display width, and holds the one width it last computed. Nothing invalidates that either: a new
+  width misses on its own, and a theme change cannot alter a category name.
+- Colour is resolved at draw time by `MinimapRenderer` from `batchColors`, so density outlives a
+  theme switch.
+
 ## Minimap Interactions
 
 The minimap supports intuitive drag interactions for viewport control:

--- a/log-viewer/src/features/timeline/optimised/FlameChart.ts
+++ b/log-viewer/src/features/timeline/optimised/FlameChart.ts
@@ -901,7 +901,7 @@ export class FlameChart<E extends EventNode = EventNode> {
     this.state.batchColorsCache = this.buildBatchColorsCache(this.state.batches);
 
     // Invalidate minimap static content to re-render with new colors
-    this.minimapOrchestrator?.invalidateCache();
+    this.minimapOrchestrator?.invalidateColors();
 
     // Request re-render
     this.requestRender();

--- a/log-viewer/src/features/timeline/optimised/FlameChart.ts
+++ b/log-viewer/src/features/timeline/optimised/FlameChart.ts
@@ -900,8 +900,7 @@ export class FlameChart<E extends EventNode = EventNode> {
     // Rebuild batch colors cache (used by bucket color resolution)
     this.state.batchColorsCache = this.buildBatchColorsCache(this.state.batches);
 
-    // Invalidate minimap static content to re-render with new colors
-    this.minimapOrchestrator?.invalidateColors();
+    this.minimapOrchestrator?.invalidateStatic();
 
     // Request re-render
     this.requestRender();

--- a/log-viewer/src/features/timeline/optimised/FlameChart.ts
+++ b/log-viewer/src/features/timeline/optimised/FlameChart.ts
@@ -196,6 +196,12 @@ export class FlameChart<E extends EventNode = EventNode> {
   /** The minimap height the last applied resize used, so a resize can tell nothing moved. */
   private appliedMinimapHeight: number | null = null;
 
+  /**
+   * Overhead the last applied layout sat under, so a change inside it is not hidden
+   * by the main timeline height staying the same.
+   */
+  private appliedOverheadHeight: number | null = null;
+
   // Cached culled rectangles (reused when viewport unchanged - Phase 3 optimization)
   // INVARIANT: These caches are invalidated when renderDirty.culling is set to true.
   // Any code that changes viewport state must call invalidateAll() or set culling dirty flag.
@@ -832,14 +838,22 @@ export class FlameChart<E extends EventNode = EventNode> {
     // stands. Load reaches here with the geometry init already set. The minimap is checked
     // too: its height is a tenth of the container's, so it can move on its own while the main
     // timeline keeps the height it had.
+    //
+    // The overhead is checked for itself, not through `mainTimelineHeight`: that is the
+    // container less the overhead, so the metric strip appearing while the container grows by
+    // the same 19px leaves it unchanged, and the minimap's height is clamped over most of the
+    // range. Skipping there left `mainTimelineYOffset` short and put every hit test and
+    // tooltip out by the strip's height.
     if (
       newWidth === oldWidth &&
       mainTimelineHeight === oldState.displayHeight &&
-      minimapHeight === this.appliedMinimapHeight
+      minimapHeight === this.appliedMinimapHeight &&
+      totalOverheadHeight === this.appliedOverheadHeight
     ) {
       return false;
     }
     this.appliedMinimapHeight = minimapHeight;
+    this.appliedOverheadHeight = totalOverheadHeight;
 
     // Update offset for converting canvas-relative to container-relative coordinates
     this.mainTimelineYOffset = totalOverheadHeight;
@@ -1026,6 +1040,7 @@ export class FlameChart<E extends EventNode = EventNode> {
 
     // This is the applied geometry, so a resize to the same size has nothing to do.
     this.appliedMinimapHeight = minimapHeight;
+    this.appliedOverheadHeight = minimapHeight + MINIMAP_GAP + metricStripHeight + METRIC_STRIP_GAP;
 
     // Create wrapper container with flexbox layout
     this.wrapper = document.createElement('div');

--- a/log-viewer/src/features/timeline/optimised/RectangleCache.ts
+++ b/log-viewer/src/features/timeline/optimised/RectangleCache.ts
@@ -186,8 +186,8 @@ export class RectangleCache {
   }
 
   /**
-   * Get spatial index of rectangles by category.
-   * Used for search functionality and segment tree construction.
+   * Get the rectangles, grouped by category and each ascending by timeStart.
+   * Read by the legacy culler and by the minimap, which sweeps them for its skyline.
    *
    * @returns Map of category to rectangles
    */
@@ -213,16 +213,6 @@ export class RectangleCache {
     depthEnd: number,
   ): LogEvent[] {
     return this.segmentTree.queryEventsInRegion(timeStart, timeEnd, depthStart, depthEnd);
-  }
-
-  /**
-   * Get the underlying segment tree for direct queries.
-   * Used by MinimapDensityQuery for O(B×log N) density computation.
-   *
-   * @returns The TemporalSegmentTree instance
-   */
-  public getSegmentTree(): TemporalSegmentTree {
-    return this.segmentTree;
   }
 
   // ============================================================================

--- a/log-viewer/src/features/timeline/optimised/TemporalSegmentTree.ts
+++ b/log-viewer/src/features/timeline/optimised/TemporalSegmentTree.ts
@@ -15,7 +15,6 @@
  * Key capabilities:
  * - Viewport culling: query() returns visible rectangles and buckets
  * - Spatial queries: queryEventsInRegion() for hit testing (O(log n + k))
- * - Density stats: queryBucketStats() for minimap visualization (O(log n))
  *
  * Key concepts:
  * - Leaf nodes represent individual events
@@ -313,124 +312,6 @@ export class TemporalSegmentTree {
     if (node.children) {
       for (const child of node.children) {
         this.collectEventsFromNode(child, queryStart, queryEnd, results);
-      }
-    }
-  }
-
-  /**
-   * Stats returned from queryBucketStats for minimap density computation.
-   */
-  public queryBucketStats(
-    timeStart: number,
-    timeEnd: number,
-  ): {
-    maxDepth: number;
-    eventCount: number;
-    selfDurationSum: number;
-    categoryWeights: Map<string, { weightedTime: number; maxDepth: number }>;
-    frames: SkylineFrame[];
-  } {
-    let maxDepth = 0;
-    let eventCount = 0;
-    let selfDurationSum = 0;
-    const categoryWeights = new Map<string, { weightedTime: number; maxDepth: number }>();
-    const frames: SkylineFrame[] = [];
-
-    // Query each depth level
-    for (const [depth, tree] of this.treesByDepth) {
-      this.aggregateStatsFromNode(
-        tree,
-        timeStart,
-        timeEnd,
-        depth,
-        categoryWeights,
-        frames,
-        (d, count, selfDur) => {
-          if (d > maxDepth) {
-            maxDepth = d;
-          }
-          eventCount += count;
-          selfDurationSum += selfDur;
-        },
-      );
-    }
-
-    return { maxDepth, eventCount, selfDurationSum, categoryWeights, frames };
-  }
-
-  /**
-   * Aggregate stats from a tree node for minimap density computation.
-   * Collects frame references for skyline computation.
-   */
-  private aggregateStatsFromNode(
-    node: SegmentNode,
-    queryStart: number,
-    queryEnd: number,
-    depth: number,
-    categoryWeights: Map<string, { weightedTime: number; maxDepth: number }>,
-    frames: SkylineFrame[],
-    onStats: (depth: number, count: number, selfDuration: number) => void,
-  ): void {
-    // Early exit: no overlap
-    if (node.timeEnd <= queryStart || node.timeStart >= queryEnd) {
-      return;
-    }
-
-    // Leaf node: aggregate its stats
-    if (node.isLeaf && node.rectRef) {
-      const rect = node.rectRef;
-
-      // Calculate visible time within query range
-      const overlapStart = Math.max(rect.timeStart, queryStart);
-      const overlapEnd = Math.min(rect.timeEnd, queryEnd);
-      const visibleTime = overlapEnd - overlapStart;
-
-      // Calculate overlap ratio for proportional self-duration attribution
-      const rectDuration = rect.timeEnd - rect.timeStart;
-      const overlapRatio = rectDuration > 0 ? visibleTime / rectDuration : 0;
-      const proportionalSelfDuration = rect.selfDuration * overlapRatio;
-
-      // Depth² weighting for category dominance (still used for fallback stats)
-      const depthWeight = (depth + 1) * (depth + 1);
-      const weightedTime = proportionalSelfDuration * depthWeight;
-
-      // Update category weights
-      const category = rect.category;
-      const existing = categoryWeights.get(category);
-      if (existing) {
-        existing.weightedTime += weightedTime;
-        if (depth > existing.maxDepth) {
-          existing.maxDepth = depth;
-        }
-      } else {
-        categoryWeights.set(category, { weightedTime, maxDepth: depth });
-      }
-
-      // Collect frame for density computation
-      frames.push({
-        timeStart: rect.timeStart,
-        timeEnd: rect.timeEnd,
-        depth,
-        category,
-        selfDuration: rect.selfDuration,
-      });
-
-      onStats(depth, 1, proportionalSelfDuration);
-      return;
-    }
-
-    // Branch node: recurse into children
-    if (node.children) {
-      for (const child of node.children) {
-        this.aggregateStatsFromNode(
-          child,
-          queryStart,
-          queryEnd,
-          depth,
-          categoryWeights,
-          frames,
-          onStats,
-        );
       }
     }
   }

--- a/log-viewer/src/features/timeline/optimised/TemporalSegmentTree.ts
+++ b/log-viewer/src/features/timeline/optimised/TemporalSegmentTree.ts
@@ -22,7 +22,6 @@
  * - Query traversal stops at nodes where nodeSpan <= threshold (2px / zoom)
  * - Pre-computed category stats enable instant bucket color resolution
  *
- * Memory usage: ~175MB for 500k events (tree + original rectangles)
  * Build time: O(n log n) for sorting + O(n) for tree construction
  * Query time: O(k log n) where k = number of visible nodes
  */
@@ -54,17 +53,6 @@ const PRIORITY_MAP = new Map<string, number>(
 );
 
 /**
- * Frame data for minimap density computation.
- * Pre-sorted by timeStart for efficient sliding window algorithms.
- */
-export interface SkylineFrame {
-  timeStart: number;
-  timeEnd: number;
-  depth: number;
-  category: string;
-}
-
-/**
  * TemporalSegmentTree
  *
  * Manages separate trees per depth level for efficient viewport culling.
@@ -81,18 +69,30 @@ type AggregationBucket = {
   dominantCategory: string; // Resolved after all nodes aggregated
 };
 
+/** Group rectangles by depth, for a caller that has not already done it. */
+function groupByDepth(
+  rectsByCategory: Map<string, PrecomputedRect[]>,
+): Map<number, PrecomputedRect[]> {
+  const rectsByDepth = new Map<number, PrecomputedRect[]>();
+  for (const rects of rectsByCategory.values()) {
+    for (const rect of rects) {
+      let depthRects = rectsByDepth.get(rect.depth);
+      if (!depthRects) {
+        depthRects = [];
+        rectsByDepth.set(rect.depth, depthRects);
+      }
+      depthRects.push(rect);
+    }
+  }
+  return rectsByDepth;
+}
+
 export class TemporalSegmentTree {
   /** Tree root per depth level: Map<depth, rootNode> */
   private treesByDepth: Map<number, SegmentNode> = new Map();
 
   /** Maximum depth in the tree */
   private maxDepth = 0;
-
-  /**
-   * Frames collected during construction, sorted and handed over by
-   * takeFramesSorted(). Null once taken, so none of this outlives the skyline.
-   */
-  private unsortedFrames: SkylineFrame[] | null = null;
 
   /**
    * Build segment trees from pre-computed rectangles.
@@ -230,29 +230,6 @@ export class TemporalSegmentTree {
   }
 
   /**
-   * Hand over every frame, sorted by timeStart, for the minimap skyline.
-   *
-   * Single use: the frames go to the caller and the tree keeps nothing. One
-   * object per event is the largest thing the tree holds, and the skyline
-   * reduces them to typed arrays, so holding both would be the log twice over.
-   * A second call returns nothing.
-   *
-   * Sorting happens here rather than during construction, so a log whose
-   * minimap is never drawn never pays for it.
-   *
-   * @returns Frames sorted by timeStart, or empty when already taken
-   */
-  public takeFramesSorted(): SkylineFrame[] {
-    const frames = this.unsortedFrames;
-    if (!frames) {
-      return [];
-    }
-    this.unsortedFrames = null;
-    frames.sort((a, b) => a.timeStart - b.timeStart);
-    return frames;
-  }
-
-  /**
    * Query events within a specific time and depth region.
    * Used for hit testing when bucket eventRefs are empty.
    * O(log n + k) complexity where k = events in region.
@@ -319,10 +296,7 @@ export class TemporalSegmentTree {
   /**
    * Build segment trees for all depth levels.
    *
-   * PERF optimizations:
-   * - Uses pre-grouped rectsByDepth when available (~12ms saved)
-   * - Collects frames for minimap during iteration (avoids O(N) traversal)
-   * - Defers frame sorting to takeFramesSorted() (~25ms saved)
+   * Uses pre-grouped rectsByDepth when available (~12ms saved).
    *
    * @param rectsByCategory - Rectangles grouped by category
    * @param preGroupedByDepth - Optional pre-grouped by depth from unified conversion
@@ -331,63 +305,17 @@ export class TemporalSegmentTree {
     rectsByCategory: Map<string, PrecomputedRect[]>,
     preGroupedByDepth?: Map<number, PrecomputedRect[]>,
   ): void {
-    // Collect frames during iteration (avoids separate tree traversal later)
-    const allFrames: SkylineFrame[] = [];
+    const rectsByDepth = preGroupedByDepth ?? groupByDepth(rectsByCategory);
 
-    // Use pre-grouped rectsByDepth if available, otherwise group from category map
-    let rectsByDepth: Map<number, PrecomputedRect[]>;
-
-    if (preGroupedByDepth) {
-      // PERF: Use pre-grouped data (~12ms saved by skipping grouping iteration)
-      rectsByDepth = preGroupedByDepth;
-
-      // Still need to collect frames and track maxDepth
-      for (const [depth, rects] of rectsByDepth) {
-        this.maxDepth = Math.max(this.maxDepth, depth);
-        for (const rect of rects) {
-          allFrames.push({
-            timeStart: rect.timeStart,
-            timeEnd: rect.timeEnd,
-            depth: rect.depth,
-            category: rect.category,
-          });
-        }
-      }
-    } else {
-      // Fallback: Group all rectangles by depth
-      rectsByDepth = new Map<number, PrecomputedRect[]>();
-
-      for (const rects of rectsByCategory.values()) {
-        for (const rect of rects) {
-          let depthRects = rectsByDepth.get(rect.depth);
-          if (!depthRects) {
-            depthRects = [];
-            rectsByDepth.set(rect.depth, depthRects);
-          }
-          depthRects.push(rect);
-          this.maxDepth = Math.max(this.maxDepth, rect.depth);
-
-          // Collect frame directly (eliminates a recursive traversal when taken)
-          allFrames.push({
-            timeStart: rect.timeStart,
-            timeEnd: rect.timeEnd,
-            depth: rect.depth,
-            category: rect.category,
-          });
-        }
-      }
-    }
-
-    // Build tree for each depth
     for (const [depth, rects] of rectsByDepth) {
+      if (depth > this.maxDepth) {
+        this.maxDepth = depth;
+      }
       const tree = this.buildTreeForDepth(rects, depth);
       if (tree) {
         this.treesByDepth.set(depth, tree);
       }
     }
-
-    // PERF: Defer sorting to takeFramesSorted() (~25ms saved at init)
-    this.unsortedFrames = allFrames;
   }
 
   /**

--- a/log-viewer/src/features/timeline/optimised/TemporalSegmentTree.ts
+++ b/log-viewer/src/features/timeline/optimised/TemporalSegmentTree.ts
@@ -62,7 +62,6 @@ export interface SkylineFrame {
   timeEnd: number;
   depth: number;
   category: string;
-  selfDuration: number;
 }
 
 /**
@@ -90,16 +89,10 @@ export class TemporalSegmentTree {
   private maxDepth = 0;
 
   /**
-   * Unsorted frames collected during tree construction.
-   * Sorting is deferred to first getAllFramesSorted() call.
+   * Frames collected during construction, sorted and handed over by
+   * takeFramesSorted(). Null once taken, so none of this outlives the skyline.
    */
   private unsortedFrames: SkylineFrame[] | null = null;
-
-  /**
-   * Cached sorted frames for minimap density computation.
-   * Lazily sorted on first access to defer ~25ms sort cost to minimap render.
-   */
-  private cachedSortedFrames: SkylineFrame[] | null = null;
 
   /**
    * Build segment trees from pre-computed rectangles.
@@ -237,23 +230,26 @@ export class TemporalSegmentTree {
   }
 
   /**
-   * Get all frames sorted by timeStart for minimap density computation.
-   * Frames are collected during tree construction but sorting is deferred
-   * to first access to avoid blocking init when minimap isn't immediately visible.
+   * Hand over every frame, sorted by timeStart, for the minimap skyline.
    *
-   * Performance: Lazy sorting defers ~25ms cost to first minimap render,
-   * reducing init time when minimap isn't immediately needed.
+   * Single use: the frames go to the caller and the tree keeps nothing. One
+   * object per event is the largest thing the tree holds, and the skyline
+   * reduces them to typed arrays, so holding both would be the log twice over.
+   * A second call returns nothing.
    *
-   * @returns Array of SkylineFrame sorted by timeStart
+   * Sorting happens here rather than during construction, so a log whose
+   * minimap is never drawn never pays for it.
+   *
+   * @returns Frames sorted by timeStart, or empty when already taken
    */
-  public getAllFramesSorted(): SkylineFrame[] {
-    // Lazy sort on first access
-    if (!this.cachedSortedFrames && this.unsortedFrames) {
-      this.cachedSortedFrames = this.unsortedFrames;
-      this.cachedSortedFrames.sort((a, b) => a.timeStart - b.timeStart);
-      this.unsortedFrames = null; // Release reference
+  public takeFramesSorted(): SkylineFrame[] {
+    const frames = this.unsortedFrames;
+    if (!frames) {
+      return [];
     }
-    return this.cachedSortedFrames ?? [];
+    this.unsortedFrames = null;
+    frames.sort((a, b) => a.timeStart - b.timeStart);
+    return frames;
   }
 
   /**
@@ -326,7 +322,7 @@ export class TemporalSegmentTree {
    * PERF optimizations:
    * - Uses pre-grouped rectsByDepth when available (~12ms saved)
    * - Collects frames for minimap during iteration (avoids O(N) traversal)
-   * - Defers frame sorting to first getAllFramesSorted() call (~25ms saved)
+   * - Defers frame sorting to takeFramesSorted() (~25ms saved)
    *
    * @param rectsByCategory - Rectangles grouped by category
    * @param preGroupedByDepth - Optional pre-grouped by depth from unified conversion
@@ -354,7 +350,6 @@ export class TemporalSegmentTree {
             timeEnd: rect.timeEnd,
             depth: rect.depth,
             category: rect.category,
-            selfDuration: rect.selfDuration,
           });
         }
       }
@@ -372,13 +367,12 @@ export class TemporalSegmentTree {
           depthRects.push(rect);
           this.maxDepth = Math.max(this.maxDepth, rect.depth);
 
-          // Collect frame directly (eliminates recursive tree traversal in getAllFramesSorted)
+          // Collect frame directly (eliminates a recursive traversal when taken)
           allFrames.push({
             timeStart: rect.timeStart,
             timeEnd: rect.timeEnd,
             depth: rect.depth,
             category: rect.category,
-            selfDuration: rect.selfDuration,
           });
         }
       }
@@ -392,7 +386,7 @@ export class TemporalSegmentTree {
       }
     }
 
-    // PERF: Defer sorting to first getAllFramesSorted() call (~25ms saved at init)
+    // PERF: Defer sorting to takeFramesSorted() (~25ms saved at init)
     this.unsortedFrames = allFrames;
   }
 

--- a/log-viewer/src/features/timeline/optimised/__tests__/FlameChartResize.test.ts
+++ b/log-viewer/src/features/timeline/optimised/__tests__/FlameChartResize.test.ts
@@ -50,6 +50,7 @@ function stubbedChart(displayHeight = 300): {
   };
   // The geometry init applied: 364 container - 60 minimap - 4 gap = the 300 below.
   internals['appliedMinimapHeight'] = 60;
+  internals['appliedOverheadHeight'] = 64;
   internals['state'] = {
     viewport: null,
     needsRender: false,
@@ -116,6 +117,29 @@ describe('FlameChart.resize', () => {
 
     expect(chart.resize(400, 605)).toBe(true);
     expect(appRender).toHaveBeenCalled();
+  });
+
+  // The metric strip appearing adds 15 + 4 to the overhead, so a container that grows by the
+  // same 19px leaves the main timeline height alone. The minimap is clamped at 60 across both,
+  // so every value the guard used to compare was unchanged while the overhead moved by 19.
+  it('draws when the overhead moved but the main timeline height did not', () => {
+    const { chart, appRender } = stubbedChart();
+    const internals = chart as unknown as Record<string, unknown>;
+    internals['metricStripOrchestrator'] = {
+      getIsVisible: () => true,
+      getHeight: () => 15,
+      resize: jest.fn(),
+      holdsHover: () => false,
+      getCursorTimeNs: () => null,
+      render: jest.fn(),
+    };
+    jest.spyOn(window, 'requestAnimationFrame').mockReturnValue(1);
+
+    // 383 - 60 - 4 - 15 - 4 = the 300 the viewport already reports, at the same width.
+    expect(chart.resize(400, 383)).toBe(true);
+    expect(appRender).toHaveBeenCalled();
+    // Stale at 64, every hit test and tooltip would sit 19px out.
+    expect(internals['mainTimelineYOffset']).toBe(83);
   });
 
   // The metric strip resizes its own canvas before asking the host to relayout, so a resize

--- a/log-viewer/src/features/timeline/optimised/__tests__/MinimapSkylineIndex.test.ts
+++ b/log-viewer/src/features/timeline/optimised/__tests__/MinimapSkylineIndex.test.ts
@@ -8,7 +8,7 @@ import { MinimapSkylineIndex } from '../minimap/MinimapSkylineIndex.js';
 import type { SkylineFrame } from '../TemporalSegmentTree.js';
 
 function frame(category: string, timeStart: number, timeEnd: number, depth: number): SkylineFrame {
-  return { category, timeStart, timeEnd, depth, selfDuration: timeEnd - timeStart };
+  return { category, timeStart, timeEnd, depth };
 }
 
 /** The index as a readable list of `[start, end, depth, category]`. */

--- a/log-viewer/src/features/timeline/optimised/__tests__/MinimapSkylineIndex.test.ts
+++ b/log-viewer/src/features/timeline/optimised/__tests__/MinimapSkylineIndex.test.ts
@@ -4,8 +4,7 @@
 
 import { describe, expect, it } from '@jest/globals';
 
-import { MinimapSkylineIndex } from '../minimap/MinimapSkylineIndex.js';
-import type { SkylineFrame } from '../TemporalSegmentTree.js';
+import { MinimapSkylineIndex, type SkylineFrame } from '../minimap/MinimapSkylineIndex.js';
 
 function frame(category: string, timeStart: number, timeEnd: number, depth: number): SkylineFrame {
   return { category, timeStart, timeEnd, depth };
@@ -19,15 +18,15 @@ function segments(index: MinimapSkylineIndex): [number, number, number, string][
       index.segmentStarts[i]!,
       index.segmentStarts[i + 1]!,
       index.segmentDepths[i]!,
-      index.categoryOf(i),
+      index.categoryNames[index.segmentCategories[i]!]!,
     ]);
   }
   return out;
 }
 
-function build(frames: SkylineFrame[], totalDuration = 1000, maxDepth = 4): MinimapSkylineIndex {
-  const sorted = [...frames].sort((a, b) => a.timeStart - b.timeStart);
-  return new MinimapSkylineIndex(sorted, totalDuration, maxDepth);
+function build(frames: SkylineFrame[], totalDuration = 1000): MinimapSkylineIndex {
+  // One group, in whatever order the test wrote it: the index orders its own input.
+  return new MinimapSkylineIndex([frames], totalDuration);
 }
 
 describe('MinimapSkylineIndex', () => {
@@ -85,8 +84,8 @@ describe('MinimapSkylineIndex', () => {
   });
 
   it('keeps a parent that starts at the same time as its child', () => {
-    // The tree can hand these over in either order; the parent must still be on
-    // top after the child ends, or a frame spanning the log is lost.
+    // The parent must still be on top after the child ends, or a frame spanning
+    // the whole log is lost.
     const index = build([frame('Method', 0, 1000, 0), frame('SOQL', 0, 100, 1)], 1000);
 
     expect(segments(index)).toEqual([
@@ -109,10 +108,9 @@ describe('MinimapSkylineIndex', () => {
     expect(index.violations).toBe(1);
   });
 
-  it('keeps the deepest of two frames that overlap at the same depth', () => {
+  it('keeps the first of two frames that overlap at the same depth', () => {
     const index = build([frame('Method', 0, 100, 0), frame('SOQL', 50, 150, 0)], 150);
 
-    // The second cannot be on top of the first, so the first holds the stretch.
     expect(segments(index)).toEqual([
       [0, 100, 0, 'Method'],
       [100, 150, 0, ''],
@@ -134,11 +132,12 @@ describe('MinimapSkylineIndex', () => {
     expect(index.categoryNames.slice(1).sort()).toEqual(['DML', 'Method']);
   });
 
-  it('holds every frame bound, in the order it swept them', () => {
+  it('counts a frame in every bucket it spans', () => {
     const index = build([frame('Method', 0, 1000, 0), frame('DML', 300, 400, 1)]);
 
-    expect(Array.from(index.frameStarts)).toEqual([0, 300]);
-    expect(Array.from(index.frameEnds)).toEqual([1000, 400]);
+    // Ten buckets of 100. The child adds a second count over 300-400, and a
+    // frame ending on a boundary counts in the bucket after it.
+    expect(Array.from(index.countFrames(10, 100))).toEqual([1, 1, 1, 2, 2, 1, 1, 1, 1, 1]);
   });
 
   it('handles a log with no frames', () => {

--- a/log-viewer/src/features/timeline/optimised/__tests__/MinimapSkylineIndex.test.ts
+++ b/log-viewer/src/features/timeline/optimised/__tests__/MinimapSkylineIndex.test.ts
@@ -1,0 +1,150 @@
+/*
+ * Copyright (c) 2026 Certinia Inc. All rights reserved.
+ */
+
+import { describe, expect, it } from '@jest/globals';
+
+import { MinimapSkylineIndex } from '../minimap/MinimapSkylineIndex.js';
+import type { SkylineFrame } from '../TemporalSegmentTree.js';
+
+function frame(category: string, timeStart: number, timeEnd: number, depth: number): SkylineFrame {
+  return { category, timeStart, timeEnd, depth, selfDuration: timeEnd - timeStart };
+}
+
+/** The index as a readable list of `[start, end, depth, category]`. */
+function segments(index: MinimapSkylineIndex): [number, number, number, string][] {
+  const out: [number, number, number, string][] = [];
+  for (let i = 0; i < index.segmentCount; i++) {
+    out.push([
+      index.segmentStarts[i]!,
+      index.segmentStarts[i + 1]!,
+      index.segmentDepths[i]!,
+      index.categoryOf(i),
+    ]);
+  }
+  return out;
+}
+
+function build(frames: SkylineFrame[], totalDuration = 1000, maxDepth = 4): MinimapSkylineIndex {
+  const sorted = [...frames].sort((a, b) => a.timeStart - b.timeStart);
+  return new MinimapSkylineIndex(sorted, totalDuration, maxDepth);
+}
+
+describe('MinimapSkylineIndex', () => {
+  it('splits the timeline where the frame on top changes', () => {
+    // depth 0: |------------ Method (0-1000) ------------|
+    // depth 1:              |-- DML (300-400) --|
+    const index = build([frame('Method', 0, 1000, 0), frame('DML', 300, 400, 1)]);
+
+    expect(segments(index)).toEqual([
+      [0, 300, 0, 'Method'],
+      [300, 400, 1, 'DML'],
+      [400, 1000, 0, 'Method'],
+    ]);
+    expect(index.violations).toBe(0);
+  });
+
+  it('leaves a gap where no frame runs', () => {
+    const index = build([frame('Method', 0, 200, 0), frame('SOQL', 600, 700, 0)]);
+
+    expect(segments(index)).toEqual([
+      [0, 200, 0, 'Method'],
+      [200, 600, 0, ''],
+      [600, 700, 0, 'SOQL'],
+      [700, 1000, 0, ''],
+    ]);
+  });
+
+  it('leaves the stretch after the last frame as a gap', () => {
+    const index = build([frame('Method', 0, 200, 0)], 1000);
+
+    // Closing the Method segment at 1000 instead would colour the rest of the
+    // minimap with a frame that had already ended.
+    expect(segments(index)).toEqual([
+      [0, 200, 0, 'Method'],
+      [200, 1000, 0, ''],
+    ]);
+  });
+
+  it('orders segments by time with no overlap', () => {
+    const frames: SkylineFrame[] = [];
+    for (let root = 0; root < 40; root++) {
+      const start = root * 25;
+      frames.push(frame('Apex', start, start + 20, 0));
+      frames.push(frame('SOQL', start + 5, start + 8, 1));
+      frames.push(frame('DML', start + 10, start + 19, 1));
+      frames.push(frame('System', start + 11, start + 14, 2));
+    }
+    const index = build(frames, 1000);
+
+    expect(index.segmentCount).toBeGreaterThan(40);
+    expect(index.violations).toBe(0);
+    for (let i = 0; i < index.segmentCount; i++) {
+      expect(index.segmentStarts[i]!).toBeLessThan(index.segmentStarts[i + 1]!);
+    }
+  });
+
+  it('keeps a parent that starts at the same time as its child', () => {
+    // The tree can hand these over in either order; the parent must still be on
+    // top after the child ends, or a frame spanning the log is lost.
+    const index = build([frame('Method', 0, 1000, 0), frame('SOQL', 0, 100, 1)], 1000);
+
+    expect(segments(index)).toEqual([
+      [0, 100, 1, 'SOQL'],
+      [100, 1000, 0, 'Method'],
+    ]);
+    expect(index.violations).toBe(0);
+  });
+
+  it('contains a frame that outlives its parent', () => {
+    // depth 0: |-- Method (0-100) --|
+    // depth 1: |------ SOQL (0-200) ------|
+    const index = build([frame('Method', 0, 100, 0), frame('SOQL', 0, 200, 1)], 200);
+
+    // The child is cut to its parent's end rather than reaching past it.
+    expect(segments(index)).toEqual([
+      [0, 100, 1, 'SOQL'],
+      [100, 200, 0, ''],
+    ]);
+    expect(index.violations).toBe(1);
+  });
+
+  it('keeps the deepest of two frames that overlap at the same depth', () => {
+    const index = build([frame('Method', 0, 100, 0), frame('SOQL', 50, 150, 0)], 150);
+
+    // The second cannot be on top of the first, so the first holds the stretch.
+    expect(segments(index)).toEqual([
+      [0, 100, 0, 'Method'],
+      [100, 150, 0, ''],
+    ]);
+    expect(index.violations).toBe(1);
+  });
+
+  it('ignores a frame with no duration', () => {
+    const index = build([frame('Method', 0, 1000, 0), frame('DML', 500, 500, 1)], 1000);
+
+    expect(segments(index)).toEqual([[0, 1000, 0, 'Method']]);
+    expect(index.violations).toBe(1);
+  });
+
+  it('names every category it saw, including one outside the known set', () => {
+    const index = build([frame('Method', 0, 500, 0), frame('DML', 100, 200, 1)]);
+
+    expect(index.categoryNames[0]).toBe('');
+    expect(index.categoryNames.slice(1).sort()).toEqual(['DML', 'Method']);
+  });
+
+  it('holds every frame bound, in the order it swept them', () => {
+    const index = build([frame('Method', 0, 1000, 0), frame('DML', 300, 400, 1)]);
+
+    expect(Array.from(index.frameStarts)).toEqual([0, 300]);
+    expect(Array.from(index.frameEnds)).toEqual([1000, 400]);
+  });
+
+  it('handles a log with no frames', () => {
+    const index = build([], 1000);
+
+    expect(segments(index)).toEqual([[0, 1000, 0, '']]);
+    expect(index.violations).toBe(0);
+  });
+});

--- a/log-viewer/src/features/timeline/optimised/__tests__/TemporalSegmentTree.test.ts
+++ b/log-viewer/src/features/timeline/optimised/__tests__/TemporalSegmentTree.test.ts
@@ -86,24 +86,6 @@ describe('TemporalSegmentTree', () => {
     'Validation',
   ]);
 
-  describe('takeFramesSorted', () => {
-    it('hands over one frame per rectangle, sorted by start, and only once', () => {
-      const events = [
-        createEvent(0, 200, 'Apex', [createEvent(50, 50, 'SOQL')]),
-        createEvent(300, 100, 'Apex'),
-      ];
-      const manager = new RectangleCache(events, categories);
-      const tree = manager.getSegmentTree();
-
-      const frames = tree.takeFramesSorted();
-      expect(frames.map((frame) => frame.timeStart)).toEqual([0, 50, 300]);
-
-      // The frames belong to the caller now. Holding them here as well would be
-      // the log twice over, so the tree keeps nothing.
-      expect(tree.takeFramesSorted()).toEqual([]);
-    });
-  });
-
   describe('tree building', () => {
     it('should build tree from rectangles', () => {
       const events = [

--- a/log-viewer/src/features/timeline/optimised/__tests__/TemporalSegmentTree.test.ts
+++ b/log-viewer/src/features/timeline/optimised/__tests__/TemporalSegmentTree.test.ts
@@ -86,6 +86,24 @@ describe('TemporalSegmentTree', () => {
     'Validation',
   ]);
 
+  describe('takeFramesSorted', () => {
+    it('hands over one frame per rectangle, sorted by start, and only once', () => {
+      const events = [
+        createEvent(0, 200, 'Apex', [createEvent(50, 50, 'SOQL')]),
+        createEvent(300, 100, 'Apex'),
+      ];
+      const manager = new RectangleCache(events, categories);
+      const tree = manager.getSegmentTree();
+
+      const frames = tree.takeFramesSorted();
+      expect(frames.map((frame) => frame.timeStart)).toEqual([0, 50, 300]);
+
+      // The frames belong to the caller now. Holding them here as well would be
+      // the log twice over, so the tree keeps nothing.
+      expect(tree.takeFramesSorted()).toEqual([]);
+    });
+  });
+
   describe('tree building', () => {
     it('should build tree from rectangles', () => {
       const events = [

--- a/log-viewer/src/features/timeline/optimised/minimap/MinimapDensityQuery.ts
+++ b/log-viewer/src/features/timeline/optimised/minimap/MinimapDensityQuery.ts
@@ -36,7 +36,8 @@
  */
 
 import type { BucketCategoryPriority } from '../../types/flamechart.types.js';
-import type { SkylineFrame, TemporalSegmentTree } from '../TemporalSegmentTree.js';
+import type { TemporalSegmentTree } from '../TemporalSegmentTree.js';
+import { MinimapSkylineIndex } from './MinimapSkylineIndex.js';
 
 /**
  * Single density bucket for minimap visualization.
@@ -86,26 +87,11 @@ const CATEGORY_WEIGHTS: Partial<Record<BucketCategoryPriority, number>> = {
   Validation: 0.8,
 };
 
-/**
- * Event type for skyline sweep-line algorithm.
- * 0 = frame start (enter), 1 = frame end (exit)
- */
-const SkylineEventType = {
-  Enter: 0,
-  Exit: 1,
-} as const;
+/** Segment category id 0: no frame on top. */
+const GAP_CATEGORY = 0;
 
-type SkylineEventType = (typeof SkylineEventType)[keyof typeof SkylineEventType];
-
-/**
- * Skyline event for sweep-line algorithm.
- * Reused via object pool to avoid allocations.
- */
-interface SkylineEvent {
-  time: number;
-  type: SkylineEventType;
-  frame: SkylineFrame;
-}
+/** What a bucket with nothing on top reports, as the old sweep's default did. */
+const DEFAULT_CATEGORY = 'Apex';
 
 export class MinimapDensityQuery {
   /** Global maximum depth across timeline. */
@@ -127,6 +113,14 @@ export class MinimapDensityQuery {
    */
   private cachedBucketCount: number | null = null;
   private cachedDensity: MinimapDensityData | null = null;
+
+  /** The log seen from above, built on the first query and never rebuilt. */
+  private index: MinimapSkylineIndex | null = null;
+
+  /** Scratch for the walk, one slot per category id. Sized with the index. */
+  private weights = new Float64Array(0);
+  private accumulated = new Float64Array(0);
+  private onTopOrder = new Int32Array(0);
 
   /** The frames every density is computed from. */
   private segmentTree: TemporalSegmentTree;
@@ -170,9 +164,13 @@ export class MinimapDensityQuery {
   // ============================================================================
 
   /**
-   * Compute density data from the tree's frames, sorted by start.
-   * Uses skyline (on-top time) algorithm for category resolution:
-   * At each moment, the deepest frame is "on top" and its category accumulates time.
+   * Compute density data by walking the skyline against the buckets.
+   *
+   * Both are ordered by time, so one pass over each: per bucket, every segment
+   * overlapping it adds its own length to that category's total, and the deepest
+   * segment gives the bar its height. A segment reaching past the bucket's end is
+   * left for the next bucket, so each is visited once plus once per boundary it
+   * crosses. Nothing is allocated per bucket.
    *
    * @param bucketCount - Number of output buckets
    * @returns MinimapDensityData
@@ -182,193 +180,147 @@ export class MinimapDensityQuery {
       return { buckets: [], globalMaxDepth: this.globalMaxDepth };
     }
 
-    const frames = this.segmentTree.getAllFramesSorted();
+    const skyline = this.skyline();
+    const { segmentCount, segmentStarts, segmentDepths, segmentCategories, categoryNames } =
+      skyline;
+    const accumulated = this.accumulated;
+    const onTopOrder = this.onTopOrder;
+    const weights = this.weights;
+
     const bucketTimeWidth = this.totalDuration / bucketCount;
-
-    // Pre-allocate bucket arrays
-    const maxDepths = new Uint16Array(bucketCount);
-    const eventCounts = new Uint32Array(bucketCount);
-
-    // Collect frames per bucket for skyline computation
-    const framesPerBucket: SkylineFrame[][] = new Array(bucketCount);
-    for (let i = 0; i < bucketCount; i++) {
-      framesPerBucket[i] = [];
-    }
-
-    // Single pass: compute maxDepth, eventCount, and collect frames
-    for (const frame of frames) {
-      const startBucket = Math.max(0, Math.floor(frame.timeStart / bucketTimeWidth));
-      const endBucket = Math.min(bucketCount - 1, Math.floor(frame.timeEnd / bucketTimeWidth));
-
-      for (let b = startBucket; b <= endBucket; b++) {
-        // Update maxDepth
-        if (frame.depth > maxDepths[b]!) {
-          maxDepths[b] = frame.depth;
-        }
-
-        // Increment event count
-        eventCounts[b]!++;
-
-        // Collect frame for skyline computation
-        framesPerBucket[b]!.push(frame);
-      }
-    }
-
-    // Build output buckets
+    const eventCounts = this.countFrames(skyline, bucketCount, bucketTimeWidth);
     const buckets: MinimapDensityBucket[] = new Array(bucketCount);
 
+    let segment = 0;
     for (let i = 0; i < bucketCount; i++) {
-      // Resolve dominant category using skyline (on-top time) algorithm
-      const dominantCategory = this.resolveCategoryFromSkyline(
-        framesPerBucket[i]!,
-        i * bucketTimeWidth,
-        (i + 1) * bucketTimeWidth,
-      );
+      const bucketStart = i * bucketTimeWidth;
+      const bucketEnd = (i + 1) * bucketTimeWidth;
+
+      // Only fires where a segment ends exactly on the boundary.
+      while (segment < segmentCount && segmentStarts[segment + 1]! <= bucketStart) {
+        segment++;
+      }
+
+      // The segments tile, so the segment holding `bucketStart` starts at or before
+      // it: this is the left-hand partial, with no clamp needed.
+      let from = bucketStart;
+      let maxDepth = 0;
+      let ordered = 0;
+
+      while (segment < segmentCount && segmentStarts[segment]! < bucketEnd) {
+        const segmentEnd = segmentStarts[segment + 1]!;
+        const to = segmentEnd < bucketEnd ? segmentEnd : bucketEnd;
+        const category = segmentCategories[segment]!;
+
+        if (category !== GAP_CATEGORY && to > from) {
+          // First on top wins a tie, which is the order the old sweep's map held.
+          if (accumulated[category] === 0) {
+            onTopOrder[ordered++] = category;
+          }
+          accumulated[category]! += to - from;
+          const depth = segmentDepths[segment]!;
+          if (depth > maxDepth) {
+            maxDepth = depth;
+          }
+        }
+
+        if (segmentEnd >= bucketEnd) {
+          break; // Straddles the end: the next bucket starts on this same segment.
+        }
+        from = segmentEnd;
+        segment++;
+      }
+
+      let winner = GAP_CATEGORY;
+      let best = -1;
+      for (let at = 0; at < ordered; at++) {
+        const category = onTopOrder[at]!;
+        const score = accumulated[category]! * weights[category]!;
+        if (score > best) {
+          best = score;
+          winner = category;
+        }
+        accumulated[category] = 0;
+      }
 
       buckets[i] = {
-        maxDepth: maxDepths[i]!,
+        maxDepth,
         eventCount: eventCounts[i]!,
-        dominantCategory,
+        dominantCategory: winner === GAP_CATEGORY ? DEFAULT_CATEGORY : categoryNames[winner]!,
       };
     }
 
     return { buckets, globalMaxDepth: this.globalMaxDepth };
   }
 
-  // ============================================================================
-  // SKYLINE ALGORITHM: On-Top Time Category Resolution
-  // ============================================================================
+  /**
+   * Count the frames overlapping each bucket, by difference array.
+   *
+   * A frame adds one to the bucket it starts in and takes one back after the
+   * bucket it ends in, so a running total gives every bucket its count in one
+   * pass. The bucket arithmetic is the old loop's, including that a frame ending
+   * exactly on a boundary counts in the bucket after it: this feeds the bar's
+   * opacity, which stays as it was.
+   */
+  private countFrames(
+    skyline: MinimapSkylineIndex,
+    bucketCount: number,
+    bucketTimeWidth: number,
+  ): Uint32Array {
+    const { frameStarts, frameEnds } = skyline;
+    const deltas = new Int32Array(bucketCount + 1);
+    const lastBucket = bucketCount - 1;
+
+    for (let i = 0; i < frameStarts.length; i++) {
+      let first = Math.floor(frameStarts[i]! / bucketTimeWidth);
+      if (first < 0) {
+        first = 0;
+      }
+      let last = Math.floor(frameEnds[i]! / bucketTimeWidth);
+      if (last > lastBucket) {
+        last = lastBucket;
+      }
+      if (last < first) {
+        continue;
+      }
+      deltas[first]!++;
+      deltas[last + 1]!--;
+    }
+
+    const counts = new Uint32Array(bucketCount);
+    let running = 0;
+    for (let b = 0; b < bucketCount; b++) {
+      running += deltas[b]!;
+      counts[b] = running;
+    }
+    return counts;
+  }
 
   /**
-   * Compute dominant category using skyline (on-top time) algorithm.
+   * The skyline, built on the first query.
    *
-   * At each moment within the bucket, the deepest frame is "on top" (visible).
-   * This correctly handles the case where a parent frame's self-duration is
-   * concentrated at the edges (parts not covered by children), not evenly
-   * distributed across the frame's time range.
-   *
-   * Algorithm: Sweep-line with depth tracking
-   * 1. Create enter/exit events for each frame
-   * 2. Sort events by time
-   * 3. Sweep through, tracking which frame is deepest at each moment
-   * 4. Accumulate on-top time per category
-   * 5. Apply CATEGORY_WEIGHTS to determine winner
-   *
-   * PERF: Uses Set for O(1) add/remove instead of indexOf+splice (O(k²) → O(k)).
-   * PERF: Tracks max depth incrementally to avoid rescanning on every frame exit.
-   *
-   * @param frames - Frames overlapping this bucket
-   * @param bucketStart - Bucket start time
-   * @param bucketEnd - Bucket end time
-   * @returns Dominant category for this bucket
+   * Not in the constructor: the tree sorts its frames on first use, and the
+   * timeline defers that cost off its own init.
    */
-  private resolveCategoryFromSkyline(
-    frames: SkylineFrame[],
-    bucketStart: number,
-    bucketEnd: number,
-  ): string {
-    // Fast path: no frames
-    if (frames.length === 0) {
-      return 'Apex';
-    }
+  private skyline(): MinimapSkylineIndex {
+    let index = this.index;
+    if (!index) {
+      index = new MinimapSkylineIndex(
+        this.segmentTree.getAllFramesSorted(),
+        this.totalDuration,
+        this.globalMaxDepth,
+      );
+      this.index = index;
 
-    // Fast path: single frame
-    if (frames.length === 1) {
-      return frames[0]!.category;
-    }
-
-    // Fast path: all same category - no need to compute skyline
-    const firstCategory = frames[0]!.category;
-    let allSameCategory = true;
-    for (let i = 1; i < frames.length; i++) {
-      if (frames[i]!.category !== firstCategory) {
-        allSameCategory = false;
-        break;
+      // One weight per category id, so the argmax needs no string lookup.
+      const names = index.categoryNames;
+      this.weights = new Float64Array(names.length);
+      for (let id = 1; id < names.length; id++) {
+        this.weights[id] = CATEGORY_WEIGHTS[names[id] as BucketCategoryPriority] ?? 1.0;
       }
+      this.accumulated = new Float64Array(names.length);
+      this.onTopOrder = new Int32Array(names.length);
     }
-    if (allSameCategory) {
-      return firstCategory;
-    }
-
-    // Build sweep-line events
-    const events: SkylineEvent[] = [];
-    for (const frame of frames) {
-      // Clamp frame to bucket bounds
-      const clampedStart = Math.max(frame.timeStart, bucketStart);
-      const clampedEnd = Math.min(frame.timeEnd, bucketEnd);
-
-      if (clampedStart < clampedEnd) {
-        events.push({ time: clampedStart, type: SkylineEventType.Enter, frame });
-        events.push({ time: clampedEnd, type: SkylineEventType.Exit, frame });
-      }
-    }
-
-    // Sort events by time, exits before enters at same time
-    events.sort((a, b) => {
-      if (a.time !== b.time) {
-        return a.time - b.time;
-      }
-      // Process exits before enters at the same time
-      return a.type - b.type;
-    });
-
-    // Sweep through events tracking on-top time per category
-    // PERF: Use Set for O(1) add/remove instead of array indexOf+splice
-    const onTopTime = new Map<string, number>();
-    const activeFrames = new Set<SkylineFrame>();
-    let currentMaxDepth = -1;
-    let currentDeepestFrame: SkylineFrame | null = null;
-    let lastTime = bucketStart;
-
-    for (const event of events) {
-      const currentTime = event.time;
-
-      // Accumulate on-top time for the deepest frame since lastTime
-      if (currentDeepestFrame && currentTime > lastTime) {
-        const duration = currentTime - lastTime;
-        const existing = onTopTime.get(currentDeepestFrame.category) ?? 0;
-        onTopTime.set(currentDeepestFrame.category, existing + duration);
-      }
-
-      lastTime = currentTime;
-
-      // Update active frames
-      if (event.type === SkylineEventType.Enter) {
-        activeFrames.add(event.frame);
-        // Update max depth tracking if this frame is deeper
-        if (event.frame.depth > currentMaxDepth) {
-          currentMaxDepth = event.frame.depth;
-          currentDeepestFrame = event.frame;
-        }
-      } else {
-        activeFrames.delete(event.frame); // O(1) instead of O(k)
-        // Only recompute max if we removed the deepest frame
-        if (event.frame === currentDeepestFrame) {
-          currentMaxDepth = -1;
-          currentDeepestFrame = null;
-          for (const f of activeFrames) {
-            if (f.depth > currentMaxDepth) {
-              currentMaxDepth = f.depth;
-              currentDeepestFrame = f;
-            }
-          }
-        }
-      }
-    }
-
-    // Apply category weights and find winner
-    let winningCategory = 'Apex';
-    let winningScore = -1;
-
-    for (const [category, time] of onTopTime) {
-      const weight = CATEGORY_WEIGHTS[category as BucketCategoryPriority] ?? 1.0;
-      const score = time * weight;
-      if (score > winningScore) {
-        winningScore = score;
-        winningCategory = category;
-      }
-    }
-
-    return winningCategory;
+    return index;
   }
 }

--- a/log-viewer/src/features/timeline/optimised/minimap/MinimapDensityQuery.ts
+++ b/log-viewer/src/features/timeline/optimised/minimap/MinimapDensityQuery.ts
@@ -36,7 +36,6 @@
  */
 
 import type { BucketCategoryPriority } from '../../types/flamechart.types.js';
-import type { PrecomputedRect } from '../RectangleCache.js';
 import type { SkylineFrame, TemporalSegmentTree } from '../TemporalSegmentTree.js';
 
 /**
@@ -109,9 +108,6 @@ interface SkylineEvent {
 }
 
 export class MinimapDensityQuery {
-  /** All rectangles grouped by category from RectangleCache. */
-  private rectsByCategory: Map<string, PrecomputedRect[]>;
-
   /** Global maximum depth across timeline. */
   private globalMaxDepth: number;
 
@@ -128,19 +124,13 @@ export class MinimapDensityQuery {
   private cachedBucketCount: number | null = null;
   private cachedDensity: MinimapDensityData | null = null;
 
-  /** Optional segment tree for O(B×log N) density computation. */
-  private segmentTree: TemporalSegmentTree | null = null;
+  /** The frames every density is computed from. */
+  private segmentTree: TemporalSegmentTree;
 
-  constructor(
-    rectsByCategory: Map<string, PrecomputedRect[]>,
-    totalDuration: number,
-    maxDepth: number,
-    segmentTree?: TemporalSegmentTree,
-  ) {
-    this.rectsByCategory = rectsByCategory;
+  constructor(segmentTree: TemporalSegmentTree, totalDuration: number, maxDepth: number) {
+    this.segmentTree = segmentTree;
     this.totalDuration = totalDuration;
     this.globalMaxDepth = maxDepth;
-    this.segmentTree = segmentTree ?? null;
   }
 
   /**
@@ -157,7 +147,7 @@ export class MinimapDensityQuery {
     // A fractional/NaN count crashes the Array/typed-array constructors below
     // with "Invalid array length" (the `<= 0` guards do not catch it), which
     // aborts timeline init and leaves interaction handlers unwired. Normalise
-    // here, the single entry point feeding both compute paths and the cache.
+    // here, the single entry point feeding both the compute and the cache.
     bucketCount = Number.isFinite(bucketCount) ? Math.floor(bucketCount) : 0;
 
     // Fast path: exact match in cache
@@ -165,11 +155,7 @@ export class MinimapDensityQuery {
       return this.cachedDensity;
     }
 
-    // Compute at exact bucket count using sliding window algorithm if tree available
-    const density = this.segmentTree
-      ? this.computeDensitySlidingWindow(bucketCount)
-      : this.computeDensity(bucketCount);
-
+    const density = this.computeDensity(bucketCount);
     this.cachedBucketCount = bucketCount;
     this.cachedDensity = density;
     return density;
@@ -186,29 +172,12 @@ export class MinimapDensityQuery {
     this.cachedDensity = null;
   }
 
-  /**
-   * Update underlying data (call when timeline changes).
-   */
-  public setData(
-    rectsByCategory: Map<string, PrecomputedRect[]>,
-    totalDuration: number,
-    maxDepth: number,
-    segmentTree?: TemporalSegmentTree,
-  ): void {
-    this.rectsByCategory = rectsByCategory;
-    this.totalDuration = totalDuration;
-    this.globalMaxDepth = maxDepth;
-    this.segmentTree = segmentTree ?? null;
-    this.invalidateCache();
-  }
-
   // ============================================================================
   // PRIVATE: DENSITY COMPUTATION
   // ============================================================================
 
   /**
-   * Compute density data by aggregating rectangles into buckets.
-   * Fallback when segment tree is not available.
+   * Compute density data from the tree's frames, sorted by start.
    * Uses skyline (on-top time) algorithm for category resolution:
    * At each moment, the deepest frame is "on top" and its category accumulates time.
    *
@@ -217,91 +186,6 @@ export class MinimapDensityQuery {
    */
   private computeDensity(bucketCount: number): MinimapDensityData {
     if (bucketCount <= 0 || this.totalDuration <= 0) {
-      return { buckets: [], globalMaxDepth: this.globalMaxDepth };
-    }
-
-    // Pre-allocate bucket aggregation arrays
-    const bucketTimeWidth = this.totalDuration / bucketCount;
-    const maxDepths = new Uint16Array(bucketCount);
-    const eventCounts = new Uint32Array(bucketCount);
-
-    // Collect frames per bucket for skyline computation
-    const framesPerBucket: SkylineFrame[][] = new Array(bucketCount);
-    for (let i = 0; i < bucketCount; i++) {
-      framesPerBucket[i] = [];
-    }
-
-    // Single pass through all rectangles
-    for (const rects of this.rectsByCategory.values()) {
-      for (const rect of rects) {
-        // Determine which bucket(s) this rect overlaps
-        const startBucket = Math.floor(rect.timeStart / bucketTimeWidth);
-        const endBucket = Math.floor(rect.timeEnd / bucketTimeWidth);
-
-        // Clamp to valid bucket range
-        const firstBucket = Math.max(0, startBucket);
-        const lastBucket = Math.min(bucketCount - 1, endBucket);
-
-        // Create frame for skyline computation
-        const frame: SkylineFrame = {
-          timeStart: rect.timeStart,
-          timeEnd: rect.timeEnd,
-          depth: rect.depth,
-          category: rect.category,
-          selfDuration: rect.selfDuration,
-        };
-
-        // Aggregate into each overlapping bucket
-        for (let b = firstBucket; b <= lastBucket; b++) {
-          // Update max depth
-          if (rect.depth > maxDepths[b]!) {
-            maxDepths[b] = rect.depth;
-          }
-
-          // Increment event count
-          eventCounts[b]!++;
-
-          // Collect frame for skyline computation
-          framesPerBucket[b]!.push(frame);
-        }
-      }
-    }
-
-    const buckets: MinimapDensityBucket[] = new Array(bucketCount);
-
-    for (let i = 0; i < bucketCount; i++) {
-      // Resolve dominant category using skyline (on-top time) algorithm
-      const dominantCategory = this.resolveCategoryFromSkyline(
-        framesPerBucket[i]!,
-        i * bucketTimeWidth,
-        (i + 1) * bucketTimeWidth,
-      );
-
-      buckets[i] = {
-        maxDepth: maxDepths[i]!,
-        eventCount: eventCounts[i]!,
-        dominantCategory,
-      };
-    }
-
-    return { buckets, globalMaxDepth: this.globalMaxDepth };
-  }
-
-  /**
-   * Compute density data using sliding window algorithm on pre-sorted frames.
-   * Uses skyline (on-top time) algorithm for category resolution:
-   * At each moment, the deepest frame is "on top" and its category accumulates time.
-   *
-   * Performance improvement over computeDensityFromTree():
-   * - Previous: O(B × D × log N) tree queries per bucket = ~90ms
-   * - New: O(N) single pass + O(B × k) skyline computation = ~10-20ms
-   *   (where k = avg frames per bucket, much smaller than N)
-   *
-   * @param bucketCount - Number of output buckets
-   * @returns MinimapDensityData
-   */
-  private computeDensitySlidingWindow(bucketCount: number): MinimapDensityData {
-    if (bucketCount <= 0 || this.totalDuration <= 0 || !this.segmentTree) {
       return { buckets: [], globalMaxDepth: this.globalMaxDepth };
     }
 

--- a/log-viewer/src/features/timeline/optimised/minimap/MinimapDensityQuery.ts
+++ b/log-viewer/src/features/timeline/optimised/minimap/MinimapDensityQuery.ts
@@ -120,6 +120,10 @@ export class MinimapDensityQuery {
    * One width at a time: every caller asks for the width on screen, and a density holds a
    * bucket per pixel of it, so keeping the widths a drag passed through would cost more memory
    * than the recompute it saves.
+   *
+   * Nothing invalidates it, and nothing needs to: a new width misses on its own, a height
+   * change leaves the entry as true as it was, a theme change cannot alter a category name,
+   * and new data means a new query object.
    */
   private cachedBucketCount: number | null = null;
   private cachedDensity: MinimapDensityData | null = null;
@@ -159,17 +163,6 @@ export class MinimapDensityQuery {
     this.cachedBucketCount = bucketCount;
     this.cachedDensity = density;
     return density;
-  }
-
-  /**
-   * Invalidate cache (call when timeline data changes).
-   *
-   * A resize needs no call: the cache is keyed by width, so a new width misses on its own and
-   * a height change leaves the entry as true as it was.
-   */
-  public invalidateCache(): void {
-    this.cachedBucketCount = null;
-    this.cachedDensity = null;
   }
 
   // ============================================================================

--- a/log-viewer/src/features/timeline/optimised/minimap/MinimapDensityQuery.ts
+++ b/log-viewer/src/features/timeline/optimised/minimap/MinimapDensityQuery.ts
@@ -20,9 +20,9 @@
  * The skyline itself does not depend on the width, so it is built once per log
  * (`MinimapSkylineIndex`) and every width walks it.
  *
- * Building it is ~73ms on a 95MB log, on the first minimap draw. That is over the
- * 50ms synchronous budget in `.claude/rules/log-viewer.md`, and moving it off the
- * paint path is still to do.
+ * Building it is ~73ms on a 95MB log, on the first minimap draw, which is over the
+ * 50ms synchronous budget in `.claude/rules/log-viewer.md`. Accepted: it is paid
+ * once per log, against the ~100ms it used to cost on every pixel of a width drag.
  */
 
 import type { BucketCategoryPriority } from '../../types/flamechart.types.js';

--- a/log-viewer/src/features/timeline/optimised/minimap/MinimapDensityQuery.ts
+++ b/log-viewer/src/features/timeline/optimised/minimap/MinimapDensityQuery.ts
@@ -117,6 +117,11 @@ export class MinimapDensityQuery {
   /** The log seen from above, built on the first query and never rebuilt. */
   private index: MinimapSkylineIndex | null = null;
 
+  /** The skyline being walked, once a query has built it. */
+  public get skyline(): MinimapSkylineIndex | null {
+    return this.index;
+  }
+
   /** Scratch for the walk, one slot per category id. Sized with the index. */
   private weights = new Float64Array(0);
   private accumulated = new Float64Array(0);
@@ -180,7 +185,7 @@ export class MinimapDensityQuery {
       return { buckets: [], globalMaxDepth: this.globalMaxDepth };
     }
 
-    const skyline = this.skyline();
+    const skyline = this.ensureSkyline();
     const { segmentCount, segmentStarts, segmentDepths, segmentCategories, categoryNames } =
       skyline;
     const accumulated = this.accumulated;
@@ -302,11 +307,11 @@ export class MinimapDensityQuery {
    * Not in the constructor: the tree sorts its frames on first use, and the
    * timeline defers that cost off its own init.
    */
-  private skyline(): MinimapSkylineIndex {
+  private ensureSkyline(): MinimapSkylineIndex {
     let index = this.index;
     if (!index) {
       index = new MinimapSkylineIndex(
-        this.segmentTree.getAllFramesSorted(),
+        this.segmentTree.takeFramesSorted(),
         this.totalDuration,
         this.globalMaxDepth,
       );

--- a/log-viewer/src/features/timeline/optimised/minimap/MinimapDensityQuery.ts
+++ b/log-viewer/src/features/timeline/optimised/minimap/MinimapDensityQuery.ts
@@ -5,39 +5,28 @@
 /**
  * MinimapDensityQuery
  *
- * Computes density data for the minimap visualization by leveraging
- * the existing RectangleCache's spatial index.
+ * One bucket per pixel of the minimap's width, each carrying the three things
+ * the renderer draws with: stack depth as the bar's height, frame count as its
+ * opacity, and a category as its colour.
  *
- * The minimap displays a heatmap where:
- * - Height = normalized stack depth (maxDepth at bucket / global maxDepth)
- * - Opacity = event count (logarithmic scale)
- * - Color = dominant category color
+ * Colour comes from the skyline, the log seen from above: at each instant the
+ * deepest frame is the visible one, so a category earns a bucket by the time it
+ * spends on top. Weights let a database operation still read through a shallower
+ * child covering it.
  *
- * Performance requirements:
- * - Cache density data (only recompute on data change)
- * - <50ms cold query, <0.1ms cached
- * - No allocations in render loop
- *
- * Category Resolution: Skyline (On-Top Time) Algorithm
- * At each moment within a bucket, the deepest frame is "on top" (visible).
- * This correctly handles parent frames whose self-duration is concentrated
- * at edges (not covered by children), rather than evenly distributed.
- *
- * Formula:
- *   onTopTime[category] = sum of time each category is deepest in the bucket
  *   score[category] = onTopTime[category] × CATEGORY_WEIGHTS[category]
  *   winner = argmax(score)
  *
- * Example: SOQL at depth 2 covers 0-100ms with Apex child at depth 3 covering 30-80ms
- * - SOQL is on-top at 0-30ms and 80-100ms = 50ms total (50%)
- * - Apex is on-top at 30-80ms = 50ms total (50%)
- * - With weights: SOQL = 50% × 2.5 = 125, Apex = 50% × 1.0 = 50
- * - SOQL wins because its weighted score is higher
+ * The skyline itself does not depend on the width, so it is built once per log
+ * (`MinimapSkylineIndex`) and every width walks it.
+ *
+ * Building it is ~73ms on a 95MB log, on the first minimap draw. That is over the
+ * 50ms synchronous budget in `.claude/rules/log-viewer.md`, and moving it off the
+ * paint path is still to do.
  */
 
 import type { BucketCategoryPriority } from '../../types/flamechart.types.js';
-import type { TemporalSegmentTree } from '../TemporalSegmentTree.js';
-import { MinimapSkylineIndex } from './MinimapSkylineIndex.js';
+import { GAP_CATEGORY, MinimapSkylineIndex, type SkylineFrame } from './MinimapSkylineIndex.js';
 
 /**
  * Single density bucket for minimap visualization.
@@ -71,10 +60,7 @@ export interface MinimapDensityData {
  * Category weights for importance-based resolution.
  * DML/SOQL are boosted to highlight database operations even when partially
  * covered by less important children. Other categories have uniform weight
- * so depth becomes the deciding factor among them.
- *
- * Balance: DML at 2.5x means it can win over a Method child 1-2 levels deeper,
- * but a child 5+ levels deeper will still dominate (depth² wins at larger gaps).
+ * so on-top time becomes the deciding factor among them.
  */
 const CATEGORY_WEIGHTS: Partial<Record<BucketCategoryPriority, number>> = {
   DML: 2.5,
@@ -87,19 +73,16 @@ const CATEGORY_WEIGHTS: Partial<Record<BucketCategoryPriority, number>> = {
   Validation: 0.8,
 };
 
-/** Segment category id 0: no frame on top. */
-const GAP_CATEGORY = 0;
-
-/** What a bucket with nothing on top reports, as the old sweep's default did. */
+/**
+ * What a bucket with nothing on top reports, as the old sweep's default did.
+ *
+ * Never drawn: such a bucket also has `maxDepth` 0, so `MinimapRenderer` skips its
+ * bar. Kept while this change is measured against the old sweep bucket by bucket;
+ * once that is done a gap can report nothing.
+ */
 const DEFAULT_CATEGORY = 'Apex';
 
 export class MinimapDensityQuery {
-  /** Global maximum depth across timeline. */
-  private globalMaxDepth: number;
-
-  /** Total duration in nanoseconds. */
-  private totalDuration: number;
-
   /**
    * The one density held, and the bucket count it was computed for.
    *
@@ -117,28 +100,26 @@ export class MinimapDensityQuery {
   /** The log seen from above, built on the first query and never rebuilt. */
   private index: MinimapSkylineIndex | null = null;
 
-  /** The skyline being walked, once a query has built it. */
-  public get skyline(): MinimapSkylineIndex | null {
-    return this.index;
-  }
+  /**
+   * The frames the skyline is built from, in groups each ascending by `timeStart`.
+   * Owned by RectangleCache, which holds them for the timeline's life regardless.
+   */
+  private readonly frameGroups: readonly (readonly SkylineFrame[])[];
+  private readonly totalDuration: number;
+  private readonly globalMaxDepth: number;
 
-  /** Scratch for the walk, one slot per category id. Sized with the index. */
-  private weights = new Float64Array(0);
-  private accumulated = new Float64Array(0);
-  private onTopOrder = new Int32Array(0);
-
-  /** The frames every density is computed from. */
-  private segmentTree: TemporalSegmentTree;
-
-  constructor(segmentTree: TemporalSegmentTree, totalDuration: number, maxDepth: number) {
-    this.segmentTree = segmentTree;
+  constructor(
+    frameGroups: readonly (readonly SkylineFrame[])[],
+    totalDuration: number,
+    maxDepth: number,
+  ) {
+    this.frameGroups = frameGroups;
     this.totalDuration = totalDuration;
     this.globalMaxDepth = maxDepth;
   }
 
   /**
    * Query density data for minimap visualization.
-   * Computes at exact bucket count using O(B × log N) tree queries.
    * Results are cached for the exact bucket count requested.
    *
    * @param bucketCount - Number of density buckets (typically display width)
@@ -164,9 +145,15 @@ export class MinimapDensityQuery {
     return density;
   }
 
-  // ============================================================================
-  // PRIVATE: DENSITY COMPUTATION
-  // ============================================================================
+  /**
+   * Shape of the skyline, for `pnpm measure minimap`. Builds it if no query has.
+   *
+   * `violations` should be 0 on a well-formed log, so it is the tripwire on a real one.
+   */
+  public stats(): { segmentCount: number; violations: number } {
+    const index = this.ensureSkyline();
+    return { segmentCount: index.segmentCount, violations: index.violations };
+  }
 
   /**
    * Compute density data by walking the skyline against the buckets.
@@ -175,7 +162,7 @@ export class MinimapDensityQuery {
    * overlapping it adds its own length to that category's total, and the deepest
    * segment gives the bar its height. A segment reaching past the bucket's end is
    * left for the next bucket, so each is visited once plus once per boundary it
-   * crosses. Nothing is allocated per bucket.
+   * crosses. The walk itself allocates nothing; the buckets it fills are the output.
    *
    * @param bucketCount - Number of output buckets
    * @returns MinimapDensityData
@@ -188,12 +175,18 @@ export class MinimapDensityQuery {
     const skyline = this.ensureSkyline();
     const { segmentCount, segmentStarts, segmentDepths, segmentCategories, categoryNames } =
       skyline;
-    const accumulated = this.accumulated;
-    const onTopOrder = this.onTopOrder;
-    const weights = this.weights;
+
+    // One slot per category id, so the argmax needs no string lookup. Under 5KB:
+    // the ids are interned per log, and no log has reached ten categories.
+    const weights = new Float64Array(categoryNames.length);
+    for (let id = 1; id < categoryNames.length; id++) {
+      weights[id] = CATEGORY_WEIGHTS[categoryNames[id] as BucketCategoryPriority] ?? 1.0;
+    }
+    const accumulated = new Float64Array(categoryNames.length);
+    const onTopOrder = new Int32Array(categoryNames.length);
 
     const bucketTimeWidth = this.totalDuration / bucketCount;
-    const eventCounts = this.countFrames(skyline, bucketCount, bucketTimeWidth);
+    const eventCounts = skyline.countFrames(bucketCount, bucketTimeWidth);
     const buckets: MinimapDensityBucket[] = new Array(bucketCount);
 
     let segment = 0;
@@ -201,23 +194,20 @@ export class MinimapDensityQuery {
       const bucketStart = i * bucketTimeWidth;
       const bucketEnd = (i + 1) * bucketTimeWidth;
 
-      // Only fires where a segment ends exactly on the boundary.
-      while (segment < segmentCount && segmentStarts[segment + 1]! <= bucketStart) {
-        segment++;
-      }
-
       // The segments tile, so the segment holding `bucketStart` starts at or before
       // it: this is the left-hand partial, with no clamp needed.
       let from = bucketStart;
       let maxDepth = 0;
       let ordered = 0;
 
-      while (segment < segmentCount && segmentStarts[segment]! < bucketEnd) {
+      // `from` already holds `segmentStarts[segment]` once the walk has advanced,
+      // and equals `bucketStart` on entry, which the segments tile at or before.
+      while (from < bucketEnd && segment < segmentCount) {
         const segmentEnd = segmentStarts[segment + 1]!;
         const to = segmentEnd < bucketEnd ? segmentEnd : bucketEnd;
         const category = segmentCategories[segment]!;
 
-        if (category !== GAP_CATEGORY && to > from) {
+        if (category !== GAP_CATEGORY) {
           // First on top wins a tie, which is the order the old sweep's map held.
           if (accumulated[category] === 0) {
             onTopOrder[ordered++] = category;
@@ -229,7 +219,7 @@ export class MinimapDensityQuery {
           }
         }
 
-        if (segmentEnd >= bucketEnd) {
+        if (segmentEnd > bucketEnd) {
           break; // Straddles the end: the next bucket starts on this same segment.
         }
         from = segmentEnd;
@@ -259,73 +249,12 @@ export class MinimapDensityQuery {
   }
 
   /**
-   * Count the frames overlapping each bucket, by difference array.
-   *
-   * A frame adds one to the bucket it starts in and takes one back after the
-   * bucket it ends in, so a running total gives every bucket its count in one
-   * pass. The bucket arithmetic is the old loop's, including that a frame ending
-   * exactly on a boundary counts in the bucket after it: this feeds the bar's
-   * opacity, which stays as it was.
-   */
-  private countFrames(
-    skyline: MinimapSkylineIndex,
-    bucketCount: number,
-    bucketTimeWidth: number,
-  ): Uint32Array {
-    const { frameStarts, frameEnds } = skyline;
-    const deltas = new Int32Array(bucketCount + 1);
-    const lastBucket = bucketCount - 1;
-
-    for (let i = 0; i < frameStarts.length; i++) {
-      let first = Math.floor(frameStarts[i]! / bucketTimeWidth);
-      if (first < 0) {
-        first = 0;
-      }
-      let last = Math.floor(frameEnds[i]! / bucketTimeWidth);
-      if (last > lastBucket) {
-        last = lastBucket;
-      }
-      if (last < first) {
-        continue;
-      }
-      deltas[first]!++;
-      deltas[last + 1]!--;
-    }
-
-    const counts = new Uint32Array(bucketCount);
-    let running = 0;
-    for (let b = 0; b < bucketCount; b++) {
-      running += deltas[b]!;
-      counts[b] = running;
-    }
-    return counts;
-  }
-
-  /**
    * The skyline, built on the first query.
    *
-   * Not in the constructor: the tree sorts its frames on first use, and the
-   * timeline defers that cost off its own init.
+   * Not in the constructor: the sort and the sweep are the timeline's largest
+   * synchronous costs, and a log whose minimap is never drawn should not pay them.
    */
   private ensureSkyline(): MinimapSkylineIndex {
-    let index = this.index;
-    if (!index) {
-      index = new MinimapSkylineIndex(
-        this.segmentTree.takeFramesSorted(),
-        this.totalDuration,
-        this.globalMaxDepth,
-      );
-      this.index = index;
-
-      // One weight per category id, so the argmax needs no string lookup.
-      const names = index.categoryNames;
-      this.weights = new Float64Array(names.length);
-      for (let id = 1; id < names.length; id++) {
-        this.weights[id] = CATEGORY_WEIGHTS[names[id] as BucketCategoryPriority] ?? 1.0;
-      }
-      this.accumulated = new Float64Array(names.length);
-      this.onTopOrder = new Int32Array(names.length);
-    }
-    return index;
+    return (this.index ??= new MinimapSkylineIndex(this.frameGroups, this.totalDuration));
   }
 }

--- a/log-viewer/src/features/timeline/optimised/minimap/MinimapDensityQuery.ts
+++ b/log-viewer/src/features/timeline/optimised/minimap/MinimapDensityQuery.ts
@@ -43,12 +43,6 @@ import type { SkylineFrame, TemporalSegmentTree } from '../TemporalSegmentTree.j
  * Single density bucket for minimap visualization.
  */
 export interface MinimapDensityBucket {
-  /** Bucket start time in nanoseconds. */
-  timeStart: number;
-
-  /** Bucket end time in nanoseconds. */
-  timeEnd: number;
-
   /** Highest depth at this time range (for height calculation). */
   maxDepth: number;
 
@@ -57,26 +51,20 @@ export interface MinimapDensityBucket {
 
   /** Dominant category for color resolution. */
   dominantCategory: string;
-
-  /** Sum of self-durations for events in this bucket (for sparkline). */
-  selfDurationSum: number;
 }
 
 /**
  * Complete density data for minimap rendering.
+ *
+ * A bucket carries no time range: the renderer takes a bar's X from the bucket's
+ * index, so the times were derivable and unread.
  */
 export interface MinimapDensityData {
-  /** Array of density buckets (one per minimap pixel approximately). */
+  /** One bucket per pixel of the minimap's width. */
   buckets: MinimapDensityBucket[];
 
   /** Global maximum depth across entire timeline. */
   globalMaxDepth: number;
-
-  /** Global maximum event count in any bucket (for opacity normalization). */
-  maxEventCount: number;
-
-  /** Total duration of timeline in nanoseconds. */
-  totalDuration: number;
 }
 
 /**
@@ -229,19 +217,13 @@ export class MinimapDensityQuery {
    */
   private computeDensity(bucketCount: number): MinimapDensityData {
     if (bucketCount <= 0 || this.totalDuration <= 0) {
-      return {
-        buckets: [],
-        globalMaxDepth: this.globalMaxDepth,
-        maxEventCount: 0,
-        totalDuration: this.totalDuration,
-      };
+      return { buckets: [], globalMaxDepth: this.globalMaxDepth };
     }
 
     // Pre-allocate bucket aggregation arrays
     const bucketTimeWidth = this.totalDuration / bucketCount;
     const maxDepths = new Uint16Array(bucketCount);
     const eventCounts = new Uint32Array(bucketCount);
-    const selfDurationSums = new Float64Array(bucketCount);
 
     // Collect frames per bucket for skyline computation
     const framesPerBucket: SkylineFrame[][] = new Array(bucketCount);
@@ -259,9 +241,6 @@ export class MinimapDensityQuery {
         // Clamp to valid bucket range
         const firstBucket = Math.max(0, startBucket);
         const lastBucket = Math.min(bucketCount - 1, endBucket);
-
-        // Pre-calculate rect duration for overlap ratio
-        const rectDuration = rect.timeEnd - rect.timeStart;
 
         // Create frame for skyline computation
         const frame: SkylineFrame = {
@@ -282,58 +261,30 @@ export class MinimapDensityQuery {
           // Increment event count
           eventCounts[b]!++;
 
-          // Calculate overlap ratio for proportional self-duration attribution (for sparkline)
-          const bucketStart = b * bucketTimeWidth;
-          const bucketEnd = (b + 1) * bucketTimeWidth;
-          const overlapStart = Math.max(rect.timeStart, bucketStart);
-          const overlapEnd = Math.min(rect.timeEnd, bucketEnd);
-          const visibleTime = overlapEnd - overlapStart;
-          const overlapRatio = rectDuration > 0 ? visibleTime / rectDuration : 0;
-          const proportionalSelfDuration = rect.selfDuration * overlapRatio;
-          selfDurationSums[b]! += proportionalSelfDuration;
-
           // Collect frame for skyline computation
           framesPerBucket[b]!.push(frame);
         }
       }
     }
 
-    // Build output buckets and find max event count
-    let maxEventCount = 0;
     const buckets: MinimapDensityBucket[] = new Array(bucketCount);
 
     for (let i = 0; i < bucketCount; i++) {
-      const eventCount = eventCounts[i]!;
-      if (eventCount > maxEventCount) {
-        maxEventCount = eventCount;
-      }
-
-      const bucketStart = i * bucketTimeWidth;
-      const bucketEnd = (i + 1) * bucketTimeWidth;
-
       // Resolve dominant category using skyline (on-top time) algorithm
       const dominantCategory = this.resolveCategoryFromSkyline(
         framesPerBucket[i]!,
-        bucketStart,
-        bucketEnd,
+        i * bucketTimeWidth,
+        (i + 1) * bucketTimeWidth,
       );
 
       buckets[i] = {
-        timeStart: bucketStart,
-        timeEnd: bucketEnd,
         maxDepth: maxDepths[i]!,
-        eventCount,
+        eventCount: eventCounts[i]!,
         dominantCategory,
-        selfDurationSum: selfDurationSums[i]!,
       };
     }
 
-    return {
-      buckets,
-      globalMaxDepth: this.globalMaxDepth,
-      maxEventCount,
-      totalDuration: this.totalDuration,
-    };
+    return { buckets, globalMaxDepth: this.globalMaxDepth };
   }
 
   /**
@@ -351,12 +302,7 @@ export class MinimapDensityQuery {
    */
   private computeDensitySlidingWindow(bucketCount: number): MinimapDensityData {
     if (bucketCount <= 0 || this.totalDuration <= 0 || !this.segmentTree) {
-      return {
-        buckets: [],
-        globalMaxDepth: this.globalMaxDepth,
-        maxEventCount: 0,
-        totalDuration: this.totalDuration,
-      };
+      return { buckets: [], globalMaxDepth: this.globalMaxDepth };
     }
 
     const frames = this.segmentTree.getAllFramesSorted();
@@ -365,7 +311,6 @@ export class MinimapDensityQuery {
     // Pre-allocate bucket arrays
     const maxDepths = new Uint16Array(bucketCount);
     const eventCounts = new Uint32Array(bucketCount);
-    const selfDurationSums = new Float64Array(bucketCount);
 
     // Collect frames per bucket for skyline computation
     const framesPerBucket: SkylineFrame[][] = new Array(bucketCount);
@@ -373,13 +318,10 @@ export class MinimapDensityQuery {
       framesPerBucket[i] = [];
     }
 
-    // Single pass: compute maxDepth, eventCount, selfDurationSums, and collect frames
+    // Single pass: compute maxDepth, eventCount, and collect frames
     for (const frame of frames) {
       const startBucket = Math.max(0, Math.floor(frame.timeStart / bucketTimeWidth));
       const endBucket = Math.min(bucketCount - 1, Math.floor(frame.timeEnd / bucketTimeWidth));
-
-      // Pre-calculate frame duration for overlap ratio
-      const frameDuration = frame.timeEnd - frame.timeStart;
 
       for (let b = startBucket; b <= endBucket; b++) {
         // Update maxDepth
@@ -390,16 +332,6 @@ export class MinimapDensityQuery {
         // Increment event count
         eventCounts[b]!++;
 
-        // Calculate overlap ratio for proportional self-duration attribution (for sparkline)
-        const bucketStart = b * bucketTimeWidth;
-        const bucketEnd = (b + 1) * bucketTimeWidth;
-        const overlapStart = Math.max(frame.timeStart, bucketStart);
-        const overlapEnd = Math.min(frame.timeEnd, bucketEnd);
-        const visibleTime = overlapEnd - overlapStart;
-        const overlapRatio = frameDuration > 0 ? visibleTime / frameDuration : 0;
-        const proportionalSelfDuration = frame.selfDuration * overlapRatio;
-        selfDurationSums[b]! += proportionalSelfDuration;
-
         // Collect frame for skyline computation
         framesPerBucket[b]!.push(frame);
       }
@@ -407,40 +339,23 @@ export class MinimapDensityQuery {
 
     // Build output buckets
     const buckets: MinimapDensityBucket[] = new Array(bucketCount);
-    let maxEventCount = 0;
 
     for (let i = 0; i < bucketCount; i++) {
-      const eventCount = eventCounts[i]!;
-      if (eventCount > maxEventCount) {
-        maxEventCount = eventCount;
-      }
-
-      const bucketStart = i * bucketTimeWidth;
-      const bucketEnd = (i + 1) * bucketTimeWidth;
-
       // Resolve dominant category using skyline (on-top time) algorithm
       const dominantCategory = this.resolveCategoryFromSkyline(
         framesPerBucket[i]!,
-        bucketStart,
-        bucketEnd,
+        i * bucketTimeWidth,
+        (i + 1) * bucketTimeWidth,
       );
 
       buckets[i] = {
-        timeStart: bucketStart,
-        timeEnd: bucketEnd,
         maxDepth: maxDepths[i]!,
-        eventCount,
+        eventCount: eventCounts[i]!,
         dominantCategory,
-        selfDurationSum: selfDurationSums[i]!,
       };
     }
 
-    return {
-      buckets,
-      globalMaxDepth: this.globalMaxDepth,
-      maxEventCount,
-      totalDuration: this.totalDuration,
-    };
+    return { buckets, globalMaxDepth: this.globalMaxDepth };
   }
 
   // ============================================================================

--- a/log-viewer/src/features/timeline/optimised/minimap/MinimapSkylineIndex.ts
+++ b/log-viewer/src/features/timeline/optimised/minimap/MinimapSkylineIndex.ts
@@ -1,0 +1,269 @@
+/*
+ * Copyright (c) 2026 Certinia Inc. All rights reserved.
+ */
+
+/**
+ * MinimapSkylineIndex
+ *
+ * The log seen from above: over each stretch of time, which frame is on top and
+ * how deep it is. The deepest frame at an instant is the one you would see
+ * looking down on the flame chart, so that frame's category is what should
+ * colour the minimap there.
+ *
+ * Built once per log, and never invalidated. Which frame is on top at a given
+ * time does not depend on how wide the minimap is, so a resize walks this index
+ * instead of rebuilding it.
+ *
+ * The segments tile the timeline: segment `i` spans
+ * `[segmentStarts[i], segmentStarts[i + 1])`, and a stretch with no frame
+ * running is a segment of its own with category id 0. So a walk needs no bounds
+ * test beyond the segment count, and no segment-end array.
+ */
+
+import type { SkylineFrame } from '../TemporalSegmentTree.js';
+
+/** Category id 0 means no frame is on top, so a zeroed buffer is never wrong. */
+const GAP_CATEGORY = 0;
+
+/** Ids are held in a Uint8Array, and id 0 is the gap. */
+const MAX_CATEGORIES = 255;
+
+/** Depths are held in a Uint16Array. Real logs reach ~30. */
+const MAX_DEPTH = 65535;
+
+/** Where the sweep writes. Null on the counting pass. */
+interface SkylineBuffers {
+  starts: Float64Array;
+  depths: Uint16Array;
+  categories: Uint8Array;
+}
+
+export class MinimapSkylineIndex {
+  /** Number of segments. `segmentStarts` holds one more, to close the last. */
+  public readonly segmentCount: number;
+
+  /** Segment boundaries, ascending. Length `segmentCount + 1`. */
+  public readonly segmentStarts: Float64Array;
+
+  /** Depth of the frame on top of each segment, 0 in a gap. */
+  public readonly segmentDepths: Uint16Array;
+
+  /** Category id of the frame on top of each segment, 0 in a gap. */
+  public readonly segmentCategories: Uint8Array;
+
+  /** Category name per id, appended to as the sweep meets them. Index 0 is the gap. */
+  public readonly categoryNames: string[] = [''];
+
+  /** Frame bounds as parallel arrays, for counting frames per bucket. */
+  public readonly frameStarts: Float64Array;
+  public readonly frameEnds: Float64Array;
+
+  /**
+   * Frames the sweep had to contain: one that outlived its parent, one that
+   * overlapped a frame at the same or a shallower depth, or one with no
+   * duration. Zero on a well-formed log; asserted by the tests.
+   */
+  public readonly violations: number;
+
+  private readonly categoryIds = new Map<string, number>();
+
+  /**
+   * @param frames - Every frame, ascending by `timeStart`. Reordered in place at equal starts.
+   * @param totalDuration - The log's end timestamp, which the last segment reaches.
+   * @param maxDepth - Deepest frame in the log, which bounds the sweep's stack.
+   */
+  constructor(frames: SkylineFrame[], totalDuration: number, maxDepth: number) {
+    orderEqualStartsByDepth(frames);
+
+    const count = frames.length;
+    this.frameStarts = new Float64Array(count);
+    this.frameEnds = new Float64Array(count);
+    for (let i = 0; i < count; i++) {
+      const frame = frames[i]!;
+      this.frameStarts[i] = frame.timeStart;
+      this.frameEnds[i] = frame.timeEnd;
+    }
+
+    // Swept twice, counting then writing, so the arrays are allocated at exactly
+    // the size needed. Growing by doubling would peak about half again as large,
+    // and this module trades speed for memory.
+    const counted = this.sweep(frames, totalDuration, maxDepth, null);
+    this.segmentCount = counted.segments;
+    this.violations = counted.violations;
+
+    this.segmentStarts = new Float64Array(counted.segments + 1);
+    this.segmentDepths = new Uint16Array(counted.segments);
+    this.segmentCategories = new Uint8Array(counted.segments);
+    this.sweep(frames, totalDuration, maxDepth, {
+      starts: this.segmentStarts,
+      depths: this.segmentDepths,
+      categories: this.segmentCategories,
+    });
+  }
+
+  /** The category a segment's id names, or the empty string for a gap. */
+  public categoryOf(segment: number): string {
+    return this.categoryNames[this.segmentCategories[segment]!]!;
+  }
+
+  /**
+   * Sweep the frames, emitting one segment per stretch with the same frame on top.
+   *
+   * Frames nest, so the deepest active frame is always the one pushed last: the
+   * sweep drains every frame that has ended before pushing the next, which is
+   * what makes a frame's own end instant belong to whatever follows it.
+   *
+   * @param buffers - Where to write, or null to only count.
+   */
+  private sweep(
+    frames: readonly SkylineFrame[],
+    totalDuration: number,
+    maxDepth: number,
+    buffers: SkylineBuffers | null,
+  ): { segments: number; violations: number } {
+    // Depth strictly increases up the stack, so it can hold no more entries than
+    // there are depths.
+    const capacity = Math.max(1, maxDepth + 2);
+    const stackEnd = new Float64Array(capacity);
+    const stackDepth = new Uint16Array(capacity);
+    const stackCategory = new Uint8Array(capacity);
+
+    let stackTop = 0;
+    let segments = 0;
+    let violations = 0;
+    let emittedTo = 0;
+    let lastDepth = -1;
+    let lastCategory = -1;
+
+    const emit = (to: number, depth: number, category: number): void => {
+      if (to <= emittedTo) {
+        return;
+      }
+      // A run with the same frame on top is one segment, however many frames
+      // started and ended alongside it.
+      if (depth === lastDepth && category === lastCategory) {
+        emittedTo = to;
+        return;
+      }
+      if (buffers) {
+        buffers.starts[segments] = emittedTo;
+        buffers.depths[segments] = depth;
+        buffers.categories[segments] = category;
+      }
+      segments++;
+      emittedTo = to;
+      lastDepth = depth;
+      lastCategory = category;
+    };
+
+    for (const frame of frames) {
+      const start = frame.timeStart;
+
+      // Retire what has ended. `<=` because a frame is not on top at its own end.
+      while (stackTop > 0 && stackEnd[stackTop - 1]! <= start) {
+        const at = stackTop - 1;
+        emit(stackEnd[at]!, stackDepth[at]!, stackCategory[at]!);
+        stackTop--;
+      }
+
+      // The stretch before this frame belongs to whatever encloses it, or to a gap.
+      if (start > emittedTo) {
+        const enclosing = stackTop - 1;
+        emit(
+          start,
+          stackTop > 0 ? stackDepth[enclosing]! : 0,
+          stackTop > 0 ? stackCategory[enclosing]! : GAP_CATEGORY,
+        );
+      }
+
+      if (frame.timeEnd <= start) {
+        violations++;
+        continue;
+      }
+
+      // A frame no deeper than the one it overlaps cannot be on top of it. Today's
+      // sweep gives that frame the same outcome, by keeping the deepest.
+      if (stackTop > 0 && frame.depth <= stackDepth[stackTop - 1]!) {
+        violations++;
+        continue;
+      }
+      if (stackTop === capacity) {
+        violations++;
+        continue;
+      }
+
+      // Contain the frame in whatever it sits inside, so `stackEnd` stays
+      // non-increasing upwards and the stack keeps its order.
+      let end = frame.timeEnd;
+      if (stackTop > 0 && end > stackEnd[stackTop - 1]!) {
+        end = stackEnd[stackTop - 1]!;
+        violations++;
+      }
+
+      stackEnd[stackTop] = end;
+      stackDepth[stackTop] = frame.depth > MAX_DEPTH ? MAX_DEPTH : frame.depth;
+      stackCategory[stackTop] = this.idFor(frame.category);
+      stackTop++;
+    }
+
+    while (stackTop > 0) {
+      const at = stackTop - 1;
+      emit(stackEnd[at]!, stackDepth[at]!, stackCategory[at]!);
+      stackTop--;
+    }
+
+    // The stretch after the last frame is a gap of its own. Closing the last real
+    // segment on it instead would credit that time to the frame's category.
+    emit(totalDuration, 0, GAP_CATEGORY);
+
+    if (buffers) {
+      buffers.starts[segments] = emittedTo;
+    }
+    return { segments, violations };
+  }
+
+  /**
+   * Intern a category name. Categories come from log events, so the set is open;
+   * a log with more than 255 of them shares the last id, which only costs colour.
+   */
+  private idFor(category: string): number {
+    const known = this.categoryIds.get(category);
+    if (known !== undefined) {
+      return known;
+    }
+    if (this.categoryNames.length > MAX_CATEGORIES) {
+      return MAX_CATEGORIES;
+    }
+    const id = this.categoryNames.length;
+    this.categoryNames.push(category);
+    this.categoryIds.set(category, id);
+    return id;
+  }
+}
+
+/**
+ * Order frames that start together by depth, shallowest first.
+ *
+ * `getAllFramesSorted` sorts by `timeStart` alone, so the order at an equal start
+ * is whatever the tree happened to build. The sweep needs the parent pushed
+ * before its child, or the child is on the stack first and the parent is dropped
+ * as an overlap - losing a frame that may span the whole log.
+ *
+ * Ties are rare, so this is a scan that almost never sorts anything.
+ */
+function orderEqualStartsByDepth(frames: SkylineFrame[]): void {
+  const count = frames.length;
+  let runStart = 0;
+  for (let i = 1; i <= count; i++) {
+    if (i < count && frames[i]!.timeStart === frames[runStart]!.timeStart) {
+      continue;
+    }
+    if (i - runStart > 1) {
+      const run = frames.slice(runStart, i).sort((a, b) => a.depth - b.depth);
+      for (let at = 0; at < run.length; at++) {
+        frames[runStart + at] = run[at]!;
+      }
+    }
+    runStart = i;
+  }
+}

--- a/log-viewer/src/features/timeline/optimised/minimap/MinimapSkylineIndex.ts
+++ b/log-viewer/src/features/timeline/optimised/minimap/MinimapSkylineIndex.ts
@@ -18,12 +18,24 @@
  * `[segmentStarts[i], segmentStarts[i + 1])`, and a stretch with no frame
  * running is a segment of its own with category id 0. So a walk needs no bounds
  * test beyond the segment count, and no segment-end array.
+ *
+ * It also keeps every frame's bounds, which is what `countFrames` needs: both are
+ * the same width-independent, once-per-log projection of the log.
  */
 
-import type { SkylineFrame } from '../TemporalSegmentTree.js';
+/**
+ * What the sweep reads off a frame. `PrecomputedRect` satisfies it, so the minimap
+ * builds straight from the rectangles rather than from objects made for it.
+ */
+export interface SkylineFrame {
+  timeStart: number;
+  timeEnd: number;
+  depth: number;
+  category: string;
+}
 
 /** Category id 0 means no frame is on top, so a zeroed buffer is never wrong. */
-const GAP_CATEGORY = 0;
+export const GAP_CATEGORY = 0;
 
 /** Ids are held in a Uint8Array, and id 0 is the gap. */
 const MAX_CATEGORIES = 255;
@@ -31,17 +43,46 @@ const MAX_CATEGORIES = 255;
 /** Depths are held in a Uint16Array. Real logs reach ~30. */
 const MAX_DEPTH = 65535;
 
-/** Where the sweep writes. Null on the counting pass. */
-interface SkylineBuffers {
+/** What the sweep produces: the segments, and how many of them are real. */
+interface Swept {
   starts: Float64Array;
   depths: Uint16Array;
   categories: Uint8Array;
+  segments: number;
+  violations: number;
+}
+
+/**
+ * Every frame in one array, in the order the sweep needs: by start, then by depth
+ * so a parent precedes the child that starts with it. Get that order wrong and the
+ * sweep drops the parent as an overlap, losing a frame that may span the whole log.
+ *
+ * A new array of references, so the caller's own arrays are never reordered. Cheap
+ * because each group arrives time-ordered, so this merges a handful of runs rather
+ * than sorting from scratch: 12ms for 431k frames, against 43ms for the same frames
+ * in the conversion's own order.
+ */
+function ordered(groups: readonly (readonly SkylineFrame[])[]): SkylineFrame[] {
+  let total = 0;
+  for (const group of groups) {
+    total += group.length;
+  }
+
+  // Pre-sized and filled by index. Growing by push costs 1.6ms and 1.5MB of copies
+  // at 431k frames, and `push(...group)` overflows the stack on a group that size.
+  const frames: SkylineFrame[] = new Array(total);
+  let at = 0;
+  for (const group of groups) {
+    for (const frame of group) {
+      frames[at++] = frame;
+    }
+  }
+
+  frames.sort((a, b) => a.timeStart - b.timeStart || a.depth - b.depth);
+  return frames;
 }
 
 export class MinimapSkylineIndex {
-  /** Number of segments. `segmentStarts` holds one more, to close the last. */
-  public readonly segmentCount: number;
-
   /** Segment boundaries, ascending. Length `segmentCount + 1`. */
   public readonly segmentStarts: Float64Array;
 
@@ -54,56 +95,101 @@ export class MinimapSkylineIndex {
   /** Category name per id, appended to as the sweep meets them. Index 0 is the gap. */
   public readonly categoryNames: string[] = [''];
 
-  /** Frame bounds as parallel arrays, for counting frames per bucket. */
-  public readonly frameStarts: Float64Array;
-  public readonly frameEnds: Float64Array;
-
   /**
-   * Frames the sweep had to contain: one that outlived its parent, one that
-   * overlapped a frame at the same or a shallower depth, or one with no
-   * duration. Zero on a well-formed log; asserted by the tests.
+   * Frames the sweep contained or dropped: one that outlived its parent, one
+   * that overlapped a frame at the same or a shallower depth, or one with no
+   * duration. Zero on a well-formed log; asserted by the tests, and printed by
+   * `pnpm measure minimap` as a tripwire on real logs.
    */
   public readonly violations: number;
+
+  /**
+   * Frame bounds as parallel arrays, for `countFrames`.
+   *
+   * A copy of numbers the rectangles already hold, so this looks like 6.6MB to
+   * reclaim. It is not: `countFrames` runs on every width change, and reading the
+   * scattered rectangles instead measures 10-15ms a call against 1ms, which would
+   * put a resize step inside the frame budget.
+   */
+  private readonly frameStarts: Float64Array;
+  private readonly frameEnds: Float64Array;
 
   private readonly categoryIds = new Map<string, number>();
 
   /**
-   * @param frames - Every frame, ascending by `timeStart`. Reordered in place at equal starts.
+   * @param groups - Frames in groups, each ascending by `timeStart`.
    * @param totalDuration - The log's end timestamp, which the last segment reaches.
-   * @param maxDepth - Deepest frame in the log, which bounds the sweep's stack.
    */
-  constructor(frames: SkylineFrame[], totalDuration: number, maxDepth: number) {
-    orderEqualStartsByDepth(frames);
-
+  constructor(groups: readonly (readonly SkylineFrame[])[], totalDuration: number) {
+    const frames = ordered(groups);
     const count = frames.length;
     this.frameStarts = new Float64Array(count);
     this.frameEnds = new Float64Array(count);
+    let deepest = 0;
     for (let i = 0; i < count; i++) {
       const frame = frames[i]!;
       this.frameStarts[i] = frame.timeStart;
       this.frameEnds[i] = frame.timeEnd;
+      if (frame.depth > deepest) {
+        deepest = frame.depth;
+      }
     }
 
-    // Swept twice, counting then writing, so the arrays are allocated at exactly
-    // the size needed. Growing by doubling would peak about half again as large,
-    // and this module trades speed for memory.
-    const counted = this.sweep(frames, totalDuration, maxDepth, null);
-    this.segmentCount = counted.segments;
-    this.violations = counted.violations;
+    // Depth strictly increases up the stack, so it can hold no more entries than
+    // there are depths. Taken from the frames rather than passed in, so the sweep
+    // cannot overflow on a caller's stale figure.
+    const swept = this.sweep(frames, totalDuration, Math.min(deepest, MAX_DEPTH) + 2);
+    this.violations = swept.violations;
 
-    this.segmentStarts = new Float64Array(counted.segments + 1);
-    this.segmentDepths = new Uint16Array(counted.segments);
-    this.segmentCategories = new Uint8Array(counted.segments);
-    this.sweep(frames, totalDuration, maxDepth, {
-      starts: this.segmentStarts,
-      depths: this.segmentDepths,
-      categories: this.segmentCategories,
-    });
+    this.segmentStarts = swept.starts.subarray(0, swept.segments + 1);
+    this.segmentDepths = swept.depths.subarray(0, swept.segments);
+    this.segmentCategories = swept.categories.subarray(0, swept.segments);
   }
 
-  /** The category a segment's id names, or the empty string for a gap. */
-  public categoryOf(segment: number): string {
-    return this.categoryNames[this.segmentCategories[segment]!]!;
+  /** Number of segments. `segmentStarts` holds one more, to close the last. */
+  public get segmentCount(): number {
+    return this.segmentDepths.length;
+  }
+
+  /**
+   * Count the frames overlapping each bucket, by difference array.
+   *
+   * A frame adds one to the bucket it starts in and takes one back after the
+   * bucket it ends in, so a running total gives every bucket its count in one
+   * pass.
+   *
+   * A frame ending exactly on a boundary counts in the bucket after it, as the
+   * per-bucket collect this replaced did. The segment walk does not, so such a
+   * bucket reports a count at depth 0 and draws no bar.
+   */
+  public countFrames(bucketCount: number, bucketTimeWidth: number): Uint32Array {
+    const { frameStarts, frameEnds } = this;
+    const deltas = new Int32Array(bucketCount + 1);
+    const lastBucket = bucketCount - 1;
+
+    for (let i = 0; i < frameStarts.length; i++) {
+      let first = Math.floor(frameStarts[i]! / bucketTimeWidth);
+      if (first < 0) {
+        first = 0;
+      }
+      let last = Math.floor(frameEnds[i]! / bucketTimeWidth);
+      if (last > lastBucket) {
+        last = lastBucket;
+      }
+      if (last < first) {
+        continue;
+      }
+      deltas[first]!++;
+      deltas[last + 1]!--;
+    }
+
+    const counts = new Uint32Array(bucketCount);
+    let running = 0;
+    for (let b = 0; b < bucketCount; b++) {
+      running += deltas[b]!;
+      counts[b] = running;
+    }
+    return counts;
   }
 
   /**
@@ -113,17 +199,20 @@ export class MinimapSkylineIndex {
    * sweep drains every frame that has ended before pushing the next, which is
    * what makes a frame's own end instant belong to whatever follows it.
    *
-   * @param buffers - Where to write, or null to only count.
+   * @param capacity - Stack depth the frames can reach.
    */
-  private sweep(
-    frames: readonly SkylineFrame[],
-    totalDuration: number,
-    maxDepth: number,
-    buffers: SkylineBuffers | null,
-  ): { segments: number; violations: number } {
-    // Depth strictly increases up the stack, so it can hold no more entries than
-    // there are depths.
-    const capacity = Math.max(1, maxDepth + 2);
+  private sweep(frames: readonly SkylineFrame[], totalDuration: number, capacity: number): Swept {
+    // At most two segments a frame - the stretch before it, and its own end - plus
+    // the trailing gap and the closer. Swept once into that bound and trimmed to a
+    // view, rather than swept twice to size exactly: measured slack over four real
+    // logs is 14 to 2,709 bytes, because a frame emits exactly two segments unless
+    // a same-category sibling at its own depth abuts it to the nanosecond. Copying
+    // into exact arrays would peak 9MB higher to reclaim that.
+    const bound = 2 * frames.length + 2;
+    const starts = new Float64Array(bound);
+    const depths = new Uint16Array(bound);
+    const categories = new Uint8Array(bound);
+
     const stackEnd = new Float64Array(capacity);
     const stackDepth = new Uint16Array(capacity);
     const stackCategory = new Uint8Array(capacity);
@@ -145,26 +234,31 @@ export class MinimapSkylineIndex {
         emittedTo = to;
         return;
       }
-      if (buffers) {
-        buffers.starts[segments] = emittedTo;
-        buffers.depths[segments] = depth;
-        buffers.categories[segments] = category;
-      }
+      starts[segments] = emittedTo;
+      depths[segments] = depth;
+      categories[segments] = category;
       segments++;
       emittedTo = to;
       lastDepth = depth;
       lastCategory = category;
     };
 
-    for (const frame of frames) {
-      const start = frame.timeStart;
-
-      // Retire what has ended. `<=` because a frame is not on top at its own end.
-      while (stackTop > 0 && stackEnd[stackTop - 1]! <= start) {
+    /** Retire what has ended by `until`. `<=` because a frame is not on top at its own end. */
+    const drainTo = (until: number): void => {
+      while (stackTop > 0 && stackEnd[stackTop - 1]! <= until) {
         const at = stackTop - 1;
         emit(stackEnd[at]!, stackDepth[at]!, stackCategory[at]!);
         stackTop--;
       }
+    };
+
+    for (const frame of frames) {
+      const start = frame.timeStart;
+      // Clamped here, not on the store: the stack's strict-increase invariant and
+      // its capacity are both in clamped units, so comparing raw depths could push
+      // two equal-after-clamp frames and run past the end.
+      const depth = frame.depth > MAX_DEPTH ? MAX_DEPTH : frame.depth;
+      drainTo(start);
 
       // The stretch before this frame belongs to whatever encloses it, or to a gap.
       if (start > emittedTo) {
@@ -183,11 +277,7 @@ export class MinimapSkylineIndex {
 
       // A frame no deeper than the one it overlaps cannot be on top of it. Today's
       // sweep gives that frame the same outcome, by keeping the deepest.
-      if (stackTop > 0 && frame.depth <= stackDepth[stackTop - 1]!) {
-        violations++;
-        continue;
-      }
-      if (stackTop === capacity) {
+      if (stackTop > 0 && depth <= stackDepth[stackTop - 1]!) {
         violations++;
         continue;
       }
@@ -201,25 +291,19 @@ export class MinimapSkylineIndex {
       }
 
       stackEnd[stackTop] = end;
-      stackDepth[stackTop] = frame.depth > MAX_DEPTH ? MAX_DEPTH : frame.depth;
+      stackDepth[stackTop] = depth;
       stackCategory[stackTop] = this.idFor(frame.category);
       stackTop++;
     }
 
-    while (stackTop > 0) {
-      const at = stackTop - 1;
-      emit(stackEnd[at]!, stackDepth[at]!, stackCategory[at]!);
-      stackTop--;
-    }
+    drainTo(Infinity);
 
     // The stretch after the last frame is a gap of its own. Closing the last real
     // segment on it instead would credit that time to the frame's category.
     emit(totalDuration, 0, GAP_CATEGORY);
 
-    if (buffers) {
-      buffers.starts[segments] = emittedTo;
-    }
-    return { segments, violations };
+    starts[segments] = emittedTo;
+    return { starts, depths, categories, segments, violations };
   }
 
   /**
@@ -238,32 +322,5 @@ export class MinimapSkylineIndex {
     this.categoryNames.push(category);
     this.categoryIds.set(category, id);
     return id;
-  }
-}
-
-/**
- * Order frames that start together by depth, shallowest first.
- *
- * `takeFramesSorted` sorts by `timeStart` alone, so the order at an equal start
- * is whatever the tree happened to build. The sweep needs the parent pushed
- * before its child, or the child is on the stack first and the parent is dropped
- * as an overlap - losing a frame that may span the whole log.
- *
- * Ties are rare, so this is a scan that almost never sorts anything.
- */
-function orderEqualStartsByDepth(frames: SkylineFrame[]): void {
-  const count = frames.length;
-  let runStart = 0;
-  for (let i = 1; i <= count; i++) {
-    if (i < count && frames[i]!.timeStart === frames[runStart]!.timeStart) {
-      continue;
-    }
-    if (i - runStart > 1) {
-      const run = frames.slice(runStart, i).sort((a, b) => a.depth - b.depth);
-      for (let at = 0; at < run.length; at++) {
-        frames[runStart + at] = run[at]!;
-      }
-    }
-    runStart = i;
   }
 }

--- a/log-viewer/src/features/timeline/optimised/minimap/MinimapSkylineIndex.ts
+++ b/log-viewer/src/features/timeline/optimised/minimap/MinimapSkylineIndex.ts
@@ -244,7 +244,7 @@ export class MinimapSkylineIndex {
 /**
  * Order frames that start together by depth, shallowest first.
  *
- * `getAllFramesSorted` sorts by `timeStart` alone, so the order at an equal start
+ * `takeFramesSorted` sorts by `timeStart` alone, so the order at an equal start
  * is whatever the tree happened to build. The sweep needs the parent pushed
  * before its child, or the child is on the stack first and the parent is dropped
  * as an overlap - losing a frame that may span the whole log.

--- a/log-viewer/src/features/timeline/optimised/orchestrators/MinimapOrchestrator.ts
+++ b/log-viewer/src/features/timeline/optimised/orchestrators/MinimapOrchestrator.ts
@@ -332,11 +332,12 @@ export class MinimapOrchestrator {
   }
 
   /**
-   * Invalidate the density cache.
-   * Call when timeline data changes.
+   * Redraw the static content after a theme change.
+   *
+   * The density is not touched: it carries category names, and the renderer resolves a
+   * colour from them at draw time.
    */
-  public invalidateCache(): void {
-    this.densityQuery?.invalidateCache();
+  public invalidateColors(): void {
     this.renderer?.invalidateStatic();
   }
 

--- a/log-viewer/src/features/timeline/optimised/orchestrators/MinimapOrchestrator.ts
+++ b/log-viewer/src/features/timeline/optimised/orchestrators/MinimapOrchestrator.ts
@@ -217,12 +217,10 @@ export class MinimapOrchestrator {
     // Initialize minimap manager (state and coordinate transforms)
     this.minimapViewport = new MinimapViewport(index.totalDuration, index.maxDepth, width, height);
 
-    // Initialize density query (leverages segment tree for O(B x log N) performance)
     this.densityQuery = new MinimapDensityQuery(
-      rectangleManager.getRectsByCategory(),
+      rectangleManager.getSegmentTree(),
       index.totalDuration,
       index.maxDepth,
-      rectangleManager.getSegmentTree(),
     );
 
     // Create minimap container on stage

--- a/log-viewer/src/features/timeline/optimised/orchestrators/MinimapOrchestrator.ts
+++ b/log-viewer/src/features/timeline/optimised/orchestrators/MinimapOrchestrator.ts
@@ -180,7 +180,7 @@ export class MinimapOrchestrator {
    * @param width - Canvas width
    * @param height - Full container height (minimap height calculated from this)
    * @param index - Timeline event index for duration/depth info
-   * @param rectangleManager - For density query and segment tree
+   * @param rectangleManager - Supplies the rectangles the density query walks
    * @param viewport - Main timeline viewport (for reading state only)
    */
   public async init(
@@ -218,7 +218,7 @@ export class MinimapOrchestrator {
     this.minimapViewport = new MinimapViewport(index.totalDuration, index.maxDepth, width, height);
 
     this.densityQuery = new MinimapDensityQuery(
-      rectangleManager.getSegmentTree(),
+      [...rectangleManager.getRectsByCategory().values()],
       index.totalDuration,
       index.maxDepth,
     );
@@ -282,9 +282,7 @@ export class MinimapOrchestrator {
 
     // No density invalidation here: it is keyed by width (see MinimapDensityQuery).
 
-    if (this.renderer) {
-      this.renderer.invalidateStatic();
-    }
+    this.invalidateStatic();
   }
 
   // ============================================================================
@@ -337,7 +335,7 @@ export class MinimapOrchestrator {
    * The density is not touched: it carries category names, and the renderer resolves a
    * colour from them at draw time.
    */
-  public invalidateColors(): void {
+  public invalidateStatic(): void {
     this.renderer?.invalidateStatic();
   }
 

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "watch": "rm -rf lana/out && rollup -w -c rollup.config.mjs",
     "watch:fast": "rolldown -w -c rolldown.config.ts",
     "copy:package-docs": "node ./scripts/copy-package-docs.mjs",
-    "typecheck": "tsc -b",
+    "typecheck": "tsc -b && tsc -p scripts/tsconfig.json",
     "typecheck:tsc6": "tsc6 -b",
     "measure": "rolldown -c scripts/measure/rolldown.config.ts && node --expose-gc --max-old-space-size=12288 scripts/measure/out/measure.mjs",
     "lint": "concurrently -r -g 'eslint . --cache --cache-location node_modules/.cache/eslint/' 'prettier --cache **/*.{ts,css,md,mdx,scss} --check --experimental-cli' 'pnpm run typecheck'",

--- a/scripts/measure/call-tree.ts
+++ b/scripts/measure/call-tree.ts
@@ -18,7 +18,7 @@ import {
   toAggregatedCallTree,
   toBottomUpTree,
 } from '../../log-viewer/src/features/call-tree/utils/Aggregation.js';
-import { time } from './harness.js';
+import { line, time } from './harness.js';
 
 // The builds slice themselves against this; resolving at once measures the work
 // rather than the frames it would hand back on screen.
@@ -72,9 +72,9 @@ export async function measureCallTree(log: ApexLog): Promise<void> {
 
   const shape = shapeOf(bottomUp);
   const counts = ({ nodes, indexes }: Shape) => `${nodes} nodes, ${indexes} indexes held`;
-  console.log(`bottom-up   ${counts(shape)}`);
-  console.log(`aggregated  ${counts(shapeOf(aggregated))}`);
-  console.log(`time-order  ${counts(shapeOf(timeOrder))}\n`);
+  line('bottom-up', counts(shape));
+  line('aggregated', counts(shapeOf(aggregated)));
+  line('time-order', `${counts(shapeOf(timeOrder))}\n`);
 
   const byPathBottomUp = await time('rowIdsByPath bottom-up', () => rowIdsByPath(bottomUp));
   const byPathAggregated = await time('rowIdsByPath aggregated', () => rowIdsByPath(aggregated));

--- a/scripts/measure/call-tree.ts
+++ b/scripts/measure/call-tree.ts
@@ -1,0 +1,100 @@
+/*
+ * Copyright (c) 2026 Certinia Inc. All rights reserved.
+ */
+
+/**
+ * Times the call tree builds and the inspector's row mark.
+ */
+import type { ApexLog } from 'apex-log-parser';
+
+import { LocatedRowIds } from '../../log-viewer/src/components/locatedRow.js';
+import {
+  buildWholeLogCallTree,
+  rowIdsByPath,
+  type ScopedRow,
+} from '../../log-viewer/src/components/scopedCallTree.js';
+import { LogStore, setCurrentLog } from '../../log-viewer/src/core/log/LogStore.js';
+import {
+  toAggregatedCallTree,
+  toBottomUpTree,
+} from '../../log-viewer/src/features/call-tree/utils/Aggregation.js';
+import { time } from './harness.js';
+
+// The builds slice themselves against this; resolving at once measures the work
+// rather than the frames it would hand back on screen.
+const yieldSlice = () => Promise.resolve();
+
+interface Shape {
+  nodes: number;
+  /** Event indexes the rows store between them: what a row per occurrence costs.
+   *  A row that derives its own stores none. */
+  indexes: number;
+  fattest: ScopedRow | null;
+}
+
+function shapeOf(rows: readonly ScopedRow[]): Shape {
+  const shape: Shape = { nodes: 0, indexes: 0, fattest: null };
+  const stack = [...rows];
+  while (stack.length) {
+    const row = stack.pop()!;
+    shape.nodes += 1;
+    const held = row.eventIndexes?.length ?? 0;
+    shape.indexes += held;
+    if (held > (shape.fattest?.eventIndexes?.length ?? 0)) {
+      shape.fattest = row;
+    }
+    if (row._children) {
+      for (const child of row._children) {
+        stack.push(child);
+      }
+    }
+  }
+  return shape;
+}
+
+export async function measureCallTree(log: ApexLog): Promise<void> {
+  setCurrentLog(log);
+
+  const scoped = await time('buildWholeLogCallTree', () => buildWholeLogCallTree({ yieldSlice }));
+  if (!scoped) {
+    throw new Error('nothing in scope');
+  }
+
+  const bottomUp = (await time('inspector bottomUp() rows', () =>
+    scoped.bottomUp({ yieldSlice }),
+  ))!;
+  const aggregated = (await time('inspector aggregated() rows', () =>
+    scoped.aggregated({ yieldSlice }),
+  ))!;
+  const timeOrder = (await time('inspector timeOrder() rows', () =>
+    scoped.timeOrder({ yieldSlice }),
+  ))!;
+
+  const shape = shapeOf(bottomUp);
+  const counts = ({ nodes, indexes }: Shape) => `${nodes} nodes, ${indexes} indexes held`;
+  console.log(`bottom-up   ${counts(shape)}`);
+  console.log(`aggregated  ${counts(shapeOf(aggregated))}`);
+  console.log(`time-order  ${counts(shapeOf(timeOrder))}\n`);
+
+  const byPathBottomUp = await time('rowIdsByPath bottom-up', () => rowIdsByPath(bottomUp));
+  const byPathAggregated = await time('rowIdsByPath aggregated', () => rowIdsByPath(aggregated));
+  console.log(`map entries: bottom-up ${byPathBottomUp.size}, aggregated ${byPathAggregated.size}`);
+
+  // The mark, on the worst row there is: the frames a picked bucket counts,
+  // translated into the ids of every row they name.
+  const picked = shape.fattest?.eventIndexes ?? [];
+  console.log(`\nfattest row: ${picked.length} occurrences of "${shape.fattest?.text ?? ''}"`);
+  const ids = new LocatedRowIds();
+  await time('mark callers (first)', () => ids.idsFor(log, picked, 'callers'));
+  await time('mark callers (same pick)', () => ids.idsFor(log, picked, 'callers'));
+  await time('mark callees', () => new LocatedRowIds().idsFor(log, picked, 'callees'));
+
+  // The Call Tree tab's own grouped builds, for comparison with the inspector's.
+  console.log('');
+  // A store of its own, so the inspector's builds above have not warmed the key
+  // table. Only the first build below is cold; the second reads what the first
+  // interned, as it does on screen where every view shares one table.
+  const gridPaths = new LogStore(log).keyPathIds();
+  await time('grid toAggregatedCallTree', () => toAggregatedCallTree(log.children, gridPaths));
+  await time('grid toBottomUpTree', () => toBottomUpTree(log.children, gridPaths));
+}

--- a/scripts/measure/harness.ts
+++ b/scripts/measure/harness.ts
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2026 Certinia Inc. All rights reserved.
+ */
+
+/**
+ * Timing and heap helpers shared by the measure scripts.
+ *
+ * Heap figures need `--expose-gc`, which the `measure` scripts pass.
+ */
+
+const gc = globalThis.gc as (() => void) | undefined;
+
+/** Heap after a collection, so a figure is what the step retained, not its litter. */
+export function heapMb(): number {
+  gc?.();
+  return Math.round(process.memoryUsage().heapUsed / 1048576);
+}
+
+/** Fractional milliseconds: a density query lands under 10ms, a cached one under 0.1ms. */
+export const nowMs = (): number => Number(process.hrtime.bigint()) / 1e6;
+
+export function report(label: string, ms: number, before: number): void {
+  const rounded = String(Math.round(ms));
+  console.log(`${label.padEnd(32)} ${rounded.padStart(7)}ms  heap ${before} -> ${heapMb()}MB`);
+}
+
+export async function time<T>(label: string, body: () => T | Promise<T>): Promise<T> {
+  const before = heapMb();
+  const start = nowMs();
+  const out = await body();
+  report(label, nowMs() - start, before);
+  return out;
+}

--- a/scripts/measure/harness.ts
+++ b/scripts/measure/harness.ts
@@ -10,24 +10,67 @@
 
 const gc = globalThis.gc as (() => void) | undefined;
 
+/** Width of the label column, so every reported line aligns into one table. */
+const LABEL_WIDTH = 32;
+
+/** Width of the millisecond column, shared by `report` and `ms`. */
+const MS_WIDTH = 7;
+
+if (!gc) {
+  console.warn('no --expose-gc: heap figures include uncollected litter\n');
+}
+
 /** Heap after a collection, so a figure is what the step retained, not its litter. */
 export function heapMb(): number {
   gc?.();
-  return Math.round(process.memoryUsage().heapUsed / 1048576);
+  return Math.round(retainedMb());
+}
+
+/**
+ * Heap plus typed-array bytes, without collecting.
+ *
+ * `heapUsed` alone misses every typed array: their backing stores are counted in
+ * `arrayBuffers`. The minimap's skyline is 15.6MB of typed arrays, so leaving them
+ * out reports its cost as zero.
+ */
+function retainedMb(): number {
+  const usage = process.memoryUsage();
+  return (usage.heapUsed + usage.arrayBuffers) / 1048576;
 }
 
 /** Fractional milliseconds: a density query lands under 10ms, a cached one under 0.1ms. */
 export const nowMs = (): number => Number(process.hrtime.bigint()) / 1e6;
 
-export function report(label: string, ms: number, before: number): void {
-  const rounded = String(Math.round(ms));
-  console.log(`${label.padEnd(32)} ${rounded.padStart(7)}ms  heap ${before} -> ${heapMb()}MB`);
+/** Two decimals, in `report`'s number column: a cached query lands under 0.1ms. */
+export const ms = (value: number): string => value.toFixed(2).padStart(MS_WIDTH);
+
+/** One reported line, in the same label column as `report`. */
+export function line(label: string, text: string): void {
+  console.log(`${label.padEnd(LABEL_WIDTH)} ${text}`);
 }
 
+export function report(label: string, milliseconds: number, before: number): void {
+  const rounded = String(Math.round(milliseconds)).padStart(MS_WIDTH);
+  line(label, `${rounded}ms  heap ${before} -> ${heapMb()}MB`);
+}
+
+/**
+ * Time a step, and report what it retained.
+ *
+ * The `after` figure collects, so it is retention rather than litter - which means
+ * it lands just before the next step and costs that step ~26% in first-touch. So
+ * compare a line against the same line on another branch, never against a budget.
+ */
 export async function time<T>(label: string, body: () => T | Promise<T>): Promise<T> {
-  const before = heapMb();
+  const before = Math.round(retainedMb());
   const start = nowMs();
   const out = await body();
   report(label, nowMs() - start, before);
   return out;
+}
+
+/** Report a usage error the way every other bad input is reported, and stop. */
+export function die(message: string): never {
+  console.error(message);
+  process.exit(1);
 }

--- a/scripts/measure/measure.ts
+++ b/scripts/measure/measure.ts
@@ -3,134 +3,78 @@
  */
 
 /**
- * Times the call tree builds and the inspector's row mark on a real log.
+ * Times the paths that have to hold up on a large log.
  *
- * The whole path is free of the DOM, so it runs under Node: a browser cannot
- * profile a 100MB log without its own parse blocking the tools.
+ * They are free of the DOM and of PixiJS, so they run under Node: a browser
+ * cannot profile a 100MB log without its own parse blocking the tools.
  *
- *   pnpm measure <path to a log>
+ *   pnpm measure                      every area, on the committed sample log
+ *   pnpm measure minimap              one area
+ *   pnpm measure --log <path>         another log
+ *   pnpm measure minimap --digest     CSV of what the minimap would draw
  *
- * Heap figures need `--expose-gc`, which the `measure` script passes. No log is
- * committed: the path is always an argument.
+ * One area per feature that has a performance budget, and one number each for
+ * what a user waits on. Heap figures need `--expose-gc`, which the `measure`
+ * script passes.
  */
 import { readFileSync } from 'node:fs';
 
-import { parse } from 'apex-log-parser';
+import { type ApexLog, parse } from 'apex-log-parser';
 
-import { LocatedRowIds } from '../../log-viewer/src/components/locatedRow.js';
-import {
-  buildWholeLogCallTree,
-  rowIdsByPath,
-  type ScopedRow,
-} from '../../log-viewer/src/components/scopedCallTree.js';
-import { LogStore, setCurrentLog } from '../../log-viewer/src/core/log/LogStore.js';
-import {
-  toAggregatedCallTree,
-  toBottomUpTree,
-} from '../../log-viewer/src/features/call-tree/utils/Aggregation.js';
+import { measureCallTree } from './call-tree.js';
+import { time } from './harness.js';
+import { measureMinimap } from './minimap.js';
 
-const gc = globalThis.gc as (() => void) | undefined;
+/** The one log every measurement runs over, so the numbers compare across branches. */
+const SAMPLE_LOG = 'sample-app/debug-logs/sample-log.log';
 
-/** Heap after a collection, so a figure is what the step retained, not its litter. */
-function heapMb(): number {
-  gc?.();
-  return Math.round(process.memoryUsage().heapUsed / 1048576);
-}
+type AreaRun = (log: ApexLog, digest: boolean) => Promise<void>;
 
-const now = (): number => Number(process.hrtime.bigint() / 1000000n);
-// The builds slice themselves against this; resolving at once measures the work
-// rather than the frames it would hand back on screen.
-const yieldSlice = () => Promise.resolve();
+const AREAS: Record<string, AreaRun> = {
+  'call-tree': measureCallTree,
+  minimap: measureMinimap,
+};
 
-function report(label: string, ms: number, before: number): void {
-  console.log(`${label.padEnd(32)} ${String(ms).padStart(7)}ms  heap ${before} -> ${heapMb()}MB`);
-}
+/** Areas that can print a digest. Anything else would corrupt the CSV with timings. */
+const DIGESTABLE = ['minimap'];
 
-async function time<T>(label: string, body: () => T | Promise<T>): Promise<T> {
-  const before = heapMb();
-  const start = now();
-  const out = await body();
-  report(label, now() - start, before);
-  return out;
-}
+const argv = process.argv.slice(2);
+const digest = argv.includes('--digest');
 
-interface Shape {
-  nodes: number;
-  /** Event indexes the rows store between them: what a row per occurrence costs.
-   *  A row that derives its own stores none. */
-  indexes: number;
-  fattest: ScopedRow | null;
-}
-
-function shapeOf(rows: readonly ScopedRow[]): Shape {
-  const shape: Shape = { nodes: 0, indexes: 0, fattest: null };
-  const stack = [...rows];
-  while (stack.length) {
-    const row = stack.pop()!;
-    shape.nodes += 1;
-    const held = row.eventIndexes?.length ?? 0;
-    shape.indexes += held;
-    if (held > (shape.fattest?.eventIndexes?.length ?? 0)) {
-      shape.fattest = row;
-    }
-    if (row._children) {
-      for (const child of row._children) {
-        stack.push(child);
-      }
-    }
-  }
-  return shape;
-}
-
-const logPath = process.argv[2];
+const logAt = argv.indexOf('--log');
+const logPath = logAt === -1 ? SAMPLE_LOG : argv[logAt + 1];
 if (!logPath) {
-  console.error('usage: pnpm measure <path to a log>');
+  console.error('usage: pnpm measure [area...] [--log <path>] [--digest]');
   process.exit(1);
 }
 
-const text = await time('read file', () => readFileSync(logPath, 'utf8'));
-console.log(`log ${Math.round(text.length / 1048576)}MB, ${text.split('\n').length} lines\n`);
-
-const log = await time('parse', () => parse(text));
-setCurrentLog(log);
-
-const scoped = await time('buildWholeLogCallTree', () => buildWholeLogCallTree({ yieldSlice }));
-if (!scoped) {
-  throw new Error('nothing in scope');
+const known = Object.keys(AREAS).join(', ');
+// `logAt === -1` would make the path index 0 and swallow the first area name.
+const pathAt = logAt === -1 ? -1 : logAt + 1;
+const named = argv.filter((arg, at) => !arg.startsWith('--') && at !== pathAt);
+for (const name of named) {
+  if (!(name in AREAS)) {
+    console.error(`unknown area "${name}". Known: ${known}`);
+    process.exit(1);
+  }
 }
 
-const bottomUp = (await time('inspector bottomUp() rows', () => scoped.bottomUp({ yieldSlice })))!;
-const aggregated = (await time('inspector aggregated() rows', () =>
-  scoped.aggregated({ yieldSlice }),
-))!;
-const timeOrder = (await time('inspector timeOrder() rows', () =>
-  scoped.timeOrder({ yieldSlice }),
-))!;
+const areas = named.length ? named : digest ? DIGESTABLE : Object.keys(AREAS);
+const undigestable = digest ? areas.filter((name) => !DIGESTABLE.includes(name)) : [];
+if (undigestable.length) {
+  console.error(`no digest for: ${undigestable.join(', ')}. Digestable: ${DIGESTABLE.join(', ')}`);
+  process.exit(1);
+}
 
-const shape = shapeOf(bottomUp);
-const counts = ({ nodes, indexes }: Shape) => `${nodes} nodes, ${indexes} indexes held`;
-console.log(`bottom-up   ${counts(shape)}`);
-console.log(`aggregated  ${counts(shapeOf(aggregated))}`);
-console.log(`time-order  ${counts(shapeOf(timeOrder))}\n`);
+const text = readFileSync(logPath, 'utf8');
+if (!digest) {
+  console.log(`log ${Math.round(text.length / 1048576)}MB, ${text.split('\n').length} lines\n`);
+}
+const log = digest ? parse(text) : await time('parse', () => parse(text));
 
-const byPathBottomUp = await time('rowIdsByPath bottom-up', () => rowIdsByPath(bottomUp));
-const byPathAggregated = await time('rowIdsByPath aggregated', () => rowIdsByPath(aggregated));
-console.log(`map entries: bottom-up ${byPathBottomUp.size}, aggregated ${byPathAggregated.size}`);
-
-// The mark, on the worst row there is: the frames a picked bucket counts,
-// translated into the ids of every row they name.
-const picked = shape.fattest?.eventIndexes ?? [];
-console.log(`\nfattest row: ${picked.length} occurrences of "${shape.fattest?.text ?? ''}"`);
-const ids = new LocatedRowIds();
-await time('mark callers (first)', () => ids.idsFor(log, picked, 'callers'));
-await time('mark callers (same pick)', () => ids.idsFor(log, picked, 'callers'));
-await time('mark callees', () => new LocatedRowIds().idsFor(log, picked, 'callees'));
-
-// The Call Tree tab's own grouped builds, for comparison with the inspector's.
-console.log('');
-// A store of its own, so the inspector's builds above have not warmed the key
-// table. Only the first build below is cold; the second reads what the first
-// interned, as it does on screen where every view shares one table.
-const gridPaths = new LogStore(log).keyPathIds();
-await time('grid toAggregatedCallTree', () => toAggregatedCallTree(log.children, gridPaths));
-await time('grid toBottomUpTree', () => toBottomUpTree(log.children, gridPaths));
+for (const area of areas) {
+  if (!digest) {
+    console.log(`\n--- ${area} ---`);
+  }
+  await AREAS[area]!(log, digest);
+}

--- a/scripts/measure/measure.ts
+++ b/scripts/measure/measure.ts
@@ -18,63 +18,82 @@
  * script passes.
  */
 import { readFileSync } from 'node:fs';
+import { parseArgs } from 'node:util';
 
 import { type ApexLog, parse } from 'apex-log-parser';
 
 import { measureCallTree } from './call-tree.js';
-import { time } from './harness.js';
-import { measureMinimap } from './minimap.js';
+import { die, time } from './harness.js';
+import { digestMinimap, measureMinimap } from './minimap.js';
 
 /** The one log every measurement runs over, so the numbers compare across branches. */
 const SAMPLE_LOG = 'sample-app/debug-logs/sample-log.log';
 
-type AreaRun = (log: ApexLog, digest: boolean) => Promise<void>;
+const USAGE = 'usage: pnpm measure [area...] [--log <path>] [--digest]';
 
-const AREAS: Record<string, AreaRun> = {
-  'call-tree': measureCallTree,
-  minimap: measureMinimap,
-};
-
-/** Areas that can print a digest. Anything else would corrupt the CSV with timings. */
-const DIGESTABLE = ['minimap'];
-
-const argv = process.argv.slice(2);
-const digest = argv.includes('--digest');
-
-const logAt = argv.indexOf('--log');
-const logPath = logAt === -1 ? SAMPLE_LOG : argv[logAt + 1];
-if (!logPath) {
-  console.error('usage: pnpm measure [area...] [--log <path>] [--digest]');
-  process.exit(1);
+interface Area {
+  run(log: ApexLog): Promise<void>;
+  /** Prints a CSV of what the area would draw. Absent where timings are all there is. */
+  digest?(log: ApexLog): void;
 }
 
-const known = Object.keys(AREAS).join(', ');
-// `logAt === -1` would make the path index 0 and swallow the first area name.
-const pathAt = logAt === -1 ? -1 : logAt + 1;
-const named = argv.filter((arg, at) => !arg.startsWith('--') && at !== pathAt);
-for (const name of named) {
-  if (!(name in AREAS)) {
-    console.error(`unknown area "${name}". Known: ${known}`);
-    process.exit(1);
+const AREAS: Record<string, Area> = {
+  'call-tree': { run: measureCallTree },
+  minimap: { run: measureMinimap, digest: digestMinimap },
+};
+
+const args = (() => {
+  try {
+    return parseArgs({
+      args: process.argv.slice(2),
+      options: { log: { type: 'string' }, digest: { type: 'boolean', default: false } },
+      allowPositionals: true,
+    });
+  } catch (error) {
+    die(`${(error as Error).message}\n${USAGE}`);
+  }
+})();
+
+const digest = args.values.digest === true;
+const logPath = args.values.log ?? SAMPLE_LOG;
+
+// Named areas, or every area that can answer. A digest of timings would corrupt the CSV.
+const names = args.positionals.length
+  ? args.positionals
+  : Object.keys(AREAS).filter((name) => !digest || AREAS[name]!.digest);
+
+for (const name of names) {
+  const area = AREAS[name];
+  if (!area) {
+    die(`unknown area "${name}". Known: ${Object.keys(AREAS).join(', ')}\n${USAGE}`);
+  }
+  if (digest && !area.digest) {
+    die(`no digest for: ${name}\n${USAGE}`);
   }
 }
 
-const areas = named.length ? named : digest ? DIGESTABLE : Object.keys(AREAS);
-const undigestable = digest ? areas.filter((name) => !DIGESTABLE.includes(name)) : [];
-if (undigestable.length) {
-  console.error(`no digest for: ${undigestable.join(', ')}. Digestable: ${DIGESTABLE.join(', ')}`);
-  process.exit(1);
+// Each digest prints its own CSV header, so two into one stdout is not a CSV.
+if (digest && names.length > 1) {
+  die(`name one area to digest: ${names.join(', ')}\n${USAGE}`);
 }
 
-const text = readFileSync(logPath, 'utf8');
+let text: string;
+try {
+  text = readFileSync(logPath, 'utf8');
+} catch (error) {
+  die(`${(error as Error).message}\n${USAGE}`);
+}
 if (!digest) {
   console.log(`log ${Math.round(text.length / 1048576)}MB, ${text.split('\n').length} lines\n`);
 }
 const log = digest ? parse(text) : await time('parse', () => parse(text));
 
-for (const area of areas) {
-  if (!digest) {
-    console.log(`\n--- ${area} ---`);
+for (const name of names) {
+  const area = AREAS[name]!;
+  if (digest && area.digest) {
+    area.digest(log);
+    continue;
   }
-  await AREAS[area]!(log, digest);
+  console.log(`\n--- ${name} ---`);
+  await area.run(log);
 }

--- a/scripts/measure/minimap.ts
+++ b/scripts/measure/minimap.ts
@@ -39,10 +39,9 @@ export async function measureMinimap(log: ApexLog, digest: boolean): Promise<voi
 
   const build = (): MinimapDensityQuery =>
     new MinimapDensityQuery(
-      cache.getRectsByCategory(),
+      cache.getSegmentTree(),
       precomputed.totalDuration,
       precomputed.maxDepth,
-      cache.getSegmentTree(),
     );
 
   if (digest) {

--- a/scripts/measure/minimap.ts
+++ b/scripts/measure/minimap.ts
@@ -8,9 +8,6 @@
  * The minimap holds one bucket per pixel of its width, so every step of a width
  * drag is a fresh bucket count and a guaranteed cache miss. The drag sweep is
  * the number a resize actually pays.
- *
- * `--digest` prints a CSV row per bucket instead of timings, so two revisions
- * can be diffed to show the picture did not change.
  */
 import type { ApexLog } from 'apex-log-parser';
 
@@ -18,7 +15,7 @@ import { MinimapDensityQuery } from '../../log-viewer/src/features/timeline/opti
 import { RectangleCache } from '../../log-viewer/src/features/timeline/optimised/RectangleCache.js';
 import { BUCKET_CONSTANTS } from '../../log-viewer/src/features/timeline/types/flamechart.types.js';
 import { logEventToTreeAndRects } from '../../log-viewer/src/features/timeline/utils/tree-converter.js';
-import { heapMb, nowMs, time } from './harness.js';
+import { heapMb, line, ms, nowMs, time } from './harness.js';
 
 /** The widths the digest samples: odd and even, and either side of a 1536px panel. */
 const DIGEST_WIDTHS = [97, 800, 1000, 1536, 1601];
@@ -30,52 +27,67 @@ const DRAG_TO = 1400;
 /** Outside the drag, so the cold query does not leave the first drag width cached. */
 const COLD_WIDTH = 1000;
 
-const ms = (value: number): string => value.toFixed(2).padStart(7);
+/**
+ * Also outside the drag. `heapMb` collects, and the first query after a full
+ * collection costs ~65ms against a steady ~4ms, so without this the drag's worst
+ * step is always step 0 and reports the collection rather than the query.
+ */
+const WARM_WIDTH = 1100;
 
-export async function measureMinimap(log: ApexLog, digest: boolean): Promise<void> {
+interface Subject {
+  query: MinimapDensityQuery;
+  frames: number;
+  maxDepth: number;
+}
+
+/** One query per run: the one width it caches makes every other width a miss anyway. */
+function build(log: ApexLog): Subject {
   const categories = new Set<string>(BUCKET_CONSTANTS.CATEGORY_PRIORITY);
   const precomputed = logEventToTreeAndRects(log.children, categories, log.exitStamp);
   const cache = new RectangleCache(log.children, categories, precomputed);
 
-  // One query for every width: the tree hands its frames over once, and the one
-  // width it caches makes each new width a miss anyway.
-  const query = new MinimapDensityQuery(
-    cache.getSegmentTree(),
-    precomputed.totalDuration,
-    precomputed.maxDepth,
-  );
+  return {
+    query: new MinimapDensityQuery(
+      [...cache.getRectsByCategory().values()],
+      precomputed.totalDuration,
+      precomputed.maxDepth,
+    ),
+    // One entry per rect the conversion made, so this is the sweep's own input.
+    frames: precomputed.rectMap.size,
+    maxDepth: precomputed.maxDepth,
+  };
+}
 
-  if (digest) {
-    console.log('width,bucket,eventCount,maxDepth,dominantCategory');
-    for (const width of DIGEST_WIDTHS) {
-      const { buckets } = query.query(width);
-      for (let b = 0; b < buckets.length; b++) {
-        const bucket = buckets[b]!;
-        console.log(
-          `${width},${b},${bucket.eventCount},${bucket.maxDepth},${bucket.dominantCategory}`,
-        );
-      }
+/** A CSV row per bucket, so two revisions can be diffed to show the picture held. */
+export function digestMinimap(log: ApexLog): void {
+  const { query } = build(log);
+  console.log('width,bucket,eventCount,maxDepth,dominantCategory');
+  for (const width of DIGEST_WIDTHS) {
+    const { buckets } = query.query(width);
+    for (let b = 0; b < buckets.length; b++) {
+      const bucket = buckets[b]!;
+      console.log(
+        `${width},${b},${bucket.eventCount},${bucket.maxDepth},${bucket.dominantCategory}`,
+      );
     }
-    return;
   }
+}
 
-  let frames = 0;
-  for (const rects of cache.getRectsByCategory().values()) {
-    frames += rects.length;
-  }
-  console.log(`${frames} frames, maxDepth ${precomputed.maxDepth}`);
+export async function measureMinimap(log: ApexLog): Promise<void> {
+  // Timed: the rectangles and the tree are built during timeline init, so this and
+  // the cold query below are one bill the user pays before the first frame appears.
+  const { query, frames, maxDepth } = await time('build rects + tree', () => build(log));
+  console.log(`${frames} frames, maxDepth ${maxDepth}`);
 
-  // Heap with the tree's frame objects still held, against heap once the skyline
-  // has taken them: the first query is where the trade happens.
-  const heldWithFrames = heapMb();
+  // The first query builds the skyline, so its own line carries the build's cost.
   await time(`cold query(${COLD_WIDTH})`, () => query.query(COLD_WIDTH));
-  const skyline = query.skyline!;
+  const stats = query.stats();
+  const perFrame = (stats.segmentCount / frames).toFixed(2);
   console.log(
-    `  ${skyline.segmentCount} segments (${(skyline.segmentCount / frames).toFixed(2)}/frame), ` +
-      `${skyline.violations} violations`,
+    `  ${stats.segmentCount} segments (${perFrame}/frame), ${stats.violations} violations`,
   );
-  console.log(`  heap ${heldWithFrames}MB with frames -> ${heapMb()}MB with the skyline`);
 
+  query.query(WARM_WIDTH);
   const drag: number[] = [];
   for (let width = DRAG_FROM; width <= DRAG_TO; width++) {
     const start = nowMs();
@@ -85,8 +97,10 @@ export async function measureMinimap(log: ApexLog, digest: boolean): Promise<voi
   const total = drag.reduce((sum, each) => sum + each, 0);
   const sorted = [...drag].sort((a, b) => a - b);
   const median = sorted[sorted.length >> 1]!;
-  console.log(
-    `drag ${DRAG_FROM}->${DRAG_TO}px                median ${ms(median)}ms  worst ${ms(sorted[sorted.length - 1]!)}ms  ${Math.round(total)}ms total`,
+  const worst = sorted[sorted.length - 1]!;
+  line(
+    `drag ${DRAG_FROM}->${DRAG_TO}px`,
+    `median ${ms(median)}ms  worst ${ms(worst)}ms  ${Math.round(total)}ms total`,
   );
 
   // The cache holds one width, and the drag left a different one, so warm it before
@@ -96,6 +110,6 @@ export async function measureMinimap(log: ApexLog, digest: boolean): Promise<voi
   for (let i = 0; i < 100; i++) {
     query.query(DRAG_TO);
   }
-  console.log(`cached, same width               ${ms((nowMs() - hitStart) / 100)}ms`);
-  console.log(`heap held                        ${heapMb()}MB`);
+  line('cached, same width', `${ms((nowMs() - hitStart) / 100)}ms`);
+  line('heap held', `${heapMb()}MB`);
 }

--- a/scripts/measure/minimap.ts
+++ b/scripts/measure/minimap.ts
@@ -15,6 +15,7 @@
 import type { ApexLog } from 'apex-log-parser';
 
 import { MinimapDensityQuery } from '../../log-viewer/src/features/timeline/optimised/minimap/MinimapDensityQuery.js';
+import { MinimapSkylineIndex } from '../../log-viewer/src/features/timeline/optimised/minimap/MinimapSkylineIndex.js';
 import { RectangleCache } from '../../log-viewer/src/features/timeline/optimised/RectangleCache.js';
 import { BUCKET_CONSTANTS } from '../../log-viewer/src/features/timeline/types/flamechart.types.js';
 import { logEventToTreeAndRects } from '../../log-viewer/src/features/timeline/utils/tree-converter.js';
@@ -63,6 +64,22 @@ export async function measureMinimap(log: ApexLog, digest: boolean): Promise<voi
     frames += rects.length;
   }
   console.log(`${frames} frames, maxDepth ${precomputed.maxDepth}`);
+
+  // The width-independent half: built once per log, so a resize walks it instead
+  // of rebuilding. Violations say how well-nested the log really is.
+  const skyline = await time('skyline index', () => {
+    const tree = cache.getSegmentTree();
+    return new MinimapSkylineIndex(
+      tree.getAllFramesSorted(),
+      precomputed.totalDuration,
+      precomputed.maxDepth,
+    );
+  });
+  const bytes = skyline.segmentCount * 11 + frames * 16;
+  console.log(
+    `  ${skyline.segmentCount} segments (${(skyline.segmentCount / frames).toFixed(2)}/frame), ` +
+      `${Math.round(bytes / 1048576)}MB, ${skyline.violations} violations`,
+  );
 
   // Apart from the drag: the first query also pays the segment tree's deferred
   // frame sort, and a resize never repeats it.

--- a/scripts/measure/minimap.ts
+++ b/scripts/measure/minimap.ts
@@ -15,7 +15,6 @@
 import type { ApexLog } from 'apex-log-parser';
 
 import { MinimapDensityQuery } from '../../log-viewer/src/features/timeline/optimised/minimap/MinimapDensityQuery.js';
-import { MinimapSkylineIndex } from '../../log-viewer/src/features/timeline/optimised/minimap/MinimapSkylineIndex.js';
 import { RectangleCache } from '../../log-viewer/src/features/timeline/optimised/RectangleCache.js';
 import { BUCKET_CONSTANTS } from '../../log-viewer/src/features/timeline/types/flamechart.types.js';
 import { logEventToTreeAndRects } from '../../log-viewer/src/features/timeline/utils/tree-converter.js';
@@ -38,17 +37,18 @@ export async function measureMinimap(log: ApexLog, digest: boolean): Promise<voi
   const precomputed = logEventToTreeAndRects(log.children, categories, log.exitStamp);
   const cache = new RectangleCache(log.children, categories, precomputed);
 
-  const build = (): MinimapDensityQuery =>
-    new MinimapDensityQuery(
-      cache.getSegmentTree(),
-      precomputed.totalDuration,
-      precomputed.maxDepth,
-    );
+  // One query for every width: the tree hands its frames over once, and the one
+  // width it caches makes each new width a miss anyway.
+  const query = new MinimapDensityQuery(
+    cache.getSegmentTree(),
+    precomputed.totalDuration,
+    precomputed.maxDepth,
+  );
 
   if (digest) {
     console.log('width,bucket,eventCount,maxDepth,dominantCategory');
     for (const width of DIGEST_WIDTHS) {
-      const { buckets } = build().query(width);
+      const { buckets } = query.query(width);
       for (let b = 0; b < buckets.length; b++) {
         const bucket = buckets[b]!;
         console.log(
@@ -65,26 +65,16 @@ export async function measureMinimap(log: ApexLog, digest: boolean): Promise<voi
   }
   console.log(`${frames} frames, maxDepth ${precomputed.maxDepth}`);
 
-  // The width-independent half: built once per log, so a resize walks it instead
-  // of rebuilding. Violations say how well-nested the log really is.
-  const skyline = await time('skyline index', () => {
-    const tree = cache.getSegmentTree();
-    return new MinimapSkylineIndex(
-      tree.getAllFramesSorted(),
-      precomputed.totalDuration,
-      precomputed.maxDepth,
-    );
-  });
-  const bytes = skyline.segmentCount * 11 + frames * 16;
+  // Heap with the tree's frame objects still held, against heap once the skyline
+  // has taken them: the first query is where the trade happens.
+  const heldWithFrames = heapMb();
+  await time(`cold query(${COLD_WIDTH})`, () => query.query(COLD_WIDTH));
+  const skyline = query.skyline!;
   console.log(
     `  ${skyline.segmentCount} segments (${(skyline.segmentCount / frames).toFixed(2)}/frame), ` +
-      `${Math.round(bytes / 1048576)}MB, ${skyline.violations} violations`,
+      `${skyline.violations} violations`,
   );
-
-  // Apart from the drag: the first query also pays the segment tree's deferred
-  // frame sort, and a resize never repeats it.
-  const query = build();
-  await time(`cold query(${COLD_WIDTH})`, () => query.query(COLD_WIDTH));
+  console.log(`  heap ${heldWithFrames}MB with frames -> ${heapMb()}MB with the skyline`);
 
   const drag: number[] = [];
   for (let width = DRAG_FROM; width <= DRAG_TO; width++) {

--- a/scripts/measure/minimap.ts
+++ b/scripts/measure/minimap.ts
@@ -1,0 +1,95 @@
+/*
+ * Copyright (c) 2026 Certinia Inc. All rights reserved.
+ */
+
+/**
+ * Times the minimap density query.
+ *
+ * The minimap holds one bucket per pixel of its width, so every step of a width
+ * drag is a fresh bucket count and a guaranteed cache miss. The drag sweep is
+ * the number a resize actually pays.
+ *
+ * `--digest` prints a CSV row per bucket instead of timings, so two revisions
+ * can be diffed to show the picture did not change.
+ */
+import type { ApexLog } from 'apex-log-parser';
+
+import { MinimapDensityQuery } from '../../log-viewer/src/features/timeline/optimised/minimap/MinimapDensityQuery.js';
+import { RectangleCache } from '../../log-viewer/src/features/timeline/optimised/RectangleCache.js';
+import { BUCKET_CONSTANTS } from '../../log-viewer/src/features/timeline/types/flamechart.types.js';
+import { logEventToTreeAndRects } from '../../log-viewer/src/features/timeline/utils/tree-converter.js';
+import { heapMb, nowMs, time } from './harness.js';
+
+/** The widths the digest samples: odd and even, and either side of a 1536px panel. */
+const DIGEST_WIDTHS = [97, 800, 1000, 1536, 1601];
+
+/** One drag across 200px of panel edge, every intermediate width a cache miss. */
+const DRAG_FROM = 1200;
+const DRAG_TO = 1400;
+
+/** Outside the drag, so the cold query does not leave the first drag width cached. */
+const COLD_WIDTH = 1000;
+
+const ms = (value: number): string => value.toFixed(2).padStart(7);
+
+export async function measureMinimap(log: ApexLog, digest: boolean): Promise<void> {
+  const categories = new Set<string>(BUCKET_CONSTANTS.CATEGORY_PRIORITY);
+  const precomputed = logEventToTreeAndRects(log.children, categories, log.exitStamp);
+  const cache = new RectangleCache(log.children, categories, precomputed);
+
+  const build = (): MinimapDensityQuery =>
+    new MinimapDensityQuery(
+      cache.getRectsByCategory(),
+      precomputed.totalDuration,
+      precomputed.maxDepth,
+      cache.getSegmentTree(),
+    );
+
+  if (digest) {
+    console.log('width,bucket,eventCount,maxDepth,dominantCategory');
+    for (const width of DIGEST_WIDTHS) {
+      const { buckets } = build().query(width);
+      for (let b = 0; b < buckets.length; b++) {
+        const bucket = buckets[b]!;
+        console.log(
+          `${width},${b},${bucket.eventCount},${bucket.maxDepth},${bucket.dominantCategory}`,
+        );
+      }
+    }
+    return;
+  }
+
+  let frames = 0;
+  for (const rects of cache.getRectsByCategory().values()) {
+    frames += rects.length;
+  }
+  console.log(`${frames} frames, maxDepth ${precomputed.maxDepth}`);
+
+  // Apart from the drag: the first query also pays the segment tree's deferred
+  // frame sort, and a resize never repeats it.
+  const query = build();
+  await time(`cold query(${COLD_WIDTH})`, () => query.query(COLD_WIDTH));
+
+  const drag: number[] = [];
+  for (let width = DRAG_FROM; width <= DRAG_TO; width++) {
+    const start = nowMs();
+    query.query(width);
+    drag.push(nowMs() - start);
+  }
+  const total = drag.reduce((sum, each) => sum + each, 0);
+  const sorted = [...drag].sort((a, b) => a - b);
+  const median = sorted[sorted.length >> 1]!;
+  console.log(
+    `drag ${DRAG_FROM}->${DRAG_TO}px                median ${ms(median)}ms  worst ${ms(sorted[sorted.length - 1]!)}ms  ${Math.round(total)}ms total`,
+  );
+
+  // The cache holds one width, and the drag left a different one, so warm it before
+  // timing: otherwise the first call is a miss and its recompute averages into all 100.
+  query.query(DRAG_TO);
+  const hitStart = nowMs();
+  for (let i = 0; i < 100; i++) {
+    query.query(DRAG_TO);
+  }
+  console.log(`cached, same width               ${ms((nowMs() - hitStart) / 100)}ms`);
+  console.log(`heap held                        ${heapMb()}MB`);
+}

--- a/scripts/tsconfig.json
+++ b/scripts/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "extends": "../log-viewer/tsconfig.json",
+  "compilerOptions": {
+    "lib": ["ES2023", "dom", "DOM.Iterable"],
+    "types": ["node"],
+    "composite": false,
+    "declarationMap": false,
+    "noEmit": true,
+    "paths": {
+      "apex-log-parser": ["../apex-log-parser/src/index.ts"]
+    }
+  },
+  "include": ["measure/**/*.ts"]
+}


### PR DESCRIPTION
Dragging the timeline's width cost **75-92ms a step** on a 95MB log, all of it in
`MinimapDensityQuery`. A height-only drag was 2-4ms, because the density cache is keyed by width
and hit.

The minimap paints one bar per pixel column, coloured by the category that was **on top** longest
in that column — the log seen from above — weighted so `DML`/`SOQL` stay visible under shallower
children. That semantic is unchanged. The cost was that "which frame is on top at time *t*" was
recomputed **inside every bucket, on every width**, though it is a property of the log and does not
depend on the minimap's width at all.

It is now built once per log as `MinimapSkylineIndex` — a stack sweep into typed arrays — and every
width walks it.

## Results

95MB log, 431,297 frames, 862,567 segments:

| | before | after |
| --- | --- | --- |
| width-drag step, median | 100.40ms | **3.72ms** |
| width-drag step, worst | — | 9.04ms |
| whole 200px drag | 22.16s | **0.74s** |
| theme switch | full recompute | free |
| frame objects built at init | 431k (~73ms) | **0** |

19MB committed sample: 20.62ms → **0.84ms** a step.

One bucket per display pixel is unchanged, so a wider screen still shows more detail.

## Proof the picture did not change

`pnpm measure minimap --digest` prints a CSV row per bucket (`width,bucket,eventCount,maxDepth,
dominantCategory`) across five widths. Against the branch point it differs in **0 of 5,035 rows**,
on the 19MB sample and on the 95MB log. Both logs also report **0 violations** and exactly **2.00
segments per frame**, so the sweep's containment guards never fire on real data.

There is one deliberate behaviour change the digest does not show, because neither log triggers it:
a frame ending exactly on a bucket boundary still counts toward that bucket's opacity but no longer
contributes a segment there, so the bucket draws no bar. The old code drew a full-height bar one
pixel past the frame's end.

## How it works

Segments **tile** the timeline — segment `i` spans `[segmentStarts[i], segmentStarts[i+1])` — so a
walk needs no bounds test and no segment-end array. A stretch with nothing running is a segment
with category id 0.

The sweep reads `PrecomputedRect` directly, so no per-event object is allocated for it, and
`TemporalSegmentTree` carries no minimap state. It sweeps once into a `2N + 2` bound (at most two
segments a frame, plus a trailing gap and a closer) and trims to views; measured slack across four
real logs is 14 to 2,709 bytes.

## Measured trade-offs, recorded so they are not retried

- **Frame bounds are copied into typed arrays** (6.6MB) rather than read off the rectangles.
  Reading the scattered rectangles costs 10-15ms a call against 1ms, and `countFrames` runs on
  every width change — it would put a resize step inside the frame budget.
- **`subarray` views, not `slice`.** Retained slack is 311 bytes on the 95MB log; copying to exact
  arrays would peak 9MB higher to reclaim it.
- **Sorting** stays a plain `Array.sort`. Keyed indices measured 26-47ms, an explicit k-way merge
  4-22ms, and the conversion's own traversal order 43ms, against 12ms shipped — it is cheap because
  each category group arrives time-ordered, so it merges a few runs. Per-depth runs are *not*
  time-ordered (40% inversions), so a depth-run merge is invalid.
- **The `onTopOrder` scratch** costs 0.73ms a step and buys the documented first-on-top tie-break.

## Also fixed here

Reviewing this branch surfaced a defect in the resize guard added by #982, so it is fixed in its
own commit with a regression test.

`resize`'s "nothing moved" guard read the main timeline height — the container less the minimap,
the metric strip and their gaps — so a change *inside* that overhead hid itself. The strip
appearing adds 15 + 4, and a container growing by the same 19px leaves the difference unchanged;
the minimap's height is clamped at 60 below ~605px, so it does not move either. Every value the
guard compared was equal while the layout had changed, so `mainTimelineYOffset` kept the offset for
a layout without the strip and **every hit test and tooltip sat 19px out** — 65px on
collapse/expand — until some unrelated resize. The next `ResizeObserver` delivery compared equal
too, so it did not self-correct.

The overhead is now compared for itself, added as an extra term rather than replacing the height
checks, so it can only apply a resize the old guard skipped and never skip one it applied.

## Accepted cost

Building the skyline is ~73ms on the first minimap draw, over the 50ms synchronous budget in
`.claude/rules/log-viewer.md`. Taken deliberately: it is paid once per log, against the ~100ms it
used to cost on *every pixel* of a width drag. Recorded in the file header so it is not read as an
oversight.

## Follow-ups, not in this PR

- One shared category id table: the same name→index map is built in `MinimapSkylineIndex`,
  `BucketColorResolver`, `TemporalSegmentTree` and per-call in `HitDetector`.
- `resolveDominantCategory` duplicates `BucketColorResolver`'s priority tie-break.
- `mergeManagedPackageEvents` can extend an event's `exitStamp` past a sibling's, which is what the
  sweep's `violations` counter exists to detect. Nothing surfaces it in the app today.

## Testing

- `pnpm lint`, `pnpm test` — 2,107 tests, 163 suites, green.
- New `MinimapSkylineIndex` suite covering gaps, the tail after the last frame, equal starts,
  containment, same-depth overlap, zero duration and an empty log.
- Checked by hand in the dev host, light and dark: same bands and heights, colours track a slow
  width drag without flicker, a height-only drag recomputes nothing, and a theme switch recolours
  without changing shape.
