### PR TITLE
refactor(log-viewer): style the located row once, not in six grids

### DIFF
--- a/log-viewer/src/components/CallStackDetail.ts
+++ b/log-viewer/src/components/CallStackDetail.ts
@@ -16,7 +16,7 @@ import { soqlInlineElement } from '../features/soql/format/inlineCell.js';
 import { soqlSyntaxStyles } from '../features/soql/styles/soql-syntax.css.js';
 import { eventBus } from '../core/events/EventBus.js';
 import { SelectionEchoGuard } from '../core/events/SelectionEchoGuard.js';
-import { LOCATED_ROW_CLASS, LocatedRowMarker, rowIndexStamper } from './locatedRow.js';
+import { LocatedRowMarker, rowIndexStamper } from './locatedRow.js';
 import { globalStyles } from '../styles/global.styles.js';
 import { progressColumnWidth } from '../tabulator/format/measureWidth.js';
 import dataGridStyles from '../tabulator/style/DataGrid.scss';
@@ -94,10 +94,6 @@ export class CallStackDetail extends LitElement {
         white-space: nowrap;
         overflow: hidden;
         text-overflow: ellipsis;
-      }
-      /* The frame under the pointer in the tab on screen. */
-      #call-stack-table .tabulator-row.${unsafeCSS(LOCATED_ROW_CLASS)} {
-        background-color: var(--lana-row-hover-bg);
       }
     `,
   ];

--- a/log-viewer/src/components/CallTreeDetail.ts
+++ b/log-viewer/src/components/CallTreeDetail.ts
@@ -38,13 +38,7 @@ import dataGridStyles from '../tabulator/style/DataGrid.scss';
 import './ContextMenu.js';
 import type { ContextMenu } from './ContextMenu.js';
 import { dispatchInspectorLocate, dispatchInspectorReveal } from './inspectorReveal.js';
-import {
-  LOCATED_ROW_CLASS,
-  LocatedRowIds,
-  LocatedRowMarker,
-  rowId,
-  rowIndexStamper,
-} from './locatedRow.js';
+import { LocatedRowIds, LocatedRowMarker, rowId, rowIndexStamper } from './locatedRow.js';
 import { PANEL_ROW_MENU_ITEMS, runPanelRowAction } from './panelRowMenu.js';
 import {
   buildScopedCallTree,
@@ -368,10 +362,6 @@ export class CallTreeDetail extends LitElement {
         white-space: nowrap;
         overflow: hidden;
         text-overflow: ellipsis;
-      }
-      /* The frame under the pointer in the tab on screen. */
-      .table-host .tabulator-row.${unsafeCSS(LOCATED_ROW_CLASS)} {
-        background-color: var(--lana-row-hover-bg);
       }
     `,
   ];

--- a/log-viewer/src/components/locatedRow.ts
+++ b/log-viewer/src/components/locatedRow.ts
@@ -10,7 +10,8 @@ import { ROOT_PATH_ID } from '../core/log/keyPathIds.js';
 import { logStoreFor } from '../core/log/LogStore.js';
 import { eventByEventIndex } from '../core/utility/EventSearch.js';
 
-/** Class the marked row carries; each table styles it itself. */
+/** Class the marked row carries. Styled once, in `tabulator/style/DataGrid.scss`,
+ *  which spells the name out: rename it here and the mark stops painting. */
 export const LOCATED_ROW_CLASS = 'located-row';
 
 /** Attribute holding a row's index, so the mark can find its element. */

