### PR TITLE
chore(vscode): open sample-app in the dev host

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -9,7 +9,11 @@
       "name": "Run Extension",
       "type": "extensionHost",
       "request": "launch",
-      "args": ["--profile=lana-dev", "--extensionDevelopmentPath=${workspaceFolder}/lana"],
+      "args": [
+        "--profile=lana-dev",
+        "${workspaceFolder}/sample-app",
+        "--extensionDevelopmentPath=${workspaceFolder}/lana"
+      ],
       "outFiles": ["${workspaceFolder}/lana/out/**/*.js"],
       "localRoot": "${workspaceFolder}/lana"
     },
@@ -22,6 +26,7 @@
       "request": "launch",
       "args": [
         "--profile=lana-dev",
+        "${workspaceFolder}/${input:worktree}/sample-app",
         "--extensionDevelopmentPath=${workspaceFolder}/${input:worktree}/lana"
       ],
       "outFiles": ["${workspaceFolder}/${input:worktree}/lana/out/**/*.js"],

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,8 +23,9 @@ Always use pnpm.
 - `pnpm lint` — type + lint check
 - `pnpm prettier-format` — auto-format
 
-**Dev host** — launch with `code-insiders --profile lana-dev --extensionDevelopmentPath=$PWD/lana`,
-use the CLI of the launched editor, `code-insiders` or `code`
+**Dev host** — launch with
+`code-insiders --profile lana-dev $PWD/sample-app --extensionDevelopmentPath=$PWD/lana`, use the
+CLI of the launched editor, `code-insiders` or `code`
 
 **Compilers** — `typecheck` = native TS7 (`tsc`); `typecheck:tsc6` = classic 6.0 (`tsc6`).
 Keep the `@typescript/typescript6` alias + `tsc6`: `typescript-eslint` and Docusaurus need


### PR DESCRIPTION
The dev host started on no folder, so the test logs were always a few clicks away. The folder arg opens `sample-app`, which holds them. The worktree config opens that worktree's own copy, and the AGENTS.md command matches.

Related: #992, which added the `lana-dev` profile these launch configs name.