### PR TITLE
test(lana): serve Salesforce Services locally for the web e2e host

### DIFF
--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -94,6 +94,22 @@ Once you’ve built the extension or run the watcher, you can run it inside a lo
 
    If you're using the **watch** mode (see below), refresh the extension host view by pressing CMD/CTRL + R or clicking the restart icon.
 
+### In VS Code Web
+
+The desktop extension host runs the desktop build only. To run the web build in a real web host:
+
+```zsh
+pnpm serve:web
+```
+
+Open `http://localhost:3001` (set `PORT` to change it). `pnpm test:e2e:web` runs the end-to-end
+tests against the same host.
+
+Commands that need a Salesforce org also need the Salesforce Services extension. The server serves
+your local copy of it, because a `localhost` page cannot fetch one from the marketplace CDN.
+Install the Salesforce Extension Pack in VS Code, or point `LANA_SERVICES_EXTENSION_PATH` at an
+unpacked copy. Without either, the log viewer still works but org commands do not.
+
 ## 🧪 Testing Your Changes
 
 Make sure your changes don’t break anything. If you’re working on a feature or bug fix that requires tests, be sure to add or update the relevant tests.

--- a/lana/test/playwright/support/servicesExtension.ts
+++ b/lana/test/playwright/support/servicesExtension.ts
@@ -1,0 +1,47 @@
+import { existsSync, readdirSync } from 'node:fs';
+import { homedir } from 'node:os';
+import path from 'node:path';
+
+const EXTENSION_PREFIX = 'salesforce.salesforcedx-vscode-services-';
+const EXTENSION_DIRECTORIES = ['.vscode', '.vscode-insiders', '.vscode-server'];
+
+const hasManifest = (location: string): boolean => existsSync(path.join(location, 'package.json'));
+
+/**
+ * The newest Salesforce Services extension unpacked by a local VS Code install, or `undefined`
+ * when there is none. `LANA_SERVICES_EXTENSION_PATH` overrides the search.
+ *
+ * The web extension host loads a gallery extension from the publisher's CDN, which sends no
+ * `Access-Control-Allow-Origin` for a `localhost` origin. Serving an unpacked copy from the test
+ * server itself keeps that fetch same-origin.
+ *
+ * @throws when `LANA_SERVICES_EXTENSION_PATH` holds no `package.json`.
+ */
+export const findServicesExtension = (): string | undefined => {
+  const override = process.env.LANA_SERVICES_EXTENSION_PATH;
+  if (override) {
+    if (!hasManifest(override)) {
+      throw new Error(`LANA_SERVICES_EXTENSION_PATH has no package.json: ${override}`);
+    }
+    return override;
+  }
+
+  return (
+    EXTENSION_DIRECTORIES.flatMap((directory) => {
+      const root = path.join(homedir(), directory, 'extensions');
+      let entries: string[];
+      try {
+        entries = readdirSync(root);
+      } catch {
+        return []; // that VS Code flavour is not installed, or its extensions are unreadable
+      }
+
+      return entries
+        .filter((entry) => entry.startsWith(EXTENSION_PREFIX))
+        .map((entry) => ({ entry, location: path.join(root, entry) }));
+    })
+      // Names carry a version and sometimes a platform suffix, so compare them numerically.
+      .sort((a, b) => b.entry.localeCompare(a.entry, undefined, { numeric: true }))
+      .find(({ location }) => hasManifest(location))?.location
+  );
+};

--- a/lana/test/playwright/web/headlessServer.ts
+++ b/lana/test/playwright/web/headlessServer.ts
@@ -4,13 +4,23 @@ import { open } from '@vscode/test-web';
 
 import { createLogWorkspace } from '../support/logWorkspace';
 import { extensionRoot, vscodeWebTestPath } from '../support/paths';
+import { findServicesExtension } from '../support/servicesExtension';
 
-// Lana declares Salesforce Services as an extension dependency, but VS Code Web
-// needs the test server to explicitly provision it for a development extension.
+// The test server has to provision Salesforce Services for a development extension.
 const SERVICES_EXTENSION_ID = 'salesforce.salesforcedx-vscode-services';
 
 const start = async (): Promise<void> => {
   const workspaceDir = await createLogWorkspace();
+  const servicesExtension = findServicesExtension();
+  if (!servicesExtension) {
+    // eslint-disable-next-line no-console -- a dev harness reports this on stderr
+    console.warn(
+      'Salesforce Services not found locally, falling back to the gallery id — which a ' +
+        'localhost origin cannot fetch, so commands needing an org will not work. Install the ' +
+        'extension in VS Code, or set LANA_SERVICES_EXTENSION_PATH.',
+    );
+  }
+
   const server = await open({
     browserType: 'none',
     quality: 'stable',
@@ -19,7 +29,11 @@ const start = async (): Promise<void> => {
     printServerLog: true,
     verbose: true,
     extensionDevelopmentPath: extensionRoot,
-    extensionIds: [{ id: SERVICES_EXTENSION_ID }],
+    // Serve a local unpacked copy when there is one: the server hosts it, so the extension host
+    // fetches it same-origin (see servicesExtension.ts). Never both — one identity, one source.
+    ...(servicesExtension
+      ? { extensionPaths: [servicesExtension] }
+      : { extensionIds: [{ id: SERVICES_EXTENSION_ID }] }),
     folderPath: workspaceDir,
     testRunnerDataDir: vscodeWebTestPath,
   });


### PR DESCRIPTION
`pnpm serve:web` could not test anything needing an org. The web extension host loads a gallery extension from the publisher's CDN, which sends no CORS header for a `localhost` origin, so Salesforce Services never activated.

Now the server serves a local unpacked copy of it, which is same-origin. It falls back to the gallery id when there is no local copy, so CI is unchanged.

`LANA_SERVICES_EXTENSION_PATH` overrides the search. `DEVELOPING.md` documents the web host, which it never mentioned.