### PR TITLE
ci: gate merges on one aggregate job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,3 +81,16 @@ jobs:
         run: |
           cd lana
           vsce package --no-dependencies
+
+  gate:
+    # The single required status check: the ruleset never needs updating when jobs change.
+    name: CI Gate
+    needs: [verify_files, tests, build]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check job results
+        if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') || contains(needs.*.result, 'skipped')
+        run: |
+          echo "A required job did not succeed."
+          exit 1


### PR DESCRIPTION
## What

Adds a `CI Gate` job to `ci.yml`. It needs `verify_files`, `tests` and `build`, and fails if any of them failed, was cancelled or was skipped.

## Why

A branch ruleset names each required status check exactly. Today that means adding, renaming or splitting a CI job also needs a ruleset edit, which is easy to forget and silently drops a check. With a gate job the ruleset needs only `CI / CI Gate`, and the job list stays in `ci.yml` where it belongs.

`if: always()` matters: without it a failed dependency leaves the gate **skipped**, and GitHub counts a skipped check as a pass.

## After merge

- Switch the ruleset to require `CI / CI Gate` and drop the per-job entries.
- CodeQL is a separate workflow, so a gate cannot cover it. `CodeQL / Analyze (javascript-typescript)` stays required on its own.
- Adding a job to `ci.yml` now means adding it to the gate's `needs` list.