### PR TITLE
build(deps): bump actions/upload-artifact from 4 to 7

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,7 +80,7 @@ jobs:
         run: pnpm run test:e2e:web
       - name: Upload Playwright HTML report
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: playwright-report-web
           path: lana/playwright-report/web
@@ -88,7 +88,7 @@ jobs:
           retention-days: 7
       - name: Upload Playwright test results
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: playwright-test-results-web
           path: lana/test-results/web


### PR DESCRIPTION
Bumps `actions/upload-artifact` from v4 to v7 in `ci.yml`. Dependabot did not propose it: the steps landed yesterday in #954, and the `github-actions` schedule is weekly.

## Why

v4 runs on Node 20. The runners force it onto Node 24 and warn on every run:

```
Node.js 20 is deprecated. The following actions target Node.js 20 but are being
forced to run on Node.js 24: actions/upload-artifact@v4
```

## Breaking changes across the three majors

| Version | Change | Effect here |
|---|---|---|
| v5 | Node 24 support | none |
| v6 | `runs.using: node24`, needs runner 2.327.1 or later | none, `ubuntu-latest` has it |
| v7 | ESM; new opt-in `archive` input | none, see below |

v7 adds `archive`. With `archive: false` the action ignores `name` and takes a single file only. Both steps upload a directory and keep the default, so `name` still applies.

All four inputs (`name`, `path`, `if-no-files-found`, `retention-days`) are unchanged and valid in v7.

`@v7` follows the style of the other `actions/*` entries, which float on the major.

## Verify

`prettier --check .github/workflows/ci.yml` passes. Both steps run `if: failure()`, so CI green on this PR does not exercise them; a red run does.