### PR TITLE
fix(log-viewer): make severity text readable on light themes

### DIFF
--- a/log-viewer/src/components/EventVitals.ts
+++ b/log-viewer/src/components/EventVitals.ts
@@ -114,14 +114,13 @@ export class EventVitals extends LitElement {
       }
       /* One hue carries the verdict through a tinted ground and its edge, as
          SelfTimeSpreadView tints a row from its own hue property. Every variant
-         sets the hue; the word takes the theme's foreground. */
+         sets the hue; the word reads as the text around it. */
       .pill {
         display: inline-block;
         padding: 0 var(--lana-space-2xs);
         border: var(--lana-stroke) solid color-mix(in srgb, var(--pill-hue) 30%, transparent);
         border-radius: var(--lana-radius-md);
         background-color: color-mix(in srgb, var(--pill-hue) 12%, transparent);
-        color: var(--lana-fg);
         font-size: var(--lana-text-xs);
         line-height: 1.4;
       }

--- a/log-viewer/src/components/EventVitals.ts
+++ b/log-viewer/src/components/EventVitals.ts
@@ -112,16 +112,16 @@ export class EventVitals extends LitElement {
         color: var(--lana-fg-muted);
         font-size: var(--lana-text-sm);
       }
-      /* One hue carries the verdict through the text, a tinted ground and its
-         edge, as SelfTimeSpreadView tints a row from its own hue property.
-         Every variant sets the hue. */
+      /* One hue carries the verdict through a tinted ground and its edge, as
+         SelfTimeSpreadView tints a row from its own hue property. Every variant
+         sets the hue; the word takes the theme's foreground. */
       .pill {
         display: inline-block;
         padding: 0 var(--lana-space-2xs);
         border: var(--lana-stroke) solid color-mix(in srgb, var(--pill-hue) 30%, transparent);
         border-radius: var(--lana-radius-md);
         background-color: color-mix(in srgb, var(--pill-hue) 12%, transparent);
-        color: var(--pill-hue);
+        color: var(--lana-fg);
         font-size: var(--lana-text-xs);
         line-height: 1.4;
       }

--- a/log-viewer/src/components/GovernorTrends.ts
+++ b/log-viewer/src/components/GovernorTrends.ts
@@ -170,7 +170,6 @@ export class GovernorTrends extends LitElement {
         border-bottom: var(--lana-stroke) solid var(--lana-surface-border);
         padding: 0;
         background: none;
-        color: inherit;
         cursor: pointer;
       }
 
