### PR TITLE
fix(lana): follow-ups to the URI-safe file access migration

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -3,6 +3,9 @@ import { defineConfig, globalIgnores } from 'eslint/config';
 import prettierConfig from 'eslint-config-prettier/flat';
 import tseslint from 'typescript-eslint';
 
+const NO_NODE_BUILTINS =
+  'lana also runs in the VS Code web extension host, where the bundler stubs these to empty modules and the failure only shows at runtime. Use the vscode API or vscode-uri Utils.';
+
 export default defineConfig(
   globalIgnores([
     // agent worktrees/scratch: nested repo copies that would otherwise be
@@ -96,6 +99,34 @@ export default defineConfig(
       '@typescript-eslint/no-import-type-side-effects': 'error',
       curly: 'warn',
       eqeqeq: 'warn',
+    },
+  },
+  {
+    files: ['lana/src/**/*.ts'],
+    ignores: [
+      'lana/src/commands/RetrieveLogFile.ts',
+      'lana/src/commands/__tests__/RetrieveLogFile.test.ts',
+      'lana/src/services/**',
+    ],
+    rules: {
+      'no-restricted-imports': [
+        'error',
+        {
+          // Bare names only: a `patterns` glob would also catch our own lana/src/fs/.
+          paths: ['fs', 'fs/promises', 'os', 'path', 'crypto', 'child_process'].map((name) => ({
+            name,
+            message: NO_NODE_BUILTINS,
+          })),
+          patterns: [
+            { group: ['node:*'], message: NO_NODE_BUILTINS },
+            {
+              group: ['**/services/salesforceServices*'],
+              message:
+                'Salesforce Services is for org operations and throws until ensureServicesAvailable() has run. Use lana/src/fs/workspaceFs.ts for file I/O.',
+            },
+          ],
+        },
+      ],
     },
   },
 );

--- a/lana/src/__tests__/mocks/vscode.ts
+++ b/lana/src/__tests__/mocks/vscode.ts
@@ -126,6 +126,16 @@ export class TabInputText {
   }
 }
 
+export class TabInputTextDiff {
+  readonly original: ReturnType<typeof Uri.parse>;
+  readonly modified: ReturnType<typeof Uri.parse>;
+
+  constructor(original: ReturnType<typeof Uri.parse>, modified: ReturnType<typeof Uri.parse>) {
+    this.original = original;
+    this.modified = modified;
+  }
+}
+
 // Mock RelativePattern (constructor used for glob searches)
 export const RelativePattern = jest.fn();
 
