### PR TITLE
fix(log-viewer): fire keyboard commands once while a key is held

### DIFF
--- a/log-viewer/src/components/PaneView.ts
+++ b/log-viewer/src/components/PaneView.ts
@@ -345,8 +345,12 @@ export class PaneView extends LitElement {
 
   private _onHeaderKey(e: KeyboardEvent, id: string) {
     if (e.key === 'Enter' || e.key === ' ') {
+      // Consumed on a repeat too, so Space never scrolls the stack.
       e.preventDefault();
-      this._toggle(id);
+      // Fires once: a repeat would flap the pane, and each toggle persists a setting.
+      if (!e.repeat) {
+        this._toggle(id);
+      }
     }
   }
 

--- a/log-viewer/src/components/__tests__/PaneView.test.ts
+++ b/log-viewer/src/components/__tests__/PaneView.test.ts
@@ -111,6 +111,34 @@ describe('PaneView', () => {
     expect(body(el, 'a')).toBeNull();
   });
 
+  it('ignores a held Enter, so the pane does not flap', async () => {
+    const el = await mount('vertical');
+    const h = header(el, 'a');
+    let toggles = 0;
+    el.addEventListener('pane-toggle', () => toggles++);
+
+    h?.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }));
+    h?.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true, repeat: true }));
+    h?.dispatchEvent(new KeyboardEvent('keydown', { key: ' ', bubbles: true, repeat: true }));
+    await el.updateComplete;
+
+    expect(toggles).toBe(1);
+    expect(body(el, 'a')).toBeNull();
+  });
+
+  it('keeps a repeated Space from scrolling the stack', async () => {
+    const el = await mount('vertical');
+    const event = new KeyboardEvent('keydown', {
+      key: ' ',
+      bubbles: true,
+      cancelable: true,
+      repeat: true,
+    });
+    header(el, 'a')?.dispatchEvent(event);
+
+    expect(event.defaultPrevented).toBe(true);
+  });
+
   it('does not collapse in horizontal mode and keeps all panes open', async () => {
     const el = await mount('horizontal');
     // No twistie, headers are not buttons.

--- a/log-viewer/src/features/timeline/__tests__/keyboard-handler.test.ts
+++ b/log-viewer/src/features/timeline/__tests__/keyboard-handler.test.ts
@@ -268,6 +268,20 @@ describe('KeyboardHandler', () => {
 
       expect(event.defaultPrevented).toBe(true);
     });
+
+    it('should not call onResetZoom on a key repeat', () => {
+      dispatchKeyEvent('keydown', 'Home');
+      dispatchKeyEvent('keydown', 'Home', { repeat: true });
+      dispatchKeyEvent('keydown', '0', { repeat: true });
+
+      expect(callbacks.onResetZoom).toHaveBeenCalledTimes(1);
+    });
+
+    it('should still prevent default on a repeated Home key', () => {
+      const event = dispatchKeyEvent('keydown', 'Home', { repeat: true });
+
+      expect(event.defaultPrevented).toBe(true);
+    });
   });
 
   describe('escape key', () => {
@@ -492,6 +506,20 @@ describe('KeyboardHandler', () => {
 
       expect(event.defaultPrevented).toBe(true);
     });
+
+    it('should not call onJumpToCallTree on a key repeat', () => {
+      dispatchKeyEvent('keydown', 'j');
+      dispatchKeyEvent('keydown', 'j', { repeat: true });
+      dispatchKeyEvent('keydown', 'j', { repeat: true });
+
+      expect(callbacks.onJumpToCallTree).toHaveBeenCalledTimes(1);
+    });
+
+    it('should still prevent default on a repeated J key', () => {
+      const event = dispatchKeyEvent('keydown', 'j', { repeat: true });
+
+      expect(event.defaultPrevented).toBe(true);
+    });
   });
 
   describe('focus keys (Enter / Z)', () => {
@@ -541,6 +569,20 @@ describe('KeyboardHandler', () => {
       expect(enterEvent.defaultPrevented).toBe(true);
       expect(zEvent.defaultPrevented).toBe(true);
     });
+
+    it('should not call onFocus on a key repeat', () => {
+      dispatchKeyEvent('keydown', 'Enter');
+      dispatchKeyEvent('keydown', 'Enter', { repeat: true });
+      dispatchKeyEvent('keydown', 'z', { repeat: true });
+
+      expect(callbacks.onFocus).toHaveBeenCalledTimes(1);
+    });
+
+    it('should still prevent default on a repeated Enter', () => {
+      const event = dispatchKeyEvent('keydown', 'Enter', { repeat: true });
+
+      expect(event.defaultPrevented).toBe(true);
+    });
   });
 
   describe('Copy (Ctrl/Cmd+C)', () => {
@@ -578,6 +620,31 @@ describe('KeyboardHandler', () => {
       const event = dispatchKeyEvent('keydown', 'c', { ctrlKey: true });
 
       expect(event.defaultPrevented).toBe(true);
+    });
+
+    it('should not call onCopy on a key repeat', () => {
+      dispatchKeyEvent('keydown', 'c', { ctrlKey: true });
+      dispatchKeyEvent('keydown', 'c', { ctrlKey: true, repeat: true });
+
+      expect(callbacks.onCopy).toHaveBeenCalledTimes(1);
+    });
+
+    it('should still prevent default on a repeated Ctrl/Cmd+C', () => {
+      const event = dispatchKeyEvent('keydown', 'c', { ctrlKey: true, repeat: true });
+
+      expect(event.defaultPrevented).toBe(true);
+    });
+  });
+
+  describe('key repeat on continuous controls', () => {
+    it('should pan and zoom on every repeat, so holding a key scrubs', () => {
+      dispatchKeyEvent('keydown', 'ArrowLeft', { repeat: true });
+      dispatchKeyEvent('keydown', 'a', { repeat: true });
+      dispatchKeyEvent('keydown', 'w', { repeat: true });
+      dispatchKeyEvent('keydown', 's', { repeat: true });
+
+      expect(callbacks.onPan).toHaveBeenCalledTimes(2);
+      expect(callbacks.onZoom).toHaveBeenCalledTimes(2);
     });
   });
 

