### PR TITLE
refactor(log-viewer): one size for code text, and tokens for the ring and the pill

### DIFF
--- a/.claude/rules/log-viewer.md
+++ b/.claude/rules/log-viewer.md
@@ -39,8 +39,9 @@ Webview UI.
 - Never define or override a `--vscode-*` name — an override is global to the webview. Exception:
   skinning a `vscode-elements` component; scope it to that element, never `:host` or `:root`.
 - Write no literal font size or family. Take a step from the ramp in `styles/tokens.css`
-  (`--lana-text-*`, `--lana-text-mono` for editor-sized text, `--lana-text-meta` for header
-  metadata) and a family from `--lana-font-mono` or `--lana-font-ui`.
+  (`--lana-text-*`, `--lana-text-meta` for header metadata) and a family from `--lana-font-mono` or
+  `--lana-font-ui`. Code-shaped text takes no size of its own: it inherits the surface that holds
+  it, so nothing in the webview follows the reader's `editor.fontSize`.
 - Mono is for text whose alignment carries meaning — stacks, code, log text. Prose takes the UI font.
 - An all-caps run takes `--lana-text-caps` and `--lana-text-caps-tracking`, one step down: every
   glyph reaches cap height, so caps read a size larger.

--- a/log-viewer/src/components/CodeBlock.ts
+++ b/log-viewer/src/components/CodeBlock.ts
@@ -48,7 +48,6 @@ export class CodeBlock extends LitElement {
       pre {
         margin: 0;
         font-family: var(--lana-font-mono);
-        font-size: var(--lana-text-mono);
         white-space: pre-wrap;
         word-break: break-word;
       }

--- a/log-viewer/src/components/EventVitals.ts
+++ b/log-viewer/src/components/EventVitals.ts
@@ -112,19 +112,24 @@ export class EventVitals extends LitElement {
         color: var(--lana-fg-muted);
         font-size: var(--lana-text-sm);
       }
+      /* One hue carries the verdict through the text, a tinted ground and its
+         edge, as SelfTimeSpreadView tints a row from its own hue property.
+         Every variant sets the hue. */
       .pill {
         display: inline-block;
-        padding: 0 var(--lana-space-sm);
-        border-radius: var(--lana-radius-sm);
+        padding: 0 var(--lana-space-2xs);
+        border: var(--lana-stroke) solid color-mix(in srgb, var(--pill-hue) 30%, transparent);
+        border-radius: var(--lana-radius-md);
+        background-color: color-mix(in srgb, var(--pill-hue) 12%, transparent);
+        color: var(--pill-hue);
         font-size: var(--lana-text-xs);
         line-height: 1.4;
-        color: var(--lana-editor-bg);
       }
       .pill--yes {
-        background-color: var(--vscode-charts-green, #388a34);
+        --pill-hue: var(--lana-severity-ok);
       }
       .pill--no {
-        background-color: var(--vscode-charts-red, #d13438);
+        --pill-hue: var(--lana-severity-warning);
       }
       .empty {
         color: var(--lana-fg-muted);

--- a/log-viewer/src/components/GovernorTrends.ts
+++ b/log-viewer/src/components/GovernorTrends.ts
@@ -152,7 +152,7 @@ export class GovernorTrends extends LitElement {
         display: block;
         width: 100%;
         border: 0;
-        border-bottom: 1px solid var(--lana-surface-border);
+        border-bottom: var(--lana-stroke) solid var(--lana-surface-border);
         padding: 0;
         background: none;
         color: inherit;
@@ -166,8 +166,8 @@ export class GovernorTrends extends LitElement {
       }
 
       .trend__chart:focus-visible {
-        outline: var(--lana-stroke) solid var(--lana-focus-border);
-        outline-offset: calc(-1 * var(--lana-stroke));
+        outline: var(--lana-focus-ring);
+        outline-offset: var(--lana-focus-inset);
       }
 
       .trend--safe {

--- a/log-viewer/src/components/OverflowList.ts
+++ b/log-viewer/src/components/OverflowList.ts
@@ -103,10 +103,10 @@ export class OverflowList extends LitElement {
       .overflow {
         display: inline-flex;
         align-items: center;
-        gap: 4px;
-        padding: 2px 6px;
-        border: 1px solid var(--lana-control-border);
-        border-radius: 4px;
+        gap: var(--lana-space-2xs);
+        padding: var(--lana-space-3xs) var(--lana-space-xs);
+        border: var(--lana-stroke) solid var(--lana-control-border);
+        border-radius: var(--lana-radius-sm);
         background-color: var(--lana-control-bg);
         color: var(--lana-fg);
         font: inherit;
@@ -123,8 +123,8 @@ export class OverflowList extends LitElement {
       }
 
       .overflow:focus-visible {
-        outline: 1px solid var(--lana-focus-border);
-        outline-offset: 1px;
+        outline: var(--lana-focus-ring);
+        outline-offset: var(--lana-focus-offset);
       }
 
       .overflow__count {

--- a/log-viewer/src/components/PaneView.ts
+++ b/log-viewer/src/components/PaneView.ts
@@ -130,7 +130,7 @@ export class PaneView extends LitElement {
         letter-spacing: var(--lana-text-caps-tracking);
         color: var(--vscode-sideBarSectionHeader-foreground);
         background-color: var(--vscode-sideBarSectionHeader-background);
-        border-top: 1px solid var(--vscode-sideBarSectionHeader-border, transparent);
+        border-top: var(--lana-stroke) solid var(--vscode-sideBarSectionHeader-border, transparent);
         user-select: none;
         white-space: nowrap;
         overflow: hidden;
@@ -143,8 +143,8 @@ export class PaneView extends LitElement {
         background-color: var(--lana-row-hover-bg);
       }
       .pane-header:focus-visible {
-        outline: 1px solid var(--lana-focus-border);
-        outline-offset: -1px;
+        outline: var(--lana-focus-ring);
+        outline-offset: var(--lana-focus-inset);
       }
       .pane-header vscode-icon {
         color: var(--lana-icon-fg);

--- a/log-viewer/src/components/datagrid-facet-filter.ts
+++ b/log-viewer/src/components/datagrid-facet-filter.ts
@@ -82,7 +82,7 @@ export class DatagridFacetFilter extends LitElement {
         font-weight: 600;
         color: var(--lana-badge-fg);
         background-color: var(--lana-badge-bg);
-        border-radius: 999px;
+        border-radius: var(--lana-radius-pill);
         padding: 0 5px;
         font-size: var(--lana-text-xs);
         line-height: 1.5;

--- a/log-viewer/src/components/datagrid-range-filter.ts
+++ b/log-viewer/src/components/datagrid-range-filter.ts
@@ -123,8 +123,8 @@ export class DatagridRangeFilter extends LitElement {
         font-size: var(--lana-text-base);
         color: var(--vscode-settings-numberInputForeground);
         background-color: var(--vscode-settings-numberInputBackground);
-        border: 1px solid var(--vscode-settings-numberInputBorder, transparent);
-        border-radius: 4px;
+        border: var(--lana-stroke) solid var(--vscode-settings-numberInputBorder, transparent);
+        border-radius: var(--lana-radius-sm);
         appearance: textfield;
       }
 
@@ -135,8 +135,8 @@ export class DatagridRangeFilter extends LitElement {
       }
 
       .range-popover__input:focus {
-        outline: 1px solid var(--lana-focus-border);
-        outline-offset: -1px;
+        outline: var(--lana-focus-ring);
+        outline-offset: var(--lana-focus-inset);
       }
 
       .range-popover__clear {

--- a/log-viewer/src/features/analysis/components/LogDiagnosticsView.ts
+++ b/log-viewer/src/features/analysis/components/LogDiagnosticsView.ts
@@ -208,8 +208,8 @@ export class LogDiagnosticsView extends LitElement {
       }
 
       .rollup__seg:focus-visible {
-        outline: var(--lana-stroke) solid var(--lana-focus-border);
-        outline-offset: var(--lana-stroke);
+        outline: var(--lana-focus-ring);
+        outline-offset: var(--lana-focus-offset);
       }
 
       /* How long the finding's own events took, and what that is of the log. Only
@@ -416,8 +416,8 @@ export class LogDiagnosticsView extends LitElement {
       }
 
       .evidence--link:focus-visible {
-        outline: var(--lana-stroke) solid var(--lana-focus-border);
-        outline-offset: var(--lana-stroke);
+        outline: var(--lana-focus-ring);
+        outline-offset: var(--lana-focus-offset);
       }
 
       .evidence__go {

--- a/log-viewer/src/features/database/components/DatabaseMetricCard.ts
+++ b/log-viewer/src/features/database/components/DatabaseMetricCard.ts
@@ -105,7 +105,7 @@ export class DatabaseMetricCard extends LitElement {
         display: block;
         width: 100%;
         height: 3px;
-        border-radius: 2px;
+        border-radius: var(--lana-radius-pill);
         background: var(--lana-surface-border);
         overflow: hidden;
       }
@@ -113,7 +113,7 @@ export class DatabaseMetricCard extends LitElement {
       .stat__fill {
         display: block;
         height: 100%;
-        border-radius: 2px;
+        border-radius: var(--lana-radius-pill);
         transition: width 150ms ease;
       }
 

--- a/log-viewer/src/features/database/components/GovernorSummary.ts
+++ b/log-viewer/src/features/database/components/GovernorSummary.ts
@@ -87,10 +87,10 @@ export class GovernorSummary extends LitElement {
         white-space: nowrap;
       }
 
+      /* No size of its own: the figure reads at whatever surface holds it. */
       .gauge__value {
         font-family: var(--lana-font-mono);
         font-variant-numeric: tabular-nums;
-        font-size: var(--lana-text-base);
         white-space: nowrap;
       }
 
@@ -106,14 +106,14 @@ export class GovernorSummary extends LitElement {
 
       .gauge__track {
         height: 5px;
-        border-radius: 3px;
+        border-radius: var(--lana-radius-pill);
         background: var(--lana-surface-border);
         overflow: hidden;
       }
 
       .gauge__fill {
         height: 100%;
-        border-radius: 3px;
+        border-radius: var(--lana-radius-pill);
         transition: width 150ms ease;
       }
 

--- a/log-viewer/src/features/notifications/components/IssueList.ts
+++ b/log-viewer/src/features/notifications/components/IssueList.ts
@@ -142,7 +142,6 @@ export class IssueList extends LitElement {
       /* Stack traces are code: keep their line breaks and their font, so each
          "at Class.method" frame reads as a frame, not one run-on paragraph. */
       .issue__message {
-        font-size: var(--lana-text-mono);
         font-family: var(--lana-font-mono);
         color: var(--lana-fg-muted);
         white-space: pre-wrap;

--- a/log-viewer/src/features/soql/styles/soql-syntax.css.ts
+++ b/log-viewer/src/features/soql/styles/soql-syntax.css.ts
@@ -6,7 +6,6 @@ export const soqlSyntaxStyles = `
 .soql-block {
   display: inline;
   font-family: var(--lana-font-mono);
-  font-size: var(--lana-text-mono);
   white-space: pre-wrap;
   word-break: break-word;
 }

--- a/log-viewer/src/styles/global.styles.ts
+++ b/log-viewer/src/styles/global.styles.ts
@@ -132,8 +132,8 @@ export const globalStyles = [
     }
 
     .vs-checkbox:focus-visible {
-      outline: 1px solid var(--lana-focus-border);
-      outline-offset: 1px;
+      outline: var(--lana-focus-ring);
+      outline-offset: var(--lana-focus-offset);
     }
 
     .vs-checkbox-label {
@@ -172,8 +172,8 @@ export const globalStyles = [
     }
 
     .filter-control:focus-visible {
-      outline: 1px solid var(--lana-focus-border);
-      outline-offset: 1px;
+      outline: var(--lana-focus-ring);
+      outline-offset: var(--lana-focus-offset);
     }
 
     /* Toggle-button counterpart to the facet/range trigger pills — same

--- a/log-viewer/src/styles/revealRow.styles.ts
+++ b/log-viewer/src/styles/revealRow.styles.ts
@@ -30,8 +30,8 @@ export const bleedRowStyles = css`
   }
 
   .bleed-row:focus-visible {
-    outline: var(--lana-stroke) solid var(--lana-focus-border);
-    outline-offset: calc(-1 * var(--lana-stroke));
+    outline: var(--lana-focus-ring);
+    outline-offset: var(--lana-focus-inset);
   }
 `;
 

--- a/log-viewer/src/styles/tokens.css
+++ b/log-viewer/src/styles/tokens.css
@@ -28,6 +28,9 @@
   /* Radius — VS Code's cornerRadius registry. */
   --lana-radius-sm: var(--vscode-cornerRadius-small, 4px);
   --lana-radius-md: var(--vscode-cornerRadius-medium, 6px);
+  /* Round the ends whatever the height, for a bar or a count. A corner radius
+     cannot say this: it un-rounds as soon as a host sets a smaller step. */
+  --lana-radius-pill: 999px;
 
   /* Space — a t-shirt scale, so a step can be re-sized without renaming it. */
   --lana-space-3xs: var(--vscode-spacing-size20, 2px);
@@ -69,10 +72,11 @@
   /* Header metadata (size · duration · identity) — just under the title size. */
   --lana-text-meta: var(--lana-text-sm);
 
-  /* Monospace, for text whose alignment carries meaning: stacks, code. The host
-     sets the editor's own size, which is not always its UI size. */
+  /* Monospace, for text whose alignment carries meaning: stacks, code. The
+     family is the editor's; the size never is. Code-shaped text inherits the
+     surface that holds it, so a grid cell, a snippet and a stack trace all read
+     at the size of the panel around them. */
   --lana-font-mono: var(--vscode-editor-font-family, monospace);
-  --lana-text-mono: var(--vscode-editor-font-size, 0.9em);
 
   --lana-font-ui: var(--vscode-font-family, sans-serif);
 
@@ -109,8 +113,13 @@
     var(--vscode-editorWidget-border, rgba(128, 128, 128, 0.35))
   );
 
-  /* One ring app-wide, so focus never reads as a hover. */
+  /* One ring app-wide, so focus never reads as a hover. `focus-inset` is for a
+     full-bleed row or input, whose ring would otherwise be clipped; a control
+     with room around it offsets by `--lana-stroke` instead. */
   --lana-focus-border: var(--vscode-focusBorder, #007fd4);
+  --lana-focus-ring: var(--lana-stroke) solid var(--lana-focus-border);
+  --lana-focus-offset: var(--lana-stroke);
+  --lana-focus-inset: calc(-1 * var(--lana-stroke));
 
   /* Icons that stand on their own, not beside the text they belong to. */
   --lana-icon-fg: var(--vscode-icon-foreground, currentColor);

--- a/log-viewer/src/tabulator/style/DataGrid.scss
+++ b/log-viewer/src/tabulator/style/DataGrid.scss
@@ -38,7 +38,10 @@ $codicon-chevron-down: '\eab4';
     $with: (
         backgroundColor: var(--lana-editor-bg),
         borderColor: transparent,
-        textSize: var(--lana-text-mono),
+        // The root must name a size: a grid is a list, not an editor, so it
+        // takes the app's step, never `editor.fontSize`. Tabulator also adds
+        // this to a margin for its header min-height, which no var() survives.
+        textSize: var(--lana-text-base),
         // header
         headerBackgroundColor: transparent,
         headerTextColor: var(--lana-editor-fg),
@@ -229,7 +232,6 @@ $codicon-chevron-down: '\eab4';
     .datagrid-code-text {
       font-family: var(--lana-font-mono);
       font-weight: var(--vscode-font-weight, normal);
-      font-size: var(--lana-text-mono);
     }
 
     .tabulator-row.tabulator-selected {


### PR DESCRIPTION
# 📝 PR Overview

Grid cells, query text, Inspector snippets and notification stack traces took their
size from the reader's `editor.fontSize`, so a 14px editor font put them two steps
over the chrome and the app could not state its own density. `.soql-block` also
overrode two surfaces that had deliberately chosen a smaller step: the diagnostics
evidence line, and the timeline tooltip, whose one-line clamp is measured against it.

Code-shaped text now takes no size of its own and inherits the surface that holds it.
One place cannot: tabulator's `textSize` is a Sass parameter, not a declaration, so the
table root names the app's step. Nothing in the webview reads `--vscode-editor-font-size`
any more, and the editor still supplies the family.

Alongside that, the appearance tokens the sweep needed: one focus ring instead of nine
copies, a pill radius for a bar that must round whatever its height, and a verdict that
reads as an outline chip.

## 🛠️ Changes made

- Code-shaped text inherits its surface: `.soql-block`, the grid's code column, `CodeBlock`'s `pre` and `IssueList`'s stack traces all drop their size. `--lana-text-mono` had no consumer left and is gone
- `--lana-focus-ring`, `--lana-focus-offset` and `--lana-focus-inset` replace the same three declarations written out nine times across seven files. The repo's rule already said a `calc` in three or more files is a token, and that `calc` was in four
- `--lana-radius-pill` on both governor gauges and the facet count. A corner radius un-rounds a thin bar as soon as a host sets a smaller step
- A verdict is an outline chip: one hue drives its text, a 12% ground and a 30% edge, matching the tint percentages already in the app. "Not selective" reads as a warning rather than an error
- `GovernorSummary`'s gauge figure states no size, so it reads at whatever surface holds it
- Literals converted in the rules the sweep touched, and the comments it made stale

## 🧩 Type of change (check all applicable)

- [ ] 🐛 Bug fix - something not working as expected
- [ ] ✨ New feature – adds new functionality
- [x] ♻️ Refactor - internal changes with no user impact
- [ ] ⚡ Performance Improvement
- [ ] 📝 Documentation - README or documentation site changes
- [ ] 🔧 Chore - dev tooling, CI, config
- [ ] 💥 Breaking change

## 📷 Screenshots / gifs / video [optional]

N/A

## 🔗 Related Issues

N/A

## ✅ Tests added?

- [x] 🙅 no, not needed

Appearance tokens only, and no test asserts a `--lana-*` value. Verified with `jest --runInBand` (2298 tests / 169 suites, all three projects), `tsc -b log-viewer --force`, eslint, prettier and a production build.

## 📚 Docs updated?

- [x] 🙅 not needed

`.claude/rules/log-viewer.md` records the rule that now holds: code-shaped text takes no size of its own, so nothing in the webview follows the reader's `editor.fontSize`.

## Anything else we need to know? [optional]

Two things found while reviewing, neither introduced here.

Tabulator's own `min-height: $textSize + ($headerMargin * 2)` cannot take a `var()` — Sass concatenates instead of adding, so the shipped rule is `min-height:var(--lana-text-base)8px`, which browsers drop. The header-cell min-height has therefore never applied, with the old token or the new one. Left alone; fixing it needs a literal or an unlayered override of upstream. The gotcha is noted on the declaration that feeds it.

The verdict chip's coloured text sits under WCAG AA on light themes, roughly 3.1:1 for Light+'s warning colour at 10px. That is inherited from `severityStyles`, which colours the Analysis findings the same way; the fix is to darken the severity tokens for light grounds, app-wide, and is tracked separately.