### PR TITLE
fix(lana): keep the web viewer's icons visible

### DIFF
--- a/lana/src/commands/LogView.ts
+++ b/lana/src/commands/LogView.ts
@@ -241,15 +241,19 @@ export class LogView {
     assets: NonNullable<ReturnType<typeof getEmbeddedLogViewerAssets>>,
   ): string {
     const fontData = `data:font/ttf;base64,${assets.codiconFont}`;
-    const codiconCss = assets.codiconCss
-      .replace(/url\((['"]?)\.\/codicon\.ttf[^)]*\)/i, `url("${fontData}")`)
-      .replace(/<\/style/gi, '<\\/style');
+    const codiconCss = assets.codiconCss.replace(
+      /url\(['"]?\.\/codicon\.ttf[^)]*\)/i,
+      `url("${fontData}")`,
+    );
+    const codiconHref = `data:text/css;charset=utf-8,${encodeURIComponent(codiconCss)}`;
     const script = assets.script.replace(/<\/script/gi, '<\\/script');
 
     return assets.html
       .replace(
         /<link\b(?=[^>]*\bid="vscode-codicon-stylesheet")[^>]*>/i,
-        () => `<style id="vscode-codicon-stylesheet">${codiconCss}</style>`,
+        // vscode-icon re-links this by its href inside every icon's shadow root, so it
+        // must stay a <link>: an inline <style> leaves each glyph blank.
+        () => `<link rel="stylesheet" id="vscode-codicon-stylesheet" href="${codiconHref}" />`,
       )
       .replace(
         /<script\b(?=[^>]*\bsrc="bundle\.js")[^>]*><\/script>/i,

--- a/lana/src/commands/LogView.ts
+++ b/lana/src/commands/LogView.ts
@@ -251,8 +251,6 @@ export class LogView {
     return assets.html
       .replace(
         /<link\b(?=[^>]*\bid="vscode-codicon-stylesheet")[^>]*>/i,
-        // vscode-icon re-links this by its href inside every icon's shadow root, so it
-        // must stay a <link>: an inline <style> leaves each glyph blank.
         () => `<link rel="stylesheet" id="vscode-codicon-stylesheet" href="${codiconHref}" />`,
       )
       .replace(

--- a/lana/src/commands/__tests__/LogView.test.ts
+++ b/lana/src/commands/__tests__/LogView.test.ts
@@ -77,7 +77,6 @@ describe('LogView', () => {
     expect(panel.webview.html).toContain(
       '<script type="module">const replacementToken = "$&"; globalThis.viewerLoaded = true;',
     );
-    // vscode-icon only finds the codicons when they stay a <link> it can read an href from.
     const codiconHref = /<link[^>]*\bid="vscode-codicon-stylesheet"[^>]*\bhref="([^"]+)"/.exec(
       panel.webview.html,
     )?.[1];

--- a/lana/src/commands/__tests__/LogView.test.ts
+++ b/lana/src/commands/__tests__/LogView.test.ts
@@ -77,8 +77,14 @@ describe('LogView', () => {
     expect(panel.webview.html).toContain(
       '<script type="module">const replacementToken = "$&"; globalThis.viewerLoaded = true;',
     );
-    expect(panel.webview.html).toContain('/* $& */');
-    expect(panel.webview.html).toContain('data:font/ttf;base64,Zm9udA==');
+    // vscode-icon only finds the codicons when they stay a <link> it can read an href from.
+    const codiconHref = /<link[^>]*\bid="vscode-codicon-stylesheet"[^>]*\bhref="([^"]+)"/.exec(
+      panel.webview.html,
+    )?.[1];
+    expect(codiconHref).toMatch(/^data:text\/css;charset=utf-8,/);
+    const codiconCss = decodeURIComponent(codiconHref!.slice(codiconHref!.indexOf(',') + 1));
+    expect(codiconCss).toContain('/* $& */');
+    expect(codiconCss).toContain('data:font/ttf;base64,Zm9udA==');
     expect(mockReadFile).not.toHaveBeenCalled();
 
     await receiveMessage?.({ cmd: 'fetchLog', requestId: 'request-1' });

--- a/log-viewer/index.html
+++ b/log-viewer/index.html
@@ -8,9 +8,8 @@
       name="description"
       content="Analyze Salesforce Apex Debug logs - Instantly visualize and debug Apex logs with interactive flame charts, dynamic call trees, and detailed SOQL/DML breakdowns. Identify performance bottlenecks, gain deep insight into complex transactions and optimize slow Apex methods"
     />
-    <!-- The extension rewrites href (see LogView.ts): a webview URI on desktop, a data: URI in
-         the web build. @vscode-elements' vscode-icon finds this by id and re-links the href
-         inside each icon's shadow root, so it must stay a stylesheet with a readable href -->
+    <!-- href is rewritten to a webview URI by the extension (see LogView.ts); required by
+         @vscode-elements' vscode-icon, which reads this link by id for the codicon font -->
     <link rel="stylesheet" id="vscode-codicon-stylesheet" href="codicon.css" />
     <style>
       html {

--- a/log-viewer/index.html
+++ b/log-viewer/index.html
@@ -8,8 +8,9 @@
       name="description"
       content="Analyze Salesforce Apex Debug logs - Instantly visualize and debug Apex logs with interactive flame charts, dynamic call trees, and detailed SOQL/DML breakdowns. Identify performance bottlenecks, gain deep insight into complex transactions and optimize slow Apex methods"
     />
-    <!-- href is rewritten to a webview URI by the extension (see LogView.ts); required by
-         @vscode-elements' vscode-icon, which reads this link by id for the codicon font -->
+    <!-- The extension rewrites href (see LogView.ts): a webview URI on desktop, a data: URI in
+         the web build. @vscode-elements' vscode-icon finds this by id and re-links the href
+         inside each icon's shadow root, so it must stay a stylesheet with a readable href -->
     <link rel="stylesheet" id="vscode-codicon-stylesheet" href="codicon.css" />
     <style>
       html {


### PR DESCRIPTION
# 📝 PR Overview

Icons were blank throughout the VS Code Web build. Follow-up to #1015.

`vscode-icon` finds the codicons by reading `#vscode-codicon-stylesheet`'s `href` and re-linking
it inside its own shadow root, where its styles carry no glyph rules. An inline `<style>` left
that href undefined, so every icon rendered empty — silently, since the library only warns when
the element is missing entirely.

## 🛠️ Changes made

- Serve the embedded codicons from a `data:` URI on the link `vscode-icon` expects, not a `<style>`.
- Percent-encode rather than base64: 49KB smaller, and `encodeURIComponent` cannot throw on a
  non-Latin1 char the way `btoa` does.
- Decode the href in the test, so a return to `<style>` fails.

## 🧩 Type of change (check all applicable)

- [x] 🐛 Bug fix - something not working as expected

## 🔗 Related Issues

related #1015

## ✅ Tests added?

- [x] 👍 yes

## 📚 Docs updated?

- [x] 🙅 not needed

## Anything else we need to know? [optional]

Desktop is unaffected — it never reaches `embedAssets`. Verified in a real VS Code Web host
(`pnpm serve:web`): icons blank before, correct after.
