### PR TITLE
fix(log-viewer): bring the frame the inspector picks into the timeline's view

### DIFF
--- a/log-viewer/src/components/__tests__/inspectorTab.test.ts
+++ b/log-viewer/src/components/__tests__/inspectorTab.test.ts
@@ -5,7 +5,7 @@ import { afterEach, describe, expect, it } from '@jest/globals';
 
 import { eventBus } from '../../core/events/EventBus.js';
 import { InspectorEmphasis } from '../inspectorEmphasis.js';
-import { wireInspectorTab } from '../inspectorTab.js';
+import { revealFirstOf, wireInspectorTab } from '../inspectorTab.js';
 
 describe('wireInspectorTab', () => {
   let off: (() => void) | null = null;
@@ -27,23 +27,25 @@ describe('wireInspectorTab', () => {
     /** Marks and moves in the order they arrived, which the two lists cannot show. */
     const order: string[] = [];
     let clears = 0;
+    const moveTo = (eventIndex: number, signal: AbortSignal): void | Promise<void> => {
+      order.push('move');
+      signals.push(signal);
+      if (reveal) {
+        return reveal(eventIndex, signal);
+      }
+      revealed.push(eventIndex);
+    };
     off = wireInspectorTab('calltree', new InspectorEmphasis(), {
       mark: (eventIndexes) => {
         marks.push(eventIndexes);
         order.push('mark');
       },
-      reveal: (eventIndex, signal) => {
-        order.push('move');
-        signals.push(signal);
-        if (reveal) {
-          return reveal(eventIndex, signal);
-        }
-        revealed.push(eventIndex);
-      },
+      reveal: moveTo,
       clear: () => {
         clears++;
       },
-      movesToMergedPick,
+      // As the tables do it, through the helper they ship with.
+      revealMerged: movesToMergedPick ? revealFirstOf(moveTo) : undefined,
     });
     return { marks, revealed, order, signals, clears: () => clears };
   }

--- a/log-viewer/src/components/inspectorTab.ts
+++ b/log-viewer/src/components/inspectorTab.ts
@@ -22,11 +22,28 @@ export interface InspectorTabSync {
   clear: () => void;
 
   /**
-   * True where a picked row that merges occurrences also moves, to the first of
-   * them. Omitted where choosing one of several would be arbitrary, which is why
-   * the Database grids and the flame chart only mark.
+   * Move for a picked row that merges occurrences. The view chooses which of them
+   * it moves to, because only it knows what "nearest" means in its own layout: a
+   * table takes the first, the flame chart the one nearest the view. Omitted where
+   * no move helps, which is why the Database grids only mark.
+   *
+   * @param signal - as {@link reveal}.
    */
-  movesToMergedPick?: boolean;
+  revealMerged?: (eventIndexes: readonly number[], signal: AbortSignal) => void | Promise<void>;
+}
+
+/**
+ * The merged-pick move for a view whose rows are ordered rather than placed: it
+ * moves to the first occurrence, as a pick of one frame does. The flame chart
+ * supplies its own, because on a time axis "first" is not what the reader wants.
+ */
+export function revealFirstOf(
+  reveal: InspectorTabSync['reveal'],
+): NonNullable<InspectorTabSync['revealMerged']> {
+  return (eventIndexes, signal) => {
+    const first = eventIndexes[0];
+    return first === undefined ? undefined : reveal(first, signal);
+  };
 }
 
 /**
@@ -44,25 +61,26 @@ export function wireInspectorTab(
   sync: InspectorTabSync,
 ): () => void {
   let moving: AbortController | null = null;
-  const move = (eventIndex: number): void => {
+  const move = (run: (signal: AbortSignal) => void | Promise<void>): void => {
     // A move waits on a render, and a pointer crossing rows asks for several, so
     // the last one asked for is the one that scrolls. Only the move is abandoned:
     // the mark of the move that is dropped went on before it.
     moving?.abort();
     moving = new AbortController();
     // The view reports its own failure; the mark stands either way.
-    void Promise.resolve(sync.reveal(eventIndex, moving.signal)).catch(() => {});
+    void Promise.resolve(run(moving.signal)).catch(() => {});
   };
 
   const offs = [
     eventBus.onSource('inspector:reveal', source, (detail) => {
-      move(detail.eventIndex);
+      move((signal) => sync.reveal(detail.eventIndex, signal));
     }),
 
     eventBus.onSource('inspector:locate', source, (detail) => {
       sync.mark(emphasis.report(detail.eventIndexes, detail.sticky));
-      if (sync.movesToMergedPick && detail.sticky && detail.eventIndexes.length) {
-        move(detail.eventIndexes[0]!);
+      const revealMerged = sync.revealMerged;
+      if (revealMerged && detail.sticky && detail.eventIndexes.length) {
+        move((signal) => revealMerged(detail.eventIndexes, signal));
       }
     }),
 

--- a/log-viewer/src/features/analysis/components/AnalysisView.ts
+++ b/log-viewer/src/features/analysis/components/AnalysisView.ts
@@ -21,7 +21,7 @@ import {
   rowFrames,
 } from '../../../components/locatedRow.js';
 import { InspectorEmphasis } from '../../../components/inspectorEmphasis.js';
-import { wireInspectorTab } from '../../../components/inspectorTab.js';
+import { revealFirstOf, wireInspectorTab } from '../../../components/inspectorTab.js';
 import { SelectionEchoGuard } from '../../../core/events/SelectionEchoGuard.js';
 import { eventByEventIndex } from '../../../core/utility/EventSearch.js';
 import { isVisible } from '../../../core/utility/Util.js';
@@ -174,7 +174,10 @@ export class AnalysisView extends LitElement {
         // The table reports the clear itself, which is what reaches the inspector.
         this.analysisTable?.deselectRow();
       },
-      movesToMergedPick: true,
+      // A row buckets calls, so a merged pick moves to the first of them.
+      revealMerged: revealFirstOf((eventIndex, signal) =>
+        this._revealEventIndex(eventIndex, signal),
+      ),
     });
     document.addEventListener('lv-find', this._findEvt);
     document.addEventListener('lv-find-match', this._findEvt);

--- a/log-viewer/src/features/call-tree/components/CalltreeView.ts
+++ b/log-viewer/src/features/call-tree/components/CalltreeView.ts
@@ -73,7 +73,7 @@ import {
   rowFrames,
 } from '../../../components/locatedRow.js';
 import { InspectorEmphasis } from '../../../components/inspectorEmphasis.js';
-import { wireInspectorTab } from '../../../components/inspectorTab.js';
+import { revealFirstOf, wireInspectorTab } from '../../../components/inspectorTab.js';
 import { createTimeOrderTable } from './TimeOrderTable.js';
 
 /** Time Order keys its rows by event index; the grouped views key theirs by the
@@ -188,8 +188,10 @@ export class CalltreeView extends LitElement {
         }
       },
       // A picked row merges calls, so the mark shows all of them while the view
-      // moves to the first, as a pick of one frame does.
-      movesToMergedPick: true,
+      // moves to the first of them.
+      revealMerged: revealFirstOf((eventIndex, signal) =>
+        this._revealEventIndex(eventIndex, signal),
+      ),
     });
     document.addEventListener(CALLTREE_GO_TO_ROW, this._goToRowEvt);
     document.addEventListener('lv-find', this._findEvt);

--- a/log-viewer/src/features/timeline/__tests__/detail-selection-sync.test.ts
+++ b/log-viewer/src/features/timeline/__tests__/detail-selection-sync.test.ts
@@ -4,7 +4,7 @@
 import { describe, expect, it } from '@jest/globals';
 
 import { TimelineViewport } from '../optimised/TimelineViewport.js';
-import { isFrameOffscreen, toDetailSelection } from '../utils/detail-selection-sync.js';
+import { revealPanAxes, toDetailSelection } from '../utils/detail-selection-sync.js';
 
 describe('toDetailSelection', () => {
   it('builds an event selection from an eventIndex', () => {
@@ -20,23 +20,41 @@ describe('toDetailSelection', () => {
   });
 });
 
-describe('isFrameOffscreen', () => {
+describe('revealPanAxes', () => {
+  // 1000px over a 1,000,000ns log, zoomed to 100,000ns starting at 200,000.
   const viewport = new TimelineViewport(1000, 600, 1_000_000, 10);
+  viewport.setZoom(0.01);
+  viewport.setPan(2000, 0);
   const bounds = viewport.getBounds();
 
-  it('reports a frame inside both ranges as on screen', () => {
-    expect(isFrameOffscreen(bounds, bounds.timeStart, 1_000, bounds.depthStart)).toBe(false);
+  it('leaves a frame that is wholly in view where it is', () => {
+    expect(revealPanAxes(bounds, 250_000, 1_000, bounds.depthStart)).toEqual({
+      time: false,
+      depth: false,
+    });
   });
 
-  it('reports a frame after the visible time range as off screen', () => {
-    expect(isFrameOffscreen(bounds, bounds.timeEnd + 1_000, 1_000, bounds.depthStart)).toBe(true);
+  it('centres a frame clipped by the edge of the view', () => {
+    expect(revealPanAxes(bounds, 299_000, 5_000, bounds.depthStart).time).toBe(true);
   });
 
-  it('reports a frame before the visible time range as off screen', () => {
-    expect(isFrameOffscreen(bounds, bounds.timeStart - 5_000, 1_000, bounds.depthStart)).toBe(true);
+  it('centres a frame that is off screen', () => {
+    expect(revealPanAxes(bounds, 400_000, 1_000, bounds.depthStart).time).toBe(true);
   });
 
-  it('reports a frame below the visible depth range as off screen', () => {
-    expect(isFrameOffscreen(bounds, bounds.timeStart, 1_000, bounds.depthEnd + 1)).toBe(true);
+  // It covers the screen either way, so a move would only lose the reader's bearings.
+  it('leaves a frame wider than the view where it is', () => {
+    expect(revealPanAxes(bounds, 100_000, 500_000, bounds.depthStart).time).toBe(false);
+  });
+
+  it('centres a frame wider than the view that it does not reach', () => {
+    expect(revealPanAxes(bounds, 400_000, 500_000, bounds.depthStart).time).toBe(true);
+  });
+
+  it('centres the depth on its own when only the depth is off screen', () => {
+    expect(revealPanAxes(bounds, 250_000, 1_000, bounds.depthEnd + 1)).toEqual({
+      time: false,
+      depth: true,
+    });
   });
 });

--- a/log-viewer/src/features/timeline/__tests__/detail-selection-sync.test.ts
+++ b/log-viewer/src/features/timeline/__tests__/detail-selection-sync.test.ts
@@ -4,7 +4,7 @@
 import { describe, expect, it } from '@jest/globals';
 
 import { TimelineViewport } from '../optimised/TimelineViewport.js';
-import { revealPanAxes, toDetailSelection } from '../utils/detail-selection-sync.js';
+import { revealTarget, toDetailSelection } from '../utils/detail-selection-sync.js';
 
 describe('toDetailSelection', () => {
   it('builds an event selection from an eventIndex', () => {
@@ -20,41 +20,72 @@ describe('toDetailSelection', () => {
   });
 });
 
-describe('revealPanAxes', () => {
+describe('revealTarget', () => {
   // 1000px over a 1,000,000ns log, zoomed to 100,000ns starting at 200,000.
   const viewport = new TimelineViewport(1000, 600, 1_000_000, 10);
   viewport.setZoom(0.01);
   viewport.setPan(2000, 0);
   const bounds = viewport.getBounds();
 
+  const frame = (timestamp: number, duration = 1_000, depth = bounds.depthStart) => ({
+    timestamp,
+    duration,
+    depth,
+  });
+
+  const axesFor = (...frames: ReturnType<typeof frame>[]) => revealTarget(bounds, frames)?.axes;
+
   it('leaves a frame that is wholly in view where it is', () => {
-    expect(revealPanAxes(bounds, 250_000, 1_000, bounds.depthStart)).toEqual({
-      time: false,
-      depth: false,
-    });
+    expect(revealTarget(bounds, [frame(250_000)])).toBeNull();
   });
 
   it('centres a frame clipped by the edge of the view', () => {
-    expect(revealPanAxes(bounds, 299_000, 5_000, bounds.depthStart).time).toBe(true);
+    expect(axesFor(frame(299_000, 5_000))).toEqual({ time: true, depth: false });
   });
 
   it('centres a frame that is off screen', () => {
-    expect(revealPanAxes(bounds, 400_000, 1_000, bounds.depthStart).time).toBe(true);
+    expect(axesFor(frame(400_000))).toEqual({ time: true, depth: false });
   });
 
-  // It covers the screen either way, so a move would only lose the reader's bearings.
-  it('leaves a frame wider than the view where it is', () => {
-    expect(revealPanAxes(bounds, 100_000, 500_000, bounds.depthStart).time).toBe(false);
+  // It fills the screen either way, so a move would only lose the reader's bearings.
+  it('leaves a frame spanning the view from edge to edge where it is', () => {
+    expect(revealTarget(bounds, [frame(100_000, 500_000)])).toBeNull();
+  });
+
+  // Wider than the view, but all of it bar a sliver is off to the left.
+  it('centres a wide frame showing only a sliver at the edge', () => {
+    expect(axesFor(frame(100_000, 100_001))).toEqual({ time: true, depth: false });
   });
 
   it('centres a frame wider than the view that it does not reach', () => {
-    expect(revealPanAxes(bounds, 400_000, 500_000, bounds.depthStart).time).toBe(true);
+    expect(axesFor(frame(400_000, 500_000))).toEqual({ time: true, depth: false });
   });
 
   it('centres the depth on its own when only the depth is off screen', () => {
-    expect(revealPanAxes(bounds, 250_000, 1_000, bounds.depthEnd + 1)).toEqual({
+    expect(axesFor(frame(250_000, 1_000, bounds.depthEnd + 1))).toEqual({
       time: false,
       depth: true,
     });
+  });
+
+  it('leaves the view alone when one of several occurrences is in it', () => {
+    expect(revealTarget(bounds, [frame(10_000), frame(260_000), frame(900_000)])).toBeNull();
+  });
+
+  it('brings in the occurrence nearest the middle of the view', () => {
+    const target = revealTarget(bounds, [frame(900_000), frame(310_000), frame(10_000)]);
+
+    expect(target?.frame.timestamp).toBe(310_000);
+  });
+
+  it('measures nearest from the middle of the frame, not its start', () => {
+    const target = revealTarget(bounds, [frame(150_000, 20_000), frame(340_000)]);
+
+    // Its middle lands at 160,000, which is nearer 250,000 than 340,500 is.
+    expect(target?.frame.timestamp).toBe(150_000);
+  });
+
+  it('has nothing to bring in for a row that merges no frames', () => {
+    expect(revealTarget(bounds, [])).toBeNull();
   });
 });

--- a/log-viewer/src/features/timeline/__tests__/inspector-reveal-pan.test.ts
+++ b/log-viewer/src/features/timeline/__tests__/inspector-reveal-pan.test.ts
@@ -1,0 +1,78 @@
+/**
+ * @jest-environment jsdom
+ */
+
+/*
+ * Copyright (c) 2026 Certinia Inc. All rights reserved.
+ */
+
+/**
+ * What a reveal from the inspector does to the view. `revealPanAxes` holds the
+ * policy and is tested with it; this covers the wiring - the axes it works out
+ * reach the chart, and a frame needing no move asks for none.
+ */
+
+import { describe, expect, it, jest } from '@jest/globals';
+import { ApexLogTimeline } from '../optimised/ApexLogTimeline.js';
+import type { ViewportBounds, ViewportPanAxes } from '../types/flamechart.types.js';
+
+/** 100,000ns of a log on screen, from 200,000, over six depths. */
+const BOUNDS: ViewportBounds = {
+  timeStart: 200_000,
+  timeEnd: 300_000,
+  depthStart: 0,
+  depthEnd: 5,
+};
+
+function timelineWith(event: { eventIndex: number; timestamp: number; total: number }): {
+  revealFromInspector: (eventIndex: number) => void;
+  centred: () => (ViewportPanAxes | undefined)[];
+} {
+  const timeline = new ApexLogTimeline();
+  const internals = timeline as unknown as Record<string, unknown>;
+  const centred: (ViewportPanAxes | undefined)[] = [];
+
+  internals['flamechart'] = {
+    locateByEventNodes: jest.fn(),
+    selectByEventNode: () => true,
+    getViewportManager: () => ({ getBounds: () => BOUNDS }),
+    centerOnSelectedFrame: (axes?: ViewportPanAxes) => {
+      centred.push(axes);
+    },
+  };
+  internals['apexLog'] = {
+    eventsById: {
+      [event.eventIndex]: {
+        eventIndex: event.eventIndex,
+        timestamp: event.timestamp,
+        duration: { total: event.total },
+        parent: null,
+      },
+    },
+  };
+
+  const reveal = internals['selectFrameByEventIndex'] as (eventIndex: number) => void;
+
+  return {
+    revealFromInspector: (eventIndex) => reveal.call(timeline, eventIndex),
+    centred: () => centred,
+  };
+}
+
+describe('revealing a frame from the inspector', () => {
+  it('centres the view on a frame the edge of the view clips', () => {
+    const timeline = timelineWith({ eventIndex: 4, timestamp: 299_000, total: 5_000 });
+
+    timeline.revealFromInspector(4);
+
+    expect(timeline.centred()).toEqual([{ time: true, depth: false }]);
+  });
+
+  it('leaves the view alone for a frame already on screen', () => {
+    const timeline = timelineWith({ eventIndex: 4, timestamp: 250_000, total: 1_000 });
+
+    timeline.revealFromInspector(4);
+
+    expect(timeline.centred()).toEqual([]);
+  });
+});

--- a/log-viewer/src/features/timeline/__tests__/inspector-reveal-pan.test.ts
+++ b/log-viewer/src/features/timeline/__tests__/inspector-reveal-pan.test.ts
@@ -7,9 +7,9 @@
  */
 
 /**
- * What a reveal from the inspector does to the view. `revealPanAxes` holds the
- * policy and is tested with it; this covers the wiring - the axes it works out
- * reach the chart, and a frame needing no move asks for none.
+ * What a reveal from the inspector does to the view. `revealTarget` holds the
+ * policy and is tested with it; this covers the wiring - the frame and axes it
+ * works out reach the chart, and a frame needing no move asks for none.
  */
 
 import { describe, expect, it, jest } from '@jest/globals';
@@ -24,48 +24,67 @@ const BOUNDS: ViewportBounds = {
   depthEnd: 5,
 };
 
-function timelineWith(event: { eventIndex: number; timestamp: number; total: number }): {
+type Frame = { eventIndex: number; timestamp: number; total: number };
+
+/** A frame the chart was panned to, with every argument it was given. */
+type Panned = { timestamp: number; duration: number; depth: number; axes: ViewportPanAxes };
+
+function timelineWith(...events: Frame[]): {
   revealFromInspector: (eventIndex: number) => void;
-  centred: () => (ViewportPanAxes | undefined)[];
+  pickMergedRow: (eventIndexes: number[]) => void;
+  panned: () => Panned[];
+  selected: () => number;
 } {
   const timeline = new ApexLogTimeline();
   const internals = timeline as unknown as Record<string, unknown>;
-  const centred: (ViewportPanAxes | undefined)[] = [];
+  const panned: Panned[] = [];
+  let selected = 0;
 
   internals['flamechart'] = {
     locateByEventNodes: jest.fn(),
-    selectByEventNode: () => true,
+    selectByEventNode: () => {
+      selected++;
+      return true;
+    },
     getViewportManager: () => ({ getBounds: () => BOUNDS }),
-    centerOnSelectedFrame: (axes?: ViewportPanAxes) => {
-      centred.push(axes);
+    panToFrame: (timestamp: number, duration: number, depth: number, axes: ViewportPanAxes) => {
+      panned.push({ timestamp, duration, depth, axes });
     },
   };
   internals['apexLog'] = {
-    eventsById: {
-      [event.eventIndex]: {
-        eventIndex: event.eventIndex,
-        timestamp: event.timestamp,
-        duration: { total: event.total },
-        parent: null,
-      },
-    },
+    eventsById: Object.fromEntries(
+      events.map((event) => [
+        event.eventIndex,
+        {
+          eventIndex: event.eventIndex,
+          timestamp: event.timestamp,
+          duration: { total: event.total },
+          parent: null,
+        },
+      ]),
+    ),
   };
 
   const reveal = internals['selectFrameByEventIndex'] as (eventIndex: number) => void;
+  const pan = internals['panToNearestFrame'] as (eventIndexes: readonly number[]) => void;
 
   return {
     revealFromInspector: (eventIndex) => reveal.call(timeline, eventIndex),
-    centred: () => centred,
+    pickMergedRow: (eventIndexes) => pan.call(timeline, eventIndexes),
+    panned: () => panned,
+    selected: () => selected,
   };
 }
 
-describe('revealing a frame from the inspector', () => {
+describe('revealing one frame from the inspector', () => {
   it('centres the view on a frame the edge of the view clips', () => {
     const timeline = timelineWith({ eventIndex: 4, timestamp: 299_000, total: 5_000 });
 
     timeline.revealFromInspector(4);
 
-    expect(timeline.centred()).toEqual([{ time: true, depth: false }]);
+    expect(timeline.panned()).toEqual([
+      { timestamp: 299_000, duration: 5_000, depth: 0, axes: { time: true, depth: false } },
+    ]);
   });
 
   it('leaves the view alone for a frame already on screen', () => {
@@ -73,6 +92,33 @@ describe('revealing a frame from the inspector', () => {
 
     timeline.revealFromInspector(4);
 
-    expect(timeline.centred()).toEqual([]);
+    expect(timeline.panned()).toEqual([]);
+  });
+});
+
+describe('picking a merged row in the inspector', () => {
+  it('pans to the occurrence nearest the view, selecting none of them', () => {
+    const timeline = timelineWith(
+      { eventIndex: 4, timestamp: 10_000, total: 1_000 },
+      { eventIndex: 5, timestamp: 310_000, total: 1_000 },
+    );
+
+    timeline.pickMergedRow([4, 5]);
+
+    expect(timeline.panned()).toEqual([
+      { timestamp: 310_000, duration: 1_000, depth: 0, axes: { time: true, depth: false } },
+    ]);
+    expect(timeline.selected()).toBe(0);
+  });
+
+  it('leaves the view alone when one occurrence is already on screen', () => {
+    const timeline = timelineWith(
+      { eventIndex: 4, timestamp: 10_000, total: 1_000 },
+      { eventIndex: 5, timestamp: 260_000, total: 1_000 },
+    );
+
+    timeline.pickMergedRow([4, 5]);
+
+    expect(timeline.panned()).toEqual([]);
   });
 });

--- a/log-viewer/src/features/timeline/__tests__/viewport.test.ts
+++ b/log-viewer/src/features/timeline/__tests__/viewport.test.ts
@@ -477,4 +477,59 @@ describe('TimelineViewport', () => {
       expect(state.zoom).toBeCloseTo(minZoom, 5);
     });
   });
+
+  describe('centerOffsetFor', () => {
+    beforeEach(() => {
+      viewport.setZoom(0.01);
+      viewport.setPan(2000, -100);
+    });
+
+    it('should center the time axis on the event midpoint', () => {
+      const state = viewport.getState();
+      const target = viewport.centerOffsetFor(250_000, 10_000, 3, { time: true, depth: false });
+
+      const eventMidpointX = (250_000 + 10_000 / 2) * state.zoom;
+      expect(target.x + DISPLAY_WIDTH / 2).toBeCloseTo(eventMidpointX, 5);
+    });
+
+    it('should hold an axis it was not asked to center', () => {
+      const state = viewport.getState();
+      const target = viewport.centerOffsetFor(250_000, 10_000, 3, { time: true, depth: false });
+
+      expect(target.y).toBe(state.offsetY);
+    });
+
+    it('should center the depth axis on the event depth', () => {
+      // Deep enough that the depth axis can scroll at all.
+      const deep = new TimelineViewport(DISPLAY_WIDTH, DISPLAY_HEIGHT, TOTAL_DURATION, 200);
+      const target = deep.centerOffsetFor(250_000, 10_000, 60, { time: false, depth: true });
+
+      const eventY = 60 * TIMELINE_CONSTANTS.EVENT_HEIGHT;
+      expect(-target.y + DISPLAY_HEIGHT / 2).toBeCloseTo(eventY, 5);
+    });
+
+    it('should center on an event on screen, unlike calculateCenterOffset', () => {
+      const onScreen = viewport.centerOffsetFor(250_000, 1_000, 3, { time: true, depth: false });
+      const gated = viewport.calculateCenterOffset(250_000, 1_000, 3);
+
+      expect(onScreen.x).not.toBe(gated.x);
+      expect(gated.x).toBe(viewport.getState().offsetX);
+    });
+
+    it('should clamp a target at the start of the log', () => {
+      const target = viewport.centerOffsetFor(0, 1_000, 3, { time: true, depth: false });
+
+      expect(target.x).toBe(0);
+    });
+
+    it('should clamp a target at the end of the log', () => {
+      const state = viewport.getState();
+      const target = viewport.centerOffsetFor(TOTAL_DURATION, 1_000, 3, {
+        time: true,
+        depth: false,
+      });
+
+      expect(target.x).toBeCloseTo(state.zoom * TOTAL_DURATION - DISPLAY_WIDTH, 5);
+    });
+  });
 });

--- a/log-viewer/src/features/timeline/__tests__/viewport.test.ts
+++ b/log-viewer/src/features/timeline/__tests__/viewport.test.ts
@@ -478,6 +478,27 @@ describe('TimelineViewport', () => {
     });
   });
 
+  describe('centerOnEvent', () => {
+    beforeEach(() => {
+      viewport.setZoom(0.01);
+      viewport.setPan(2000, 0);
+    });
+
+    it('should center an event that is off screen', () => {
+      viewport.centerOnEvent(400_000, 1_000, 0);
+
+      const state = viewport.getState();
+      const eventMidpointX = (400_000 + 1_000 / 2) * state.zoom;
+      expect(state.offsetX + DISPLAY_WIDTH / 2).toBeCloseTo(eventMidpointX, 5);
+    });
+
+    it('should hold an event that is on screen', () => {
+      viewport.centerOnEvent(250_000, 1_000, 0);
+
+      expect(viewport.getState().offsetX).toBe(2000);
+    });
+  });
+
   describe('centerOffsetFor', () => {
     beforeEach(() => {
       viewport.setZoom(0.01);

--- a/log-viewer/src/features/timeline/optimised/ApexLogTimeline.ts
+++ b/log-viewer/src/features/timeline/optimised/ApexLogTimeline.ts
@@ -24,7 +24,11 @@ import { eventBus, type TimelineNavigateMode } from '../../../core/events/EventB
 import { SelectionEchoGuard } from '../../../core/events/SelectionEchoGuard.js';
 import { copyToClipboard } from '../../../core/utility/Clipboard.js';
 import { vscodeMessenger } from '../../../core/messaging/VSCodeExtensionMessenger.js';
-import { findEventByEventIndex, findEventByTimestamp } from '../../../core/utility/EventSearch.js';
+import {
+  findEventByEventIndex,
+  findEventByTimestamp,
+  type EventSearchResult,
+} from '../../../core/utility/EventSearch.js';
 import { goToRow } from '../../call-tree/navigation.js';
 import { formatCallStack, formatEventDetails } from '../../call-tree/utils/eventText.js';
 import { getTheme } from '../themes/ThemeSelector.js';
@@ -42,7 +46,11 @@ import {
 import type { SearchCursor } from '../types/search.types.js';
 import { InspectorEmphasis } from '../../../components/inspectorEmphasis.js';
 import { wireInspectorTab } from '../../../components/inspectorTab.js';
-import { revealPanAxes, toDetailSelection } from '../utils/detail-selection-sync.js';
+import {
+  revealTarget,
+  toDetailSelection,
+  type FramePlacement,
+} from '../utils/detail-selection-sync.js';
 import { extractExceptionMarkers, extractMarkers, noDataSpans } from '../utils/marker-utils.js';
 import { seekWindow } from '../utils/navigate-window.js';
 import { logEventToTreeAndRects } from '../utils/tree-converter.js';
@@ -57,6 +65,15 @@ interface ApexTimelineOptions extends TimelineOptions {
 /** The flame chart already draws the subtree top down, so the inspector answers
  *  a selection with where its time went. */
 const TIMELINE_VIEW = 'callees' as const;
+
+/** Where a found event sits, as the reveal policy reads it. */
+function placementOf(result: EventSearchResult): FramePlacement {
+  return {
+    timestamp: result.event.timestamp,
+    duration: result.event.duration.total,
+    depth: result.depth,
+  };
+}
 
 export class ApexLogTimeline {
   private flamechart: FlameChart;
@@ -221,6 +238,7 @@ export class ApexLogTimeline {
     this.inspectorUnsubscribe = wireInspectorTab('timeline', this.emphasis, {
       mark: (eventIndexes) => this.applyEmphasis(eventIndexes),
       reveal: (eventIndex) => this.selectFrameByEventIndex(eventIndex),
+      revealMerged: (eventIndexes) => this.panToNearestFrame(eventIndexes),
       clear: () => {
         // The chart reports the clear itself. Its own Escape, with the container
         // focused, consumes the key before this.
@@ -254,19 +272,37 @@ export class ApexLogTimeline {
     // run: the select inside it clears the mark, as any chart select does.
     this.pickEmphasis(eventIndex);
 
+    this.bringIntoView([placementOf(result)]);
+  }
+
+  /**
+   * Bring one of a merged row's frames into view, the one nearest what is on
+   * screen. Selects nothing: the row names no single frame, so its mark on all
+   * of them is what locates them.
+   */
+  private panToNearestFrame(eventIndexes: readonly number[]): void {
+    this.bringIntoView(this.resolveEvents(eventIndexes).map(placementOf));
+  }
+
+  /**
+   * Pan to whichever of `frames` the view should show, and only when it shows
+   * none of them already. Never zooms - a full focus would be too disruptive.
+   */
+  private bringIntoView(frames: readonly FramePlacement[]): void {
     const bounds = this.flamechart.getViewportManager()?.getBounds();
-    if (!bounds) {
-      return;
+    const target = bounds ? revealTarget(bounds, frames) : null;
+    if (target) {
+      const { timestamp, duration, depth } = target.frame;
+      this.flamechart.panToFrame(timestamp, duration, depth, target.axes);
     }
-    const axes = revealPanAxes(
-      bounds,
-      result.event.timestamp,
-      result.event.duration.total,
-      result.depth,
-    );
-    if (axes.time || axes.depth) {
-      this.flamechart.centerOnSelectedFrame(axes);
-    }
+  }
+
+  /** The events `eventIndexes` name, with their depths, skipping any the log lost. */
+  private resolveEvents(eventIndexes: readonly number[]): EventSearchResult[] {
+    const apexLog = this.apexLog;
+    return apexLog
+      ? eventIndexes.flatMap((eventIndex) => findEventByEventIndex(apexLog, eventIndex) ?? [])
+      : [];
   }
 
   /**
@@ -275,20 +311,9 @@ export class ApexLogTimeline {
    * it merges, so all of them light at once. Never selects, never pans.
    */
   private applyEmphasis(eventIndexes: readonly number[]): void {
-    const apexLog = this.apexLog;
-    if (!eventIndexes.length || !apexLog) {
-      this.flamechart.locateByEventNodes([]);
-      return;
-    }
-
-    const nodes: EventNode[] = [];
-    for (const eventIndex of eventIndexes) {
-      const result = findEventByEventIndex(apexLog, eventIndex);
-      if (result) {
-        nodes.push(this.toEventNode(result));
-      }
-    }
-    this.flamechart.locateByEventNodes(nodes);
+    this.flamechart.locateByEventNodes(
+      this.resolveEvents(eventIndexes).map((result) => this.toEventNode(result)),
+    );
   }
 
   /** Rest the emphasis on one frame, until something else picks or clears it. */

--- a/log-viewer/src/features/timeline/optimised/ApexLogTimeline.ts
+++ b/log-viewer/src/features/timeline/optimised/ApexLogTimeline.ts
@@ -42,7 +42,7 @@ import {
 import type { SearchCursor } from '../types/search.types.js';
 import { InspectorEmphasis } from '../../../components/inspectorEmphasis.js';
 import { wireInspectorTab } from '../../../components/inspectorTab.js';
-import { isFrameOffscreen, toDetailSelection } from '../utils/detail-selection-sync.js';
+import { revealPanAxes, toDetailSelection } from '../utils/detail-selection-sync.js';
 import { extractExceptionMarkers, extractMarkers, noDataSpans } from '../utils/marker-utils.js';
 import { seekWindow } from '../utils/navigate-window.js';
 import { logEventToTreeAndRects } from '../utils/tree-converter.js';
@@ -230,8 +230,8 @@ export class ApexLogTimeline {
   }
 
   /**
-   * Select the frame for `eventIndex` and pan to it when it is off-screen.
-   * Passive sync, so it never zooms - a full focus would be too disruptive.
+   * Select the frame for `eventIndex` and centre the view on it. Passive sync,
+   * so it never zooms - a full focus would be too disruptive.
    */
   private selectFrameByEventIndex(eventIndex: number): void {
     if (!this.apexLog) {
@@ -255,11 +255,17 @@ export class ApexLogTimeline {
     this.pickEmphasis(eventIndex);
 
     const bounds = this.flamechart.getViewportManager()?.getBounds();
-    if (
-      bounds &&
-      isFrameOffscreen(bounds, result.event.timestamp, result.event.duration.total, result.depth)
-    ) {
-      this.flamechart.centerOnSelectedFrame();
+    if (!bounds) {
+      return;
+    }
+    const axes = revealPanAxes(
+      bounds,
+      result.event.timestamp,
+      result.event.duration.total,
+      result.depth,
+    );
+    if (axes.time || axes.depth) {
+      this.flamechart.centerOnSelectedFrame(axes);
     }
   }
 

--- a/log-viewer/src/features/timeline/optimised/FlameChart.ts
+++ b/log-viewer/src/features/timeline/optimised/FlameChart.ts
@@ -81,6 +81,9 @@ import { waitForNextFrame } from '../../../core/utility/FrameBudget.js';
  */
 const SIZE_WAIT_FRAMES = 60;
 
+/** How long a pan to a frame takes, matching the moves the selection sync animates. */
+const PAN_ANIMATION_MS = 300;
+
 export interface FlameChartCallbacks {
   onMouseMove?: (
     screenX: number,
@@ -1613,18 +1616,11 @@ export class FlameChart<E extends EventNode = EventNode> {
       onMarkerSelectionChange: (marker: TimelineMarker | null) => {
         this.callbacks.onMarkerSelect?.(marker);
       },
-      onCenterOnFrame: (
-        timestamp: number,
-        duration: number,
-        depth: number,
-        axes?: ViewportPanAxes,
-      ) => {
+      onCenterOnFrame: (timestamp: number, duration: number, depth: number) => {
         if (!this.viewport) {
           return null;
         }
-        return axes
-          ? this.viewport.centerOffsetFor(timestamp, duration, depth, axes)
-          : this.viewport.calculateCenterOffset(timestamp, duration, depth);
+        return this.viewport.calculateCenterOffset(timestamp, duration, depth);
       },
       onCenterOnMarker: (startTime: number, duration: number, depth: number) => {
         if (!this.viewport) {
@@ -1653,12 +1649,7 @@ export class FlameChart<E extends EventNode = EventNode> {
         this.callbacks.onMarkerNavigate?.(marker, screenX, screenY);
       },
       onAnimateToPosition: (targetX: number, targetY: number, durationMs: number) => {
-        if (!this.viewport || !this.viewportAnimator) {
-          return;
-        }
-        this.viewportAnimator.animate(this.viewport, targetX, targetY, durationMs, () =>
-          this.notifyViewportChange(),
-        );
+        this.animateViewportTo(targetX, targetY, durationMs);
       },
       requestRender: () => {
         // Selection change only needs highlights + overlays (Phase 3 optimization)
@@ -2173,14 +2164,38 @@ export class FlameChart<E extends EventNode = EventNode> {
   }
 
   /**
-   * Pan (without changing zoom) so the currently selected frame is visible.
-   * Animated, and a no-op when the view already sits at the target - use this
-   * for the passive selection sync, where a zoom-to-fit would be too disruptive.
+   * Pan (without changing zoom) to put a frame in the middle of the view, on the
+   * axes asked for. Selects nothing, so a caller standing for several frames can
+   * bring one into view without naming it as the selection.
    *
-   * @param axes - Axes to centre on; left out, only an off-screen frame moves the view
+   * @param timestamp - Frame start time in nanoseconds
+   * @param duration - Frame duration in nanoseconds
+   * @param depth - Frame depth in the call tree
+   * @param axes - Axes to centre on
    */
-  public centerOnSelectedFrame(axes?: ViewportPanAxes): void {
-    this.selectionOrchestrator?.centerOnSelectedFrame(axes);
+  public panToFrame(
+    timestamp: number,
+    duration: number,
+    depth: number,
+    axes: ViewportPanAxes,
+  ): void {
+    if (!this.viewport) {
+      return;
+    }
+
+    const target = this.viewport.centerOffsetFor(timestamp, duration, depth, axes);
+    this.animateViewportTo(target.x, target.y, PAN_ANIMATION_MS);
+  }
+
+  /** Animate the view to an offset, abandoning whatever move was in flight. */
+  private animateViewportTo(targetX: number, targetY: number, durationMs: number): void {
+    if (!this.viewport || !this.viewportAnimator) {
+      return;
+    }
+
+    this.viewportAnimator.animate(this.viewport, targetX, targetY, durationMs, () =>
+      this.notifyViewportChange(),
+    );
   }
 
   /**

--- a/log-viewer/src/features/timeline/optimised/FlameChart.ts
+++ b/log-viewer/src/features/timeline/optimised/FlameChart.ts
@@ -25,6 +25,7 @@ import type {
   TimelineOptions,
   TimelineState,
   TreeNode,
+  ViewportPanAxes,
   ViewportState,
 } from '../types/flamechart.types.js';
 import { TIMELINE_CONSTANTS, TimelineError, TimelineErrorCode } from '../types/flamechart.types.js';
@@ -1612,11 +1613,18 @@ export class FlameChart<E extends EventNode = EventNode> {
       onMarkerSelectionChange: (marker: TimelineMarker | null) => {
         this.callbacks.onMarkerSelect?.(marker);
       },
-      onCenterOnFrame: (timestamp: number, duration: number, depth: number) => {
+      onCenterOnFrame: (
+        timestamp: number,
+        duration: number,
+        depth: number,
+        axes?: ViewportPanAxes,
+      ) => {
         if (!this.viewport) {
           return null;
         }
-        return this.viewport.calculateCenterOffset(timestamp, duration, depth);
+        return axes
+          ? this.viewport.centerOffsetFor(timestamp, duration, depth, axes)
+          : this.viewport.calculateCenterOffset(timestamp, duration, depth);
       },
       onCenterOnMarker: (startTime: number, duration: number, depth: number) => {
         if (!this.viewport) {
@@ -2166,11 +2174,13 @@ export class FlameChart<E extends EventNode = EventNode> {
 
   /**
    * Pan (without changing zoom) so the currently selected frame is visible.
-   * Animated, and a no-op if the frame is already in view - use this for the
-   * passive selection sync, where a full zoom-to-fit would be too disruptive.
+   * Animated, and a no-op when the view already sits at the target - use this
+   * for the passive selection sync, where a zoom-to-fit would be too disruptive.
+   *
+   * @param axes - Axes to centre on; left out, only an off-screen frame moves the view
    */
-  public centerOnSelectedFrame(): void {
-    this.selectionOrchestrator?.centerOnSelectedFrame();
+  public centerOnSelectedFrame(axes?: ViewportPanAxes): void {
+    this.selectionOrchestrator?.centerOnSelectedFrame(axes);
   }
 
   /**

--- a/log-viewer/src/features/timeline/optimised/TimelineViewport.ts
+++ b/log-viewer/src/features/timeline/optimised/TimelineViewport.ts
@@ -9,7 +9,7 @@
  * Handles coordinate transformations and boundary constraints.
  */
 
-import type { ViewportBounds, ViewportState } from '../types/flamechart.types.js';
+import type { ViewportBounds, ViewportPanAxes, ViewportState } from '../types/flamechart.types.js';
 import { TIMELINE_CONSTANTS } from '../types/flamechart.types.js';
 
 export class TimelineViewport {
@@ -351,37 +351,48 @@ export class TimelineViewport {
     eventDuration: number,
     eventDepth: number,
   ): { x: number; y: number } {
-    // ========== Horizontal Centering ==========
     const eventX = eventTimestamp * this.state.zoom;
     const eventWidth = eventDuration * this.state.zoom;
-    const eventMidpoint = eventX + eventWidth / 2;
-
-    // Check if off-screen (left or right)
     const screenX = eventX - this.state.offsetX;
-    const isOffScreenHorizontal = screenX > this.state.displayWidth || screenX + eventWidth < 0;
 
-    let targetOffsetX = this.state.offsetX;
-    if (isOffScreenHorizontal) {
-      // Center event midpoint at screen center
-      targetOffsetX = this.clampOffsetX(eventMidpoint - this.state.displayWidth / 2);
-    }
-
-    // ========== Vertical Centering ==========
     const eventY = eventDepth * TIMELINE_CONSTANTS.EVENT_HEIGHT;
-
-    // Calculate screen Y position of event
     const worldYBottom = -this.state.offsetY;
     const screenY = this.state.displayHeight - (eventY - worldYBottom);
 
-    // Check if off-screen (top or bottom)
-    const isOffScreenVertical = screenY < 0 || screenY > this.state.displayHeight;
+    return this.centerOffsetFor(eventTimestamp, eventDuration, eventDepth, {
+      time: screenX > this.state.displayWidth || screenX + eventWidth < 0,
+      depth: screenY < 0 || screenY > this.state.displayHeight,
+    });
+  }
+
+  /**
+   * Target offsets that put an event in the middle of the view, on the axes
+   * asked for; an axis left out keeps its current offset. Unlike
+   * {@link calculateCenterOffset} it asks nothing about whether the event is on
+   * screen - that policy belongs to the caller.
+   *
+   * @param eventTimestamp - Event start time in nanoseconds
+   * @param eventDuration - Event duration in nanoseconds
+   * @param eventDepth - Event depth in call tree (0-indexed)
+   * @param axes - Axes to center on
+   * @returns Target offsets (clamped to valid range)
+   */
+  public centerOffsetFor(
+    eventTimestamp: number,
+    eventDuration: number,
+    eventDepth: number,
+    axes: ViewportPanAxes,
+  ): { x: number; y: number } {
+    let targetOffsetX = this.state.offsetX;
+    if (axes.time) {
+      const eventMidpoint = (eventTimestamp + eventDuration / 2) * this.state.zoom;
+      targetOffsetX = this.clampOffsetX(eventMidpoint - this.state.displayWidth / 2);
+    }
 
     let targetOffsetY = this.state.offsetY;
-    if (isOffScreenVertical) {
-      // Center event at vertical center
-      const targetWorldY = eventY;
-      const newWorldYBottom = targetWorldY - this.state.displayHeight / 2;
-      targetOffsetY = this.clampOffsetY(-newWorldYBottom);
+    if (axes.depth) {
+      const eventY = eventDepth * TIMELINE_CONSTANTS.EVENT_HEIGHT;
+      targetOffsetY = this.clampOffsetY(-(eventY - this.state.displayHeight / 2));
     }
 
     return { x: targetOffsetX, y: targetOffsetY };

--- a/log-viewer/src/features/timeline/optimised/TimelineViewport.ts
+++ b/log-viewer/src/features/timeline/optimised/TimelineViewport.ts
@@ -250,79 +250,27 @@ export class TimelineViewport {
     // Clamp to valid zoom range
     const clampedZoom = Math.max(this.getMinZoom(), Math.min(this.getMaxZoom(), newZoom));
 
-    // Apply new zoom
+    // Apply new zoom, which the centring below reads
     this.state.zoom = clampedZoom;
 
-    // Calculate target offsets to center the event
-    const eventX = eventTimestamp * this.state.zoom;
-    const eventWidth = eventDuration * this.state.zoom;
-    const eventMidpoint = eventX + eventWidth / 2;
-
-    // Center event midpoint at screen center
-    const newOffsetX = eventMidpoint - this.state.displayWidth / 2;
-    this.state.offsetX = this.clampOffsetX(newOffsetX);
-
-    // Center vertically on the event depth
-    const eventY = eventDepth * TIMELINE_CONSTANTS.EVENT_HEIGHT;
-    const newWorldYBottom = eventY - this.state.displayHeight / 2;
-    this.state.offsetY = this.clampOffsetY(-newWorldYBottom);
+    const { x, y } = this.centerOffsetFor(eventTimestamp, eventDuration, eventDepth, {
+      time: true,
+      depth: true,
+    });
+    this.setOffset(x, y);
   }
 
   /**
-   * Center viewport on a specific event.
-   * Scrolls horizontally and vertically to center the event in the viewport.
-   * Only scrolls if event is off-screen or not fully visible.
+   * Center viewport on a specific event, on whichever axis the event is off
+   * screen on. The zoom is left alone.
    *
    * @param eventTimestamp - Event start time in nanoseconds
    * @param eventDuration - Event duration in nanoseconds
    * @param eventDepth - Event depth in call tree (0-indexed)
-   *
-   * Algorithm (from legacy Timeline.ts lines 1023-1041):
-   * - Calculate event midpoint in pixels
-   * - Check if event is off-screen
-   * - If off-screen: center event midpoint at screen center
-   * - Apply boundary constraints
-   * - Trigger viewport change notification
    */
   public centerOnEvent(eventTimestamp: number, eventDuration: number, eventDepth: number): void {
-    // ========== Horizontal Centering ==========
-
-    const eventX = eventTimestamp * this.state.zoom;
-    const eventWidth = eventDuration * this.state.zoom;
-    const eventMidpoint = eventX + eventWidth / 2;
-
-    // Check if off-screen (left or right)
-    const screenX = eventX - this.state.offsetX;
-    const isOffScreenHorizontal = screenX > this.state.displayWidth || screenX + eventWidth < 0;
-
-    if (isOffScreenHorizontal) {
-      // Center event midpoint at screen center
-      const newOffsetX = eventMidpoint - this.state.displayWidth / 2;
-
-      // Apply boundary constraints
-      this.state.offsetX = this.clampOffsetX(newOffsetX);
-    }
-
-    // ========== Vertical Centering ==========
-
-    const eventY = eventDepth * TIMELINE_CONSTANTS.EVENT_HEIGHT;
-
-    // Calculate screen Y position of event
-    const worldYBottom = -this.state.offsetY;
-    const screenY = this.state.displayHeight - (eventY - worldYBottom);
-
-    // Check if off-screen (top or bottom)
-    const isOffScreenVertical = screenY < 0 || screenY > this.state.displayHeight;
-
-    if (isOffScreenVertical) {
-      // Center event at vertical center
-      const targetWorldY = eventY; // World Y of event center
-      const newWorldYBottom = targetWorldY - this.state.displayHeight / 2;
-      const newOffsetY = -newWorldYBottom;
-
-      // Apply boundary constraints
-      this.state.offsetY = this.clampOffsetY(newOffsetY);
-    }
+    const { x, y } = this.calculateCenterOffset(eventTimestamp, eventDuration, eventDepth);
+    this.setOffset(x, y);
   }
 
   /**

--- a/log-viewer/src/features/timeline/optimised/orchestrators/SelectionOrchestrator.ts
+++ b/log-viewer/src/features/timeline/optimised/orchestrators/SelectionOrchestrator.ts
@@ -24,6 +24,7 @@ import type {
   EventNode,
   TimelineMarker,
   TreeNode,
+  ViewportPanAxes,
   ViewportState,
 } from '../../types/flamechart.types.js';
 import type { NavigationMaps } from '../../utils/tree-converter.js';
@@ -68,12 +69,14 @@ export interface SelectionOrchestratorCallbacks {
    * @param timestamp - Event start time in nanoseconds
    * @param duration - Event duration in nanoseconds
    * @param depth - Event depth in tree
+   * @param axes - Axes to center on; left out, only an off-screen frame moves the view
    * @returns Target offset { x, y } for animation
    */
   onCenterOnFrame: (
     timestamp: number,
     duration: number,
     depth: number,
+    axes?: ViewportPanAxes,
   ) => { x: number; y: number } | null;
 
   /**
@@ -429,8 +432,10 @@ export class SelectionOrchestrator<E extends EventNode = EventNode> {
   /**
    * Center viewport on the currently selected frame.
    * Uses smooth animation when navigating to off-screen frames.
+   *
+   * @param axes - Axes to center on; left out, only an off-screen frame moves the view
    */
-  public centerOnSelectedFrame(): void {
+  public centerOnSelectedFrame(axes?: ViewportPanAxes): void {
     const selectedNode = this.selectionNavigator?.getSelected();
     if (!selectedNode || !this.viewport) {
       return;
@@ -440,7 +445,12 @@ export class SelectionOrchestrator<E extends EventNode = EventNode> {
     const depth = selectedNode.depth ?? 0;
 
     // Request target offset calculation via callback
-    const targetOffset = this.callbacks.onCenterOnFrame(event.timestamp, event.duration, depth);
+    const targetOffset = this.callbacks.onCenterOnFrame(
+      event.timestamp,
+      event.duration,
+      depth,
+      axes,
+    );
 
     if (!targetOffset) {
       return;

--- a/log-viewer/src/features/timeline/optimised/orchestrators/SelectionOrchestrator.ts
+++ b/log-viewer/src/features/timeline/optimised/orchestrators/SelectionOrchestrator.ts
@@ -24,7 +24,6 @@ import type {
   EventNode,
   TimelineMarker,
   TreeNode,
-  ViewportPanAxes,
   ViewportState,
 } from '../../types/flamechart.types.js';
 import type { NavigationMaps } from '../../utils/tree-converter.js';
@@ -69,14 +68,12 @@ export interface SelectionOrchestratorCallbacks {
    * @param timestamp - Event start time in nanoseconds
    * @param duration - Event duration in nanoseconds
    * @param depth - Event depth in tree
-   * @param axes - Axes to center on; left out, only an off-screen frame moves the view
    * @returns Target offset { x, y } for animation
    */
   onCenterOnFrame: (
     timestamp: number,
     duration: number,
     depth: number,
-    axes?: ViewportPanAxes,
   ) => { x: number; y: number } | null;
 
   /**
@@ -432,10 +429,8 @@ export class SelectionOrchestrator<E extends EventNode = EventNode> {
   /**
    * Center viewport on the currently selected frame.
    * Uses smooth animation when navigating to off-screen frames.
-   *
-   * @param axes - Axes to center on; left out, only an off-screen frame moves the view
    */
-  public centerOnSelectedFrame(axes?: ViewportPanAxes): void {
+  public centerOnSelectedFrame(): void {
     const selectedNode = this.selectionNavigator?.getSelected();
     if (!selectedNode || !this.viewport) {
       return;
@@ -445,12 +440,7 @@ export class SelectionOrchestrator<E extends EventNode = EventNode> {
     const depth = selectedNode.depth ?? 0;
 
     // Request target offset calculation via callback
-    const targetOffset = this.callbacks.onCenterOnFrame(
-      event.timestamp,
-      event.duration,
-      depth,
-      axes,
-    );
+    const targetOffset = this.callbacks.onCenterOnFrame(event.timestamp, event.duration, depth);
 
     if (!targetOffset) {
       return;

--- a/log-viewer/src/features/timeline/types/flamechart.types.ts
+++ b/log-viewer/src/features/timeline/types/flamechart.types.ts
@@ -68,6 +68,18 @@ export interface ViewportBounds {
 }
 
 /**
+ * Which axes a viewport move should centre. An axis left out keeps its current
+ * offset, so a caller can pan in time without disturbing the depth on screen.
+ */
+export interface ViewportPanAxes {
+  /** Centre horizontally, on the frame's midpoint. */
+  time: boolean;
+
+  /** Centre vertically, on the frame's depth. */
+  depth: boolean;
+}
+
+/**
  * Modifier keys state from mouse/keyboard events.
  * Used for Cmd/Ctrl+Click navigation.
  */

--- a/log-viewer/src/features/timeline/utils/detail-selection-sync.ts
+++ b/log-viewer/src/features/timeline/utils/detail-selection-sync.ts
@@ -17,10 +17,12 @@ export function toDetailSelection(eventIndex: number | undefined): DetailSelecti
 
 /**
  * Which axes a reveal should centre the frame on, given what the view already
- * shows. A frame wider than the view keeps its place: it covers the screen
- * either way, so centring its midpoint would only lose the reader's bearings.
+ * shows. A frame spanning the view from edge to edge keeps its place: it fills
+ * the screen either way, so centring its midpoint would only lose the reader's
+ * bearings. One merely wider than the view still moves, or a frame showing a
+ * sliver at the edge would never be brought in.
  */
-export function revealPanAxes(
+function revealPanAxes(
   bounds: ViewportBounds,
   timestamp: number,
   duration: number,
@@ -28,11 +30,53 @@ export function revealPanAxes(
 ): ViewportPanAxes {
   const frameEnd = timestamp + duration;
   const fullyVisible = timestamp >= bounds.timeStart && frameEnd <= bounds.timeEnd;
-  const fits = duration <= bounds.timeEnd - bounds.timeStart;
-  const overlaps = frameEnd >= bounds.timeStart && timestamp <= bounds.timeEnd;
+  const fillsTheView = timestamp <= bounds.timeStart && frameEnd >= bounds.timeEnd;
 
   return {
-    time: !fullyVisible && (fits || !overlaps),
+    time: !fullyVisible && !fillsTheView,
     depth: depth < bounds.depthStart || depth > bounds.depthEnd,
   };
+}
+
+/** Where a frame sits, as the reveal policy reads it. */
+export interface FramePlacement {
+  timestamp: number;
+  duration: number;
+  depth: number;
+}
+
+/** The frame to bring into view, and the axes to centre it on. */
+export interface RevealTarget {
+  frame: FramePlacement;
+  axes: ViewportPanAxes;
+}
+
+/**
+ * Which frame a reveal should bring into view - of several, the one nearest the
+ * middle of what is on screen - or null when one of them is already there. A row
+ * that merges occurrences names no single frame, so the view moves without
+ * selecting: the mark on every occurrence is what says where they all are.
+ */
+export function revealTarget(
+  bounds: ViewportBounds,
+  frames: readonly FramePlacement[],
+): RevealTarget | null {
+  const middle = (bounds.timeStart + bounds.timeEnd) / 2;
+  let nearest: RevealTarget | null = null;
+  let shortest = Infinity;
+
+  for (const frame of frames) {
+    const axes = revealPanAxes(bounds, frame.timestamp, frame.duration, frame.depth);
+    if (!axes.time && !axes.depth) {
+      return null;
+    }
+
+    const distance = Math.abs(frame.timestamp + frame.duration / 2 - middle);
+    if (distance < shortest) {
+      shortest = distance;
+      nearest = { frame, axes };
+    }
+  }
+
+  return nearest;
 }

--- a/log-viewer/src/features/timeline/utils/detail-selection-sync.ts
+++ b/log-viewer/src/features/timeline/utils/detail-selection-sync.ts
@@ -8,22 +8,31 @@
  * flame chart instance.
  */
 import type { DetailSelection } from '../../../core/events/EventBus.js';
-import type { ViewportBounds } from '../types/flamechart.types.js';
+import type { ViewportBounds, ViewportPanAxes } from '../types/flamechart.types.js';
 
 /** The `detail:select` payload for a frame, or null when it carries no eventIndex. */
 export function toDetailSelection(eventIndex: number | undefined): DetailSelection | null {
   return eventIndex === undefined ? null : { kind: 'event', eventIndex };
 }
 
-/** True when the frame falls outside the viewport in time or in depth. */
-export function isFrameOffscreen(
+/**
+ * Which axes a reveal should centre the frame on, given what the view already
+ * shows. A frame wider than the view keeps its place: it covers the screen
+ * either way, so centring its midpoint would only lose the reader's bearings.
+ */
+export function revealPanAxes(
   bounds: ViewportBounds,
   timestamp: number,
   duration: number,
   depth: number,
-): boolean {
+): ViewportPanAxes {
   const frameEnd = timestamp + duration;
-  const inTimeRange = frameEnd >= bounds.timeStart && timestamp <= bounds.timeEnd;
-  const inDepthRange = depth >= bounds.depthStart && depth <= bounds.depthEnd;
-  return !(inTimeRange && inDepthRange);
+  const fullyVisible = timestamp >= bounds.timeStart && frameEnd <= bounds.timeEnd;
+  const fits = duration <= bounds.timeEnd - bounds.timeStart;
+  const overlaps = frameEnd >= bounds.timeStart && timestamp <= bounds.timeEnd;
+
+  return {
+    time: !fullyVisible && (fits || !overlaps),
+    depth: depth < bounds.depthStart || depth > bounds.depthEnd,
+  };
 }


### PR DESCRIPTION
# 📝 PR Overview

Zoomed into the timeline, picking a row in the inspector marked the frame but left the view where it was. A single-frame row panned only when the frame overlapped the view nowhere, so one showing a pixel at the screen edge stayed there; an aggregated or bottom-up row moved nothing at all, and with every occurrence off screen the chart dimmed with no lit frame anywhere.

A pick now brings a frame into view: the one it names, or for a merged row the occurrence nearest the middle of the view. Nothing moves when what you need is already on screen, a frame spanning the view edge to edge stays put, and a merged pick still selects none of its occurrences — the mark on all of them is what locates them. Zoom is never touched.

## 🛠️ Changes made

- `revealTarget` — one policy for both cases: which frame to bring in, and which axes to centre it on, or nothing when the view already shows one. A single frame is a one-element list.
- `TimelineViewport.centerOffsetFor(…, axes)` holds the centring maths. `calculateCenterOffset`, `centerOnEvent` and `focusOnEvent` all delegate to it, so the midpoint-and-clamp maths and the off-screen test each exist once instead of three times — search navigation included.
- `FlameChart.panToFrame` pans without a selection, which is what lets a merged pick move without naming one occurrence as the pick.
- `revealMerged?` replaces `movesToMergedPick?: boolean` in the inspector wiring: the view chooses which occurrence, because only it knows what nearest means in its own layout. The tables keep first-occurrence behaviour through the shared `revealFirstOf`; the Database grids still only mark.

## 🧩 Type of change (check all applicable)

- [x] 🐛 Bug fix - something not working as expected
- [ ] ✨ New feature – adds new functionality
- [x] ♻️ Refactor - internal changes with no user impact
- [ ] ⚡ Performance Improvement
- [ ] 📝 Documentation - README or documentation site changes
- [ ] 🔧 Chore - dev tooling, CI, config
- [ ] 💥 Breaking change

## 📷 Screenshots / gifs / video [optional]

N/A — the change is a viewport movement, not a new surface.

## 🔗 Related Issues

related #373
related #405

## ✅ Tests added?

- [x] 👍 yes
- [ ] 🙅 no, not needed
- [ ] 🙋 no, I need help

`pnpm lint && pnpm test`. New cases cover the policy (`detail-selection-sync.test.ts`), the geometry and its clamping (`viewport.test.ts`), and the wiring for both a single frame and a merged row (`inspector-reveal-pan.test.ts`). The new `centerOnEvent` cases pass against the pre-refactor implementation too, which is what pins that commit as behaviour-preserving.

To check by hand: open a log, Timeline tab, zoom well in, then in the inspector pick a narrow Call Tree row off to one side (the view slides so the frame is centred), a Call Stack ancestor that spans the screen (nothing moves), a row at a depth off screen (the view scrolls to that depth), and an aggregated or bottom-up row whose calls are all off screen (the view moves to the nearest one, and no frame is selected).

## 📚 Docs updated?

- [ ] 🔖 README.md
- [ ] 🔖 CHANGELOG.md
- [ ] 📖 help site
- [ ] 🧪 Marked any pre-release-only features (README `🧪` badge — see [RELEASING.md](../RELEASING.md#-marking-pre-release-only-features))
- [x] 🙅 not needed