### PR TITLE
feat(log-viewer): inspector text a step under the chrome, grids pinned

### DIFF
--- a/.claude/rules/log-viewer.md
+++ b/.claude/rules/log-viewer.md
@@ -38,9 +38,11 @@ Webview UI.
   and no consumer fallback can fire.
 - Never define or override a `--vscode-*` name — an override is global to the webview. Exception:
   skinning a `vscode-elements` component; scope it to that element, never `:host` or `:root`.
-- Write no literal font size or family. Take a step from the ramp in `styles/tokens.css`
-  (`--lana-text-*`, `--lana-text-mono` for editor-sized text, `--lana-text-meta` for header
-  metadata) and a family from `--lana-font-mono` or `--lana-font-ui`.
+- Write no literal font size or family. Name a role where one fits: `--lana-text-grid` for grid
+  text, `--lana-text-panel-body` for Inspector content, `--lana-text-meta` for header metadata,
+  `--lana-text-mono` for code the reader also edits. Otherwise take a step from the ramp in
+  `styles/tokens.css`. Families come from `--lana-font-mono` or `--lana-font-ui`.
+- The pane body owns the Inspector's text size. A section inherits it and never restates it.
 - Mono is for text whose alignment carries meaning — stacks, code, log text. Prose takes the UI font.
 - An all-caps run takes `--lana-text-caps` and `--lana-text-caps-tracking`, one step down: every
   glyph reaches cap height, so caps read a size larger.

