### PR TITLE
fix(log-viewer): keep one governor trend chart reading at a time

### DIFF
--- a/log-viewer/src/components/GovernorTrends.ts
+++ b/log-viewer/src/components/GovernorTrends.ts
@@ -2,7 +2,7 @@
  * Copyright (c) 2026 Certinia Inc. All rights reserved.
  */
 import { consume } from '@lit/context';
-import { LitElement, css, html, svg } from 'lit';
+import { LitElement, css, html, svg, type PropertyValues } from 'lit';
 import { customElement, property, state } from 'lit/decorators.js';
 
 import { eventBus } from '../core/events/EventBus.js';
@@ -24,6 +24,17 @@ import {
   type TrendSeries,
 } from './governorTrendData.js';
 import { NO_CUMULATIVE_LIMITS_TEXT } from './logOverviewMetrics.js';
+
+/** A placed cursor: the sample, and the chart it belongs to. */
+interface Cursor {
+  label: string;
+  point: TrendPoint;
+}
+
+/** The cursor's sample, when it is this chart's. */
+function pointOn(cursor: Cursor | null, series: TrendSeries): TrendPoint | null {
+  return cursor?.label === series.label ? cursor.point : null;
+}
 
 /** Chart-space size; the SVG stretches to fill its row. */
 const VIEW_W = 100;
