### PR TITLE
fix(lana): bundle the web extension as a single file

### DIFF
--- a/rolldown.config.ts
+++ b/rolldown.config.ts
@@ -41,7 +41,9 @@ export default defineConfig([
       format: 'cjs',
       dir: './lana/out/web',
       entryFileNames: 'Main.web.cjs',
-      chunkFileNames: 'lana-[name].js',
+      // The web extension host resolves only require('vscode'), so a split
+      // bundle cannot load its own chunks.
+      codeSplitting: false,
       sourcemap: false,
       keepNames: true,
       minify: production,

--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -66,7 +66,9 @@ export default [
       format: 'cjs',
       dir: './lana/out/web',
       entryFileNames: 'Main.web.cjs',
-      chunkFileNames: 'lana-[name].js',
+      // The web extension host resolves only require('vscode'), so a split
+      // bundle cannot load its own chunks.
+      inlineDynamicImports: true,
       sourcemap: false,
     },
     external: ['vscode'],


### PR DESCRIPTION
# PR overview

Follow-up to #953 and #957. `Log: Retrieve Apex Log And Show Analysis` cannot work in the web
extension host, because the web bundle is split across two files.

## The problem

The web extension host does not use Node's loader. It fetches the entry point as text and wraps
it:

```js
initFn = new Function('module', 'exports', 'require', fullSource);
```

The `require` it supplies resolves only `'vscode'`. `importScripts` is blocked, and `require`
and `define` are set to `undefined` in the worker. The docs say it plainly: "Importing or
requiring other modules is not supported... the code must be packaged to a single file."

Both web builds emitted two files:

```
lana/out/web/
  Main.web.cjs
  lana-salesforceServices.js
```

`RetrieveLogFile.ts:56` does `await import('../services/salesforceServices.js')`, which rollup
lowers to `require("./lana-salesforceServices.js")`. That require throws in the web host.

It sits in the lazy path near the end of the file, not at the top, so the extension still
activates and only Retrieve is affected.

## Changes made

- `rollup.config.mjs`: `inlineDynamicImports: true` on the web output.
- `rolldown.config.ts`: `codeSplitting: false` on the web output. Rolldown deprecates
  `inlineDynamicImports` in favour of this name, hence the difference.
- Drop `chunkFileNames` from both, now that neither emits a chunk.

## Type of change

- [x] Bug fix

## Validation

Built both paths, production mode:

| | before | after |
|---|---|---|
| rollup `lana/out/web/` | 2 files | **1 file**, `Main.web.cjs`, 806,071 bytes |
| rolldown `lana/out/web/` | 2 files | **1 file**, `Main.web.cjs` |
| requires in the entry | `require("vscode")` + `require("./lana-salesforceServices.js")` | **`require("vscode")` only** |

The desktop entry is unchanged and still ESM.

Not validated: I have not run this in a live web host, so the fix is verified against the
emitted bundle and the documented loader, not observed. The web e2e in CI exercises
`Log: Show Apex Log Analysis`, not Retrieve, so it will not catch this either way.

## Related

Considered and rejected in the same area: dropping `nodePolyfills()` from the web target. The
build succeeds without it, but 11 `process.` references survive, and while most are guarded by
`typeof process`, `path.resolve()`'s shim calls a bare `process.cwd()`. Removing the plugin
would turn a working shim into a latent `ReferenceError`, so it stays.