--- a/log-viewer/src/features/analysis/components/AnalysisView.ts
+++ b/log-viewer/src/features/analysis/components/AnalysisView.ts
@@ -15,7 +15,6 @@ import '../../../components/ContextMenu.js';
 import type { ContextMenu } from '../../../components/ContextMenu.js';
 import { eventBus } from '../../../core/events/EventBus.js';
 import {
-  LOCATED_ROW_CLASS,
   LocatedRowIds,
   LocatedRowMarker,
   rowDetailSelection,
@@ -77,11 +76,6 @@ export class AnalysisView extends LitElement {
         /* inset previously provided by the tab panel's padding */
         padding: 10px 6px;
         box-sizing: border-box;
-      }
-
-      /* The frame under the pointer in the inspector. */
-      .tabulator-row.${unsafeCSS(LOCATED_ROW_CLASS)} {
-        background-color: var(--lana-row-hover-bg);
       }
 
       .analysis-view {

--- a/log-viewer/src/features/call-tree/components/CalltreeView.ts
+++ b/log-viewer/src/features/call-tree/components/CalltreeView.ts
@@ -66,7 +66,6 @@ import {
   toggleField,
 } from '../../../tabulator/ColumnViews.js';
 import {
-  LOCATED_ROW_CLASS,
   LocatedRowIds,
   LocatedRowMarker,
   rowDetailSelection,
@@ -300,11 +299,6 @@ export class CalltreeView extends LitElement {
         visibility: hidden;
         opacity: 0;
         pointer-events: none;
-      }
-
-      /* The frame under the pointer in the inspector. */
-      .tabulator-row.${unsafeCSS(LOCATED_ROW_CLASS)} {
-        background-color: var(--lana-row-hover-bg);
       }
     `,
     categoryColoringStyles,

--- a/log-viewer/src/features/database/components/DatabaseTimeTree.ts
+++ b/log-viewer/src/features/database/components/DatabaseTimeTree.ts
@@ -17,11 +17,7 @@ import {
   dispatchInspectorLocate,
   dispatchInspectorReveal,
 } from '../../../components/inspectorReveal.js';
-import {
-  LOCATED_ROW_CLASS,
-  LocatedRowMarker,
-  rowIndexStamper,
-} from '../../../components/locatedRow.js';
+import { LocatedRowMarker, rowIndexStamper } from '../../../components/locatedRow.js';
 import { PANEL_ROW_MENU_ITEMS, runPanelRowAction } from '../../../components/panelRowMenu.js';
 import { eventBus } from '../../../core/events/EventBus.js';
 import { logContext } from '../../../core/log/logContext.js';
@@ -192,10 +188,6 @@ export class DatabaseTime extends LitElement {
         white-space: nowrap;
         overflow: hidden;
         text-overflow: ellipsis;
-      }
-      /* The statement under the pointer in the grid beside. */
-      .tabulator-row.${unsafeCSS(LOCATED_ROW_CLASS)} {
-        background-color: var(--lana-row-hover-bg);
       }
     `,
   ];

--- a/log-viewer/src/features/database/components/DatabaseView.scss
+++ b/log-viewer/src/features/database/components/DatabaseView.scss
@@ -1,10 +1,5 @@
 @use '../../../tabulator/style/DataGrid';
 
-/* The statement under the pointer in the inspector (LOCATED_ROW_CLASS). */
-.tabulator-row.located-row {
-  background-color: var(--lana-row-hover-bg);
-}
-
 .db-group-row {
   display: flex;
   min-width: 0;

--- a/log-viewer/src/tabulator/style/DataGrid.scss
+++ b/log-viewer/src/tabulator/style/DataGrid.scss
@@ -238,6 +238,14 @@ $codicon-chevron-down: '\eab4';
       color: var(--vscode-list-activeSelectionForeground);
     }
 
+    // What the inspector located: the row it named, in whichever grid is on
+    // screen. It ties with hover and with selection, so it has to come after
+    // both — a mark holds until Escape, where a hover is only where the pointer
+    // is now.
+    .tabulator-row.located-row {
+      background-color: var(--lana-row-hover-bg);
+    }
+
     .tabulator-cell.datagrid-textarea {
       white-space: pre-wrap;
       overflow-wrap: break-word;


### PR DESCRIPTION
# 📝 PR Overview

The inspector marks what it locates: hover a row there and the grid marks the rows it names, and a click keeps the mark until `Escape`. Every grid that supports it carried its own copy of the same one-line rule - six copies of `background-color: var(--lana-row-hover-bg)`. They had started to drift: three different comments for one rule, and two selectors scoped for no reason.

The rule now lives once, in the grid stylesheet all six already load, beside the hover and selection rules it has to outrank. Nothing on screen changes.

## 🛠️ Changes made

- One `.tabulator-row.located-row` rule in `DataGrid.scss`, after the hover and selected rules, since inside a cascade layer it is source order that keeps a marked row reading as marked. The old copies won by sitting outside the layer, which nothing said.
- The six copies removed, along with the `LOCATED_ROW_CLASS` imports they were the only user of.
- `locatedRow.ts` notes that the stylesheet spells the class name out, so renaming the constant would stop the mark painting.

## 🧩 Type of change (check all applicable)

- [ ] 🐛 Bug fix - something not working as expected
- [ ] ✨ New feature – adds new functionality
- [x] ♻️ Refactor - internal changes with no user impact
- [ ] ⚡ Performance Improvement
- [ ] 📝 Documentation - README or documentation site changes
- [ ] 🔧 Chore - dev tooling, CI, config
- [ ] 💥 Breaking change

## 📷 Screenshots / gifs / video [optional]

N/A - the mark looks exactly as it did.

## 🔗 Related Issues

N/A

## ✅ Tests added?

- [x] 🙅 no, not needed

No behaviour changes, and the existing `locatedRow` tests still cover applying the class. Because ordering is the whole risk of moving into a cascade layer, I checked the shipped CSS instead: in `lana/out/bundle.js` the rule compiles to `.tabulator .tabulator-row.located-row` and lands after both hover rules, which it ties with on specificity and so beats on order, and after `.tabulator-row.tabulator-selected`, which it beats on specificity. It appears twice, matching the stylesheet's existing delivery to both the shadow DOM and `document.head`.

\`\`\`
pnpm test    # 169 suites, 2317 tests
pnpm lint
\`\`\`

Dev host: in Call Tree, Analysis, Database (SOQL, DML, SOSL), the Database time tree and the inspector's own call tree and call stack, hover an inspector row and the marked rows still mark; hovering or selecting a marked row still reads as marked.

## 📚 Docs updated?

- [x] 🙅 not needed