--- a/log-viewer/src/components/DetailDock.ts
+++ b/log-viewer/src/components/DetailDock.ts
@@ -97,6 +97,7 @@ export class DetailDock extends LitElement {
         flex: 1 1 auto;
         padding: var(--lana-space-md) var(--lana-space-lg);
         color: var(--lana-fg-muted);
+        font-size: var(--lana-text-panel-body);
       }
     `,
   ];

--- a/log-viewer/src/components/EventVitals.ts
+++ b/log-viewer/src/components/EventVitals.ts
@@ -105,12 +105,11 @@ export class EventVitals extends LitElement {
         overflow-wrap: anywhere;
       }
       /* Secondary readings (a percentage, a self time, a query cost) sit in
-         brackets one step down in size so the primary number still leads. The
-         colour is the theme's own secondary token — not a lower alpha — because
-         thinning contrast to de-emphasise costs legibility. */
+         brackets, demoted by colour: the theme's own secondary token, not a
+         lower alpha, because thinning contrast to de-emphasise costs
+         legibility. */
       .qualifier {
         color: var(--lana-fg-muted);
-        font-size: var(--lana-text-sm);
       }
       .pill {
         display: inline-block;

--- a/log-viewer/src/components/PaneView.ts
+++ b/log-viewer/src/components/PaneView.ts
@@ -159,15 +159,15 @@ export class PaneView extends LitElement {
         flex: 0 0 auto;
       }
 
-      /* The body owns the panel's content edge and its base text size, so every
-         section reads at one scale and only steps away from it deliberately. */
+      /* The body owns the panel's content edge and its text size; a section
+         inherits both and steps away only deliberately. */
       .pane-body {
         flex: 1 1 auto;
         min-height: 0;
         min-width: 0;
         overflow: auto;
         padding: var(--lana-space-2xs) var(--lana-space-md) var(--lana-space-sm);
-        font-size: var(--lana-text-base);
+        font-size: var(--lana-text-panel-body);
       }
 
       .pane-sash {

--- a/log-viewer/src/components/StackedTimeBar.ts
+++ b/log-viewer/src/components/StackedTimeBar.ts
@@ -162,7 +162,6 @@ export class StackedTimeBar extends LitElement {
         pointer-events: none;
         width: max-content;
         max-width: min(40ch, 90vw);
-        font-size: var(--lana-text-sm);
         color: var(--lana-fg);
         padding: var(--lana-space-3xs) var(--lana-space-xs);
         background: var(--lana-popover-bg);
@@ -183,7 +182,6 @@ export class StackedTimeBar extends LitElement {
         align-items: baseline;
         gap: var(--lana-space-2xs);
         white-space: nowrap;
-        font-size: var(--lana-text-sm);
         color: var(--lana-fg);
       }
 

--- a/log-viewer/src/components/VariablesDetail.ts
+++ b/log-viewer/src/components/VariablesDetail.ts
@@ -145,7 +145,6 @@ export class VariablesDetail extends LitElement {
         overflow: hidden;
         color: var(--lana-fg-muted);
         font-family: var(--lana-font-mono);
-        font-size: var(--lana-text-sm);
         text-overflow: ellipsis;
         white-space: nowrap;
       }
@@ -182,7 +181,6 @@ export class VariablesDetail extends LitElement {
       .missing {
         flex: 0 0 auto;
         color: var(--lana-fg-muted);
-        font-size: var(--lana-text-sm);
         font-style: italic;
       }
 
@@ -204,7 +202,6 @@ export class VariablesDetail extends LitElement {
         flex: 0 0 auto;
         color: var(--lana-fg-muted);
         font-family: var(--lana-font-mono);
-        font-size: var(--lana-text-sm);
       }
 
       .count {
@@ -214,7 +211,6 @@ export class VariablesDetail extends LitElement {
         padding: 0 var(--lana-space-2xs);
         background-color: var(--lana-badge-bg);
         color: var(--lana-badge-fg);
-        font-size: var(--lana-text-sm);
         font-variant-numeric: tabular-nums;
         text-align: center;
       }
@@ -226,7 +222,6 @@ export class VariablesDetail extends LitElement {
         border-radius: var(--lana-radius-md);
         padding: 0 var(--lana-space-2xs);
         color: var(--lana-fg-muted);
-        font-size: var(--lana-text-sm);
       }
 
       .row.is-note {

--- a/log-viewer/src/features/analysis/components/LogDiagnosticsView.ts
+++ b/log-viewer/src/features/analysis/components/LogDiagnosticsView.ts
@@ -189,7 +189,6 @@ export class LogDiagnosticsView extends LitElement {
         padding: var(--lana-space-3xs) var(--lana-space-2xs);
         background-color: transparent;
         color: var(--lana-fg-muted);
-        font-size: var(--lana-text-sm);
         font-variant-numeric: tabular-nums;
         cursor: pointer;
         transition:
@@ -216,7 +215,6 @@ export class LogDiagnosticsView extends LitElement {
          the findings the log times carry one. */
       .share {
         color: var(--lana-fg-muted);
-        font-size: var(--lana-text-sm);
         font-variant-numeric: tabular-nums;
         white-space: nowrap;
       }
@@ -228,7 +226,6 @@ export class LogDiagnosticsView extends LitElement {
         gap: var(--lana-space-xs);
         padding: var(--lana-space-sm) var(--lana-space-2xs);
         color: var(--lana-fg-muted);
-        font-size: var(--lana-text-sm);
       }
 
       /* One finding is one row, with the detail behind a disclosure: the chevron and
@@ -286,7 +283,6 @@ export class LogDiagnosticsView extends LitElement {
       .meta {
         color: var(--lana-fg-muted);
         font-family: var(--lana-font-mono);
-        font-size: var(--lana-text-sm);
         font-variant-numeric: tabular-nums;
       }
 
@@ -297,7 +293,6 @@ export class LogDiagnosticsView extends LitElement {
         padding: 0 var(--lana-space-2xs);
         background-color: var(--lana-badge-bg);
         color: var(--lana-badge-fg);
-        font-size: var(--lana-text-sm);
         font-variant-numeric: tabular-nums;
         text-align: center;
       }
@@ -328,14 +323,12 @@ export class LogDiagnosticsView extends LitElement {
       .cause__label {
         flex: 0 0 auto;
         color: var(--lana-fg-muted);
-        font-size: var(--lana-text-sm);
       }
 
       .cause__name {
         flex: 1 1 auto;
         min-width: 0;
         font-family: var(--lana-font-mono);
-        font-size: var(--lana-text-sm);
         overflow: hidden;
         text-overflow: ellipsis;
         white-space: nowrap;
@@ -346,7 +339,6 @@ export class LogDiagnosticsView extends LitElement {
         margin-left: auto;
         color: var(--lana-fg);
         font-family: var(--lana-font-mono);
-        font-size: var(--lana-text-sm);
         font-variant-numeric: tabular-nums;
         font-weight: 600;
       }
@@ -367,7 +359,6 @@ export class LogDiagnosticsView extends LitElement {
         background-color: var(--lana-code-bg);
         color: var(--lana-fg);
         font-family: var(--lana-font-mono);
-        font-size: var(--lana-text-sm);
         text-align: left;
       }
 
@@ -395,7 +386,6 @@ export class LogDiagnosticsView extends LitElement {
       .evidence__head {
         margin: var(--lana-space-sm) 0 0;
         color: var(--lana-fg-muted);
-        font-size: var(--lana-text-sm);
       }
 
       /* How many times this one line ran. */
@@ -432,7 +422,6 @@ export class LogDiagnosticsView extends LitElement {
       .note {
         padding: var(--lana-space-sm) var(--lana-space-2xs);
         color: var(--lana-fg-muted);
-        font-size: var(--lana-text-sm);
       }
     `,
   ];