@@ -246,7 +245,7 @@ export class GovernorTrends extends LitElement {
     const cursor = this._cursorFor(series);
     const cursorX = cursor ? x(cursor.t).toFixed(2) : null;
 
-    return html`<div class="trend trend--${governorTier(series.finalRatio)}">
+    return html`<div class="trend">
       <div class="trend__head">
         <span class="trend__label">${series.label}</span>
         <span class="trend__value" aria-live="polite"
@@ -256,7 +255,7 @@ export class GovernorTrends extends LitElement {
         >
       </div>
       <button
-        class="trend__chart"
+        class="trend__chart trend--${governorTier(series.finalRatio)}"
         type="button"
         aria-label="${series.label}: ${Math.round(
           series.finalRatio,

--- a/log-viewer/src/components/HotPath.ts
+++ b/log-viewer/src/components/HotPath.ts
@@ -19,6 +19,7 @@ import {
 import { globalStyles } from '../styles/global.styles.js';
 import { inspectorSectionStyles } from '../styles/inspectorSection.styles.js';
 import { revealRowStyles } from '../styles/revealRow.styles.js';
+import { severityStyles } from '../styles/severity.styles.js';
 import { CategoryPaletteController, categoryLabel } from './categoryTime.js';
 import { dispatchInspectorLocate, dispatchInspectorReveal } from './inspectorReveal.js';
 import { revealRowMeter, revealRowTitle } from './revealRowMeter.js';
@@ -58,6 +59,7 @@ export class HotPath extends LitElement {
     globalStyles,
     inspectorSectionStyles,
     revealRowStyles,
+    severityStyles,
     css`
       /* An actionable data-quality caveat, tinted so it reads apart from the rows. */
       .caveat-row {
@@ -66,7 +68,6 @@ export class HotPath extends LitElement {
         margin-bottom: var(--lana-space-2xs);
         padding: var(--lana-space-2xs) var(--lana-space-xs);
         background: var(--lana-callout-warning-bg);
-        color: var(--lana-severity-warning);
         white-space: normal;
       }
 
@@ -74,6 +75,7 @@ export class HotPath extends LitElement {
         background: var(--lana-callout-warning-bg-hover);
       }
 
+      /* The icon carries the warning, not the sentence. */
       .caveat-row vscode-icon {
         flex: 0 0 auto;
       }
@@ -243,7 +245,7 @@ export class HotPath extends LitElement {
       title="Show the first truncated call in the tree"
       @click=${() => dispatchInspectorReveal(this, truncation.firstEventIndex)}
     >
-      <vscode-icon name="warning"></vscode-icon>
+      <vscode-icon class="sev-warning" name="warning"></vscode-icon>
       <span>${text}</span>
     </button>`;
   }

--- a/log-viewer/src/components/__tests__/EventVitals.test.ts
+++ b/log-viewer/src/components/__tests__/EventVitals.test.ts
@@ -145,6 +145,35 @@ describe('EventVitals', () => {
     expect(shown).not.toContain('Object rows');
   });
 
+  it('gives the selectivity verdict a chip, which the tier colours', async () => {
+    // The log above records no query plan, so the verdict needs one of its own.
+    const explained = parse(
+      '09:18:22.6 (6574780)|EXECUTION_STARTED\n' +
+        '17:33:36.2 (1672655920)|SOQL_EXECUTE_BEGIN|[198]|Aggregations:0|SELECT Id FROM Account\n' +
+        '17:33:36.2 (1672700000)|SOQL_EXECUTE_EXPLAIN|[198]|Index on Account : [Id], cardinality: 1, sobjectCardinality: 1, relativeCost 0.65\n' +
+        '17:33:36.2 (1680000000)|SOQL_EXECUTE_BEGIN|[199]|Aggregations:0|SELECT Id FROM Contact\n' +
+        '17:33:36.2 (1680100000)|SOQL_EXECUTE_EXPLAIN|[199]|TableScan on Contact : [], cardinality: 9, sobjectCardinality: 9, relativeCost 2.5\n' +
+        '09:18:22.6 (7400000)|EXECUTION_FINISHED\n',
+    );
+    const explainStore = logStoreFor(explained);
+    const indexOf = (query: string) =>
+      explained.eventsById.find((e) => e.text === query)!.eventIndex;
+
+    const selective = await mount(explainStore, {
+      eventIndex: indexOf('SELECT Id FROM Account'),
+      type: 'soql',
+    });
+    const notSelective = await mount(explainStore, {
+      eventIndex: indexOf('SELECT Id FROM Contact'),
+      type: 'soql',
+    });
+
+    expect(
+      [selective, notSelective].map((el) => el.shadowRoot?.querySelector('.pill')?.className),
+    ).toEqual(['pill pill--yes', 'pill pill--no']);
+    expect(notSelective.shadowRoot?.querySelector('.pill')?.textContent).toBe('Not selective');
+  });
+
   it('omits fields with no value', async () => {
     const el = await mount(store, { eventIndex: dmlIndex, type: 'dml' });
     // A DML statement allocates no heap and throws nothing in this log.

--- a/log-viewer/src/components/__tests__/HotPath.test.ts
+++ b/log-viewer/src/components/__tests__/HotPath.test.ts
@@ -289,6 +289,16 @@ describe('hot-path', () => {
     ]);
   });
 
+  it('heads a truncated log with a caveat the shared warning glyph marks', async () => {
+    highlights = { ...pathOf(1), truncation: { regionCount: 2, firstEventIndex: 5 } };
+
+    const element = await hotPath();
+
+    const caveat = element.shadowRoot!.querySelector('.caveat-row')!;
+    expect(caveat.textContent).toContain('2 truncated calls');
+    expect(caveat.querySelector('vscode-icon')?.className).toBe('sev-warning');
+  });
+
   it('marks every merged instance of the row under the pointer', async () => {
     highlights = pathOf(1);
     highlights.hotPath[0]!.eventIndexes = [4, 9];

--- a/log-viewer/src/features/database/components/DatabaseRowBudget.ts
+++ b/log-viewer/src/features/database/components/DatabaseRowBudget.ts
@@ -216,13 +216,25 @@ export class DatabaseRowBudget extends LitElement {
   }
 }
 
+/** What a marked tier says, and the severity that carries it. */
+const TIER_MARK = {
+  warn: { severity: 'warning', title: 'Near the row limit' },
+  danger: { severity: 'error', title: 'Past the row limit' },
+} as const;
+
 /** The tier as a mark, so a figure over its limit says so without colouring its text. */
 function tierMark(tier: ReturnType<typeof governorTier>): TemplateResult | string {
   if (tier === 'safe') {
     return '';
   }
-  const severity = tier === 'danger' ? 'error' : 'warning';
-  return html`<vscode-icon class="sev-${severity}" name=${severityIcon(severity)}></vscode-icon>`;
+  const { severity, title } = TIER_MARK[tier];
+  // Sized to the figure: the stock 16px glyph grows the line it sits in.
+  return html`<vscode-icon
+    class="sev-${severity}"
+    name=${severityIcon(severity)}
+    size="12"
+    title=${title}
+  ></vscode-icon>`;
 }
 
 /** Whether the segments passed the limit, which is when the bar marks it. */

--- a/log-viewer/src/features/database/components/DatabaseRowBudget.ts
+++ b/log-viewer/src/features/database/components/DatabaseRowBudget.ts
@@ -5,6 +5,7 @@ import { consume } from '@lit/context';
 import { LitElement, css, html, type TemplateResult } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
 
+import '#vscode-elements/vscode-icon.js';
 import { CategoryPaletteController } from '../../../components/categoryTime.js';
 import {
   ESTIMATED_LIMITS_TEXT,
@@ -17,6 +18,7 @@ import type { LogStore } from '../../../core/log/LogStore.js';
 import { formatInteger } from '../../../core/utility/Util.js';
 import { globalStyles } from '../../../styles/global.styles.js';
 import { inspectorSectionStyles } from '../../../styles/inspectorSection.styles.js';
+import { severityIcon, severityStyles } from '../../../styles/severity.styles.js';
 import { NO_STATEMENTS } from '../services/databaseOverview.js';
 import {
   rowBudgets,
@@ -56,6 +58,7 @@ export class DatabaseRowBudget extends LitElement {
   static styles = [
     globalStyles,
     inspectorSectionStyles,
+    severityStyles,
     css`
       .note {
         padding: var(--lana-space-2xs) 0 0;
@@ -85,14 +88,8 @@ export class DatabaseRowBudget extends LitElement {
         font-variant-numeric: tabular-nums;
       }
 
-      .budget__figure--safe {
-        color: var(--lana-fg);
-      }
-      .budget__figure--warn {
-        color: var(--lana-severity-warning);
-      }
-      .budget__figure--danger {
-        color: var(--lana-severity-error);
+      .budget__figure vscode-icon {
+        margin-right: var(--lana-space-2xs);
       }
 
       .counts {
@@ -186,6 +183,7 @@ export class DatabaseRowBudget extends LitElement {
   private _budget(budget: RowBudget, hue: string): TemplateResult {
     const shown = budget.used ?? budget.observed;
     const percent = budget.limit > 0 ? (shown / budget.limit) * 100 : 0;
+    const tier = governorTier(percent);
     const against = budget.limit > 0 ? ` / ${formatInteger(budget.limit)}` : '';
     const segments = objectSegments(budget.groups, hue);
     // What the governor counted and no statement holds. Never negative: the
@@ -204,9 +202,7 @@ export class DatabaseRowBudget extends LitElement {
       <div class="budget">
         <p class="budget__head">
           <span>${KIND_LABEL[budget.kind]}</span>
-          <span class="budget__figure budget__figure--${governorTier(percent)}"
-            >${formatInteger(shown)}${against}</span
-          >
+          <span class="budget__figure">${tierMark(tier)}${formatInteger(shown)}${against}</span>
         </p>
         <stacked-time-bar
           .format=${formatInteger}
@@ -218,6 +214,15 @@ export class DatabaseRowBudget extends LitElement {
       </div>
     `;
   }
+}
+
+/** The tier as a mark, so a figure over its limit says so without colouring its text. */
+function tierMark(tier: ReturnType<typeof governorTier>): TemplateResult | string {
+  if (tier === 'safe') {
+    return '';
+  }
+  const severity = tier === 'danger' ? 'error' : 'warning';
+  return html`<vscode-icon class="sev-${severity}" name=${severityIcon(severity)}></vscode-icon>`;
 }
 
 /** Whether the segments passed the limit, which is when the bar marks it. */

--- a/log-viewer/src/features/database/components/__tests__/DatabaseRowBudget.test.ts
+++ b/log-viewer/src/features/database/components/__tests__/DatabaseRowBudget.test.ts
@@ -18,6 +18,7 @@ let budgets: RowBudgets;
 jest.mock('../../services/rowBudget.js', () => ({
   rowBudgets: () => budgets,
 }));
+jest.mock('#vscode-elements/vscode-icon.js', () => ({}));
 
 import '../DatabaseRowBudget.js';
 
@@ -81,6 +82,12 @@ const texts = (element: Element, selector: string) =>
     (node.textContent ?? '').replace(/\s+/g, ' ').trim(),
   );
 
+/** The glyph each figure carries, in order, `null` where the tier is safe. */
+const marks = (element: Element) =>
+  [...(element.shadowRoot?.querySelectorAll('.budget__figure') ?? [])].map(
+    (figure) => figure.querySelector('vscode-icon')?.getAttribute('name') ?? null,
+  );
+
 const bars = (element: Element) =>
   [...(element.shadowRoot?.querySelectorAll('stacked-time-bar') ?? [])] as StackedTimeBar[];
 
@@ -142,12 +149,18 @@ describe('database-rows', () => {
     ]);
   });
 
-  it('warns as a limit is approached, and alarms once it is near breach', async () => {
+  it('warns as a limit is approached, marking the tier with a glyph', async () => {
     const element = await mount();
 
     // 90% of the query rows, 4% of the DML rows.
-    expect(texts(element, '.budget__figure--warn')).toEqual(['45,000 / 50,000']);
-    expect(texts(element, '.budget__figure--safe')).toEqual(['400 / 10,000']);
+    expect(texts(element, '.budget__figure')).toEqual(['45,000 / 50,000', '400 / 10,000']);
+    expect(marks(element)).toEqual(['warning', null]);
+  });
+
+  it('marks a breached limit as an error', async () => {
+    budgets = withBudgets({ used: 60_000, observed: 60_000 });
+
+    expect(marks(await mount())[0]).toBe('error');
   });
 
   it('counts the statements of every kind against its own limit', async () => {

--- a/log-viewer/src/features/database/components/__tests__/DatabaseRowBudget.test.ts
+++ b/log-viewer/src/features/database/components/__tests__/DatabaseRowBudget.test.ts
@@ -157,10 +157,14 @@ describe('database-rows', () => {
     expect(marks(element)).toEqual(['warning', null]);
   });
 
-  it('marks a breached limit as an error', async () => {
+  it('marks a breached limit as an error, and says what the mark means', async () => {
     budgets = withBudgets({ used: 60_000, observed: 60_000 });
+    const element = await mount();
 
-    expect(marks(await mount())[0]).toBe('error');
+    expect(marks(element)[0]).toBe('error');
+    expect(
+      element.shadowRoot?.querySelector('.budget__figure vscode-icon')?.getAttribute('title'),
+    ).toBe('Past the row limit');
   });
 
   it('counts the statements of every kind against its own limit', async () => {

--- a/log-viewer/src/styles/severity.styles.ts
+++ b/log-viewer/src/styles/severity.styles.ts
@@ -20,7 +20,7 @@ export function severityIcon(severity: Severity): string {
 /**
  * Colours for `class="sev-<severity>"`, where the severity is lower case. For a
  * mark only: an icon, a border, a tint, a bar fill, where 3:1 applies. Text
- * keeps the theme foreground, since these hues are tuned for a glyph and a
+ * reads as the text around it, since these hues are tuned for a glyph and a
  * light theme can read one at 2:1 as a word.
  */
 export const severityStyles = css`

--- a/log-viewer/src/styles/severity.styles.ts
+++ b/log-viewer/src/styles/severity.styles.ts
@@ -17,7 +17,12 @@ export function severityIcon(severity: Severity): string {
   }
 }
 
-/** Colours for `class="sev-<severity>"`, where the severity is lower case. */
+/**
+ * Colours for `class="sev-<severity>"`, where the severity is lower case. For a
+ * mark only: an icon, a border, a tint, a bar fill, where 3:1 applies. Text
+ * keeps the theme foreground, since these hues are tuned for a glyph and a
+ * light theme can read one at 2:1 as a word.
+ */
 export const severityStyles = css`
   .sev-error {
     color: var(--lana-severity-error);

--- a/log-viewer/src/styles/tokens.css
+++ b/log-viewer/src/styles/tokens.css
@@ -154,8 +154,9 @@
     var(--vscode-editorInfo-foreground, #3794ff)
   );
 
-  /* Nothing wrong — the colour VS Code marks a passing test with. */
-  --lana-severity-ok: var(--vscode-testing-iconPassed, var(--vscode-charts-green, #73c991));
+  /* Nothing wrong. The chart green leads: `testing-iconPassed` carries one hex
+     for light and dark, so a light theme reads a dark theme's green at 2:1. */
+  --lana-severity-ok: var(--vscode-charts-green, var(--vscode-testing-iconPassed, #388a34));
 
   /* Row hover, for lists whose rows can be opened or picked. */
   --lana-row-hover-bg: var(--vscode-list-hoverBackground, rgba(128, 128, 128, 0.12));


### PR DESCRIPTION
Severity colour in the inspector fails WCAG AA on a light theme. Measured against the editor surface on Light Modern: the selectivity chip reads at 1.85:1, the governor trend value at 2:1, the hot-path caveat at 2.8:1. The bar for text is 4.5:1.

Two causes. `--lana-severity-*` is a foreground with no paired background, unlike `--lana-badge-bg` / `-fg`, so a hue tuned for a Problems-panel glyph lands on whatever surface a component uses. And `--lana-severity-ok` resolved through `--vscode-testing-iconPassed`, which VS Code registers with the same hex for light and dark, so a light theme read a dark theme's green.

The fix is what VS Code's own Problems panel does: colour the mark, not the text. The hue stays on icons, borders, tints and bar fills, where 3:1 applies. Text goes back to the theme foreground, about 13:1.

## Changes

- `--lana-severity-ok` leads with `--vscode-charts-green`, which is themed per background; `testing-iconPassed` is the fallback.
- Selectivity chip: the word takes the theme foreground, the tinted ground and its edge still carry the verdict hue.
- Governor trend: the tier moves off the container onto the chart button, its only consumer, so the value reads at full strength and the sparkline keeps its tier.
- Hot-path caveat: the sentence goes neutral and the icon carries the warning, through the shared `sev-*` classes rather than a local rule.
- Row budget: the figure had colour as its only tier cue, so warn and danger now carry a codicon before it.
- The rule is stated once, on `severityStyles`: a severity hue is for a mark, never a run of text.

## Test plan

- `pnpm test` - 169 suites, 2320 tests.
- New cases: the row budget renders a `warning` glyph at 90% and an `error` glyph past the limit, and none while safe; the hot-path caveat carries `sev-warning`; the selectivity chip keeps its tier class.
- Manual, light theme then dark, side dock then bottom dock: the chip, the trend value, the caveat sentence and the row figure all read clearly, and each still shows its tier.