### PR TITLE
ci: stop installing vsce and ovsx unpinned

### DIFF
--- a/.github/workflows/cd-prerelease.yml
+++ b/.github/workflows/cd-prerelease.yml
@@ -71,8 +71,6 @@ jobs:
         with:
           node-version: '24'
           cache: 'pnpm'
-      - name: Install ovsx
-        run: pnpm add --global ovsx
       - name: Dependencies
         run: pnpm run ci:install
       - name: update pre-release version
@@ -93,7 +91,7 @@ jobs:
 
           echo "
           Verify ovsx token has not expired"
-          ovsx verify-pat
+          pnpm dlx ovsx@1.1.1 verify-pat
 
           versionNum=$(jq -r '.version' package.json)
           pkgPath="lana-${versionNum}.vsix"
@@ -104,7 +102,7 @@ jobs:
 
           echo "
           Publish to ovsx"
-          ovsx publish "${pkgPath}" --no-dependencies --pre-release --skip-duplicate
+          pnpm dlx ovsx@1.1.1 publish "${pkgPath}" --no-dependencies --pre-release --skip-duplicate
       - name: Update pre-release tag
         run: |
           echo "Updating pre release tag"

--- a/.github/workflows/cd-prerelease.yml
+++ b/.github/workflows/cd-prerelease.yml
@@ -71,10 +71,8 @@ jobs:
         with:
           node-version: '24'
           cache: 'pnpm'
-      - name: Install vsce + ovsx
-        run: |
-          pnpm add --global @vscode/vsce
-          pnpm add --global ovsx
+      - name: Install ovsx
+        run: pnpm add --global ovsx
       - name: Dependencies
         run: pnpm run ci:install
       - name: update pre-release version
@@ -82,9 +80,7 @@ jobs:
           echo "Updating pre-release version"
           pnpm run bump-prerelease;
       - name: Package the extension
-        run: |
-          cd lana
-          vsce package --pre-release --no-dependencies
+        run: pnpm --filter lana exec vsce package --pre-release --no-dependencies
       - name: Publish to VS Code Marketplace + Open VSX Registry
         # Tokens via env (not -p) so they don't appear in the process list.
         env:
@@ -93,7 +89,7 @@ jobs:
         run: |
           cd lana
           echo "Verify vsce token has not expired"
-          vsce verify-pat
+          pnpm exec vsce verify-pat
 
           echo "
           Verify ovsx token has not expired"
@@ -104,7 +100,7 @@ jobs:
 
           echo "Publish to vsce
           vsix name: $pkgPath"
-          vsce publish --packagePath "${pkgPath}" --no-dependencies --pre-release --skip-duplicate
+          pnpm exec vsce publish --packagePath "${pkgPath}" --no-dependencies --pre-release --skip-duplicate
 
           echo "
           Publish to ovsx"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,14 +110,10 @@ jobs:
         with:
           node-version: '24'
           cache: 'pnpm'
-      - name: Install vsce
-        run: pnpm add --global @vscode/vsce
       - name: Install Dependencies
         run: pnpm run ci:install
       - name: Build VSCode Package
-        run: |
-          cd lana
-          vsce package --no-dependencies
+        run: pnpm --filter lana run build:vsix
 
   gate:
     # The single required status check: the ruleset never needs updating when jobs change.

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -24,8 +24,6 @@ jobs:
         with:
           node-version: '24'
           cache: 'pnpm'
-      - name: Install ovsx
-        run: pnpm add --global ovsx
       - name: Dependencies
         run: pnpm run ci:install
       - name: Build extension
@@ -42,9 +40,9 @@ jobs:
           echo "Verify vsce token has not expired"
           pnpm exec vsce verify-pat
           echo "Verify ovsx token has not expired"
-          ovsx verify-pat
+          pnpm dlx ovsx@1.1.1 verify-pat
 
           echo "Publish to vsce"
           pnpm exec vsce publish --packagePath "lana-${TAG}.vsix" --no-dependencies
           echo "Publish to ovsx"
-          ovsx publish "lana-${TAG}.vsix" --no-dependencies
+          pnpm dlx ovsx@1.1.1 publish "lana-${TAG}.vsix" --no-dependencies

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -24,16 +24,12 @@ jobs:
         with:
           node-version: '24'
           cache: 'pnpm'
-      - name: Install vsce + ovsx
-        run: |
-          pnpm add --global @vscode/vsce
-          pnpm add --global ovsx
+      - name: Install ovsx
+        run: pnpm add --global ovsx
       - name: Dependencies
         run: pnpm run ci:install
       - name: Build extension
-        run: |
-          cd lana
-          vsce package --no-dependencies
+        run: pnpm --filter lana run build:vsix
       - name: Publish to VS Code Marketplace + Open VSX Registry
         # Secrets and the release tag are passed via env (not interpolated into the
         # shell) to avoid leaking tokens in the process list and shell injection.
@@ -44,11 +40,11 @@ jobs:
         run: |
           cd lana
           echo "Verify vsce token has not expired"
-          vsce verify-pat
+          pnpm exec vsce verify-pat
           echo "Verify ovsx token has not expired"
           ovsx verify-pat
 
           echo "Publish to vsce"
-          vsce publish --packagePath "lana-${TAG}.vsix" --no-dependencies
+          pnpm exec vsce publish --packagePath "lana-${TAG}.vsix" --no-dependencies
           echo "Publish to ovsx"
           ovsx publish "lana-${TAG}.vsix" --no-dependencies


### PR DESCRIPTION
# PR overview

Every publish path installed its own tooling with `pnpm add --global @vscode/vsce` and
`pnpm add --global ovsx`, which takes whatever the registry serves that day. The pre-release
job runs unattended every Tuesday, so nobody sees what version it picked.

- **vsce** is already a `lana` devDependency, so it is already in the lockfile. Call it through
  `pnpm exec` / the existing `build:vsix` script instead of a global install.
- **ovsx** is not a dependency and does not need to be: it only uploads at release time. Running
  it as `pnpm dlx ovsx@1.1.1` pins the version without putting its native keyring binaries into
  every CI job and every developer's install.

No `package.json` or lockfile change, so `pnpm install --frozen-lockfile` is unaffected.

## Trade-off worth knowing

Dependabot cannot see a version inside a `run:` block, so the `ovsx` pin will not be bumped
automatically the way `vsce` is. A stale pin fails loudly at `verify-pat`, before anything is
published. The alternative — `ovsx` as a devDependency — costs 56 extra packages
(`@napi-rs/keyring`, `@node-rs/crc32` and the inquirer tree) on every install, for a tool used
twice a release.

## Type of change

- [x] Chore

## Validation

- `pnpm install --frozen-lockfile` passes against the unchanged lockfile.
- `pnpm --filter lana exec vsce package --pre-release --no-dependencies` runs in `lana/` with the
  flags passed through unchanged.
- `ovsx@1.1.1` is current latest and still takes `verify-pat`, `--no-dependencies`,
  `--pre-release` and `--skip-duplicate`.
- The `dlx` fetch happens at `verify-pat`, before any upload, so a download failure cannot land
  mid-publish.

## Known gap

`cd-prerelease.yml` still packages inline (`vsce package --pre-release`) while `ci.yml` and
`publish.yml` call the `build:vsix` script, because `build:vsix` has no `--pre-release` flag.
Unifying them needs a second script in `lana/package.json`; left out to keep this PR to
workflows only.