--- a/log-viewer/src/features/database/components/DatabaseOverview.ts
+++ b/log-viewer/src/features/database/components/DatabaseOverview.ts
@@ -135,7 +135,6 @@ export class DatabaseConcentration extends LitElement {
 
       .headline {
         padding-bottom: var(--lana-space-xs);
-        font-size: var(--lana-text-sm);
       }
 
       .headline__figure {
@@ -150,7 +149,6 @@ export class DatabaseConcentration extends LitElement {
         gap: var(--lana-space-sm);
         padding-top: var(--lana-space-2xs);
         color: var(--lana-fg-muted);
-        font-size: var(--lana-text-sm);
       }
 
       .tail__value {
@@ -272,7 +270,6 @@ export class DatabaseNamespaces extends LitElement {
 
       .bar__title {
         padding-bottom: var(--lana-space-2xs);
-        font-size: var(--lana-text-sm);
       }
     `,
   ];

--- a/log-viewer/src/features/database/components/DatabaseRowBudget.ts
+++ b/log-viewer/src/features/database/components/DatabaseRowBudget.ts
@@ -59,7 +59,6 @@ export class DatabaseRowBudget extends LitElement {
     css`
       .note {
         padding: var(--lana-space-2xs) 0 0;
-        font-size: var(--lana-text-sm);
       }
 
       .budget + .budget {
@@ -69,7 +68,6 @@ export class DatabaseRowBudget extends LitElement {
       .budget__head,
       .objects__head {
         padding-bottom: var(--lana-space-2xs);
-        font-size: var(--lana-text-sm);
       }
 
       .budget__head {
@@ -101,7 +99,6 @@ export class DatabaseRowBudget extends LitElement {
         gap: var(--lana-space-3xs) var(--lana-space-lg);
         padding-top: var(--lana-space-sm);
         color: var(--lana-fg-muted);
-        font-size: var(--lana-text-sm);
       }
 
       .counts__value {

--- a/log-viewer/src/features/soql/styles/soql-syntax.css.ts
+++ b/log-viewer/src/features/soql/styles/soql-syntax.css.ts
@@ -15,6 +15,11 @@ export const soqlSyntaxStyles = `
   white-space: nowrap;
 }
 
+/* In a grid the query is one cell among others, so it reads as grid text. */
+.tabulator .soql-block {
+  font-size: var(--lana-text-grid);
+}
+
 .soql-tok-keyword {
   color: var(--vscode-debugTokenExpression-name, inherit);
   font-weight: 700;

--- a/log-viewer/src/styles/tokens.css
+++ b/log-viewer/src/styles/tokens.css
@@ -53,8 +53,8 @@
   /* Type — VS Code's own UI ramp, so the app follows the size registry rather
      than a scale of our own: `bodyFontSize` 13px, `.small` 12px, `.xSmall` 11px.
      (`--vscode-font-size` is not one of them: a webview gets it hardcoded at
-     13px, so it tracks nothing.) Dense data reads at `small`, so that is the
-     base. Only the last step has no registered size; it is derived and rounded
+     13px, so it tracks nothing.) The chrome and the grids read at `small`, so
+     that is the base. Only the last step has no registered size; it is derived and rounded
      to a whole pixel, because text this small lands badly on a fraction. */
   --lana-text-lg: var(--vscode-bodyFontSize, 13px);
   --lana-text-base: var(--vscode-bodyFontSize-small, 12px);
@@ -62,15 +62,23 @@
   --lana-text-xs: round(nearest, calc(var(--lana-text-base) * 0.84), 1px);
 
   /* Uppercase micro-labels, whose caps height carries the size: one step under
-     the body, let out with tracking so caps read as a label, not a shout. */
+     the app base, let out with tracking so caps read as a label, not a shout.
+     A token declared on every component's `:host` cannot be stepped down for a
+     subtree, so in the Inspector caps sits level with the body. */
   --lana-text-caps: var(--lana-text-sm);
   --lana-text-caps-tracking: 0.06em;
 
   /* Header metadata (size · duration · identity) — just under the title size. */
   --lana-text-meta: var(--lana-text-sm);
 
-  /* Monospace, for text whose alignment carries meaning: stacks, code. The host
-     sets the editor's own size, which is not always its UI size. */
+  /* Roles, so a surface names what it is rather than a step. The panel body is
+     the Inspector's content, under the chrome around it. A grid is a list, not
+     an editor, so its text is UI-sized. */
+  --lana-text-panel-body: var(--lana-text-sm);
+  --lana-text-grid: var(--lana-text-base);
+
+  /* Monospace, for code the reader also edits: code blocks and query spans.
+     The host sets the editor's own size, which is not always its UI size. */
   --lana-font-mono: var(--vscode-editor-font-family, monospace);
   --lana-text-mono: var(--vscode-editor-font-size, 0.9em);
 

--- a/log-viewer/src/tabulator/style/DataGrid.scss
+++ b/log-viewer/src/tabulator/style/DataGrid.scss
@@ -38,7 +38,7 @@ $codicon-chevron-down: '\eab4';
     $with: (
         backgroundColor: var(--lana-editor-bg),
         borderColor: transparent,
-        textSize: var(--lana-text-mono),
+        textSize: var(--lana-text-grid),
         // header
         headerBackgroundColor: transparent,
         headerTextColor: var(--lana-editor-fg),
@@ -229,7 +229,7 @@ $codicon-chevron-down: '\eab4';
     .datagrid-code-text {
       font-family: var(--lana-font-mono);
       font-weight: var(--vscode-font-weight, normal);
-      font-size: var(--lana-text-mono);
+      font-size: var(--lana-text-grid);
     }
 
     .tabulator-row.tabulator-selected {


### PR DESCRIPTION
# 📝 PR Overview

The Inspector read at the same size as the chrome around it, so its sections had
no visual rank against the tabs and filter bar above them. The grids took their
size from the reader's `editor.fontSize`, so a 14px editor font put grid cells
two steps over the chrome, and the app could not state its own density.

The Inspector's content now reads one step under the chrome, and grid text is
UI-sized, because a grid is a list and not an editor. Twenty-five section
declarations that only restated the body size are gone, so each section has one
declared scale and steps away from it only deliberately.

| Plane | Size |
| --- | --- |
| Grids, main views and the Inspector's own trees alike | `--lana-text-grid`, 12px |
| Chrome: tabs, filter bar, nav | 12px |
| Inspector prose and metadata | `--lana-text-panel-body`, 11px |
| Captions and pills | 10px |

## 🛠️ Changes made

- `--lana-text-panel-body` and `--lana-text-grid` name the two roles, beside the existing caps and meta aliases, so a surface says what it is rather than which step it picked
- The pane body owns the Inspector's size, and the empty state takes it too, so "Nothing selected." no longer reads a step above section prose
- Grid text leaves `--lana-text-mono`, which now serves only code the reader also edits: code blocks, query spans and the issue list
- A query cell takes grid text, declared in the syntax sheet. That sheet is unlayered, so a rule in `DataGrid.scss`, inside `@layer tabulator`, could never reach it
- 25 `--lana-text-sm` declarations removed from six dock-only components; they restated the inherited body size
- `.claude/rules/log-viewer.md` records the contract those deletions rest on

## 🧩 Type of change (check all applicable)

- [ ] 🐛 Bug fix - something not working as expected
- [x] ✨ New feature – adds new functionality
- [ ] ♻️ Refactor - internal changes with no user impact
- [ ] ⚡ Performance Improvement
- [ ] 📝 Documentation - README or documentation site changes
- [ ] 🔧 Chore - dev tooling, CI, config
- [ ] 💥 Breaking change

## 📷 Screenshots / gifs / video [optional]

N/A

## 🔗 Related Issues

N/A

## ✅ Tests added?

- [x] 🙅 no, not needed

CSS only, and no test asserts a `--lana-text-*` value. Verified with `jest --selectProjects log-viewer` (1793 tests / 144 suites), `tsc -b log-viewer --force`, eslint, prettier and a production build.

## 📚 Docs updated?

- [x] 🙅 not needed

## Anything else we need to know? [optional]

One limit worth recording. `--lana-text-caps` is declared on every component's `:host` through `tokenStyles`, and a declared value beats an inherited one, so the token cannot be stepped down for a subtree. Inside the Inspector an uppercase label therefore sits level with the body, carried by weight, tracking and the section-header background. `tokens.css` states this, so the next reader does not attempt the override.

Code blocks and query spans in prose still take the editor font, so code inside a section can read a step or two above the body. That is deliberate: it is text the reader also edits.