### PR TITLE
ci(dependabot): drop the dead salesforce group

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,10 +12,6 @@ updates:
     # majors are deliberately left out of the minor/patch groups so each one still
     # arrives as its own PR - they need reading and are reverted individually
     groups:
-      # exception: @salesforce/apex-node majors require the matching
-      # @salesforce/core major, so these move in lockstep incl. majors
-      salesforce:
-        patterns: ['@salesforce/*']
       production-dependencies:
         dependency-type: 'production'
         update-types: ['minor', 'patch']


### PR DESCRIPTION
Removes the `salesforce` group from `.github/dependabot.yml`. It guards a coupling that no longer exists.

## Why

The group was added in #907 for this reason:

> exception: `@salesforce/apex-node` majors require the matching `@salesforce/core` major, so these move in lockstep incl. majors

#951 (`refactor(lana): use Salesforce Services`) moved `lana` onto `@salesforce/vscode-services`. Neither `@salesforce/core` nor `@salesforce/apex-node` is a direct dependency now. `@salesforce/core@9.1.7` is left in the lockfile only under `@salesforce/vscode-services` -> `@salesforce/source-deploy-retrieve`, and dependabot does not raise version updates for transitive dependencies.

## What is left

Both remaining `@salesforce/*` packages are dev dependencies, and their versions are independent:

| Package | Range | Where |
|---|---|---|
| `@salesforce/playwright-vscode-ext` | `^1.3.10` | root |
| `@salesforce/vscode-services` | `^67.15.0` | `lana/` |

`development-dependencies` already covers them. `@salesforce/vscode-services` 67.12 -> 67.15 arrived there in #993.

## Effect

`@salesforce/*` majors now arrive as their own PR, which is what the comment above `groups:` already asks for:

> majors are deliberately left out of the minor/patch groups so each one still arrives as its own PR

So this makes the file consistent rather than changing policy.

## Verify

`prettier --check .github/dependabot.yml` passes. Config-only, so CI does not exercise it; the next scheduled dependabot run is the real check.