### PR TITLE
fix(log-viewer): finish the fire-once contract for held keys

### DIFF
--- a/log-viewer/src/components/VariablesDetail.ts
+++ b/log-viewer/src/components/VariablesDetail.ts
@@ -575,12 +575,17 @@ export class VariablesDetail extends LitElement {
         break;
       case 'Enter':
       case ' ':
-        if (row.expandable) {
+        // Fires once: a repeat would flap the row open and shut. The arrows open
+        // and close in one direction each, so they carry on repeating.
+        if (row.expandable && !event.repeat) {
           this._toggle(row.id, !row.open);
         }
         break;
       case '*':
-        this._openAll(row.depth);
+        // Fires once: every row at this depth is open after the first press.
+        if (!event.repeat) {
+          this._openAll(row.depth);
+        }
         break;
       default:
         return;

--- a/log-viewer/src/components/__tests__/VariablesDetail.test.ts
+++ b/log-viewer/src/components/__tests__/VariablesDetail.test.ts
@@ -192,9 +192,21 @@ function tabStop(el: VariablesDetail): string | null {
   return el.shadowRoot?.querySelector('[tabindex="0"]')?.getAttribute('data-id') ?? null;
 }
 
-async function press(el: VariablesDetail, key: string): Promise<void> {
-  tree(el).dispatchEvent(new KeyboardEvent('keydown', { key, bubbles: true }));
+/** Returns the event, so a caller can read back whether the tree consumed it. */
+async function press(
+  el: VariablesDetail,
+  key: string,
+  options: Partial<KeyboardEventInit> = {},
+): Promise<KeyboardEvent> {
+  const event = new KeyboardEvent('keydown', {
+    key,
+    bubbles: true,
+    cancelable: true,
+    ...options,
+  });
+  tree(el).dispatchEvent(event);
   await el.updateComplete;
+  return event;
 }
 
 describe('VariablesDetail groups', () => {
@@ -565,6 +577,54 @@ describe('VariablesDetail keyboard', () => {
     await press(el, 'Enter');
 
     expect(treeRows(el)[0]?.getAttribute('aria-expanded')).toBe('false');
+  });
+});
+
+describe('VariablesDetail keyboard, key repeat', () => {
+  it('holds a row where a held Enter left it, rather than flapping', async () => {
+    const store = logOf(FRAME);
+    const el = await mount(store, { eventIndex: indexOf(store, 'ns.Outer.run()') });
+
+    await press(el, 'Enter');
+    await press(el, 'Enter', { repeat: true });
+    const afterEnter = treeRows(el)[0]?.getAttribute('aria-expanded');
+    await press(el, ' ', { repeat: true });
+
+    expect(afterEnter).toBe('false');
+    expect(treeRows(el)[0]?.getAttribute('aria-expanded')).toBe('false');
+  });
+
+  it('leaves a group closed that a held star would re-open', async () => {
+    const store = logOf(FRAME);
+    const el = await mount(store, { eventIndex: indexOf(store, 'ns.Outer.run()') });
+    const local = () => treeRows(el).find((row) => row.dataset.id === 'local');
+
+    // Local starts open, and holds the tab stop, so Enter closes it.
+    await press(el, 'Enter');
+    await press(el, '*', { repeat: true });
+
+    expect(local()?.getAttribute('aria-expanded')).toBe('false');
+  });
+
+  it('keeps the key consumed on a suppressed repeat', async () => {
+    const store = logOf(FRAME);
+    const el = await mount(store, { eventIndex: indexOf(store, 'ns.Outer.run()') });
+
+    const event = await press(el, 'Enter', { repeat: true });
+
+    expect(event.defaultPrevented).toBe(true);
+  });
+
+  it('walks on every repeat, so holding an arrow scrubs', async () => {
+    const store = logOf(FRAME);
+    const el = await mount(store, { eventIndex: indexOf(store, 'ns.Outer.run()') });
+
+    await press(el, 'ArrowDown');
+    const second = tabStop(el);
+    await press(el, 'ArrowDown', { repeat: true });
+
+    expect(second).not.toBe('local');
+    expect(tabStop(el)).not.toBe(second);
   });
 });
 

--- a/log-viewer/src/features/timeline/__tests__/keyboard-handler.test.ts
+++ b/log-viewer/src/features/timeline/__tests__/keyboard-handler.test.ts
@@ -636,6 +636,79 @@ describe('KeyboardHandler', () => {
     });
   });
 
+  describe('minimap commands (pointer over the minimap)', () => {
+    beforeEach(() => {
+      (callbacks.isInMinimapArea as jest.Mock).mockReturnValue(true);
+    });
+
+    it('should call each command once on a held key', () => {
+      dispatchKeyEvent('keydown', 'Home');
+      dispatchKeyEvent('keydown', 'Home', { repeat: true });
+      dispatchKeyEvent('keydown', 'End');
+      dispatchKeyEvent('keydown', 'End', { repeat: true });
+      // 0 and Escape are the same command, so a repeat of either is suppressed.
+      dispatchKeyEvent('keydown', '0');
+      dispatchKeyEvent('keydown', 'Escape', { repeat: true });
+
+      expect(callbacks.onMinimapJumpStart).toHaveBeenCalledTimes(1);
+      expect(callbacks.onMinimapJumpEnd).toHaveBeenCalledTimes(1);
+      expect(callbacks.onMinimapResetZoom).toHaveBeenCalledTimes(1);
+    });
+
+    // End is this area's alone: the main timeline ignores it, so a repeat that
+    // reported nothing prevented would mean the area handler never saw it.
+    it('should still prevent default on a repeated command', () => {
+      const event = dispatchKeyEvent('keydown', 'End', { repeat: true });
+
+      expect(event.defaultPrevented).toBe(true);
+    });
+
+    it('should pan and zoom the lens on every repeat', () => {
+      dispatchKeyEvent('keydown', 'ArrowLeft', { repeat: true });
+      dispatchKeyEvent('keydown', 'ArrowRight', { repeat: true });
+      dispatchKeyEvent('keydown', 'w', { repeat: true });
+
+      expect(callbacks.onMinimapPanViewport).toHaveBeenCalledTimes(2);
+      expect(callbacks.onMinimapZoom).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('metric strip commands (pointer over the strip)', () => {
+    beforeEach(() => {
+      (callbacks.isInMetricStripArea as jest.Mock).mockReturnValue(true);
+    });
+
+    it('should call each command once on a held key', () => {
+      dispatchKeyEvent('keydown', 'Home');
+      dispatchKeyEvent('keydown', 'Home', { repeat: true });
+      dispatchKeyEvent('keydown', 'End');
+      dispatchKeyEvent('keydown', 'End', { repeat: true });
+      dispatchKeyEvent('keydown', '0');
+      dispatchKeyEvent('keydown', 'Escape', { repeat: true });
+
+      expect(callbacks.onMetricStripJumpStart).toHaveBeenCalledTimes(1);
+      expect(callbacks.onMetricStripJumpEnd).toHaveBeenCalledTimes(1);
+      expect(callbacks.onMetricStripResetZoom).toHaveBeenCalledTimes(1);
+    });
+
+    // End is this area's alone: the main timeline ignores it, so a repeat that
+    // reported nothing prevented would mean the area handler never saw it.
+    it('should still prevent default on a repeated command', () => {
+      const event = dispatchKeyEvent('keydown', 'End', { repeat: true });
+
+      expect(event.defaultPrevented).toBe(true);
+    });
+
+    it('should pan and zoom the strip on every repeat', () => {
+      dispatchKeyEvent('keydown', 'ArrowLeft', { repeat: true });
+      dispatchKeyEvent('keydown', 'ArrowRight', { repeat: true });
+      dispatchKeyEvent('keydown', 'w', { repeat: true });
+
+      expect(callbacks.onMetricStripPanViewport).toHaveBeenCalledTimes(2);
+      expect(callbacks.onMetricStripZoom).toHaveBeenCalledTimes(1);
+    });
+  });
+
   describe('key repeat on continuous controls', () => {
     it('should pan and zoom on every repeat, so holding a key scrubs', () => {
       dispatchKeyEvent('keydown', 'ArrowLeft', { repeat: true });

--- a/log-viewer/src/features/timeline/optimised/interaction/KeyboardHandler.ts
+++ b/log-viewer/src/features/timeline/optimised/interaction/KeyboardHandler.ts
@@ -344,19 +344,27 @@ export class KeyboardHandler {
         return true;
     }
 
-    // Jump to start/end (Home/End)
+    // Jump to start/end (Home/End). Each fires once: the lens lands on a fixed
+    // end of the log, so a repeat only re-renders it there.
     switch (event.key) {
       case 'Home':
-        this.callbacks.onMinimapJumpStart?.();
+        if (!event.repeat) {
+          this.callbacks.onMinimapJumpStart?.();
+        }
         return true;
       case 'End':
-        this.callbacks.onMinimapJumpEnd?.();
+        if (!event.repeat) {
+          this.callbacks.onMinimapJumpEnd?.();
+        }
         return true;
     }
 
-    // Reset zoom (0/Escape)
+    // Reset zoom (0/Escape). Fires once: the viewport is already reset, so a
+    // repeat only re-renders.
     if (key === '0' || event.key === 'Escape') {
-      this.callbacks.onMinimapResetZoom?.();
+      if (!event.repeat) {
+        this.callbacks.onMinimapResetZoom?.();
+      }
       return true;
     }
 
@@ -436,19 +444,27 @@ export class KeyboardHandler {
         return true;
     }
 
-    // Jump to start/end (Home/End)
+    // Jump to start/end (Home/End). Each fires once: the strip lands on a fixed
+    // end of the log, so a repeat only re-renders it there.
     switch (event.key) {
       case 'Home':
-        this.callbacks.onMetricStripJumpStart?.();
+        if (!event.repeat) {
+          this.callbacks.onMetricStripJumpStart?.();
+        }
         return true;
       case 'End':
-        this.callbacks.onMetricStripJumpEnd?.();
+        if (!event.repeat) {
+          this.callbacks.onMetricStripJumpEnd?.();
+        }
         return true;
     }
 
-    // Reset zoom (0/Escape)
+    // Reset zoom (0/Escape). Fires once: the viewport is already reset, so a
+    // repeat only re-renders.
     if (key === '0' || event.key === 'Escape') {
-      this.callbacks.onMetricStripResetZoom?.();
+      if (!event.repeat) {
+        this.callbacks.onMetricStripResetZoom?.();
+      }
       return true;
     }
 


### PR DESCRIPTION
# 📝 PR Overview

#1016 gave the webview one rule: a key repeat scrubs a continuous control, but must not re-run a command. A sweep of every keydown handler found the rule unfinished in three places. Holding `Home`, `End` or `0` over the minimap or the metric strip re-ran the jump at the repeat rate, redrawing the chart where it already stood, about 10ms of render per repeat for no visible change. In the Variables section, holding `Enter` or `Space` flapped a tree row open and shut, and a held `*` re-opened rows that were already open, rebuilding the tree and re-rendering each time.

All eight now fire once, and the key stays consumed on the repeats, so the browser never acts on them either. Everything continuous is untouched: panning and zooming the minimap and the strip still repeat, and so do the tree arrows, since holding one is how you walk into a tree.

## 🛠️ Changes made

- Minimap and metric strip: `Home`, `End` and `0`/`Escape` fire once each.
- Variables tree: `Enter`, `Space` and `*` fire once each. The arrows keep repeating, because each opens or closes in one direction only.
- The guard sits on the callback, never on the shared `_toggle`, which the arrows and the mouse also use.
- First tests for the minimap and metric strip key handlers. The suite had left both area checks reporting false, so nothing had ever reached them.

## 🧩 Type of change (check all applicable)

- [x] 🐛 Bug fix - something not working as expected
- [ ] ✨ New feature – adds new functionality
- [ ] ♻️ Refactor - internal changes with no user impact
- [x] ⚡ Performance Improvement
- [ ] 📝 Documentation - README or documentation site changes
- [ ] 🔧 Chore - dev tooling, CI, config
- [ ] 💥 Breaking change

## 📷 Screenshots / gifs / video [optional]

N/A - keyboard behaviour, nothing new on screen.

## 🔗 Related Issues

related #1016

## ✅ Tests added?

- [x] 👍 yes

Twelve tests. Every guard was mutation proved: break it, watch its own test fail, restore it. The tests also pin the two contracts the guard must not break - a suppressed repeat still prevents the default, and the continuous keys still fire on every repeat. Those use `End`, which only these handlers claim, so a gate in the wrong place cannot hide behind the main timeline.

\`\`\`
pnpm test    # 169 suites, 2327 tests
pnpm lint
\`\`\`

Dev host: rest the pointer on the minimap and hold `Home`. The lens jumps once. Hold an arrow there and it still pans. In Variables, hold `Enter` on a row that opens: it opens and stays open.

## 📚 Docs updated?

- [x] 🙅 not needed

The Variables section is unreleased, so its flap reaches nobody as a change, and the timeline repeats are wasted work a reader cannot see. Same call as #1016.

## Anything else we need to know? [optional]

The two area handlers stay near-identical twins. Merging them means passing seven callbacks at each of the two call sites, which is the same code behind indirection, and the file already documents the pair as a deliberate mirror.