### PR TITLE
test(lana): fix the web e2e log fixture

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,4 @@
 *.log filter=lfs diff=lfs merge=lfs -text
+
+# e2e fixture: small enough to keep in git, and LFS pointers are not Apex logs
+lana/test/playwright/fixtures/*.log -filter diff merge text

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,21 +79,21 @@ jobs:
       - name: Tests
         run: pnpm run test:e2e:web
       - name: Upload Playwright HTML report
-        if: always()
+        if: failure()
         uses: actions/upload-artifact@v4
         with:
           name: playwright-report-web
           path: lana/playwright-report/web
           if-no-files-found: ignore
-          retention-days: 14
+          retention-days: 7
       - name: Upload Playwright test results
-        if: always()
+        if: failure()
         uses: actions/upload-artifact@v4
         with:
           name: playwright-test-results-web
           path: lana/test-results/web
           if-no-files-found: ignore
-          retention-days: 14
+          retention-days: 7
 
   build:
     name: Verify VSCode Package Build

--- a/lana/test/playwright/fixtures/apex-log.log
+++ b/lana/test/playwright/fixtures/apex-log.log
@@ -1,0 +1,28 @@
+64.0 APEX_CODE,FINE;APEX_PROFILING,FINE;CALLOUT,FINEST;DATA_ACCESS,INFO;DB,FINEST;NBA,FINE;SYSTEM,FINE;VALIDATION,INFO;VISUALFORCE,FINE;WAVE,FINE;WORKFLOW,FINE
+Execute Anonymous: AccountService.createAccountsAndContacts();
+10:29:24.6 (6297619)|USER_INFO|[EXTERNAL]|005Ea00000R6orz|first-last@example.com|(GMT-07:00) Pacific Daylight Time (America/Los_Angeles)|GMT-07:00
+10:29:24.6 (6329577)|EXECUTION_STARTED
+10:29:24.6 (6337821)|CODE_UNIT_STARTED|[EXTERNAL]|execute_anonymous_apex
+10:29:24.6 (6957638)|SYSTEM_MODE_ENTER|false
+10:29:24.6 (84434204)|METHOD_ENTRY|[5]|01pEa00000CgcGT|AccountService.AccountService()
+10:29:24.6 (84539933)|SYSTEM_METHOD_ENTRY|[7]|com.salesforce.api.interop.apex.bcl.DateMethods.newInstance(Integer, Integer, Integer)
+10:29:24.6 (84645761)|SYSTEM_METHOD_EXIT|[7]|com.salesforce.api.interop.apex.bcl.DateMethods.newInstance(Integer, Integer, Integer)
+10:29:24.6 (84669076)|METHOD_EXIT|[5]|AccountService
+10:29:24.6 (84707278)|METHOD_ENTRY|[1]|01pEa00000CgcGT|AccountService.createAccountsAndContacts()
+10:29:24.6 (84756747)|METHOD_ENTRY|[11]|01pEa00000CgcGT|AccountService.getRevenue()
+10:29:24.6 (84822141)|SYSTEM_METHOD_ENTRY|[120]|com.salesforce.api.interop.apex.bcl.DateMethods.today()
+10:29:24.6 (84859046)|SYSTEM_METHOD_EXIT|[120]|com.salesforce.api.interop.apex.bcl.DateMethods.today()
+10:29:24.6 (84869926)|METHOD_ENTRY|[120]|01pEa00000CgcGT|AccountService.getDayValue(Date)
+10:29:24.6 (84890620)|SYSTEM_METHOD_ENTRY|[142]|com.salesforce.api.interop.apex.bcl.DateMethods.daysBetween(Date)
+10:29:24.6 (84904980)|SYSTEM_METHOD_EXIT|[142]|com.salesforce.api.interop.apex.bcl.DateMethods.daysBetween(Date)
+10:29:24.6 (84949994)|SYSTEM_METHOD_ENTRY|[1]|Math.Math()
+10:29:24.6 (84998791)|SYSTEM_METHOD_EXIT|[1]|Math
+10:29:24.6 (85010745)|METHOD_ENTRY|[143]||System.Math.mod(Integer, Integer)
+10:29:24.6 (86075910)|METHOD_EXIT|[143]||System.Math.mod(Integer, Integer)
+10:29:24.6 (86151658)|METHOD_EXIT|[120]|01pEa00000CgcGT|AccountService.getDayValue(Date)
+10:29:24.6 (86198738)|SYSTEM_METHOD_ENTRY|[120]|Decimal.multiply(Decimal)
+10:29:24.6 (86225666)|SYSTEM_METHOD_EXIT|[120]|Decimal.multiply(Decimal)
+10:29:24.6 (86232986)|METHOD_EXIT|[11]|01pEa00000CgcGT|AccountService.getRevenue()
+10:29:24.6 (86300000)|METHOD_EXIT|[1]|01pEa00000CgcGT|AccountService.createAccountsAndContacts()
+10:29:24.6 (86400000)|CODE_UNIT_FINISHED|execute_anonymous_apex
+10:29:24.6 (86500000)|EXECUTION_FINISHED

--- a/lana/test/playwright/support/logAnalysis.ts
+++ b/lana/test/playwright/support/logAnalysis.ts
@@ -6,7 +6,7 @@ import {
   webviewActiveFrame,
 } from '@salesforce/playwright-vscode-ext';
 
-import { SAMPLE_LOG_NAME } from './logWorkspace';
+import { LOG_FILE_NAME } from './logWorkspace';
 
 export const assertLogAnalysisRenders = async (page: Page): Promise<void> => {
   const analysis = await webviewActiveFrame(page, hasContent('log-viewer'), {
@@ -14,15 +14,15 @@ export const assertLogAnalysisRenders = async (page: Page): Promise<void> => {
   });
 
   const flameChart = analysis.locator('timeline-flame-chart');
-  await expect(flameChart).toBeVisible({ timeout: 120_000 });
+  await expect(flameChart).toBeVisible({ timeout: 30_000 });
 
   await analysis.locator('vscode-tab-header').filter({ hasText: 'Call Tree' }).click();
   const callTree = analysis.locator('call-tree-view');
   await expect(callTree).toBeVisible();
-  await expect(callTree.locator('.tabulator-row').first()).toBeVisible({ timeout: 120_000 });
+  await expect(callTree.locator('.tabulator-row').first()).toBeVisible({ timeout: 30_000 });
 };
 
 export const openLogAnalysis = async (page: Page): Promise<void> => {
-  await openFileFromExplorerTree(page, SAMPLE_LOG_NAME);
+  await openFileFromExplorerTree(page, LOG_FILE_NAME);
   await executeCommandWithCommandPalette(page, 'Log: Show Apex Log Analysis');
 };

--- a/lana/test/playwright/support/logWorkspace.ts
+++ b/lana/test/playwright/support/logWorkspace.ts
@@ -3,12 +3,12 @@ import path from 'node:path';
 
 import { createTestWorkspace } from '@salesforce/playwright-vscode-ext';
 
-import { sampleLogPath } from './paths';
+import { fixtureLogPath } from './paths';
 
-export const SAMPLE_LOG_NAME = 'sample-log.log';
+export const LOG_FILE_NAME = 'apex-log.log';
 
 export const createLogWorkspace = async (): Promise<string> => {
   const workspaceDir = await createTestWorkspace();
-  await fs.copyFile(sampleLogPath, path.join(workspaceDir, SAMPLE_LOG_NAME));
+  await fs.copyFile(fixtureLogPath, path.join(workspaceDir, LOG_FILE_NAME));
   return workspaceDir;
 };

--- a/lana/test/playwright/support/paths.ts
+++ b/lana/test/playwright/support/paths.ts
@@ -2,5 +2,11 @@ import path from 'node:path';
 
 export const repoRoot = path.resolve(__dirname, '../../../..');
 export const extensionRoot = path.join(repoRoot, 'lana');
-export const sampleLogPath = path.join(repoRoot, 'sample-app', 'debug-logs', 'sample-log.log');
+export const fixtureLogPath = path.join(
+  extensionRoot,
+  'test',
+  'playwright',
+  'fixtures',
+  'apex-log.log',
+);
 export const vscodeWebTestPath = path.join(repoRoot, '.vscode-test-web');


### PR DESCRIPTION
# PR overview

Follow-up to #954. Fix web e2e + trims the job.

- Replace the e2e workspace log with a 28 line fixture, exempt from LFS.
- Upload the Playwright report and traces only when the e2e fails, and keep them 7 days not 14.

## Why the e2e failed

`.gitattributes` keeps every `*.log` in LFS. The `e2e` job checks out without `lfs: true`, so
`createLogWorkspace()` copied a 130 byte pointer into the test workspace and not text e.g

```
version https://git-lfs.github.com/spec/v1
oid sha256:f5fbbb9b17e9b614ac08e0e1bfd48aeb227e6c5cfba197b882e5d34a939a3bd3
size 19739334
```

That is not an Apex log, so `lana.isApexLog` stayed false and `Log: Show Apex Log Analysis`
never appeared in the command palette. All three attempts failed the same way.

A fixture is better than `lfs: true`: no LFS bandwidth on every run, and the job gets faster.
`sample-app/debug-logs/sample-log.log` is unchanged and still available for manual work.

## The fixture

A slice of `sample-log.log`: header, `USER_INFO`, `EXECUTION_STARTED`, `CODE_UNIT_STARTED`
and the  `AccountService.getRevenue()` subtree. 19,739,334 bytes to 2,418.

It parses into a 14 node tree over 5 levels with no log issues, so the Call Tree assertion has
plenty of rows:

```
LOG_ROOT
  EXECUTION_STARTED
    execute_anonymous_apex
      AccountService.AccountService()
      AccountService.createAccountsAndContacts()
        AccountService.getRevenue()
          AccountService.getDayValue(Date)
            System.Math.mod(Integer, Integer)
          ...
```

Drop `120_000` timeouts to `30_000` 


## Type of change

- [x] Bug fix
- [x] Test
- [x] Chore