@@ -88,11 +99,15 @@ function trendGeometry(series: TrendSeries, logTotal: number): TrendGeometry {
  */
 @customElement('governor-trends')
 export class GovernorTrends extends LitElement {
-  /** The sample under the pointer or the arrow keys, on the one chart that holds
-   *  it. `from` says which placed it: a pointer leaving takes its own cursor
-   *  with it, never one the keys placed. */
+  /** The sample under the pointer, on the chart it is over. Cleared when the
+   *  pointer leaves, so it never outlives the hover that made it. */
   @state()
-  private _cursor: { label: string; point: TrendPoint; from: 'pointer' | 'key' } | null = null;
+  private _hover: Cursor | null = null;
+
+  /** Where the arrow keys left the cursor. Held apart from the hover because a
+   *  pointer crossing any chart would otherwise erase a stepped position. */
+  @state()
+  private _keyed: Cursor | null = null;
 
   /** The log on screen, from the app root. */
   @consume({ context: logContext, subscribe: true })
@@ -268,20 +283,53 @@ export class GovernorTrends extends LitElement {
     </div>`;
   }
 
-  private _onPointerMove(event: PointerEvent, series: TrendSeries, logTotal: number): void {
-    const point = this._pointFrom(event, series, logTotal);
-    this._cursor = point ? { label: series.label, point, from: 'pointer' } : null;
-  }
-
-  private _onPointerLeave(): void {
-    if (this._cursor?.from === 'pointer') {
-      this._cursor = null;
+  /** A cursor belongs to the log that placed it; metric labels repeat. */
+  protected willUpdate(changed: PropertyValues<this>): void {
+    if (changed.has('logStore')) {
+      this._hover = null;
+      this._keyed = null;
     }
   }
 
+  private _onPointerMove(event: PointerEvent, series: TrendSeries, logTotal: number): void {
+    const point = this._pointFrom(event, series, logTotal);
+    this._hover = point ? { label: series.label, point } : null;
+  }
+
+  /** Puts the cursor where the keys left it. A resting pointer would otherwise
+   *  answer every step from the same sample, so the keys take this chart from
+   *  it; moving the pointer takes it back. */
+  private _hold(series: TrendSeries, point: TrendPoint | null | undefined): TrendPoint | null {
+    if (!point) {
+      return null;
+    }
+    this._keyed = { label: series.label, point };
+    if (this._hover?.label === series.label) {
+      this._hover = null;
+    }
+    return point;
+  }
+
+  /**
+   * What an activation moves to: the sample given, else this chart's cursor,
+   * else the last sample, since consumption never falls inside a transaction
+   * and that is where the metric stands highest.
+   */
+  private _target(series: TrendSeries, placed: TrendPoint | null): TrendPoint | null {
+    return placed ?? this._cursorFor(series) ?? series.points.at(-1) ?? null;
+  }
+
+  private _onPointerLeave(): void {
+    this._hover = null;
+  }
+
   private _onClick(event: PointerEvent, series: TrendSeries, logTotal: number): void {
-    // Where the pointer is wins: the cursor may sit where the arrow keys left it.
-    const point = this._pointFrom(event, series, logTotal) ?? this._cursorFor(series);
+    // Where the pointer is wins, but a click carrying no coordinates (assistive
+    // tech, or `click()`) reports x 0, which would seek the log's start.
+    const placed = event.detail === 0 ? null : this._pointFrom(event, series, logTotal);
+    // No cursor is kept: the pointer is still on the chart and holds its own,
+    // and a second chart reading at once says two things at the same time.
+    const point = this._target(series, placed);
     if (point) {
       this._seek(point.t);
     }
@@ -295,28 +343,33 @@ export class GovernorTrends extends LitElement {
   private _onKeyDown(event: KeyboardEvent, series: TrendSeries, logTotal: number): void {
     const step =
       event.key === 'ArrowRight' ? KEY_STEP : event.key === 'ArrowLeft' ? -KEY_STEP : undefined;
+    const activates = event.key === 'Enter' || event.key === ' ';
+    if (step === undefined && !activates) {
+      return;
+    }
+    event.preventDefault();
     if (step !== undefined) {
       const from = this._cursorFor(series)?.t ?? 0;
       const t = Math.min(Math.max(from + step * logTotal, 0), logTotal);
-      const point = pointAt(series.points, t);
-      if (point) {
-        this._cursor = { label: series.label, point, from: 'key' };
-      }
-      event.preventDefault();
+      this._hold(series, pointAt(series.points, t));
       return;
     }
-    if (event.key === 'Enter' || event.key === ' ') {
-      const point = this._cursorFor(series) ?? series.points.at(-1);
-      if (point) {
-        this._seek(point.t);
-      }
-      event.preventDefault();
+    // Arrows repeat, so holding one scrubs the cursor. An activation must not:
+    // it would re-zoom the flame chart on every repeat.
+    if (event.repeat) {
+      return;
+    }
+    // The cursor stays where this landed, so the arrows carry on from it.
+    const point = this._hold(series, this._target(series, null));
+    if (point) {
+      this._seek(point.t);
     }
   }
 
-  /** The cursor, when this chart is the one holding it. */
+  /** This chart's cursor: the pointer's while it is over the chart, else the
+   *  keys'. */
   private _cursorFor(series: TrendSeries): TrendPoint | null {
-    return this._cursor?.label === series.label ? this._cursor.point : null;
+    return pointOn(this._hover, series) ?? pointOn(this._keyed, series);
   }
 
   /** The series' value at the pointer, in the log's own time. */

--- a/log-viewer/src/components/__tests__/GovernorTrends.test.ts
+++ b/log-viewer/src/components/__tests__/GovernorTrends.test.ts
@@ -25,8 +25,8 @@ import '../GovernorTrends.js';
 
 const LOG_NS = 1_000;
 
-const trend = (): TrendSeries => ({
-  label: 'SOQL queries',
+const trend = (label = 'SOQL queries'): TrendSeries => ({
+  label,
   points: [
     { t: 0, ratio: 0, used: 0 },
     { t: 400, ratio: 40, used: 40 },
@@ -38,23 +38,36 @@ const trend = (): TrendSeries => ({
   format: String,
 });
 
+const aLog = () => ({ log: { duration: { total: LOG_NS } } }) as unknown as LogStore;
+
 async function mount(): Promise<LitElement> {
   const element = document.createElement('governor-trends');
   // No provider in the test, so the consumed store is assigned straight on.
-  (element as unknown as { logStore: LogStore }).logStore = {
-    log: { duration: { total: LOG_NS } },
-  } as unknown as LogStore;
+  (element as unknown as { logStore: LogStore }).logStore = aLog();
   document.body.append(element);
   await element.updateComplete;
   return element;
 }
 
 /** The chart, given a width so a pointer x maps to a time. */
-function chartOf(element: LitElement): HTMLButtonElement {
-  const chart = element.shadowRoot!.querySelector('.trend__chart') as HTMLButtonElement;
+function chartOf(element: LitElement, at = 0): HTMLButtonElement {
+  const chart = element.shadowRoot!.querySelectorAll('.trend__chart')[at] as HTMLButtonElement;
   chart.getBoundingClientRect = () => ({ left: 0, width: 100, top: 0, height: 44 }) as DOMRect;
   return chart;
 }
+
+/** A key press on a chart. */
+const press = (chart: HTMLButtonElement, key: string, init: KeyboardEventInit = {}) =>
+  chart.dispatchEvent(new KeyboardEvent('keydown', { key, ...init }));
+
+/** A pointer over a chart, at an x the chart's width maps to a time. */
+const hover = (chart: HTMLButtonElement, clientX: number) =>
+  chart.dispatchEvent(new MouseEvent('pointermove', { clientX }));
+
+/** A click. `detail` is 1 for a real pointer and 0 where there are no
+ *  coordinates: assistive tech, or `click()`. */
+const click = (chart: HTMLButtonElement, clientX: number, detail = 1) =>
+  chart.dispatchEvent(new MouseEvent('click', { clientX, detail }));
 
 let seeks: { timestamp?: number; mode?: string }[];
 let unsubscribe: () => void;
@@ -73,7 +86,7 @@ describe('governor-trends', () => {
   it('moves the timeline to the instant clicked on a chart', async () => {
     const element = await mount();
 
-    chartOf(element).dispatchEvent(new MouseEvent('click', { clientX: 60 }));
+    click(chartOf(element), 60);
 
     expect(seeks).toEqual([{ timestamp: 600, mode: 'seek' }]);
   });
@@ -129,6 +142,109 @@ describe('governor-trends', () => {
     chartOf(element).dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter' }));
 
     expect(seeks).toEqual([{ timestamp: 800, mode: 'seek' }]);
+  });
+
+  it('reads the cursor when a click carries no coordinates', async () => {
+    const element = await mount();
+    const chart = chartOf(element);
+
+    press(chart, 'ArrowRight');
+    click(chart, 0, 0);
+
+    expect(seeks).toEqual([{ timestamp: 20, mode: 'seek' }]);
+  });
+
+  it('answers the last sample when a click carries neither coordinates nor a cursor', async () => {
+    const element = await mount();
+
+    click(chartOf(element), 0, 0);
+
+    // x 0 is the log's start, which is never where a limit stands highest.
+    expect(seeks).toEqual([{ timestamp: 800, mode: 'seek' }]);
+  });
+
+  it('holds a stepped cursor against a pointer on another chart', async () => {
+    series = [trend(), trend('DML statements')];
+    const element = await mount();
+    const [first, second] = [chartOf(element), chartOf(element, 1)];
+
+    press(first, 'ArrowRight');
+    // The pointer rests on the second chart: its hover is not this chart's cursor.
+    hover(second, 40);
+    press(first, 'Enter');
+
+    expect(seeks).toEqual([{ timestamp: 20, mode: 'seek' }]);
+
+    // And losing that hover leaves the stepped cursor where it was.
+    second.dispatchEvent(new MouseEvent('pointerleave'));
+    press(first, 'Enter');
+
+    expect(seeks).toEqual([
+      { timestamp: 20, mode: 'seek' },
+      { timestamp: 20, mode: 'seek' },
+    ]);
+  });
+
+  it('keeps stepping while the pointer rests on the chart', async () => {
+    const element = await mount();
+    const chart = chartOf(element);
+
+    hover(chart, 40);
+    press(chart, 'ArrowRight');
+    press(chart, 'ArrowRight');
+    press(chart, 'Enter');
+
+    // Two steps on from the hover, not the hover answered twice.
+    expect(seeks).toEqual([{ timestamp: 440, mode: 'seek' }]);
+  });
+
+  it('leaves one chart reading at a time after a click', async () => {
+    series = [trend(), trend('DML statements')];
+    const element = await mount();
+    const [first, second] = [chartOf(element), chartOf(element, 1)];
+
+    hover(first, 30);
+    click(first, 30);
+    first.dispatchEvent(new MouseEvent('pointerleave'));
+    hover(second, 40);
+    await element.updateComplete;
+
+    expect(element.shadowRoot?.querySelectorAll('.trend__cursor')).toHaveLength(1);
+  });
+
+  it('steps on from the sample Enter answered', async () => {
+    const element = await mount();
+    const chart = chartOf(element);
+
+    press(chart, 'Enter');
+    press(chart, 'ArrowLeft');
+    press(chart, 'Enter');
+
+    // One step back from the last sample, not from the log's start.
+    expect(seeks).toEqual([
+      { timestamp: 800, mode: 'seek' },
+      { timestamp: 780, mode: 'seek' },
+    ]);
+  });
+
+  it('drops the cursor when another log arrives', async () => {
+    const element = await mount();
+
+    press(chartOf(element), 'ArrowRight');
+    (element as unknown as { logStore: LogStore }).logStore = aLog();
+    await element.updateComplete;
+    press(chartOf(element), 'Enter');
+
+    // The label repeats across logs, so a kept cursor would seek the old point.
+    expect(seeks).toEqual([{ timestamp: 800, mode: 'seek' }]);
+  });
+
+  it('ignores a held Enter, so the flame chart is not re-zoomed', async () => {
+    const element = await mount();
+
+    press(chartOf(element), 'Enter', { repeat: true });
+
+    expect(seeks).toEqual([]);
   });
 
   // A button, so the focus ring only shows for keyboard focus, never a click.

--- a/log-viewer/src/components/__tests__/HotPath.test.ts
+++ b/log-viewer/src/components/__tests__/HotPath.test.ts
@@ -93,7 +93,6 @@ describe('hot-path', () => {
       'self 0.001 ms (50.0%) \u00b7 0.001 ms (50.0%) below this frame \u00b7 the hot spot',
     );
     // The hue is decorative, so the category is named in text a reader can hear.
-    expect(row?.querySelector('.reveal-row__swatch')).toBeNull();
     expect(row?.querySelector('.reveal-row__sr')?.textContent).toBe('Apex');
   });
 

--- a/log-viewer/src/components/__tests__/HotSpots.test.ts
+++ b/log-viewer/src/components/__tests__/HotSpots.test.ts
@@ -68,7 +68,6 @@ describe('hot-spots', () => {
     // The bar runs to the 40% total share; half of it — the 20% self share — is solid.
     expect(row?.style.getPropertyValue('--self-pct')).toBe('50%');
     // The hue is decorative, so the category is named in text a reader can hear.
-    expect(row?.querySelector('.reveal-row__swatch')).toBeNull();
     expect(row?.querySelector('.reveal-row__sr')?.textContent).toBe('Apex');
     expect(
       element.shadowRoot?.querySelector<HTMLElement>('.reveal-row__meter-fill')?.style.width,

--- a/log-viewer/src/features/analysis/components/SelfTimeSpreadView.ts
+++ b/log-viewer/src/features/analysis/components/SelfTimeSpreadView.ts
@@ -157,7 +157,7 @@ export class SelfTimeSpreadView extends LitElement {
   private _row(row: SingleRow, title: string, value: number, extras: TemplateResult | '') {
     return html`
       <button
-        class="bleed-row reveal-row reveal-row--no-swatch"
+        class="bleed-row reveal-row"
         type="button"
         title=${title}
         style=${styleMap({ '--row-hue': this._palette.colorFor(row.category) })}

--- a/log-viewer/src/features/analysis/components/__tests__/SelfTimeSpreadView.test.ts
+++ b/log-viewer/src/features/analysis/components/__tests__/SelfTimeSpreadView.test.ts
@@ -83,10 +83,6 @@ describe('self-time-spread', () => {
     );
     // The hue is decorative, so the category is named in text a reader can hear.
     expect(text(element, '.reveal-row__sr')).toBe('Apex');
-    // No swatch, so the name must take the flexible track and truncate there.
-    expect(element.shadowRoot?.querySelector('.reveal-row')?.classList).toContain(
-      'reveal-row--no-swatch',
-    );
   });
 
   it('draws a bin per bucket at the height the lane worked out', async () => {


### PR DESCRIPTION
# 📝 PR Overview

The four Governor trend charts shared one cursor. A sample read on one chart answered the arrow keys and the live region on the other three, so the keyboard reported a figure from a chart the reader was not on. Holding Enter also re-zoomed the flame chart on every key repeat.

A cursor now belongs to the chart that placed it, and to the log that placed it. Each chart reads only its own sample, and one chart reads at a time.

## 🛠️ Changes made

- A cursor carries its chart's label, so a sample on one chart no longer answers another.
- A held Enter is ignored after the first press - a key repeat must not re-zoom the flame chart. Arrows still repeat, so holding one scrubs.
- A click with no coordinates (assistive tech, a programmatic click) reads the chart's cursor, else the last sample, so it always reaches a frame.
- The arrows carry on from the sample Enter answered, and keep stepping while the pointer rests on the chart.
- A new log clears the cursor: metric labels repeat between logs.
- Removes `reveal-row--no-swatch`, a class with no rule behind it, and the three tests that asserted the absence of an element it never controlled.

## 🧩 Type of change (check all applicable)

- [x] 🐛 Bug fix - something not working as expected
- [ ] ✨ New feature – adds new functionality
- [x] ♻️ Refactor - internal changes with no user impact
- [ ] ⚡ Performance Improvement
- [ ] 📝 Documentation - README or documentation site changes
- [ ] 🔧 Chore - dev tooling, CI, config
- [ ] 💥 Breaking change

## 📷 Screenshots / gifs / video [optional]

N/A - keyboard and pointer behaviour, nothing new on screen.

## 🔗 Related Issues

related #950

## ✅ Tests added?

- [x] 👍 yes

Eight tests in `GovernorTrends.test.ts` cover the cursor rules. Each new guard was mutation proved: break it, watch its own test fail, restore it.

\`\`\`
pnpm test    # 169 suites, 2306 tests
pnpm lint
\`\`\`

Dev host: step the arrows on one chart, then rest the pointer on another. The stepped chart keeps answering, and only one chart reads at a time.

## 📚 Docs updated?

- [x] 🙅 not needed

The trend seek feature is unreleased, so this fix reaches nobody as a change. The Inspector changelog entry already covers it.