@@ -334,6 +344,7 @@ export const window = {
   createWebviewPanel: jest.fn(),
   tabGroups: {
     activeTabGroup: { activeTab: undefined as { input: unknown } | undefined },
+    all: [] as { tabs: { input: unknown }[] }[],
     onDidChangeTabs: jest.fn((_listener: (event: unknown) => unknown) => ({
       dispose: jest.fn(),
     })),
@@ -540,6 +551,12 @@ export const resetMocks = (): void => {
   window.activeTextEditor = undefined;
   window.visibleTextEditors = [];
   window.tabGroups.activeTabGroup.activeTab = undefined;
+  window.tabGroups.all = [];
+};
+
+/** Arranges open tabs for isOpenAsTextTab; one group is enough for most tests. */
+export const setOpenTabs = (...inputs: unknown[]): void => {
+  window.tabGroups.all = [{ tabs: inputs.map((input) => ({ input })) }];
 };
 
 // Export as default for module replacement
@@ -550,6 +567,7 @@ export default {
   ViewColumn,
   Uri,
   TabInputText,
+  TabInputTextDiff,
   RelativePattern,
   FoldingRange,
   FoldingRangeKind,

--- a/lana/src/codelenses/ShowAnalysisCodeLens.ts
+++ b/lana/src/codelenses/ShowAnalysisCodeLens.ts
@@ -1,6 +1,7 @@
 import { CodeLens, Range, languages, type CodeLensProvider, type TextDocument } from 'vscode';
 
 import type { Context } from '../Context.js';
+import { isOpenAsTextTab } from '../editor/TabState.js';
 import { ShowLogAnalysis } from '../commands/ShowLogAnalysis.js';
 import { isApexLogContent } from '../language/ApexLogLanguageDetector.js';
 
@@ -12,7 +13,7 @@ class ShowAnalysisCodeLens implements CodeLensProvider {
   }
 
   async provideCodeLenses(document: TextDocument): Promise<CodeLens[]> {
-    if (!isApexLogContent(document)) {
+    if (!isOpenAsTextTab(document.uri) || !isApexLogContent(document)) {
       return [];
     }
 

--- a/lana/src/commands/LogView.ts
+++ b/lana/src/commands/LogView.ts
@@ -177,9 +177,13 @@ export class LogView {
             if (isSaveFileRequest(payload)) {
               const { fileContent, options } = payload;
               const defaultWorkspace = (workspace.workspaceFolders || [])[0];
-              const defaultDir = defaultWorkspace?.uri ?? context.context.extensionUri;
               const destinationFile = await vscWindow.showSaveDialog({
-                defaultUri: Utils.joinPath(defaultDir, options.defaultFileName),
+                // With no workspace folder, let VS Code pick its own last-used location:
+                // the extension's install directory is wrong, and os.homedir() is a web
+                // polyfill that reports '/'.
+                defaultUri: defaultWorkspace
+                  ? Utils.joinPath(defaultWorkspace.uri, options.defaultFileName)
+                  : undefined,
               });
 
               if (destinationFile) {

--- a/lana/src/decorations/RawLogLineDecoration.ts
+++ b/lana/src/decorations/RawLogLineDecoration.ts
@@ -15,6 +15,7 @@ import type { LogEvent } from 'apex-log-parser';
 
 import type { Context } from '../Context.js';
 import { LogEventCache } from '../cache/LogEventCache.js';
+import { isOpenAsTextTab } from '../editor/TabState.js';
 import { isApexLogContent } from '../language/ApexLogLanguageDetector.js';
 import { buildMetricParts, formatDuration, TIMESTAMP_REGEX } from '../log-utils.js';
 
@@ -89,6 +90,11 @@ export class RawLogLineDecoration {
 
     const timestamp = parseInt(match[1], 10);
     const filePath = document.uri.toString();
+
+    if (!isOpenAsTextTab(document.uri)) {
+      this.clearDecorations(editor);
+      return;
+    }
 
     const apexLog = await LogEventCache.getApexLog(document.uri);
     if (!apexLog) {

--- a/lana/src/editor/TabState.ts
+++ b/lana/src/editor/TabState.ts
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2026 Certinia Inc. All rights reserved.
+ */
+import { TabInputText, window, type Uri } from 'vscode';
+
+/**
+ * True when `uri` is open as a plain text tab.
+ *
+ * A URI can back a TextDocument the user is not reading: either side of a diff,
+ * a notebook cell, a custom editor's backing document. Those fire
+ * onDidOpenTextDocument and appear in workspace.textDocuments like any other
+ * open, so work that costs a full read and parse must be gated on this —
+ * diffing a log should not parse it.
+ *
+ * Deliberately not a scheme check: a scheme names the filesystem provider, not
+ * how the resource is shown, and a memfs: or vscode-vfs: log in a normal tab is
+ * a normal open. Allow-list rather than a diff deny-list so tab kinds this build
+ * has never seen count as "not viewing", the safe direction for a gate.
+ */
+export function isOpenAsTextTab(uri: Uri): boolean {
+  const key = uri.toString();
+  for (const group of window.tabGroups.all) {
+    for (const tab of group.tabs) {
+      if (tab.input instanceof TabInputText && tab.input.uri.toString() === key) {
+        return true;
+      }
+    }
+  }
+  return false;
+}

--- a/lana/src/editor/__tests__/TabState.test.ts
+++ b/lana/src/editor/__tests__/TabState.test.ts
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2026 Certinia Inc. All rights reserved.
+ */
+import { describe, expect, it } from '@jest/globals';
+
+import {
+  TabInputText,
+  TabInputTextDiff,
+  Uri,
+  setOpenTabs,
+  window,
+} from '../../__tests__/mocks/vscode.js';
+import { isOpenAsTextTab } from '../TabState.js';
+
+describe('isOpenAsTextTab', () => {
+  it('is true for a URI open as a plain text tab', () => {
+    const uri = Uri.file('/logs/run.log');
+    setOpenTabs(new TabInputText(uri));
+
+    expect(isOpenAsTextTab(uri)).toBe(true);
+  });
+
+  it('is true when the tab is in a non-active group', () => {
+    const uri = Uri.file('/logs/run.log');
+    window.tabGroups.all = [
+      { tabs: [{ input: new TabInputText(Uri.file('/other.log')) }] },
+      { tabs: [{ input: new TabInputText(uri) }] },
+    ];
+
+    expect(isOpenAsTextTab(uri)).toBe(true);
+  });
+
+  it('is false for a URI shown only as a diff side', () => {
+    const original = Uri.parse('git:/repo/run.log');
+    const modified = Uri.file('/repo/run.log');
+    setOpenTabs(new TabInputTextDiff(original, modified));
+
+    expect(isOpenAsTextTab(original)).toBe(false);
+    expect(isOpenAsTextTab(modified)).toBe(false);
+  });
+
+  it('is true when the same URI is open in a diff and in a normal tab', () => {
+    const uri = Uri.file('/repo/run.log');
+    setOpenTabs(new TabInputTextDiff(Uri.parse('git:/repo/run.log'), uri), new TabInputText(uri));
+
+    expect(isOpenAsTextTab(uri)).toBe(true);
+  });
+
+  it('is not a scheme check: a memfs log in a normal tab counts', () => {
+    const uri = Uri.parse('memfs:/logs/virtual.log');
+    setOpenTabs(new TabInputText(uri));
+
+    expect(isOpenAsTextTab(uri)).toBe(true);
+  });
+
+  it('is false for tab kinds it does not recognise', () => {
+    const uri = Uri.file('/logs/run.log');
+    setOpenTabs({});
+
+    expect(isOpenAsTextTab(uri)).toBe(false);
+  });
+
+  it('is false when no tabs are open', () => {
+    expect(isOpenAsTextTab(Uri.file('/logs/run.log'))).toBe(false);
+  });
+});

--- a/lana/src/folding/RawLogFoldingProvider.ts
+++ b/lana/src/folding/RawLogFoldingProvider.ts
@@ -17,6 +17,7 @@ import type { LogEvent } from 'apex-log-parser';
 
 import type { Context } from '../Context.js';
 import { LogEventCache } from '../cache/LogEventCache.js';
+import { isOpenAsTextTab } from '../editor/TabState.js';
 import { isApexLogContent } from '../language/ApexLogLanguageDetector.js';
 import { TIMESTAMP_REGEX } from '../log-utils.js';
 
@@ -28,6 +29,10 @@ class RawLogFoldingProvider implements FoldingRangeProvider {
     document: TextDocument,
     _context: FoldingContext,
   ): Promise<FoldingRange[]> {
+    if (!isOpenAsTextTab(document.uri)) {
+      return [];
+    }
+
     const apexLog = await LogEventCache.getApexLog(document.uri);
 
     if (!apexLog) {
@@ -86,7 +91,7 @@ class RawLogFoldingProvider implements FoldingRangeProvider {
    * unrelated action forces a re-evaluation.
    */
   private warmAndSignal(document: TextDocument): void {
-    if (!isApexLogContent(document)) {
+    if (!isOpenAsTextTab(document.uri) || !isApexLogContent(document)) {
       return;
     }
 
@@ -104,11 +109,17 @@ class RawLogFoldingProvider implements FoldingRangeProvider {
     context.context.subscriptions.push(
       provider.changeEmitter,
       languages.registerFoldingRangeProvider(docSelector, provider),
-      workspace.onDidOpenTextDocument((doc) => {
-        provider.warmAndSignal(doc);
+      // Not onDidOpenTextDocument: it fires before the tab model is updated, so the
+      // gate would reject a legitimate open. A tab change is also the repair path —
+      // a folding request that lost the race is re-requested by the next fire().
+      window.tabGroups.onDidChangeTabs(() => {
+        const editor = window.activeTextEditor;
+        if (editor) {
+          provider.warmAndSignal(editor.document);
+        }
       }),
       // Reopening a closed editor often re-attaches the retained document model
-      // without re-firing onDidOpenTextDocument, so also signal on editor activation.
+      // without re-firing the tab change, so also signal on editor activation.
       window.onDidChangeActiveTextEditor((editor) => {
         if (editor) {
           provider.warmAndSignal(editor.document);

--- a/lana/src/folding/__tests__/RawLogFoldingProvider.test.ts
+++ b/lana/src/folding/__tests__/RawLogFoldingProvider.test.ts
@@ -10,7 +10,12 @@ import {
   createMockContext,
   createMockLogEvent,
 } from '../../__tests__/helpers/test-builders.js';
-import { createMockTextDocument } from '../../__tests__/mocks/vscode.js';
+import {
+  TabInputText,
+  Uri,
+  createMockTextDocument,
+  setOpenTabs,
+} from '../../__tests__/mocks/vscode.js';
 import { LogEventCache } from '../../cache/LogEventCache.js';
 import { RawLogFoldingProvider } from '../RawLogFoldingProvider.js';
 
@@ -29,6 +34,8 @@ describe('RawLogFoldingProvider', () => {
   beforeEach(() => {
     provider = new RawLogFoldingProvider();
     mockGetApexLog.mockReset();
+    // The provider only works for a document the user has open as a text tab.
+    setOpenTabs(new TabInputText(Uri.file('/test/file.log')));
   });
 
   describe('provideFoldingRanges', () => {
@@ -317,12 +324,15 @@ describe('RawLogFoldingProvider', () => {
       );
     });
 
-    it('should register an onDidOpenTextDocument listener', () => {
+    it('warms on tab changes, not on document open', () => {
       const mockContext = createMockContext();
 
       RawLogFoldingProvider.apply(mockContext as unknown as import('../../Context.js').Context);
 
-      expect(workspace.onDidOpenTextDocument).toHaveBeenCalledTimes(1);
+      // onDidOpenTextDocument fires before the tab model updates, so isOpenAsTextTab
+      // would reject a legitimate open.
+      expect(window.tabGroups.onDidChangeTabs).toHaveBeenCalledTimes(1);
+      expect(workspace.onDidOpenTextDocument).not.toHaveBeenCalled();
     });
 
     it('should add disposables to context subscriptions', () => {
@@ -330,7 +340,7 @@ describe('RawLogFoldingProvider', () => {
 
       RawLogFoldingProvider.apply(mockContext as unknown as import('../../Context.js').Context);
 
-      // emitter + folding provider registration + open listener + active-editor listener
+      // emitter + folding provider registration + tab listener + active-editor listener
       expect(mockContext.context.subscriptions.length).toBe(4);
     });
   });
@@ -345,11 +355,17 @@ describe('RawLogFoldingProvider', () => {
 
       const registeredProvider = (languages.registerFoldingRangeProvider as jest.Mock).mock
         .calls[0]?.[1] as RawLogFoldingProvider;
-      const openHandler = (workspace.onDidOpenTextDocument as jest.Mock).mock.calls[0]?.[0] as (
-        doc: unknown,
+      const tabsHandler = (window.tabGroups.onDidChangeTabs as jest.Mock).mock.calls[0]?.[0] as (
+        event: unknown,
       ) => void;
       const activeEditorHandler = (window.onDidChangeActiveTextEditor as jest.Mock).mock
         .calls[0]?.[0] as (editor: unknown) => void;
+
+      // The tab handler reads the active editor rather than taking a document.
+      const openHandler = (doc: unknown) => {
+        window.activeTextEditor = { document: doc } as typeof window.activeTextEditor;
+        tabsHandler({});
+      };
 
       return { registeredProvider, openHandler, activeEditorHandler };
     }

--- a/lana/src/hovers/RawLogHoverProvider.ts
+++ b/lana/src/hovers/RawLogHoverProvider.ts
@@ -13,6 +13,7 @@ import {
 } from 'vscode';
 
 import { LogEventCache } from '../cache/LogEventCache.js';
+import { isOpenAsTextTab } from '../editor/TabState.js';
 import type { Context } from '../Context.js';
 import { buildMetricParts, TIMESTAMP_REGEX } from '../log-utils.js';
 
@@ -22,6 +23,10 @@ class RawLogHoverProvider implements HoverProvider {
     const match = line.text.match(TIMESTAMP_REGEX);
 
     if (!match?.[1]) {
+      return null;
+    }
+
+    if (!isOpenAsTextTab(document.uri)) {
       return null;
     }
 

--- a/lana/src/language/ApexLogLanguageDetector.ts
+++ b/lana/src/language/ApexLogLanguageDetector.ts
@@ -19,8 +19,6 @@ const EXECUTION_STARTED = /^\d{2}:\d{2}:\d{2}\.\d{1,} \(\d+\)\|EXECUTION_STARTED
 const USER_INFO = /^\d{2}:\d{2}:\d{2}\.\d{1,} \(\d+\)\|USER_INFO\|/;
 const DETECT_EXTENSIONS = new Set(['.log', '.txt']);
 const MAX_LINES_TO_CHECK = 100;
-const MAX_BYTES_TO_READ = 4096;
-let contextUpdateGeneration = 0;
 
 export function isApexLogContent(doc: TextDocument): boolean {
   if (doc.lineCount === 0) {
@@ -38,29 +36,6 @@ export function isApexLogContent(doc: TextDocument): boolean {
   return false;
 }
 
-export async function isApexLogFile(uri: Uri): Promise<boolean> {
-  try {
-    const text = await readFilePrefix(uri);
-    const lines = text.split(/\r?\n/);
-
-    const linesToCheck = Math.min(MAX_LINES_TO_CHECK, lines.length);
-    for (let i = 0; i < linesToCheck; i++) {
-      const line = lines[i] ?? '';
-      if (APEXLOG_HEADER.test(line) || EXECUTION_STARTED.test(line) || USER_INFO.test(line)) {
-        return true;
-      }
-    }
-    return false;
-  } catch {
-    return false;
-  }
-}
-
-async function readFilePrefix(uri: Uri): Promise<string> {
-  const bytes = await workspace.fs.readFile(uri);
-  return new TextDecoder().decode(bytes.subarray(0, MAX_BYTES_TO_READ));
-}
-
 function hasDetectExtension(uri: Uri): boolean {
   return DETECT_EXTENSIONS.has(Utils.extname(uri).toLowerCase());
 }
@@ -74,38 +49,20 @@ function getActiveTabUri(): Uri | undefined {
 }
 
 function updateContextKey(): void {
-  const generation = ++contextUpdateGeneration;
   const editor = window.activeTextEditor;
   if (editor) {
     const doc = editor.document;
-    if (hasDetectExtension(doc.uri)) {
-      const detected = isApexLogContent(doc);
-      commands.executeCommand('setContext', 'lana.isApexLog', detected);
-      return;
-    }
-    commands.executeCommand('setContext', 'lana.isApexLog', false);
+    const detected = hasDetectExtension(doc.uri) && isApexLogContent(doc);
+    commands.executeCommand('setContext', 'lana.isApexLog', detected);
     return;
   }
 
-  // Fallback to tab API for large files where activeTextEditor is undefined
+  // No text document, so the only way here is a file VS Code refused to open as one.
+  // Sniffing it means pulling the whole file through workspace.fs, which has no ranged
+  // read: a full read and allocation on every tab event, over an RPC in the web host.
+  // Trust the extension instead and accept offering the command on a large non-Apex file.
   const tabUri = getActiveTabUri();
-  if (tabUri && hasDetectExtension(tabUri)) {
-    const tabKey = tabUri.toString();
-    void isApexLogFile(tabUri).then((detected) => {
-      const activeTabUri = getActiveTabUri();
-      if (
-        generation !== contextUpdateGeneration ||
-        window.activeTextEditor ||
-        activeTabUri?.toString() !== tabKey
-      ) {
-        return;
-      }
-      commands.executeCommand('setContext', 'lana.isApexLog', detected);
-    });
-    return;
-  }
-
-  commands.executeCommand('setContext', 'lana.isApexLog', false);
+  commands.executeCommand('setContext', 'lana.isApexLog', !!tabUri && hasDetectExtension(tabUri));
 }
 
 export class ApexLogLanguageDetector {

--- a/lana/src/language/__tests__/ApexLogLanguageDetector.test.ts
+++ b/lana/src/language/__tests__/ApexLogLanguageDetector.test.ts
@@ -13,11 +13,7 @@ import {
   window,
   workspace,
 } from '../../__tests__/mocks/vscode.js';
-import {
-  ApexLogLanguageDetector,
-  isApexLogContent,
-  isApexLogFile,
-} from '../ApexLogLanguageDetector.js';
+import { ApexLogLanguageDetector, isApexLogContent } from '../ApexLogLanguageDetector.js';
 
 describe('isApexLogContent', () => {
   it('should detect standard log with settings header on line 1', () => {
@@ -108,31 +104,6 @@ describe('isApexLogContent', () => {
   });
 });
 
-describe('isApexLogFile', () => {
-  it('decodes only the first 4 KB returned by the filesystem provider', async () => {
-    const prefix = 'not an Apex log'.padEnd(4096, ' ');
-    workspace.fs.readFile.mockResolvedValue(
-      new TextEncoder().encode(`${prefix}09:45:31.888 (1000)|EXECUTION_STARTED`),
-    );
-    const uri = Uri.file('/logs/large.log');
-
-    await expect(isApexLogFile(uri)).resolves.toBe(false);
-
-    expect(workspace.fs.readFile).toHaveBeenCalledWith(uri);
-  });
-
-  it('uses the registered filesystem provider for an arbitrary URI scheme', async () => {
-    workspace.fs.readFile.mockResolvedValue(
-      new TextEncoder().encode('09:45:31.888 (1000)|EXECUTION_STARTED'),
-    );
-    const uri = Uri.parse('git:/repository/logs/virtual.log');
-
-    await expect(isApexLogFile(uri)).resolves.toBe(true);
-
-    expect(workspace.fs.readFile).toHaveBeenCalledWith(uri);
-  });
-});
-
 describe('ApexLogLanguageDetector', () => {
   it.each(['log', 'txt'])('detects .%s Apex logs from arbitrary URI schemes', (extension) => {
     const doc = createMockTextDocument({
@@ -166,39 +137,49 @@ describe('ApexLogLanguageDetector', () => {
     expect(languages.setTextDocumentLanguage).not.toHaveBeenCalled();
   });
 
-  it('does not publish a stale async result after the active tab changes', async () => {
-    let resolveSlowRead: ((bytes: Uint8Array) => void) | undefined;
-    const slowRead = new Promise<Uint8Array>((resolve) => {
-      resolveSlowRead = resolve;
-    });
-    const slowUri = Uri.parse('memfs:/logs/slow.log');
-    const fastUri = Uri.parse('memfs:/logs/fast.log');
-    workspace.fs.readFile.mockImplementation((uri: { path: string }) =>
-      uri.path === slowUri.path
-        ? slowRead
-        : Promise.resolve(new TextEncoder().encode('not an Apex log')),
-    );
-
-    let notifyTabsChanged: (() => void) | undefined;
-    window.tabGroups.onDidChangeTabs.mockImplementation((listener: (event: unknown) => void) => {
-      notifyTabsChanged = () => listener({});
-      return { dispose: jest.fn() };
-    });
-    window.tabGroups.activeTabGroup.activeTab = { input: new TabInputText(slowUri) };
+  it('sets the key from the extension alone when there is no text document', () => {
+    window.tabGroups.activeTabGroup.activeTab = {
+      input: new TabInputText(Uri.parse('memfs:/logs/huge.log')),
+    };
 
     ApexLogLanguageDetector.apply(
       createMockContext() as unknown as import('../../Context.js').Context,
     );
-    window.tabGroups.activeTabGroup.activeTab = { input: new TabInputText(fastUri) };
-    notifyTabsChanged?.();
-    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(commands.executeCommand).toHaveBeenLastCalledWith('setContext', 'lana.isApexLog', true);
+  });
+
+  it('never reads the file when there is no text document', () => {
+    window.tabGroups.activeTabGroup.activeTab = {
+      input: new TabInputText(Uri.parse('memfs:/logs/huge.log')),
+    };
+
+    ApexLogLanguageDetector.apply(
+      createMockContext() as unknown as import('../../Context.js').Context,
+    );
+
+    expect(workspace.fs.readFile).not.toHaveBeenCalled();
+  });
+
+  it('clears the key for a non-log extension in the tab fallback', () => {
+    window.tabGroups.activeTabGroup.activeTab = {
+      input: new TabInputText(Uri.parse('memfs:/notes.json')),
+    };
+
+    ApexLogLanguageDetector.apply(
+      createMockContext() as unknown as import('../../Context.js').Context,
+    );
 
     expect(commands.executeCommand).toHaveBeenLastCalledWith('setContext', 'lana.isApexLog', false);
+  });
 
-    resolveSlowRead?.(new TextEncoder().encode('09:45:31.888 (1000)|EXECUTION_STARTED'));
-    await slowRead;
-    await new Promise((resolve) => setTimeout(resolve, 0));
+  it('clears the key when the active tab is not a text tab', () => {
+    window.tabGroups.activeTabGroup.activeTab = { input: {} };
 
-    expect(commands.executeCommand).not.toHaveBeenCalledWith('setContext', 'lana.isApexLog', true);
+    ApexLogLanguageDetector.apply(
+      createMockContext() as unknown as import('../../Context.js').Context,
+    );
+
+    expect(commands.executeCommand).toHaveBeenLastCalledWith('setContext', 'lana.isApexLog', false);
   });
 });

--- a/lana/src/symbols/RawLogSymbolProvider.ts
+++ b/lana/src/symbols/RawLogSymbolProvider.ts
@@ -16,6 +16,7 @@ import type { LogEvent } from 'apex-log-parser';
 
 import type { Context } from '../Context.js';
 import { LogEventCache } from '../cache/LogEventCache.js';
+import { isOpenAsTextTab } from '../editor/TabState.js';
 import { formatDuration, TIMESTAMP_REGEX } from '../log-utils.js';
 
 /**
@@ -29,6 +30,10 @@ class RawLogSymbolProvider implements DocumentSymbolProvider {
     document: TextDocument,
     _token: CancellationToken,
   ): Promise<DocumentSymbol[]> {
+    if (!isOpenAsTextTab(document.uri)) {
+      return [];
+    }
+
     const apexLog = await LogEventCache.getApexLog(document.uri);
 
     if (!apexLog) {

--- a/lana/src/symbols/__tests__/RawLogSymbolProvider.test.ts
+++ b/lana/src/symbols/__tests__/RawLogSymbolProvider.test.ts
@@ -10,7 +10,12 @@ import {
   createMockContext,
   createMockLogEvent,
 } from '../../__tests__/helpers/test-builders.js';
-import { createMockTextDocument } from '../../__tests__/mocks/vscode.js';
+import {
+  TabInputText,
+  Uri,
+  createMockTextDocument,
+  setOpenTabs,
+} from '../../__tests__/mocks/vscode.js';
 import { LogEventCache } from '../../cache/LogEventCache.js';
 import { RawLogSymbolProvider } from '../RawLogSymbolProvider.js';
 
@@ -28,6 +33,8 @@ describe('RawLogSymbolProvider', () => {
   beforeEach(() => {
     provider = new RawLogSymbolProvider();
     mockGetApexLog.mockReset();
+    // The provider only works for a document the user has open as a text tab.
+    setOpenTabs(new TabInputText(Uri.file('/test/file.log')));
   });
 
   describe('provideDocumentSymbols', () => {

--- a/log-viewer/src/components/LogTitle.ts
+++ b/log-viewer/src/components/LogTitle.ts
@@ -85,6 +85,6 @@ export class LogTitle extends LitElement {
   }
 
   _goToLog() {
-    vscodeMessenger.send<string>('openPath', this.logPath);
+    vscodeMessenger.send('openPath');
   }
 }


### PR DESCRIPTION
# PR overview

The remaining findings from the #952 review, after #988 took the blocking one.
Five independent commits; any can be dropped without affecting the others.

## Changes made

**Stop reading the whole log to set the context key.** The tab fallback only runs
when VS Code refused to open the file as a document, so sniffing it pulled the
entire file through `workspace.fs`, which has no ranged read. Measured on the
19.7MB sample log: **0.056ms to 2.9ms and a 163MB RSS peak, on every tab event** —
and worse over the provider RPC in the web host, where a 100MB log allocates
100MB inside a browser tab. It now decides from the `.log`/`.txt` extension
there, which makes the branch synchronous and retires the generation guards
added for the async read. Closes the thread left open on #952.

**Only parse a log the user is viewing as a text tab.** Dropping the
`scheme: 'file'` selectors in #952 was right and is not reverted here, but it let
`warmAndSignal` parse either side of a diff — a full read and parse of a log
being diffed, evicting real entries from the 10-item cache. New
`isOpenAsTextTab` gates the UI-driven callers (folding warm and provider,
document symbols, the line decoration, the code lens). Explicit commands stay
ungated since they can run with no tab open.

**Stop the save dialog defaulting to the extension directory.** With no workspace
folder open it offered to save inside `~/.vscode/extensions/financialforce.lana-*/`.

**Drop the ignored `openPath` payload.** The extension uses its captured log URI,
not the display path the webview sends.

**Ban node builtins and Salesforce Services file I/O in `lana/src`.** Both
failures are silent: the web bundle stubs node builtins to empty modules so an
import only fails at runtime in the web host, and Salesforce Services throws
until `ensureServicesAvailable()` has run — which `LogEventCache` swallowed,
silently disabling folding, symbols, sticky scroll and the line decoration until
#988.

## Behaviour changes to be aware of

- The command is now offered on a very large `.txt`/`.log` that is not an Apex
  log, where it reports a parse error. That is the trade for never doing a
  full read per tab event, and it only applies to files too big to open as a
  document.
- The code lens no longer appears on either side of a diff. Clicking it would
  have parsed the log, which is the work being avoided.
- Folding warms on `onDidChangeTabs` rather than `onDidOpenTextDocument`, which
  fires before the tab model updates and would make the gate reject a legitimate
  open. The tab change is also the repair path if a folding request loses the
  race.

## Type of change

- [x] Bug fix
- [x] Performance

## Related issues

related W-23939830

## Validation

- `tsc -b lana` clean, `eslint` clean
- **2104 tests across 163 suites** pass
- New `TabState` suite covers the diff-side case in both directions and pins that
  the gate is not a scheme check, so a `memfs:` log in a normal tab still works
- New detector case asserts `workspace.fs.readFile` is never called when there is
  no text document
- The lint rule was verified against a probe file importing both banned kinds

## Still needs a manual check

`DocumentSymbolProvider` has no change event, so it has no repair path if a
symbols request ever loses the tab-model race. Opening a log fresh from the
explorer in a cold window should populate the Outline and pin sticky scroll.