--- a/log-viewer/src/features/timeline/optimised/interaction/KeyboardHandler.ts
+++ b/log-viewer/src/features/timeline/optimised/interaction/KeyboardHandler.ts
@@ -633,7 +633,10 @@ export class KeyboardHandler {
     switch (event.key) {
       case 'Home':
       case '0':
-        this.callbacks.onResetZoom?.();
+        // Fires once: the viewport is already reset, so a repeat only re-renders.
+        if (!event.repeat) {
+          this.callbacks.onResetZoom?.();
+        }
         return true;
       default:
         return false;
@@ -664,7 +667,10 @@ export class KeyboardHandler {
     }
 
     if (event.key === 'j' || event.key === 'J') {
-      this.callbacks.onJumpToCallTree?.();
+      // Fires once: a repeat would rebuild the call tree at the repeat rate.
+      if (!event.repeat) {
+        this.callbacks.onJumpToCallTree?.();
+      }
       return true;
     }
     return false;
@@ -681,7 +687,10 @@ export class KeyboardHandler {
     }
 
     if (event.key === 'Enter' || event.key === 'z' || event.key === 'Z') {
-      this.callbacks.onFocus?.();
+      // Fires once: a repeat would re-zoom to the same frame at the repeat rate.
+      if (!event.repeat) {
+        this.callbacks.onFocus?.();
+      }
       return true;
     }
     return false;
@@ -699,7 +708,10 @@ export class KeyboardHandler {
     }
 
     if (event.key === 'c' || event.key === 'C') {
-      this.callbacks.onCopy?.();
+      // Fires once: a repeat would rewrite the clipboard on every press.
+      if (!event.repeat) {
+        this.callbacks.onCopy?.();
+      }
       return true;
     }
     return false;


### PR DESCRIPTION
# 📝 PR Overview

A key repeat should scrub a continuous control, not re-run a command. Held keys did both. Holding Enter or Space on an Inspector section header flapped the pane open and shut and wrote the collapsed setting to disk on every repeat, roughly 30 times a second. On the timeline, holding Enter re-zoomed to the same frame, J rebuilt the call-tree table, Home reset an already-reset viewport, and Ctrl/Cmd+C rewrote the clipboard, each at the repeat rate.

Every command now fires once. The key stays consumed on the repeats, so Space still cannot scroll the pane stack and the browser never acts on a repeat. Pan and zoom repeat as before, so holding an arrow key still scrubs.

## 🛠️ Changes made

- `PaneView` header keys toggle once, so the pane no longer flaps and the setting is written once per press.
- Timeline `Enter`/`Z` (focus), `J` (jump to call tree), `Home`/`0` (reset zoom) and `Ctrl`/`Cmd`+`C` (copy) each fire once.
- `preventDefault` still runs on a suppressed repeat, so the key stays ours; an unrelated held key, such as `Tab`, is untouched.
- Pan, zoom and `Escape` are unchanged: the first two are continuous, and `Escape` converges on its own.

## 🧩 Type of change (check all applicable)

- [x] 🐛 Bug fix - something not working as expected
- [ ] ✨ New feature – adds new functionality
- [ ] ♻️ Refactor - internal changes with no user impact
- [x] ⚡ Performance Improvement
- [ ] 📝 Documentation - README or documentation site changes
- [ ] 🔧 Chore - dev tooling, CI, config
- [ ] 💥 Breaking change

## 📷 Screenshots / gifs / video [optional]

N/A - keyboard behaviour, nothing new on screen.

## 🔗 Related Issues

N/A

## ✅ Tests added?

- [x] 👍 yes

Eleven tests, and every guard was mutation proved: break it, watch its own test fail, restore it. Tests also hold the two contracts the guard must not break - a suppressed repeat still prevents the default, and pan and zoom still act on every repeat.

\`\`\`
pnpm test    # 169 suites, 2317 tests
pnpm lint
\`\`\`

Dev host: hold Enter on an Inspector section header. The pane toggles once. Reopen the log and the collapsed state matches, so the setting was written once. Then hold an arrow key on the timeline: pan still scrubs.

## 📚 Docs updated?

- [x] 🙅 not needed

## Anything else we need to know? [optional]

The minimap and metric strip carry their own `Home`/`End`/`0` bindings, which are the same class of command and still re-fire on a repeat. They only fire while the pointer is over those strips, and guarding them means six more branches inside two switch statements, which is the point at which a declarative continuous-or-command binding table earns its keep. Left out of this fix on purpose.